### PR TITLE
Fix sparse gpu

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,70 +107,24 @@ build:linux-profiling:
   tags:
     - docker
 
-.build-solver-benchmark-template:
-  stage: build
-  needs: ["docker:centos"]
-  image: ${DOCKER_IMAGE_DEV}-centos:${DOCKER_TAG}
-  artifacts:
-    paths:
-      - build
-  tags:
-    - docker
-
-build:solver-benchmark 1/3:
-  extends: .build-solver-benchmark-template
-  script:
-    - mkdir -p build
-    - cd build
-    - cmake -DWITH_CUDA=OFF -DWITH_SPARSE=OFF -DWITH_SPDLOG_SUBMODULE=ON ..
-    - make -j $(nproc) WSCC_9bus_mult_coupled
-  cache:
-    paths:
-      - build
-    key: build-solver-benchmark-dense-cpu
-
-build:solver-benchmark 2/3:
-  extends: .build-solver-benchmark-template
-  script:
-    - mkdir -p build
-    - cd build
-    - cmake -DWITH_CUDA=ON -DWITH_SPARSE=OFF -DWITH_SPDLOG_SUBMODULE=ON ..
-    - make -j $(nproc) WSCC_9bus_mult_coupled
-  cache:
-    paths:
-      - build
-    key: build-solver-benchmark-dense-gpu
-  
-build:solver-benchmark 3/3:
-  extends: .build-solver-benchmark-template
-  script:
-    - mkdir -p build
-    - cd build
-    - cmake -DWITH_CUDA=OFF -DWITH_SPARSE=ON -DWITH_SPDLOG_SUBMODULE=ON ..
-    - make -j $(nproc) WSCC_9bus_mult_coupled
-  cache:
-    paths:
-      - build
-    key: build-solver-benchmark-sparse-cpu
-
 build:linux-cuda:
   stage: build
   needs: ["docker:centos"]
+  image: ${DOCKER_IMAGE_DEV}-centos:${DOCKER_TAG}
+  artifacts:
+    paths:
+      - build
+  tags:
+    - docker
   script:
     - mkdir -p build
     - cd build
-    - cmake -DWITH_SPDLOG_SUBMODULE=ON ..
-    - make -j 32
-  image: ${DOCKER_IMAGE_DEV}-centos:${DOCKER_TAG}
+    - cmake -DWITH_CUDA=ON -DWITH_SPARSE=ON -DWITH_SPDLOG_SUBMODULE=ON -DWITH_MAGMA=ON ..
+    - make -j$(nproc)
   cache:
     paths:
       - build
-    key: build-linux-cuda
-  artifacts:
-    paths:
-     - build
-  tags:
-    - docker
+    key: build-linux-cuda-sparse
 
 #build:windows:
 #  stage: build
@@ -357,11 +311,11 @@ test:examples 2/2:
   tags:
     - docker
 
-test:solver-benchmark 1/3:
+test:solver-benchmark 1/2:
     extends: .benchmark-step-times
-    needs: ["build:solver-benchmark 1/3"]
+    needs: ["build:linux-cuda"]
     dependencies:
-      - build:solver-benchmark 1/3
+      - build:linux-cuda
     variables:
 # Metrics-filename
       METRICS_ID: 'cpu-dense'
@@ -371,6 +325,7 @@ test:solver-benchmark 1/3:
       TEST_BINARY_PATH: 'build/Examples/Cxx'
 # Up to how many copies should be benchmarked (WSCC_9bus - Example)
       TEST_NUM_COPIES: 6
+      TEST_PARAM: "-U EigenDense"
     artifacts:
       reports:
           metrics: cpu-dense-metrics.txt
@@ -378,32 +333,12 @@ test:solver-benchmark 1/3:
         - cpu-dense-metrics.txt
       expose_as: 'step-times-benchmark'
 
-test:solver-benchmark 2/3:
-    extends: .remote-gpu
-    needs: ["build:solver-benchmark 2/3"]
-    dependencies:
-      - build:solver-benchmark 2/3
-    variables:
-# Metrics-filename
-      METRICS_ID: 'gpu-dense'
-# Name of the test binary
-      TEST_BINARY: 'WSCC_9bus_mult_coupled'
-# Path where the test binary is located
-      TEST_BINARY_PATH: 'build/Examples/Cxx'
-# Up to how many copies should be benchmarked (WSCC_9bus - Example)
-      TEST_NUM_COPIES: 6
-    artifacts:
-      reports:
-          metrics: gpu-dense-metrics.txt
-      paths:
-        - gpu-dense-metrics.txt
-      expose_as: 'step-times-benchmark'
 
-test:solver-benchmark 3/3:
+test:solver-benchmark 2/2:
     extends: .benchmark-step-times
-    needs: ["build:solver-benchmark 3/3"]
+    needs: ["build:linux-cuda"]
     dependencies:
-      - build:solver-benchmark 3/3
+      - build:linux-cuda
     variables:
 # Metrics-filename
       METRICS_ID: 'cpu-sparse'
@@ -413,12 +348,14 @@ test:solver-benchmark 3/3:
       TEST_BINARY_PATH: 'build/Examples/Cxx'
 # Up to how many copies should be benchmarked (WSCC_9bus - Example)
       TEST_NUM_COPIES: 6
+      TEST_PARAM: "-U EigenSparse"
     artifacts:
       reports:
           metrics: cpu-sparse-metrics.txt
       paths:
         - cpu-sparse-metrics.txt
       expose_as: 'step-times-benchmark'
+
 
 .gpu-init-script: &gpu-init-script |
     mkdir ~/.ssh &&
@@ -436,16 +373,12 @@ test:solver-benchmark 3/3:
     scp -r $LDIR/* $GPU_TARGET:$RDIR/
 
 .gpu-run-script: &gpu-run-script |
-    for ((copies=0;copies<=$TEST_NUM_COPIES;copies++))
-    do
-      ssh $GPU_TARGET "LD_LIBRARY_PATH=$RDIR:${LD_LIBRARY_PATH} LD_PRELOAD=$RDIR/cricket-server.so $RDIR/$TEST_BINARY" &
-      sleep 2
-      echo "Running with $copies copies"
-      PATH=$LDIR:${PATH} LD_PRELOAD=$LDIR/cricket-client.so $TEST_BINARY_PATH/$TEST_BINARY $TEST_PARAM -o copies=$copies 2>&1 | tee output.log
-      cat output.log |
-      sed -n -E -e 's/^.*Average step time. ([0-9]+\.[0-9]+)$/\1/p' |
-      tee -a ${METRICS_ID}-metrics.txt
-    done
+  ssh $GPU_TARGET "LD_LIBRARY_PATH=$RDIR:${LD_LIBRARY_PATH} LD_PRELOAD=$RDIR/cricket-server.so $RDIR/$TEST_BINARY" &
+  sleep 2
+  PATH=$LDIR:${PATH} REMOTE_GPU_ADDRESS=ghost.acs-lab.eonerc.rwth-aachen.de LD_PRELOAD=$LDIR/cricket-client.so $TEST_BINARY_PATH/$TEST_BINARY $TEST_PARAM 2>&1 | tee output.log
+  cat output.log |
+  sed -n -E -e 's/^.*Average step time. ([0-9]+\.[0-9]+)$/\1/p' |
+  tee -a ${METRICS_ID}-metrics.txt
 
 .remote-gpu:
   stage: test
@@ -478,25 +411,22 @@ test:solver-benchmark 3/3:
   tags:
     - docker
 
-test:cuda 1/2:
+test:cuda 1/3:
     extends: .remote-gpu
     needs: ["build:linux-cuda"]
     dependencies:
     - build:linux-cuda
-    allow_failure: true
     variables:
 # Metrics-filename
       METRICS_ID: 'cuda'
 # Name of the test binary
-      TEST_BINARY: 'WSCC_9bus_mult_decoupled'
+      TEST_BINARY: 'WSCC_9bus_mult_coupled'
 # Path where the test binary is located
       TEST_BINARY_PATH: 'build/Examples/Cxx'
 # Additional files that are necessary to run the application on the GPU node
       TEST_FILE: ''
 # Command line parameters for the test binary
-      TEST_PARAM: ''
-# Up to how many copies should be benchmarked (WSCC_9bus - Example)
-      TEST_NUM_COPIES: 0
+      TEST_PARAM: "-U CUDADense"
     artifacts:
       reports:
           metrics: cuda-metrics.txt
@@ -504,7 +434,7 @@ test:cuda 1/2:
         - cuda-metrics.txt
       expose_as: 'step-times-benchmark'
 
-test:cuda 2/2:
+test:cuda 2/3:
     extends: .remote-gpu
     needs: ["build:linux-cuda"]
     dependencies:
@@ -520,15 +450,38 @@ test:cuda 2/2:
 # Additional files that are necessary to run the application on the GPU node
       TEST_FILE: ''
 # Command line parameters for the test binary
-      TEST_PARAM: ''
-# Up to how many copies should be benchmarked (WSCC_9bus - Example)
-      TEST_NUM_COPIES: 0
+      TEST_PARAM: '-U CUDASparse'
     artifacts:
       reports:
           metrics: cuda-metrics.txt
       paths:
         - cuda-metrics.txt
       expose_as: 'step-times-benchmark'
+
+test:cuda 3/3:
+    extends: .remote-gpu
+    needs: ["build:linux-cuda"]
+    allow_failure: true
+    dependencies:
+    - build:linux-cuda
+    variables:
+# Metrics-filename
+      METRICS_ID: 'cuda'
+# Name of the test binary
+      TEST_BINARY: 'WSCC_9bus_mult_coupled'
+# Path where the test binary is located
+      TEST_BINARY_PATH: 'build/Examples/Cxx'
+# Additional files that are necessary to run the application on the GPU node
+      TEST_FILE: ''
+# Command line parameters for the test binary
+      TEST_PARAM: '-U CUDAMagma'
+    artifacts:
+      reports:
+          metrics: cuda-metrics.txt
+      paths:
+        - cuda-metrics.txt
+      expose_as: 'step-times-benchmark'
+
 
 
 ##############################################################################
@@ -570,7 +523,7 @@ generate:packages:
 
 generate:metrics:
   stage: generate
-  needs: ["test:solver-benchmark 1/3", "test:solver-benchmark 2/3", "test:solver-benchmark 3/3"]
+  needs: ["test:solver-benchmark 1/2", "test:solver-benchmark 2/2"]
   script:
     - echo "set terminal svg size 800, 500; set output 'metrics.svg'; set title 'Speed of different Solver-Configurations'; set style data lines; set key outside; set xlabel \"Copies (WSCC-9bus Example)\"; set ylabel \"Average steptime (µs)\"; set xtics 1; set xtics nomirror; set ytics nomirror; set grid; plot \"cpu-dense-metrics.txt\" using (\$1 * 1000000) title \"Solving with CPU and dense matrices\", \"gpu-dense-metrics.txt\" using (\$1 * 1000000) title \"Solving with GPU and dense matrices\", \"cpu-sparse-metrics.txt\" using (\$1 * 1000000) title \"Solving with CPU and sparse matrices\"" > script.p
     - gnuplot script.p

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ find_package(CUDA)
 find_package(GSL)
 find_package(Graphviz)
 find_package(VILLASnode)
+find_package(MAGMA)
 
 if (WITH_PYBIND_MODULE)
 	include(cmake/GetPybindModule.cmake)
@@ -161,7 +162,8 @@ cmake_dependent_option(WITH_CIM     	"Enable support for parsing CIM"     	ON 	"
 cmake_dependent_option(WITH_OPENMP  	"Enable OpenMP-based parallelisation"	ON 	"OPENMP_FOUND"    	OFF)
 cmake_dependent_option(WITH_CUDA    	"Enable CUDA-based parallelisation"  	OFF	"CUDA_FOUND"      	OFF)
 cmake_dependent_option(WITH_GRAPHVIZ	"Enable Graphviz Graphs"             	ON 	"GRAPHVIZ_FOUND"  	OFF)
-cmake_dependent_option(WITH_PYBIND     	"Enable PYBIND support"                	ON 	"pybind11_FOUND"   	OFF)
+cmake_dependent_option(WITH_PYBIND     	"Enable PYBIND support"            	ON 	"pybind11_FOUND"   	OFF)
+cmake_dependent_option(WITH_MAGMA     	"Enable MAGMA features"            	ON 	"MAGMA_FOUND"   	OFF)
 
 if(WITH_CUDA)
     # BEGIN OF WORKAROUND - enable cuda dynamic linking.

--- a/Include/dpsim/Config.h.in
+++ b/Include/dpsim/Config.h.in
@@ -26,6 +26,7 @@
 #cmakedefine WITH_OPENMP
 #cmakedefine WITH_CUDA
 #cmakedefine WITH_SPARSE
+#cmakedefine WITH_MAGMA
 #cmakedefine CGMES_BUILD
 
 #cmakedefine HAVE_TIMERFD

--- a/Include/dpsim/MNASolverFactory.h
+++ b/Include/dpsim/MNASolverFactory.h
@@ -18,6 +18,9 @@
 	#include <dpsim/MNASolverGpuDense.h>
 #ifdef WITH_SPARSE
 	#include <dpsim/MNASolverGpuSparse.h>
+#ifdef WITH_MAGMA
+	#include <dpsim/MNASolverGpuMagma.h>
+#endif
 #endif
 #endif
 
@@ -33,6 +36,7 @@ class MnaSolverFactory {
 		EigenSparse,
 		CUDADense,
 		CUDASparse,
+		CUDAMagma,
 	};
 
 	/// MNA implementations supported by this compilation
@@ -47,6 +51,9 @@ class MnaSolverFactory {
 #ifdef WITH_SPARSE
 			/* CUDASparse is not currently wokring correctly, DO NOT USE IT! */
 			//CUDASparse,
+#ifdef WITH_MAGMA
+			CUDAMagma,
+#endif //WITH_MAGMA
 #endif //WITH_SPARSE
 #endif //WITH_CUDA
 		};
@@ -83,6 +90,11 @@ class MnaSolverFactory {
 		case MnaSolverImpl::CUDASparse:
 			log->info("creating CUDASparse solver implementation");
 			return std::make_shared<MnaSolverGpuSparse<VarType>>(name, domain, logLevel);
+#ifdef WITH_MAGMA
+		case MnaSolverImpl::CUDAMagma:
+			log->info("creating CUDAMagma solver implementation");
+			return std::make_shared<MnaSolverGpuMagma<VarType>>(name, domain, logLevel);
+#endif
 #endif
 #endif
 		default:

--- a/Include/dpsim/MNASolverGpuMagma.h
+++ b/Include/dpsim/MNASolverGpuMagma.h
@@ -12,6 +12,7 @@ namespace DPsim {
     class MnaSolverGpuMagma : public MnaSolverEigenSparse<VarType>{
 	protected:
 
+		std::unique_ptr<Eigen::PermutationMatrix<Eigen::Dynamic>> mTransp;
 		// #### Attributes required for GPU ####
 		/// Solver-Handle
 		magma_dopts mMagmaOpts;

--- a/Include/dpsim/MNASolverGpuMagma.h
+++ b/Include/dpsim/MNASolverGpuMagma.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <dpsim/MNASolverEigenSparse.h>
+
+#include <magma_v2.h>
+#include <magmasparse.h>
+
+
+namespace DPsim {
+
+	template <typename VarType>
+    class MnaSolverGpuMagma : public MnaSolverEigenSparse<VarType>{
+	protected:
+
+		// #### Attributes required for GPU ####
+		/// Solver-Handle
+		magma_dopts mMagmaOpts;
+		magma_queue_t mMagmaQueue;
+
+		/// Systemmatrix
+		magma_d_matrix mHostSysMat;
+		magma_d_matrix mDevSysMat;
+
+		/// RHS-Vector
+		magma_d_matrix mHostRhsVec;
+		magma_d_matrix mDevRhsVec;
+		/// LHS-Vector
+		magma_d_matrix mHostLhsVec;
+		magma_d_matrix mDevLhsVec;
+
+		using Solver::mSLog;
+
+		/// Initialize cuSparse-library
+        void initialize() override;
+		/// ILU factorization
+		void iluPreconditioner();
+		///
+		void solve(Real time, Int timeStepCount) override;
+
+	private:
+
+	public:
+		MnaSolverGpuMagma(String name,
+			CPS::Domain domain = CPS::Domain::DP,
+			CPS::Logger::Level logLevel = CPS::Logger::Level::info);
+
+		virtual ~MnaSolverGpuMagma();
+
+		CPS::Task::List getTasks() override;
+
+		class SolveTask : public CPS::Task {
+		public:
+			SolveTask(MnaSolverGpuMagma<VarType>& solver) :
+				Task(solver.mName + ".Solve"), mSolver(solver) {
+
+				for (auto it : solver.mMNAComponents) {
+					if (it->template attribute<Matrix>("right_vector")->get().size() != 0)
+						mAttributeDependencies.push_back(it->attribute("right_vector"));
+				}
+				for (auto node : solver.mNodes) {
+					mModifiedAttributes.push_back(node->attribute("v"));
+				}
+				mModifiedAttributes.push_back(solver.attribute("left_vector"));
+			}
+
+			void execute(Real time, Int timeStepCount) { mSolver.solve(time, timeStepCount); }
+
+		private:
+			MnaSolverGpuMagma<VarType>& mSolver;
+		};
+
+		class LogTask : public CPS::Task {
+		public:
+			LogTask(MnaSolverGpuMagma<VarType>& solver) :
+				Task(solver.mName + ".Log"), mSolver(solver) {
+				mAttributeDependencies.push_back(solver.attribute("left_vector"));
+				mModifiedAttributes.push_back(Scheduler::external);
+			}
+
+			void execute(Real time, Int timeStepCount) { mSolver.log(time, timeStepCount); }
+
+		private:
+			MnaSolverGpuMagma<VarType>& mSolver;
+		};
+    };
+
+}

--- a/Packaging/Docker/Dockerfile.dev-centos
+++ b/Packaging/Docker/Dockerfile.dev-centos
@@ -20,27 +20,12 @@ RUN dnf -y update && \
     dnf config-manager --set-enabled remi
 
 # CUDA dependencies
-RUN dnf -y install https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-repo-rhel8-10.2.89-1.x86_64.rpm && \
-    dnf --refresh -y install cuda-compiler-10-2 cuda-libraries-dev-10-2 && \
-    ln -s cuda-10.2 /usr/local/cuda
+RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && \
+    dnf --refresh -y install cuda-compiler-11-4 cuda-libraries-devel-11-4 cuda-nvprof-11-4 && \
+    ln -s cuda-11.4 /usr/local/cuda
 
 ENV PATH="/usr/local/cuda/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
-
-# CUDARPC and dependencies
-RUN dnf install -y make bash git gcc autoconf libtool automake \
-                   ncurses-devel zlib-devel binutils-devel mesa-libGL-devel \
-                   libvdpau-devel mesa-libEGL-devel openssl-devel rpcbind \
-                   rpcgen texinfo bison flex
-
-ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
-# copy gitlab-runner ssh credentials into build container
-RUN git clone -b 1.0  --depth 1 --recurse-submodules https://git.rwth-aachen.de/acs/public/virtualization/cricket.git && \
-    cd cricket && \
-    make -j 16 LOG=INFO
-
-ENV PATH="$PWD/cricket/bin:${PATH}"
-ENV LD_LIBRARY_PATH="$PWD/cricket/bin:${LD_LIBRARY_PATH}"
 
 # Toolchain
 RUN dnf -y install \
@@ -52,7 +37,11 @@ RUN dnf -y install \
 	graphviz \
 	pandoc \
 	python3-pip \
-	pkg-config
+	pkg-config \
+    wget \
+    libarchive \
+    openblas-devel \
+    gcc-gfortran
 
 # Dependencies
 RUN dnf --refresh -y install \
@@ -71,6 +60,24 @@ RUN dnf -y install \
     libcurl-devel \
     jansson-devel \
     mosquitto-devel
+
+# CUDARPC and dependencies
+RUN dnf install -y make bash git gcc autoconf libtool automake \
+                   ncurses-devel zlib-devel binutils-devel mesa-libGL-devel \
+                   libvdpau-devel mesa-libEGL-devel openssl-devel rpcbind \
+                   rpcgen texinfo bison flex
+
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
+# copy gitlab-runner ssh credentials into build container
+RUN git clone -b 2.0  --depth 1 --recurse-submodules https://git.rwth-aachen.de/acs/public/virtualization/cricket.git && \
+    cd cricket && \
+    make -j16 bin/cricket-client.so LOG=INFO && \
+    make -j16 bin/cricket-server.so LOG=INFO && \
+    make -j16 bin/libtirpc.so LOG=INFO && \
+    make -j16 bin/libtirpc.so.3 LOG=INFO
+
+ENV PATH="$PWD/cricket/bin:${PATH}"
+ENV LD_LIBRARY_PATH="$PWD/cricket/bin:${LD_LIBRARY_PATH}"
 
 # Install Libwebsockets from source because the repo variant is not suitable
 RUN git clone --branch v4.0-stable --depth 1 https://libwebsockets.org/repo/libwebsockets && \
@@ -101,6 +108,16 @@ RUN cd /tmp && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
 	cmake -DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 -DUSE_CIM_VERSION=${CIM_VERSION} -DBUILD_SHARED_LIBS=ON -DBUILD_ARABICA_EXAMPLES=OFF .. && make -j$(nproc) install && \
 	rm -rf /tmp/libcimpp
+
+# Install MAGMA from source
+RUN cd /tmp && \
+    wget http://icl.utk.edu/projectsfiles/magma/downloads/magma-2.6.0.tar.gz && \
+    tar -xvzf magma-2.6.0.tar.gz && \
+    mkdir -p magma-2.6.0/build && cd magma-2.6.0/build && \
+    cmake .. -DMAGMA_ENABLE_CUDA=ON -DCMAKE_INSTALL_PREFIX=/ -DGPU_TARGET='Pascal Turing Ampere' -DBUILD_SHARED_LIBS=on && \
+    make -j$(nproc) install && rm -rf /tmp/magma-2.6.0
+
+
 
 # CIMpp and VILLAS are installed here
 ENV LD_LIBRARY_PATH="/usr/local/lib64:${LD_LIBRARY_PATH}"

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -63,12 +63,20 @@ if(WITH_CUDA)
 		
 		list(APPEND DPSIM_LIBRARIES ${CUDA_LIBRARIES} ${CUDA_cusolver_LIBRARY})
 
+	if(WITH_MAGMA)
+		list(APPEND DPSIM_SOURCES
+			MNASolverGpuMagma.cpp
+			)
+		list(APPEND DPSIM_LIBRARIES ${MAGMA_LIBRARIES})
+		list(APPEND DPSIM_INCLUDE_DIRS ${MAGMA_INCLUDE_DIR})
+	endif()
 	if(WITH_SPARSE)
 		list(APPEND DPSIM_SOURCES
 			MNASolverGpuSparse.cpp
 		)
 
 		list(APPEND DPSIM_LIBRARIES ${CUDA_cusparse_LIBRARY})
+
 	endif()
 endif()
 

--- a/Source/MNASolverEigenSparse.cpp
+++ b/Source/MNASolverEigenSparse.cpp
@@ -78,7 +78,7 @@ void MnaSolverEigenSparse<Complex>::createEmptySystemMatrix() {
 			mLuFactorizations[bit].push_back(std::make_shared<LUFactorizedSparse>());
 		}
 		mBaseSystemMatrix.resize(2 * (mNumTotalMatrixNodeIndices), 2 * (mNumTotalMatrixNodeIndices));
-	}	
+	}
 }
 
 template <typename VarType>
@@ -114,6 +114,7 @@ void MnaSolverEigenSparse<VarType>::solve(Real time, Int timeStepCount) {
 
 	if (mSwitchedMatrices.size() > 0)
 		mLeftSideVector = mLuFactorizations[mCurrentSwitchStatus][0]->solve(mRightSideVector);
+
 
 	// TODO split into separate task? (dependent on x, updating all v attributes)
 	for (UInt nodeIdx = 0; nodeIdx < mNumNetNodes; ++nodeIdx)

--- a/Source/MNASolverGpuMagma.cpp
+++ b/Source/MNASolverGpuMagma.cpp
@@ -1,0 +1,130 @@
+#include "magma_types.h"
+#include <dpsim/MNASolverGpuMagma.h>
+#include <dpsim/SequentialScheduler.h>
+#include <Eigen/Eigen>
+
+using namespace DPsim;
+using namespace CPS;
+
+namespace DPsim {
+
+template <typename VarType>
+MnaSolverGpuMagma<VarType>::MnaSolverGpuMagma(String name,
+	CPS::Domain domain, CPS::Logger::Level logLevel) :
+    MnaSolverEigenSparse<VarType>(name, domain, logLevel)
+{
+	magma_init();
+	magma_queue_create(0, &mMagmaQueue);
+	mHostSysMat = {Magma_CSR};
+	mDevSysMat = {Magma_CSR};
+	mHostRhsVec = {Magma_CSR};
+	mDevRhsVec = {Magma_CSR};
+	mHostLhsVec = {Magma_CSR};
+	mDevLhsVec = {Magma_CSR};
+}
+
+template <typename VarType>
+MnaSolverGpuMagma<VarType>::~MnaSolverGpuMagma() {
+	magma_dmfree(&mDevSysMat, mMagmaQueue);
+	magma_dmfree(&mDevRhsVec, mMagmaQueue);
+	magma_dmfree(&mDevLhsVec, mMagmaQueue);
+
+	magma_queue_destroy(mMagmaQueue);
+	magma_finalize();
+}
+
+
+template <typename VarType>
+void MnaSolverGpuMagma<VarType>::initialize() {
+    MnaSolver<VarType>::initialize();
+
+	auto hMat = this->mSwitchedMatrices[std::bitset<SWITCH_NUM>(0)];
+    int size = this->mRightSideVector.rows();
+	magma_dcsrset(size, size,
+				  hMat[0].outerIndexPtr(),
+				  hMat[0].innerIndexPtr(),
+				  hMat[0].valuePtr(),
+				  &mHostSysMat,
+				  mMagmaQueue);
+
+    mMagmaOpts.solver_par.solver     = Magma_PIDRMERGE;
+    mMagmaOpts.solver_par.restart    = 8;
+    mMagmaOpts.solver_par.maxiter    = 1000;
+    mMagmaOpts.solver_par.rtol       = 1e-10;
+    mMagmaOpts.solver_par.maxiter    = 1000;
+    mMagmaOpts.precond_par.solver    = Magma_ILU;
+    mMagmaOpts.precond_par.levels    = 0;
+    mMagmaOpts.precond_par.trisolver = Magma_CUSOLVE;
+
+	magma_dsolverinfo_init(&mMagmaOpts.solver_par,
+						   &mMagmaOpts.precond_par,
+						   mMagmaQueue);
+
+	magma_dmtransfer(mHostSysMat, &mDevSysMat, Magma_CPU, Magma_DEV, mMagmaQueue);
+    magma_d_precondsetup(mDevSysMat, mDevSysMat, &mMagmaOpts.solver_par, &mMagmaOpts.precond_par, mMagmaQueue);
+}
+
+template <typename VarType>
+Task::List MnaSolverGpuMagma<VarType>::getTasks() {
+    Task::List l;
+
+    for (auto comp : this->mMNAComponents) {
+		for (auto task : comp->mnaTasks()) {
+			l.push_back(task);
+		}
+	}
+	for (auto node : this->mNodes) {
+		for (auto task : node->mnaTasks())
+			l.push_back(task);
+	}
+	// TODO signal components should be moved out of MNA solver
+	for (auto comp : this->mSimSignalComps) {
+		for (auto task : comp->getTasks()) {
+			l.push_back(task);
+		}
+	}
+	l.push_back(std::make_shared<MnaSolverGpuMagma<VarType>::SolveTask>(*this));
+    l.push_back(std::make_shared<MnaSolverGpuMagma<VarType>::LogTask>(*this));
+	return l;
+}
+
+template <typename VarType>
+void MnaSolverGpuMagma<VarType>::solve(Real time, Int timeStepCount) {
+	int size = this->mRightSideVector.rows();
+	int one = 0;
+    // Reset source vector
+	this->mRightSideVector.setZero();
+
+    // Add together the right side vector (computed by the components'
+	// pre-step tasks)
+	for (const auto &stamp : this->mRightVectorStamps)
+		this->mRightSideVector += *stamp;
+
+	if (!this->mIsInInitialization)
+		this->updateSwitchStatus();
+
+    //Copy right vector to device
+	magma_dvset(size, 1, this->mRightSideVector.data(), &mHostRhsVec, mMagmaQueue);
+	magma_dmtransfer(mHostRhsVec, &mDevRhsVec, Magma_CPU, Magma_DEV, mMagmaQueue);
+	magma_dvinit(&mDevLhsVec, Magma_DEV, mHostRhsVec.num_rows, mHostRhsVec.num_cols, 0.0, mMagmaQueue);
+
+    // Solve
+	magma_d_solver(mDevSysMat, mDevRhsVec, &mDevLhsVec, &mMagmaOpts, mMagmaQueue);
+
+    //Copy Solution back
+	magma_dmtransfer(mDevLhsVec, &mHostLhsVec, Magma_DEV, Magma_CPU, mMagmaQueue);
+	magma_dvcopy(mDevLhsVec, &size, &one, this->leftSideVector().data(), mMagmaQueue);
+
+    mSLog->debug("result has size ({},{})", size, one);
+
+	// TODO split into separate task? (dependent on x, updating all v attributes)
+	for (UInt nodeIdx = 0; nodeIdx < this->mNumNetNodes; ++nodeIdx)
+		this->mNodes[nodeIdx]->mnaUpdateVoltage(this->mLeftSideVector);
+
+
+	// Components' states will be updated by the post-step tasks
+}
+
+}
+template class DPsim::MnaSolverGpuMagma<Real>;
+template class DPsim::MnaSolverGpuMagma<Complex>;

--- a/Source/MNASolverGpuSparse.cpp
+++ b/Source/MNASolverGpuSparse.cpp
@@ -67,7 +67,7 @@ void MnaSolverGpuSparse<VarType>::initialize() {
     int structural_zero;
     int numerical_zero;
 
-	size_t nnz = hMat.nonZeros();
+	size_t nnz = hMat[0].nonZeros();
 
     // step 1: create a descriptor which contains
     // - matrix M is base-1
@@ -105,9 +105,9 @@ void MnaSolverGpuSparse<VarType>::initialize() {
 
 	cso_status = cusolverSpDcsrzfdHost(
 		mCusolverhandle, N,nnz, descr_M,
-		hMat.valuePtr(),
-		hMat.outerIndexPtr(),
-		hMat.innerIndexPtr(),
+		hMat[0].valuePtr(),
+		hMat[0].outerIndexPtr(),
+		hMat[0].innerIndexPtr(),
 		p, &p_nnz);
 
 	if (cso_status != CUSOLVER_STATUS_SUCCESS) {
@@ -119,10 +119,10 @@ void MnaSolverGpuSparse<VarType>::initialize() {
 			Eigen::Map< Eigen::Matrix<int, Eigen::Dynamic, 1> >(p, N, 1)));
 
 	// apply permutation
-	hMat = *mTransp * hMat;
+	hMat[0] = *mTransp * hMat[0];
 
 	// copy P' to GPU
-    mSysMat = std::unique_ptr<cuda::CudaMatrix<double, int>>(new cuda::CudaMatrix<double, int>(hMat, N));
+    mSysMat = std::unique_ptr<cuda::CudaMatrix<double, int>>(new cuda::CudaMatrix<double, int>(hMat[0], N));
 
 	double *d_csrVal = mSysMat->val.data();
 	int *d_csrRowPtr = mSysMat->row.data();

--- a/Source/MNASolverGpuSparse.cpp
+++ b/Source/MNASolverGpuSparse.cpp
@@ -280,7 +280,7 @@ void MnaSolverGpuSparse<VarType>::solve(Real time, Int timeStepCount) {
 	}
 
 	//Apply inverse Permutation L = P' * L'
-	this->mLeftSideVector = mTransp->inverse() * this->mLeftSideVector;
+	//this->mLeftSideVector = mTransp->inverse() * this->mLeftSideVector;
 
 	// TODO split into separate task? (dependent on x, updating all v attributes)
 	for (UInt nodeIdx = 0; nodeIdx < this->mNumNetNodes; ++nodeIdx)

--- a/Source/MNASolverGpuSparse.cpp
+++ b/Source/MNASolverGpuSparse.cpp
@@ -5,6 +5,8 @@
 using namespace DPsim;
 using namespace CPS;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 namespace DPsim {
 
 template <typename VarType>
@@ -293,3 +295,4 @@ void MnaSolverGpuSparse<VarType>::solve(Real time, Int timeStepCount) {
 }
 template class DPsim::MnaSolverGpuSparse<Real>;
 template class DPsim::MnaSolverGpuSparse<Complex>;
+#pragma GCC diagnostic pop

--- a/Source/Utils.cpp
+++ b/Source/Utils.cpp
@@ -255,6 +255,8 @@ void CommandLineArgs::parseArguments(int argc, char *argv[])
 					mnaImpl = MnaSolverFactory::CUDADense;
 				} else if (arg == "CUDASparse") {
 					mnaImpl = MnaSolverFactory::CUDASparse;
+				} else if (arg == "CUDAMagma") {
+					mnaImpl = MnaSolverFactory::CUDAMagma;
 				} else {
 					throw std::invalid_argument("Invalid value for --solver-mna-impl");
 				}
@@ -449,7 +451,7 @@ std::list<fs::path> DPsim::Utils::findFiles(std::list<fs::path> filennames, cons
 }
 
 void DPsim::Utils::applySimulationParametersFromJson(const json config, Simulation &sim){
-	if (config.contains("timestep"))		
+	if (config.contains("timestep"))
 			sim.setTimeStep(config["timestep"].get<double>());
 	if (config.contains("duration"))
 			sim.setFinalTime(config["duration"].get<double>());

--- a/cmake/FindMAGMA.cmake
+++ b/cmake/FindMAGMA.cmake
@@ -1,0 +1,31 @@
+if(NOT MAGMA_FOUND)
+
+    include(FindPackageHandleStandardArgs)
+
+    find_path(MAGMA_INCLUDE_DIR
+        NAMES magma_v2.h magmasparse.h
+        PATH_SUFFIXES "include"
+        PATHS ${MAGMA_DIR}
+    )
+    find_library(MAGMA_LIBRARY
+	    NAMES magma
+        PATH_SUFFIXES "lib"
+        PATHS ${MAGMA_DIR}
+    )
+    find_library(MAGMA_SPARSE_LIBRARY
+	    NAMES magma_sparse
+        PATH_SUFFIXES "lib"
+        PATHS ${MAGMA_DIR}
+    )
+
+
+    if(MAGMA_LIBRARY AND MAGMA_SPARSE_LIBRARY)
+        set(MAGMA_LIBRARIES ${MAGMA_LIBRARY} ${MAGMA_SPARSE_LIBRARY})
+    endif()
+    if(MAGMA_LIBRARIES AND MAGMA_INCLUDE_DIR)
+        set(MAGMA_FOUND TRUE)
+    else()
+        set(MAGMA_FOUND FALSE)
+    endif()
+    find_package_handle_standard_args(MAGMA DEFAULT_MSG MAGMA_LIBRARIES MAGMA_INCLUDE_DIR)
+endif(NOT MAGMA_FOUND)


### PR DESCRIPTION
This PR addresses the non-working CUDASparse solver. It also adds a new sparse CUDA-based solver: MNASolverGPUMagma, based on the [magma library](https://icl.cs.utk.edu/magma/).

1. MNASolverGpuSparse did not compile because of a change in MNASolver (making the system matrix a vector of matrices).
     - This PR fixes MNASolverGPUSparse so it will compile again
2. MNASolverGpuSparse produces wrong results if there are zeroes on the main diagonal of the system matrix.
     - This PR adds MNASolverGPUMagma based on the better documented magma library instead of using CUDASparse and CUDASolver directly.
     - The algorithm used by MNASolverGpuMagma is based on an incomplete LU factorization (ILU), similarly to MNASolverGpuSparse. This algorithm requires non-zeroes on the main diagonal of the system matrix. The matrix is transmuted so that this is guaranteed
  
The CI and Dockerfile have also been modified to install magma and test MNASolverGpuMagma. However, actually running the test for MNASolverGpuMagma currently does not work, as we use cricket for remote execution of the test, which does not yet support CUDA kernels in shared objects (libmagma.so).

MNASolverGpuSparse is not fully fixed by this PR! It still produces wrong results. We might remove MNASolverGpuSparse in the future, as MNASolverGpuMagma does the same job and is more flexible.
Magma supports many more solvers and hardware platforms.