### PR TITLE
Examples refactoring rebase

### DIFF
--- a/Examples/Cxx/CIM/DP_CIGRE_MV_withDG.cpp
+++ b/Examples/Cxx/CIM/DP_CIGRE_MV_withDG.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv){
 
 	// Simulation parameters
 	String simName = "DP_CIGRE_MV_withDG";
-	Examples::CIGREMV::ScenarioConfig scenario;
+	Examples::Grids::CIGREMV::ScenarioConfig scenario;
 	std::list<fs::path> filenames;
 	Real timeStep;
 	Real finalTime;
@@ -45,7 +45,7 @@ int main(int argc, char** argv){
 	Logger::setLogDir("logs/" + simNamePF);
     CIM::Reader reader(simNamePF, Logger::Level::debug, Logger::Level::debug);
     SystemTopology systemPF = reader.loadCIM(scenario.systemFrequency, filenames, Domain::SP);
-	Examples::CIGREMV::addInvertersToCIGREMV(systemPF, scenario, Domain::SP);
+	Examples::Grids::CIGREMV::addInvertersToCIGREMV(systemPF, scenario, Domain::SP);
 
 	// define logging
     auto loggerPF = DPsim::DataLogger::make(simNamePF);
@@ -70,7 +70,7 @@ int main(int argc, char** argv){
 	Logger::setLogDir("logs/" + simName);
 	CIM::Reader reader2(simName, Logger::Level::debug, Logger::Level::debug);
     SystemTopology systemDP = reader2.loadCIM(scenario.systemFrequency, filenames, CPS::Domain::DP);
-	Examples::CIGREMV::addInvertersToCIGREMV(systemDP, scenario, Domain::DP);
+	Examples::Grids::CIGREMV::addInvertersToCIGREMV(systemDP, scenario, Domain::DP);
 	reader2.initDynamicSystemTopologyWithPowerflow(systemPF, systemDP);
 
 	auto logger = DPsim::DataLogger::make(simName);
@@ -96,7 +96,7 @@ int main(int argc, char** argv){
 	// log output of PV connected at N11
 	String pv_name = "pv_N11";
 	auto pv = systemDP.component<CPS::SimPowerComp<Complex>>(pv_name);
-	Examples::CIGREMV::logPVAttributes(logger, pv);
+	Examples::Grids::CIGREMV::logPVAttributes(logger, pv);
 
 	Simulation sim(simName, Logger::Level::debug);
 	sim.setSystem(systemDP);

--- a/Examples/Cxx/CIM/DP_CIGRE_MV_withDG_withLoadStep.cpp
+++ b/Examples/Cxx/CIM/DP_CIGRE_MV_withDG_withLoadStep.cpp
@@ -95,10 +95,10 @@ int main(int argc, char** argv){
 	Examples::Grids::CIGREMV::logPVAttributes(logger, pv);
 
 	// // load step sized relative to nominal load at N11
-	// std::shared_ptr<SwitchEvent> loadStepEvent = Examples::createEventAddPowerConsumption("N11", 2-timeStep, 5*systemPF.component<CPS::SP::Ph1::Load>("LOAD-H-11")->attribute<CPS::Real>("P")->get(), systemDP, Domain::DP, logger);
+	// std::shared_ptr<SwitchEvent> loadStepEvent = Examples::Events::createEventAddPowerConsumption("N11", 2-timeStep, 5*systemPF.component<CPS::SP::Ph1::Load>("LOAD-H-11")->attribute<CPS::Real>("P")->get(), systemDP, Domain::DP, logger);
 
 	// load step sized in absolute terms
-	std::shared_ptr<SwitchEvent> loadStepEvent = Examples::createEventAddPowerConsumption("N11", 2-timeStep, 1500.0e3, systemDP, Domain::DP, logger);
+	std::shared_ptr<SwitchEvent> loadStepEvent = Examples::Events::createEventAddPowerConsumption("N11", 2-timeStep, 1500.0e3, systemDP, Domain::DP, logger);
 	
 	Simulation sim(simName, Logger::Level::debug);
 	sim.setSystem(systemDP);

--- a/Examples/Cxx/CIM/DP_CIGRE_MV_withDG_withLoadStep.cpp
+++ b/Examples/Cxx/CIM/DP_CIGRE_MV_withDG_withLoadStep.cpp
@@ -10,7 +10,7 @@ using namespace CPS::CIM;
 int main(int argc, char** argv){
 
 	// Simulation parameters
-	Examples::CIGREMV::ScenarioConfig scenario;
+	Examples::Grids::CIGREMV::ScenarioConfig scenario;
 	std::list<fs::path> filenames;
 	Real timeStep;
 	Real finalTime;
@@ -42,7 +42,7 @@ int main(int argc, char** argv){
 	Logger::setLogDir("logs/" + simNamePF);
     CIM::Reader reader(simNamePF, Logger::Level::debug, Logger::Level::debug);
     SystemTopology systemPF = reader.loadCIM(scenario.systemFrequency, filenames, Domain::SP);
-	Examples::CIGREMV::addInvertersToCIGREMV(systemPF, scenario, Domain::SP);	 
+	Examples::Grids::CIGREMV::addInvertersToCIGREMV(systemPF, scenario, Domain::SP);	 
 
 	// define logging
     auto loggerPF = DPsim::DataLogger::make(simNamePF);
@@ -66,7 +66,7 @@ int main(int argc, char** argv){
 	Logger::setLogDir("logs/" + simName);
 	CIM::Reader reader2(simName, Logger::Level::info, Logger::Level::debug);
     SystemTopology systemDP = reader2.loadCIM(scenario.systemFrequency, filenames, CPS::Domain::DP);
-	Examples::CIGREMV::addInvertersToCIGREMV(systemDP, scenario, Domain::DP);
+	Examples::Grids::CIGREMV::addInvertersToCIGREMV(systemDP, scenario, Domain::DP);
 	reader.initDynamicSystemTopologyWithPowerflow(systemPF, systemDP);
 
 	auto logger = DPsim::DataLogger::make(simName);
@@ -92,7 +92,7 @@ int main(int argc, char** argv){
 	// log output of PV connected at N11
 	String pv_name = "pv_N11";
 	auto pv = systemDP.component<CPS::SimPowerComp<Complex>>(pv_name);
-	Examples::CIGREMV::logPVAttributes(logger, pv);
+	Examples::Grids::CIGREMV::logPVAttributes(logger, pv);
 
 	// // load step sized relative to nominal load at N11
 	// std::shared_ptr<SwitchEvent> loadStepEvent = Examples::createEventAddPowerConsumption("N11", 2-timeStep, 5*systemPF.component<CPS::SP::Ph1::Load>("LOAD-H-11")->attribute<CPS::Real>("P")->get(), systemDP, Domain::DP, logger);

--- a/Examples/Cxx/CIM/EMT_CIGRE_MV_withDG.cpp
+++ b/Examples/Cxx/CIM/EMT_CIGRE_MV_withDG.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv){
 
 	// Simulation parameters
 	String simName = "EMT_CIGRE_MV_withDG";
-	Examples::CIGREMV::ScenarioConfig scenario;
+	Examples::Grids::CIGREMV::ScenarioConfig scenario;
 	std::list<fs::path> filenames;
 	Real timeStep;
 	Real finalTime;
@@ -42,7 +42,7 @@ int main(int argc, char** argv){
 	Logger::setLogDir("logs/" + simNamePF);
     CIM::Reader reader(simNamePF, Logger::Level::debug, Logger::Level::debug);
     SystemTopology systemPF = reader.loadCIM(scenario.systemFrequency, filenames, Domain::SP);
-	Examples::CIGREMV::addInvertersToCIGREMV(systemPF, scenario, Domain::SP);
+	Examples::Grids::CIGREMV::addInvertersToCIGREMV(systemPF, scenario, Domain::SP);
 
 	// define logging
     auto loggerPF = DPsim::DataLogger::make(simNamePF);
@@ -67,7 +67,7 @@ int main(int argc, char** argv){
 	Logger::setLogDir("logs/" + simName);
 	CIM::Reader reader2(simName, Logger::Level::debug, Logger::Level::debug);
     SystemTopology systemEMT = reader2.loadCIM(scenario.systemFrequency, filenames, CPS::Domain::EMT, PhaseType::ABC);
-	Examples::CIGREMV::addInvertersToCIGREMV(systemEMT, scenario, Domain::EMT);
+	Examples::Grids::CIGREMV::addInvertersToCIGREMV(systemEMT, scenario, Domain::EMT);
 	reader2.initDynamicSystemTopologyWithPowerflow(systemPF, systemEMT);
 
 	auto logger = DPsim::DataLogger::make(simName);
@@ -90,7 +90,7 @@ int main(int argc, char** argv){
 	
 	// log output of PV connected at N11
 	auto pv = systemEMT.component<CPS::SimPowerComp<Real>>("pv_N11");
-	Examples::CIGREMV::logPVAttributes(logger, pv);
+	Examples::Grids::CIGREMV::logPVAttributes(logger, pv);
 
 	Simulation sim(simName, Logger::Level::debug);
 	sim.setSystem(systemEMT);

--- a/Examples/Cxx/CIM/EMT_CIGRE_MV_withDG_withLoadStep.cpp
+++ b/Examples/Cxx/CIM/EMT_CIGRE_MV_withDG_withLoadStep.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv){
 	auto pv = systemEMT.component<CPS::SimPowerComp<Real>>("pv_N11");
 	Examples::Grids::CIGREMV::logPVAttributes(logger, pv);
 
-	std::shared_ptr<SwitchEvent3Ph> loadStepEvent = Examples::createEventAddPowerConsumption3Ph("N11", 2-timeStep, 1500.0e3, systemEMT, Domain::EMT, logger);
+	std::shared_ptr<SwitchEvent3Ph> loadStepEvent = Examples::Events::createEventAddPowerConsumption3Ph("N11", 2-timeStep, 1500.0e3, systemEMT, Domain::EMT, logger);
 	Simulation sim(simName, Logger::Level::debug);
 	sim.setSystem(systemEMT);
 	sim.setTimeStep(timeStep);

--- a/Examples/Cxx/CIM/EMT_CIGRE_MV_withDG_withLoadStep.cpp
+++ b/Examples/Cxx/CIM/EMT_CIGRE_MV_withDG_withLoadStep.cpp
@@ -11,7 +11,7 @@ using namespace CPS::CIM;
 int main(int argc, char** argv){
 
 	// Simulation parameters
-	Examples::CIGREMV::ScenarioConfig scenario;
+	Examples::Grids::CIGREMV::ScenarioConfig scenario;
 	std::list<fs::path> filenames;
 	Real timeStep;
 	Real finalTime;
@@ -42,7 +42,7 @@ int main(int argc, char** argv){
 	Logger::setLogDir("logs/" + simNamePF);
     CIM::Reader reader(simNamePF, Logger::Level::debug, Logger::Level::debug);
     SystemTopology systemPF = reader.loadCIM(scenario.systemFrequency, filenames, Domain::SP);
-	Examples::CIGREMV::addInvertersToCIGREMV(systemPF, scenario, Domain::SP);
+	Examples::Grids::CIGREMV::addInvertersToCIGREMV(systemPF, scenario, Domain::SP);
 
 	// define logging
     auto loggerPF = DPsim::DataLogger::make(simNamePF);
@@ -67,7 +67,7 @@ int main(int argc, char** argv){
 	Logger::setLogDir("logs/" + simName);
 	CIM::Reader reader2(simName, Logger::Level::debug, Logger::Level::debug);
     SystemTopology systemEMT = reader2.loadCIM(scenario.systemFrequency, filenames, CPS::Domain::EMT, PhaseType::ABC);
-	Examples::CIGREMV::addInvertersToCIGREMV(systemEMT, scenario, Domain::EMT);
+	Examples::Grids::CIGREMV::addInvertersToCIGREMV(systemEMT, scenario, Domain::EMT);
 	reader2.initDynamicSystemTopologyWithPowerflow(systemPF, systemEMT);
 
 	auto logger = DPsim::DataLogger::make(simName);
@@ -90,7 +90,7 @@ int main(int argc, char** argv){
 
 	// log output of PV connected at N11
 	auto pv = systemEMT.component<CPS::SimPowerComp<Real>>("pv_N11");
-	Examples::CIGREMV::logPVAttributes(logger, pv);
+	Examples::Grids::CIGREMV::logPVAttributes(logger, pv);
 
 	std::shared_ptr<SwitchEvent3Ph> loadStepEvent = Examples::createEventAddPowerConsumption3Ph("N11", 2-timeStep, 1500.0e3, systemEMT, Domain::EMT, logger);
 	Simulation sim(simName, Logger::Level::debug);

--- a/Examples/Cxx/CIM/PF_CIGRE_MV_withDG.cpp
+++ b/Examples/Cxx/CIM/PF_CIGRE_MV_withDG.cpp
@@ -29,13 +29,13 @@ int main(int argc, char** argv){
 	Real timeStep = 1;
 	Real finalTime = 2;
 	String simName = "PF_CIGRE_MV_withDG";
-	Examples::CIGREMV::ScenarioConfig scenario;
+	Examples::Grids::CIGREMV::ScenarioConfig scenario;
 	Logger::setLogDir("logs/" + simName);
 
 	// read original network topology
     CIM::Reader reader(simName, Logger::Level::debug, Logger::Level::debug);
     SystemTopology system = reader.loadCIM(scenario.systemFrequency, filenames, Domain::SP);
-	Examples::CIGREMV::addInvertersToCIGREMV(system, scenario, Domain::SP);
+	Examples::Grids::CIGREMV::addInvertersToCIGREMV(system, scenario, Domain::SP);
 
     auto loggerPF = DPsim::DataLogger::make(simName);
     for (auto node : system.mNodes)

--- a/Examples/Cxx/Circuits/DP_Slack_PiLine_PQLoad_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/DP_Slack_PiLine_PQLoad_with_PF_Init.cpp
@@ -123,7 +123,7 @@ int main(int argc, char* argv[]) {
 	loggerDP->addAttribute("f_src", extnetDP->attribute("f_src"));
 
 	// load step sized in absolute terms
-	//std::shared_ptr<SwitchEvent> loadStepEvent = CIM::Examples::createEventAddPowerConsumption("n2", 0.1-timeStepDP, 100e3, systemDP, Domain::DP, loggerDP);
+	//std::shared_ptr<SwitchEvent> loadStepEvent = CIM::Examples::Events::createEventAddPowerConsumption("n2", 0.1-timeStepDP, 100e3, systemDP, Domain::DP, loggerDP);
 
 	// Simulation
 	Simulation sim(simNameDP, Logger::Level::debug);

--- a/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
@@ -132,7 +132,7 @@ int main(int argc, char* argv[]) {
 	CIM::Examples::Grids::CIGREMV::logPVAttributes(loggerDP, pv);
 
 	// load step sized in absolute terms
-	// std::shared_ptr<SwitchEvent> loadStepEvent = CIM::Examples::createEventAddPowerConsumption("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemDP, Domain::DP, loggerDP);
+	// std::shared_ptr<SwitchEvent> loadStepEvent = CIM::Examples::Events::createEventAddPowerConsumption("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemDP, Domain::DP, loggerDP);
 
 	// Simulation
 	Simulation sim(simNameDP, Logger::Level::debug);

--- a/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
@@ -14,7 +14,7 @@ using namespace CPS;
 
 int main(int argc, char* argv[]) {
 
-	CIM::Examples::SGIB::ScenarioConfig scenario;
+	CIM::Examples::Grids::SGIB::ScenarioConfig scenario;
 	
 	Real finalTime = 2;
 	Real timeStep = 0.0001;
@@ -129,7 +129,7 @@ int main(int argc, char* argv[]) {
 	loggerDP->addAttribute("i12", lineDP->attribute("i_intf"));
 	loggerDP->addAttribute("f_src", extnetDP->attribute("f_src"));
 
-	CIM::Examples::CIGREMV::logPVAttributes(loggerDP, pv);
+	CIM::Examples::Grids::CIGREMV::logPVAttributes(loggerDP, pv);
 
 	// load step sized in absolute terms
 	// std::shared_ptr<SwitchEvent> loadStepEvent = CIM::Examples::createEventAddPowerConsumption("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemDP, Domain::DP, loggerDP);

--- a/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_with_PF_Init.cpp
@@ -14,7 +14,7 @@ using namespace CPS;
 
 int main(int argc, char* argv[]) {
 
-	CIM::Examples::SGIB::ScenarioConfig scenario;
+	CIM::Examples::Grids::SGIB::ScenarioConfig scenario;
 	
 	Real finalTime = 2;
 	Real timeStep = 0.0001;
@@ -128,7 +128,7 @@ int main(int argc, char* argv[]) {
 	loggerDP->addAttribute("v2", n2DP->attribute("v"));
 	loggerDP->addAttribute("i12", lineDP->attribute("i_intf"));
 
-	CIM::Examples::CIGREMV::logPVAttributes(loggerDP, pv);
+	CIM::Examples::Grids::CIGREMV::logPVAttributes(loggerDP, pv);
 
 	// load step sized in absolute terms
 	// std::shared_ptr<SwitchEvent> loadStepEvent = CIM::Examples::createEventAddPowerConsumption("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemDP, Domain::DP, loggerDP);

--- a/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_with_PF_Init.cpp
@@ -131,7 +131,7 @@ int main(int argc, char* argv[]) {
 	CIM::Examples::Grids::CIGREMV::logPVAttributes(loggerDP, pv);
 
 	// load step sized in absolute terms
-	// std::shared_ptr<SwitchEvent> loadStepEvent = CIM::Examples::createEventAddPowerConsumption("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemDP, Domain::DP, loggerDP);
+	// std::shared_ptr<SwitchEvent> loadStepEvent = CIM::Examples::Events::createEventAddPowerConsumption("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemDP, Domain::DP, loggerDP);
 
 	// Simulation
 	Simulation sim(simNameDP, Logger::Level::debug);

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::Components::ThreeBus::ScenarioConfig ThreeBus;
+CIM::Examples::ThreeBus::ScenarioConfig ThreeBus;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e12;

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
@@ -1,76 +1,17 @@
 #include <DPsim.h>
-
+#include "../Examples.h"
 
 using namespace DPsim;
 using namespace CPS;
 
-
-//-----------Power system-----------//
-//Voltage level as Base Voltage
-Real Vnom = 230e3;
-
-//-----------Generator 1 (bus1)-----------//
-//Machine parameters
-Real nomPower_G1 = 300e6;
-Real nomPhPhVoltRMS_G1 = 25e3;
-Real nomFreq_G1 = 60;
-Real H_G1 = 6;
-Real Xpd_G1=0.3; //in p.u
-Real Rs_G1 = 0.003*0;
-Real Kd_G1 = 1.5;
-// Initialization parameters 
-Real initActivePower_G1 = 270e6;
-Real initMechPower_G1 = 270e6;
-Real setPointVoltage_G1=nomPhPhVoltRMS_G1+0.05*nomPhPhVoltRMS_G1;
-
-//-----------Generator 2 (bus2)-----------//
-//Machine parameters in per unit
-Real nomPower_G2 = 50e6;
-Real nomPhPhVoltRMS_G2 = 13.8e3;
-Real nomFreq_G2 = 60;
-Real H_G2 = 2;
-Real Xpd_G2=0.1; //in p.u
-Real Rs_G2 = 0.003*0;
-Real Kd_G2 =1.5;
-// Initialization parameters 
-Real initActivePower_G2 = 45e6;
-// Real initReactivePower_G2 = 106e6;
-Real initMechPower_G2 = 45e6;
-Real setPointVoltage_G2=nomPhPhVoltRMS_G2-0.05*nomPhPhVoltRMS_G2;
-
-//-----------Transformers-----------//
-Real t1_ratio=Vnom/nomPhPhVoltRMS_G1;
-Real t2_ratio=Vnom/nomPhPhVoltRMS_G2;
-
-//-----------Load (bus3)-----------
-Real activePower_L= 310e6;
-Real reactivePower_L= 150e6;
-
-//-----------Transmission Lines-----------//
-//PiLine parameters
-//line 1-2 (180km)
-Real lineResistance12 = 0.04*180;
-Real lineInductance12 = (0.4/377)*180;
-Real lineCapacitance12 = (4.3e-6/377)*180;
-// Real lineCapacitance12 =0;
-Real lineConductance12 =0;
-//line 1-3 (150km)
-Real lineResistance13 = 0.0267*150;
-Real lineInductance13 = (0.267/377)*150;
-Real lineCapacitance13 = (4.3e-6/377)*150;
-Real lineConductance13 =0;
-//line 2-3 (80km)
-Real lineResistance23 = 0.04*80;
-Real lineInductance23 = (0.267/377)*80;
-Real lineCapacitance23 = (4.3e-6/377)*80;
-Real lineConductance23 =0;
+CIM::Examples::Components::ThreeBus::ScenarioConfig ThreeBus;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e12;
 Real SwitchClosed = 0.1;
 
-void DP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, bool startFaultEvent, bool endFaultEvent, Real startTimeFault, Real endTimeFault, Real cmdInertia) {
-	//  // ----- POWERFLOW FOR INITIALIZATION -----
+void DP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, bool startFaultEvent, bool endFaultEvent, Real startTimeFault, Real endTimeFault, Real cmdInertia_G1, Real cmdInertia_G2, Real cmdDamping_G1, Real cmdDamping_G2) {
+	// ----- POWERFLOW FOR INITIALIZATION -----
 	Real timeStepPF = finalTime;
 	Real finalTimePF = finalTime+timeStepPF;
 	String simNamePF = simName + "_PF";
@@ -84,32 +25,32 @@ void DP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	//Synchronous generator 1
 	auto gen1PF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	gen1PF->setParameters(nomPower_G1, nomPhPhVoltRMS_G1, initActivePower_G1, setPointVoltage_G1*t1_ratio, PowerflowBusType::VD);
-	gen1PF->setBaseVoltage(Vnom);
+	gen1PF->setParameters(ThreeBus.nomPower_G1, ThreeBus.nomPhPhVoltRMS_G1, ThreeBus.initActivePower_G1, ThreeBus.setPointVoltage_G1*ThreeBus.t1_ratio, PowerflowBusType::VD);
+	gen1PF->setBaseVoltage(ThreeBus.Vnom);
 
 	//Synchronous generator 2
 	auto gen2PF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	gen2PF->setParameters(nomPower_G2, nomPhPhVoltRMS_G2, initActivePower_G2, setPointVoltage_G2*t2_ratio, PowerflowBusType::PV);
-	gen2PF->setBaseVoltage(Vnom);
+	gen2PF->setParameters(ThreeBus.nomPower_G2, ThreeBus.nomPhPhVoltRMS_G2, ThreeBus.initActivePower_G2, ThreeBus.setPointVoltage_G2*ThreeBus.t2_ratio, PowerflowBusType::PV);
+	gen2PF->setBaseVoltage(ThreeBus.Vnom);
 
 	//use Shunt as Load for powerflow
 	auto loadPF = SP::Ph1::Shunt::make("Load", Logger::Level::debug);
-	loadPF->setParameters(activePower_L / std::pow(Vnom, 2), - reactivePower_L / std::pow(Vnom, 2));
-	loadPF->setBaseVoltage(Vnom);
+	loadPF->setParameters(ThreeBus.activePower_L / std::pow(ThreeBus.Vnom, 2), - ThreeBus.reactivePower_L / std::pow(ThreeBus.Vnom, 2));
+	loadPF->setBaseVoltage(ThreeBus.Vnom);
 	
 	//Line12
 	auto line12PF = SP::Ph1::PiLine::make("PiLine12", Logger::Level::debug);
-	line12PF->setParameters(lineResistance12, lineInductance12, lineCapacitance12, lineConductance12);
-	line12PF->setBaseVoltage(Vnom);
+	line12PF->setParameters(ThreeBus.lineResistance12, ThreeBus.lineInductance12, ThreeBus.lineCapacitance12, ThreeBus.lineConductance12);
+	line12PF->setBaseVoltage(ThreeBus.Vnom);
 	//Line13
 	auto line13PF = SP::Ph1::PiLine::make("PiLine13", Logger::Level::debug);
-	line13PF->setParameters(lineResistance13, lineInductance13, lineCapacitance13, lineConductance13);
-	line13PF->setBaseVoltage(Vnom);
+	line13PF->setParameters(ThreeBus.lineResistance13, ThreeBus.lineInductance13, ThreeBus.lineCapacitance13, ThreeBus.lineConductance13);
+	line13PF->setBaseVoltage(ThreeBus.Vnom);
 	//Line23
 	auto line23PF = SP::Ph1::PiLine::make("PiLine23", Logger::Level::debug);
-	line23PF->setParameters(lineResistance23, lineInductance23, lineCapacitance23, lineConductance23);
-	line23PF->setBaseVoltage(Vnom);
+	line23PF->setParameters(ThreeBus.lineResistance23, ThreeBus.lineInductance23, ThreeBus.lineCapacitance23, ThreeBus.lineConductance23);
+	line23PF->setBaseVoltage(ThreeBus.Vnom);
 	//Switch
 	auto faultPF = CPS::SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	faultPF->setParameters(SwitchOpen, SwitchClosed);
@@ -159,48 +100,48 @@ void DP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	//Synchronous generator 1
 	auto gen1DP = DP::Ph1::SynchronGeneratorTrStab::make("SynGen1", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	gen1DP->setStandardParametersPU(nomPower_G1, nomPhPhVoltRMS_G1, nomFreq_G1, Xpd_G1*std::pow(t1_ratio,2), cmdInertia*H_G1, Rs_G1, Kd_G1 );
+	gen1DP->setStandardParametersPU(ThreeBus.nomPower_G1, ThreeBus.nomPhPhVoltRMS_G1, ThreeBus.nomFreq_G1, ThreeBus.Xpd_G1*std::pow(ThreeBus.t1_ratio,2), cmdInertia_G1*ThreeBus.H_G1, ThreeBus.Rs_G1, cmdDamping_G1*ThreeBus.D_G1);
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower_G1= gen1PF->getApparentPower();
-	gen1DP->setInitialValues(initApparentPower_G1, initMechPower_G1);
+	gen1DP->setInitialValues(initApparentPower_G1, ThreeBus.initMechPower_G1);
 
 	//Synchronous generator 2
 	auto gen2DP = DP::Ph1::SynchronGeneratorTrStab::make("SynGen2", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	gen2DP->setStandardParametersPU(nomPower_G2, nomPhPhVoltRMS_G2, nomFreq_G2, Xpd_G2*std::pow(t2_ratio,2), cmdInertia*H_G2, Rs_G2, Kd_G2 );
+	gen2DP->setStandardParametersPU(ThreeBus.nomPower_G2, ThreeBus.nomPhPhVoltRMS_G2, ThreeBus.nomFreq_G2, ThreeBus.Xpd_G2*std::pow(ThreeBus.t2_ratio,2), cmdInertia_G2*ThreeBus.H_G2, ThreeBus.Rs_G2, cmdDamping_G2*ThreeBus.D_G2);
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower_G2= gen2PF->getApparentPower();
-	gen2DP->setInitialValues(initApparentPower_G2, initMechPower_G2);
+	gen2DP->setInitialValues(initApparentPower_G2, ThreeBus.initMechPower_G2);
 
 	gen2DP->setModelFlags(true, true);
 	gen2DP->setReferenceOmega(gen1DP->attribute<Real>("w_r"), gen1DP->attribute<Real>("delta_r"));
 	
 	///Load
 	auto loadDP=DP::Ph1::RXLoad::make("Load", Logger::Level::debug);
-	loadDP->setParameters(activePower_L, reactivePower_L, Vnom);
+	loadDP->setParameters(ThreeBus.activePower_L, ThreeBus.reactivePower_L, ThreeBus.Vnom);
 
 	//Line12
 	auto line12DP = DP::Ph1::PiLine::make("PiLine12", Logger::Level::debug);
-	line12DP->setParameters(lineResistance12, lineInductance12, lineCapacitance12, lineConductance12);
+	line12DP->setParameters(ThreeBus.lineResistance12, ThreeBus.lineInductance12, ThreeBus.lineCapacitance12, ThreeBus.lineConductance12);
 	//Line13
 	auto line13DP = DP::Ph1::PiLine::make("PiLine13", Logger::Level::debug);
-	line13DP->setParameters(lineResistance13, lineInductance13, lineCapacitance13, lineConductance13);
+	line13DP->setParameters(ThreeBus.lineResistance13, ThreeBus.lineInductance13, ThreeBus.lineCapacitance13, ThreeBus.lineConductance13);
 	//Line23
 	auto line23DP = DP::Ph1::PiLine::make("PiLine23", Logger::Level::debug);
-	line23DP->setParameters(lineResistance23, lineInductance23, lineCapacitance23, lineConductance23);
+	line23DP->setParameters(ThreeBus.lineResistance23, ThreeBus.lineInductance23, ThreeBus.lineCapacitance23, ThreeBus.lineConductance23);
 
 	// //Switch
 	// auto faultDP = DP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	// faultDP->setParameters(SwitchOpen, SwitchClosed);
 	// faultDP->open();
 
-	//Switch
+	//Variable resistance Switch
 	auto faultDP = DP::Ph1::varResSwitch::make("Br_fault", Logger::Level::debug);
 	faultDP->setParameters(SwitchOpen, SwitchClosed);
 	faultDP->setInitParameters(timeStep);
 	faultDP->open();
 
-		// Topology
+	// Topology
 	gen1DP->connect({ n1DP });
 	gen2DP->connect({ n2DP });
 	loadDP->connect({ n3DP });
@@ -230,24 +171,21 @@ void DP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	loggerDP->addAttribute("v_line23", line23DP->attribute("v_intf"));
 	loggerDP->addAttribute("i_line23", line23DP->attribute("i_intf"));
 	loggerDP->addAttribute("Ep_gen1", gen1DP->attribute("Ep_mag"));	
-	loggerDP->addAttribute("Ep_gen2", gen2DP->attribute("Ep_mag"));
 	loggerDP->addAttribute("v_gen1", gen1DP->attribute("v_intf"));
 	loggerDP->addAttribute("i_gen1", gen1DP->attribute("i_intf"));
 	loggerDP->addAttribute("wr_gen1", gen1DP->attribute("w_r"));
 	loggerDP->addAttribute("delta_gen1", gen1DP->attribute("delta_r"));
+	loggerDP->addAttribute("Ep_gen2", gen2DP->attribute("Ep_mag"));
 	loggerDP->addAttribute("v_gen2", gen2DP->attribute("v_intf"));
 	loggerDP->addAttribute("i_gen2", gen2DP->attribute("i_intf"));
 	loggerDP->addAttribute("wr_gen2", gen2DP->attribute("w_r"));
 	loggerDP->addAttribute("wref_gen2", gen2DP->attribute("w_ref"));
 	loggerDP->addAttribute("delta_gen2", gen2DP->attribute("delta_r"));
-
 	loggerDP->addAttribute("i_fault", faultDP->attribute("i_intf"));
-
 	loggerDP->addAttribute("v_load", loadDP->attribute("v_intf"));
 	loggerDP->addAttribute("i_load", loadDP->attribute("i_intf"));
 	loggerDP->addAttribute("P_mech1", gen1DP->attribute("P_mech"));
 	loggerDP->addAttribute("P_mech2", gen2DP->attribute("P_mech"));
-
 	loggerDP->addAttribute("P_elec1", gen1DP->attribute("P_elec"));
 	loggerDP->addAttribute("P_elec2", gen2DP->attribute("P_elec"));
 
@@ -287,7 +225,10 @@ int main(int argc, char* argv[]) {
 	Bool endFaultEvent=true;
 	Real startTimeFault=10;
 	Real endTimeFault=10.2;
-	Real cmdInertia= 1.0;
+	Real cmdInertia_G1= 1.0;
+	Real cmdInertia_G2= 1.0;
+	Real cmdDamping_G1=1.0;
+	Real cmdDamping_G2=1.0;
 
 	CommandLineArgs args(argc, argv);
 	if (argc > 1) {
@@ -295,13 +236,19 @@ int main(int argc, char* argv[]) {
 		finalTime = args.duration;
 		if (args.name != "dpsim")
 			simName = args.name;
-		if (args.options.find("SCALEINERTIA") != args.options.end())
-			cmdInertia = args.options["SCALEINERTIA"];
+		if (args.options.find("SCALEINERTIA_G1") != args.options.end())
+			cmdInertia_G1 = args.options["SCALEINERTIA_G1"];
+		if (args.options.find("SCALEINERTIA_G2") != args.options.end())
+			cmdInertia_G2 = args.options["SCALEINERTIA_G2"];
+		if (args.options.find("SCALEDAMPING_G1") != args.options.end())
+			cmdDamping_G1 = args.options["SCALEDAMPING_G1"];
+		if (args.options.find("SCALEDAMPING_G2") != args.options.end())
+			cmdDamping_G2 = args.options["SCALEDAMPING_G2"];	
 		if (args.options.find("STARTTIMEFAULT") != args.options.end())
 			startTimeFault = args.options["STARTTIMEFAULT"];
 		if (args.options.find("ENDTIMEFAULT") != args.options.end())
 			endTimeFault = args.options["ENDTIMEFAULT"];	
 	}
 	
-	DP_SynGenTrStab_3Bus_Fault(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia);
+	DP_SynGenTrStab_3Bus_Fault(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia_G1, cmdInertia_G2, cmdDamping_G1, cmdDamping_G2);
 }

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
@@ -3,8 +3,9 @@
 
 using namespace DPsim;
 using namespace CPS;
+using namespace CIM::Examples::Grids::ThreeBus;
 
-CIM::Examples::Grids::ThreeBus::ScenarioConfig ThreeBus;
+ScenarioConfig ThreeBus;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e12;

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::ThreeBus::ScenarioConfig ThreeBus;
+CIM::Examples::Grids::ThreeBus::ScenarioConfig ThreeBus;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e12;

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_SteadyState.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::ThreeBus::ScenarioConfig ThreeBus;
+CIM::Examples::Grids::ThreeBus::ScenarioConfig ThreeBus;
 
 void DP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia_G1, Real cmdInertia_G2, Real cmdDamping_G1, Real cmdDamping_G2) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_SteadyState.cpp
@@ -1,73 +1,13 @@
 #include <DPsim.h>
-
+#include "../Examples.h"
 
 using namespace DPsim;
 using namespace CPS;
 
+CIM::Examples::Components::ThreeBus::ScenarioConfig ThreeBus;
 
-//-----------Power system-----------//
-//Voltage level as Base Voltage
-Real Vnom = 230e3;
-
-//-----------Generator 1 (bus1)-----------//
-//Machine parameters
-Real nomPower_G1 = 300e6;
-Real nomPhPhVoltRMS_G1 = 25e3;
-Real nomFreq_G1 = 60;
-Real H_G1 = 6;
-Real Xpd_G1=0.3; //in p.u
-Real Rs_G1 = 0.003*0;
-Real Kd_G1 = 1;
-// Initialization parameters 
-Real initActivePower_G1 = 270e6;
-//Real initReactivePower_G1 = 106e6;
-Real initMechPower_G1 = 270e6;
-Real setPointVoltage_G1=nomPhPhVoltRMS_G1+0.05*nomPhPhVoltRMS_G1;
-
-//-----------Generator 2 (bus2)-----------//
-//Machine parameters in per unit
-Real nomPower_G2 = 50e6;
-Real nomPhPhVoltRMS_G2 = 13.8e3;
-Real nomFreq_G2 = 60;
-Real H_G2 = 2;
-Real Xpd_G2=0.1; //in p.u
-Real Rs_G2 = 0.003*0;
-Real Kd_G2 =1;
-// Initialization parameters 
-Real initActivePower_G2 = 45e6;
-// Real initReactivePower_G2 = 106e6;
-Real initMechPower_G2 = 45e6;
-Real setPointVoltage_G2=nomPhPhVoltRMS_G2-0.05*nomPhPhVoltRMS_G2;
-
-//-----------Transformers-----------//
-Real t1_ratio=Vnom/nomPhPhVoltRMS_G1;
-Real t2_ratio=Vnom/nomPhPhVoltRMS_G2;
-
-//-----------Load (bus3)-----------
-Real activePower_L= 310e6;
-Real reactivePower_L= 150e6;
-
-//-----------Transmission Lines-----------//
-//PiLine parameters
-//line 1-2 (180km)
-Real lineResistance12 = 0.04*180;
-Real lineInductance12 = (0.4/377)*180;
-Real lineCapacitance12 = (4.3e-6/377)*180;
-// Real lineCapacitance12 =0;
-Real lineConductance12 =0;
-//line 1-3 (150km)
-Real lineResistance13 = 0.0267*150;
-Real lineInductance13 = (0.267/377)*150;
-Real lineCapacitance13 = (4.3e-6/377)*150;
-Real lineConductance13 =0;
-//line 2-3 (80km)
-Real lineResistance23 = 0.04*80;
-Real lineInductance23 = (0.267/377)*80;
-Real lineCapacitance23 = (4.3e-6/377)*80;
-Real lineConductance23 =0;
-
-void DP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalTime, bool startFaultEvent, bool endFaultEvent, Real startTimeFault, Real endTimeFault, Real cmdInertia) {
-	//  // ----- POWERFLOW FOR INITIALIZATION -----
+void DP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia_G1, Real cmdInertia_G2, Real cmdDamping_G1, Real cmdDamping_G2) {
+	// ----- POWERFLOW FOR INITIALIZATION -----
 	Real timeStepPF = finalTime;
 	Real finalTimePF = finalTime+timeStepPF;
 	String simNamePF = simName + "_PF";
@@ -81,32 +21,32 @@ void DP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalT
 	//Synchronous generator 1
 	auto gen1PF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	gen1PF->setParameters(nomPower_G1, nomPhPhVoltRMS_G1, initActivePower_G1, setPointVoltage_G1*t1_ratio, PowerflowBusType::VD);
-	gen1PF->setBaseVoltage(Vnom);
+	gen1PF->setParameters(ThreeBus.nomPower_G1, ThreeBus.nomPhPhVoltRMS_G1, ThreeBus.initActivePower_G1, ThreeBus.setPointVoltage_G1*ThreeBus.t1_ratio, PowerflowBusType::VD);
+	gen1PF->setBaseVoltage(ThreeBus.Vnom);
 
 	//Synchronous generator 2
 	auto gen2PF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	gen2PF->setParameters(nomPower_G2, nomPhPhVoltRMS_G2, initActivePower_G2, setPointVoltage_G2*t2_ratio, PowerflowBusType::PV);
-	gen2PF->setBaseVoltage(Vnom);
+	gen2PF->setParameters(ThreeBus.nomPower_G2, ThreeBus.nomPhPhVoltRMS_G2, ThreeBus.initActivePower_G2, ThreeBus.setPointVoltage_G2*ThreeBus.t2_ratio, PowerflowBusType::PV);
+	gen2PF->setBaseVoltage(ThreeBus.Vnom);
 
 	//use Shunt as Load for powerflow
 	auto loadPF = SP::Ph1::Shunt::make("Load", Logger::Level::debug);
-	loadPF->setParameters(activePower_L / std::pow(Vnom, 2), - reactivePower_L / std::pow(Vnom, 2));
-	loadPF->setBaseVoltage(Vnom);
+	loadPF->setParameters(ThreeBus.activePower_L / std::pow(ThreeBus.Vnom, 2), - ThreeBus.reactivePower_L / std::pow(ThreeBus.Vnom, 2));
+	loadPF->setBaseVoltage(ThreeBus.Vnom);
 	
 	//Line12
 	auto line12PF = SP::Ph1::PiLine::make("PiLine12", Logger::Level::debug);
-	line12PF->setParameters(lineResistance12, lineInductance12, lineCapacitance12, lineConductance12);
-	line12PF->setBaseVoltage(Vnom);
+	line12PF->setParameters(ThreeBus.lineResistance12, ThreeBus.lineInductance12, ThreeBus.lineCapacitance12, ThreeBus.lineConductance12);
+	line12PF->setBaseVoltage(ThreeBus.Vnom);
 	//Line13
 	auto line13PF = SP::Ph1::PiLine::make("PiLine13", Logger::Level::debug);
-	line13PF->setParameters(lineResistance13, lineInductance13, lineCapacitance13, lineConductance13);
-	line13PF->setBaseVoltage(Vnom);
+	line13PF->setParameters(ThreeBus.lineResistance13, ThreeBus.lineInductance13, ThreeBus.lineCapacitance13, ThreeBus.lineConductance13);
+	line13PF->setBaseVoltage(ThreeBus.Vnom);
 	//Line23
 	auto line23PF = SP::Ph1::PiLine::make("PiLine23", Logger::Level::debug);
-	line23PF->setParameters(lineResistance23, lineInductance23, lineCapacitance23, lineConductance23);
-	line23PF->setBaseVoltage(Vnom);
+	line23PF->setParameters(ThreeBus.lineResistance23, ThreeBus.lineInductance23, ThreeBus.lineCapacitance23, ThreeBus.lineConductance23);
+	line23PF->setBaseVoltage(ThreeBus.Vnom);
 
 	// Topology
 	gen1PF->connect({ n1PF });
@@ -149,33 +89,34 @@ void DP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalT
 	//Synchronous generator 1
 	auto gen1DP = DP::Ph1::SynchronGeneratorTrStab::make("SynGen", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	gen1DP->setStandardParametersPU(nomPower_G1, nomPhPhVoltRMS_G1, nomFreq_G1, Xpd_G1*std::pow(t1_ratio,2), cmdInertia*H_G1, Rs_G1, Kd_G1 );
+	gen1DP->setStandardParametersPU(ThreeBus.nomPower_G1, ThreeBus.nomPhPhVoltRMS_G1, ThreeBus.nomFreq_G1, ThreeBus.Xpd_G1*std::pow(ThreeBus.t1_ratio,2), cmdInertia_G1*ThreeBus.H_G1, ThreeBus.Rs_G1, cmdDamping_G1*ThreeBus.D_G1);
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower_G1= gen1PF->getApparentPower();
-	gen1DP->setInitialValues(initApparentPower_G1, initMechPower_G1);
+	gen1DP->setInitialValues(initApparentPower_G1, ThreeBus.initMechPower_G1);
 
 	//Synchronous generator 2
 	auto gen2DP = DP::Ph1::SynchronGeneratorTrStab::make("SynGen", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	gen2DP->setStandardParametersPU(nomPower_G2, nomPhPhVoltRMS_G2, nomFreq_G2, Xpd_G2*std::pow(t2_ratio,2), cmdInertia*H_G2, Rs_G2, Kd_G2 );
+	gen2DP->setStandardParametersPU(ThreeBus.nomPower_G2, ThreeBus.nomPhPhVoltRMS_G2, ThreeBus.nomFreq_G2, ThreeBus.Xpd_G2*std::pow(ThreeBus.t2_ratio,2), cmdInertia_G2*ThreeBus.H_G2, ThreeBus.Rs_G2, cmdDamping_G2*ThreeBus.D_G2);
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower_G2= gen2PF->getApparentPower();
-	gen2DP->setInitialValues(initApparentPower_G2, initMechPower_G2);
+	gen2DP->setInitialValues(initApparentPower_G2, ThreeBus.initMechPower_G2);
 
 	///Load
-	auto loadDP=DP::Ph1::RXLoad::make("Load", Logger::Level::debug);
-	loadDP->setParameters(activePower_L, reactivePower_L, Vnom);
+	auto loadDP = DP::Ph1::RXLoad::make("Load", Logger::Level::debug);
+	loadDP->setParameters(ThreeBus.activePower_L, ThreeBus.reactivePower_L, ThreeBus.Vnom);
+
 	//Line12
 	auto line12DP = DP::Ph1::PiLine::make("PiLine12", Logger::Level::debug);
-	line12DP->setParameters(lineResistance12, lineInductance12, lineCapacitance12, lineConductance12);
+	line12DP->setParameters(ThreeBus.lineResistance12, ThreeBus.lineInductance12, ThreeBus.lineCapacitance12, ThreeBus.lineConductance12);
 	//Line13
 	auto line13DP = DP::Ph1::PiLine::make("PiLine13", Logger::Level::debug);
-	line13DP->setParameters(lineResistance13, lineInductance13, lineCapacitance13, lineConductance13);
+	line13DP->setParameters(ThreeBus.lineResistance13, ThreeBus.lineInductance13, ThreeBus.lineCapacitance13, ThreeBus.lineConductance13);
 	//Line23
 	auto line23DP = DP::Ph1::PiLine::make("PiLine23", Logger::Level::debug);
-	line23DP->setParameters(lineResistance23, lineInductance23, lineCapacitance23, lineConductance23);
+	line23DP->setParameters(ThreeBus.lineResistance23, ThreeBus.lineInductance23, ThreeBus.lineCapacitance23, ThreeBus.lineConductance23);
 
-		// Topology
+	// Topology
 	gen1DP->connect({ n1DP });
 	gen2DP->connect({ n2DP });
 	loadDP->connect({ n3DP });
@@ -201,20 +142,22 @@ void DP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalT
 	loggerDP->addAttribute("i_line13", line13DP->attribute("i_intf"));
 	loggerDP->addAttribute("v_line23", line23DP->attribute("v_intf"));
 	loggerDP->addAttribute("i_line23", line23DP->attribute("i_intf"));
+	loggerDP->addAttribute("Ep_gen1", gen1DP->attribute("Ep_mag"));
 	loggerDP->addAttribute("v_gen1", gen1DP->attribute("v_intf"));
 	loggerDP->addAttribute("i_gen1", gen1DP->attribute("i_intf"));
 	loggerDP->addAttribute("wr_gen1", gen1DP->attribute("w_r"));
 	loggerDP->addAttribute("delta_gen1", gen1DP->attribute("delta_r"));
-	loggerDP->addAttribute("Ep_gen1", gen1DP->attribute("Ep_mag"));
+	loggerDP->addAttribute("Ep_gen2", gen2DP->attribute("Ep_mag"));
 	loggerDP->addAttribute("v_gen2", gen2DP->attribute("v_intf"));
 	loggerDP->addAttribute("i_gen2", gen2DP->attribute("i_intf"));
-	loggerDP->addAttribute("wr_gen2", gen2DP->attribute("w_r"));
-	loggerDP->addAttribute("delta_gen2", gen2DP->attribute("delta_r"));
-	loggerDP->addAttribute("Ep_gen2", gen2DP->attribute("Ep_mag"));
-	////ADD LOAD v_intf & i_intf to log attributes
-	// loggerDP->addAttribute("v_load", loadDP->attribute("v_intf"));
-	// loggerDP->addAttribute("i_load", loadDP->attribute("i_intf"));
-
+	loggerDP->addAttribute("wr_gen2", gen2DP->attribute("w_r"));	
+	loggerDP->addAttribute("wref_gen2", gen2DP->attribute("w_ref"));
+	loggerDP->addAttribute("delta_gen2", gen2DP->attribute("delta_r"));	
+	loggerDP->addAttribute("v_load", loadDP->attribute("v_intf"));
+	loggerDP->addAttribute("i_load", loadDP->attribute("i_intf"));
+	loggerDP->addAttribute("P_mech1", gen1DP->attribute("P_mech"));
+	loggerDP->addAttribute("P_mech2", gen2DP->attribute("P_mech"));
+	loggerDP->addAttribute("P_elec1", gen1DP->attribute("P_elec"));
 	loggerDP->addAttribute("P_elec2", gen2DP->attribute("P_elec"));
 
 	Simulation sim(simNameDP, Logger::Level::debug);
@@ -232,13 +175,28 @@ int main(int argc, char* argv[]) {
 
 	//Simultion parameters
 	String simName="DP_SynGenTrStab_3Bus_SteadyState";
-	Real finalTime = 10;
+	Real finalTime = 30;
 	Real timeStep = 0.001;
-	Bool startFaultEvent=false;
-	Bool endFaultEvent=false;
-	Real startTimeFault=10;
-	Real endTimeFault=10.1;
-	Real cmdInertia= 1.0;
+	Real cmdInertia_G1= 1.0;
+	Real cmdInertia_G2= 1.0;
+	Real cmdDamping_G1=1.0;
+	Real cmdDamping_G2=1.0;
 
-	DP_SynGenTrStab_3Bus_SteadyState(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia);
+		CommandLineArgs args(argc, argv);
+	if (argc > 1) {
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+		if (args.name != "dpsim")
+			simName = args.name;
+		if (args.options.find("SCALEINERTIA_G1") != args.options.end())
+			cmdInertia_G1 = args.options["SCALEINERTIA_G1"];
+		if (args.options.find("SCALEINERTIA_G2") != args.options.end())
+			cmdInertia_G2 = args.options["SCALEINERTIA_G2"];
+		if (args.options.find("SCALEDAMPING_G1") != args.options.end())
+			cmdDamping_G1 = args.options["SCALEDAMPING_G1"];
+		if (args.options.find("SCALEDAMPING_G2") != args.options.end())
+			cmdDamping_G2 = args.options["SCALEDAMPING_G2"];
+	}
+
+	DP_SynGenTrStab_3Bus_SteadyState(simName, timeStep, finalTime, cmdInertia_G1, cmdInertia_G2, cmdDamping_G1, cmdDamping_G2);
 }

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_SteadyState.cpp
@@ -3,8 +3,9 @@
 
 using namespace DPsim;
 using namespace CPS;
+using namespace CIM::Examples::Grids::ThreeBus;
 
-CIM::Examples::Grids::ThreeBus::ScenarioConfig ThreeBus;
+ScenarioConfig ThreeBus;
 
 void DP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia_G1, Real cmdInertia_G2, Real cmdDamping_G1, Real cmdDamping_G2) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_SteadyState.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::Components::ThreeBus::ScenarioConfig ThreeBus;
+CIM::Examples::ThreeBus::ScenarioConfig ThreeBus;
 
 void DP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia_G1, Real cmdInertia_G2, Real cmdDamping_G1, Real cmdDamping_G2) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::Components::SMIB::ScenarioConfig smib;
+CIM::Examples::SMIB::ScenarioConfig smib;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e6;

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
@@ -3,8 +3,9 @@
 
 using namespace DPsim;
 using namespace CPS;
+using namespace CIM::Examples::Grids::SMIB;
 
-CIM::Examples::Grids::SMIB::ScenarioConfig smib;
+ScenarioConfig smib;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e6;

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
@@ -1,47 +1,17 @@
 #include <DPsim.h>
-
+#include "../Examples.h"
 
 using namespace DPsim;
 using namespace CPS;
 
-
-//-----------Power system-----------//
-//Voltage level as Base Voltage
-Real Vnom = 230e3;
-
-//-----------Generator-----------//
-Real nomPower = 500e6;
-Real nomPhPhVoltRMS = 22e3;
-Real nomFreq = 60;
-Real nomOmega= nomFreq* 2*PI;
-Real H = 5;
-Real Xpd=0.31;
-Real Rs = 0.003*0;
-Real D = 1.5;
-// Initialization parameters
-Real initMechPower= 300e6;
-Real initActivePower = 300e6;
-Real setPointVoltage=nomPhPhVoltRMS + 0.05*nomPhPhVoltRMS;
-
-//-----------Transformer-----------//
-Real t_ratio=Vnom/nomPhPhVoltRMS;
-
-//PiLine parameters calculated from CIGRE Benchmark system
-Real lineResistance = 6.7;
-Real lineInductance = 47./nomOmega;
-Real lineCapacitance = 3.42e-4/nomOmega;
-Real lineConductance =0;
-
-// Parameters for powerflow initialization
-// Slack voltage: 1pu
-Real Vslack = Vnom;
+CIM::Examples::Components::SMIB::ScenarioConfig smib;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e6;
 Real SwitchClosed = 0.1;
 
 void DP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bool startFaultEvent, bool endFaultEvent, Real startTimeFault, Real endTimeFault, Real cmdInertia, Real cmdDamping) {
-	//  // ----- POWERFLOW FOR INITIALIZATION -----
+	// ----- POWERFLOW FOR INITIALIZATION -----
 	Real timeStepPF = finalTime;
 	Real finalTimePF = finalTime+timeStepPF;
 	String simNamePF = simName + "_PF";
@@ -54,20 +24,20 @@ void DP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bo
 	//Synchronous generator ideal model
 	auto genPF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	genPF->setParameters(nomPower, nomPhPhVoltRMS, initActivePower, setPointVoltage*t_ratio, PowerflowBusType::PV);
-	genPF->setBaseVoltage(Vnom);
+	genPF->setParameters(smib.nomPower, smib.nomPhPhVoltRMS, smib.initActivePower, smib.setPointVoltage*smib.t_ratio, PowerflowBusType::PV);
+	genPF->setBaseVoltage(smib.Vnom);
 	genPF->modifyPowerFlowBusType(PowerflowBusType::PV);
 
 	//Grid bus as Slack
 	auto extnetPF = SP::Ph1::NetworkInjection::make("Slack", Logger::Level::debug);
-	extnetPF->setParameters(Vslack);
-	extnetPF->setBaseVoltage(Vnom);
+	extnetPF->setParameters(smib.Vnom);
+	extnetPF->setBaseVoltage(smib.Vnom);
 	extnetPF->modifyPowerFlowBusType(PowerflowBusType::VD);
 	
 	//Line
 	auto linePF = SP::Ph1::PiLine::make("PiLine", Logger::Level::debug);
-	linePF->setParameters(lineResistance, lineInductance, lineCapacitance, lineConductance);
-	linePF->setBaseVoltage(Vnom);
+	linePF->setParameters(smib.lineResistance, smib.lineInductance, smib.lineCapacitance, smib.lineConductance);
+	linePF->setBaseVoltage(smib.Vnom);
 
 	//Switch
 	auto faultPF = CPS::SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
@@ -110,23 +80,24 @@ void DP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bo
 	// Components
 	auto genDP = DP::Ph1::SynchronGeneratorTrStab::make("SynGen", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	genDP->setStandardParametersPU(nomPower, nomPhPhVoltRMS, nomFreq, Xpd*std::pow(t_ratio,2), cmdInertia*H, Rs, cmdDamping*D );
+	genDP->setStandardParametersPU(smib.nomPower, smib.nomPhPhVoltRMS, smib.nomFreq, smib.Xpd*std::pow(smib.t_ratio,2), cmdInertia*smib.H, smib.Rs, cmdDamping*smib.D );
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower= genPF->getApparentPower();
-	genDP->setInitialValues(initApparentPower, initMechPower);
+	genDP->setInitialValues(initApparentPower, smib.initMechPower);
 
 	//Grid bus as Slack
 	auto extnetDP = DP::Ph1::NetworkInjection::make("Slack", Logger::Level::debug);
-	// extnetDP->setParameters(Vslack);
+	extnetDP->setParameters(smib.Vnom);
 	// Line
 	auto lineDP = DP::Ph1::PiLine::make("PiLine", Logger::Level::debug);
-	lineDP->setParameters(lineResistance, lineInductance, lineCapacitance, lineConductance);
+	lineDP->setParameters(smib.lineResistance, smib.lineInductance, smib.lineCapacitance, smib.lineConductance);
+	
 	// //Switch
 	// auto faultDP = DP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	// faultDP->setParameters(SwitchOpen, SwitchClosed);
 	// faultDP->open();
 
-	//Switch
+	// Variable resistance Switch
 	auto faultDP = DP::Ph1::varResSwitch::make("Br_fault", Logger::Level::debug);
 	faultDP->setParameters(SwitchOpen, SwitchClosed);
 	faultDP->setInitParameters(timeStep);
@@ -168,7 +139,6 @@ void DP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bo
 	loggerDP->addAttribute("i_slack", extnetDP->attribute("i_intf"));
 
 
-
 	Simulation simDP(simNameDP, Logger::Level::debug);
 	simDP.setSystem(systemDP);
 	simDP.setTimeStep(timeStep);
@@ -199,7 +169,7 @@ int main(int argc, char* argv[]) {
 
 	//Simultion parameters
 	String simName="DP_SynGenTrStab_SMIB_Fault";
-	Real finalTime = 20;
+	Real finalTime = 30;
 	Real timeStep = 0.001;
 	Bool startFaultEvent=true;
 	Bool endFaultEvent=true;
@@ -216,14 +186,13 @@ int main(int argc, char* argv[]) {
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA") != args.options.end())
 			cmdInertia = args.options["SCALEINERTIA"];
+		if (args.options.find("SCALEDAMPING") != args.options.end())
+			cmdDamping = args.options["SCALEDAMPING"];
 		if (args.options.find("STARTTIMEFAULT") != args.options.end())
 			startTimeFault = args.options["STARTTIMEFAULT"];
 		if (args.options.find("ENDTIMEFAULT") != args.options.end())
-			endTimeFault = args.options["ENDTIMEFAULT"];
-		if (args.options.find("SCALEDAMPING") != args.options.end())
-			cmdDamping = args.options["SCALEDAMPING"];		
+			endTimeFault = args.options["ENDTIMEFAULT"];	
 	}
-
 
 	DP_1ph_SynGenTrStab_Fault(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia, cmdDamping);
 }

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::SMIB::ScenarioConfig smib;
+CIM::Examples::Grids::SMIB::ScenarioConfig smib;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e6;

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_SteadyState.cpp
@@ -3,8 +3,9 @@
 
 using namespace DPsim;
 using namespace CPS;
+using namespace CIM::Examples::Grids::SMIB;
 
-CIM::Examples::Grids::SMIB::ScenarioConfig smib;
+ScenarioConfig smib;
 
 void DP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia, Real cmdDamping) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_SteadyState.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::SMIB::ScenarioConfig smib;
+CIM::Examples::Grids::SMIB::ScenarioConfig smib;
 
 void DP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia, Real cmdDamping) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_SteadyState.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::Components::SMIB::ScenarioConfig smib;
+CIM::Examples::SMIB::ScenarioConfig smib;
 
 void DP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia, Real cmdDamping) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_SteadyState.cpp
@@ -1,43 +1,13 @@
 #include <DPsim.h>
-
+#include "../Examples.h"
 
 using namespace DPsim;
 using namespace CPS;
 
+CIM::Examples::Components::SMIB::ScenarioConfig smib;
 
-//-----------Power system-----------//
-//Voltage level as Base Voltage
-Real Vnom = 230e3;
-
-//-----------Generator-----------//
-Real nomPower = 500e6;
-Real nomPhPhVoltRMS = 22e3;
-Real nomFreq = 60;
-Real nomOmega= nomFreq* 2*PI;
-Real H = 5;
-Real Xpd=0.31;
-Real Rs = 0.003*0;
-Real Kd = 1;
-// Initialization parameters
-Real initMechPower= 300e6;
-Real initActivePower = 300e6;
-Real setPointVoltage=nomPhPhVoltRMS + 0.05*nomPhPhVoltRMS;
-
-//-----------Transformer-----------//
-Real t_ratio=Vnom/nomPhPhVoltRMS;
-
-//PiLine parameters calculated from CIGRE Benchmark system
-Real lineResistance = 6.7;
-Real lineInductance = 47./nomOmega;
-Real lineCapacitance = 3.42e-4/nomOmega;
-Real lineConductance =0;
-
-// Parameters for powerflow initialization
-// Slack voltage: 1pu
-Real Vslack = Vnom;
-
-void DP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTime, bool startFaultEvent, bool endFaultEvent, Real startTimeFault, Real endTimeFault, Real cmdInertia) {
-	//  // ----- POWERFLOW FOR INITIALIZATION -----
+void DP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia, Real cmdDamping) {
+	// ----- POWERFLOW FOR INITIALIZATION -----
 	Real timeStepPF = finalTime;
 	Real finalTimePF = finalTime+timeStepPF;
 	String simNamePF = simName + "_PF";
@@ -50,20 +20,20 @@ void DP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTi
 	//Synchronous generator ideal model
 	auto genPF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	genPF->setParameters(nomPower, nomPhPhVoltRMS, initActivePower, setPointVoltage*t_ratio, PowerflowBusType::PV);
-	genPF->setBaseVoltage(Vnom);
+	genPF->setParameters(smib.nomPower, smib.nomPhPhVoltRMS, smib.initActivePower, smib.setPointVoltage*smib.t_ratio, PowerflowBusType::PV);
+	genPF->setBaseVoltage(smib.Vnom);
 	genPF->modifyPowerFlowBusType(PowerflowBusType::PV);
 
 	//Grid bus as Slack
 	auto extnetPF = SP::Ph1::NetworkInjection::make("Slack", Logger::Level::debug);
-	extnetPF->setParameters(Vslack);
-	extnetPF->setBaseVoltage(Vnom);
+	extnetPF->setParameters(smib.Vnom);
+	extnetPF->setBaseVoltage(smib.Vnom);
 	extnetPF->modifyPowerFlowBusType(PowerflowBusType::VD);
 	
 	//Line
 	auto linePF = SP::Ph1::PiLine::make("PiLine", Logger::Level::debug);
-	linePF->setParameters(lineResistance, lineInductance, lineCapacitance, lineConductance);
-	linePF->setBaseVoltage(Vnom);
+	linePF->setParameters(smib.lineResistance, smib.lineInductance, smib.lineCapacitance, smib.lineConductance);
+	linePF->setBaseVoltage(smib.Vnom);
 
 	// Topology
 	genPF->connect({ n1PF });
@@ -100,17 +70,17 @@ void DP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTi
 	// Components
 	auto genDP = DP::Ph1::SynchronGeneratorTrStab::make("SynGen", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	genDP->setStandardParametersPU(nomPower, nomPhPhVoltRMS, nomFreq, Xpd*std::pow(t_ratio,2), cmdInertia*H, Rs, Kd );
+	genDP->setStandardParametersPU(smib.nomPower, smib.nomPhPhVoltRMS, smib.nomFreq, smib.Xpd*std::pow(smib.t_ratio,2), cmdInertia*smib.H, smib.Rs, cmdDamping*smib.D );
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower= genPF->getApparentPower();
-	genDP->setInitialValues(initApparentPower, initMechPower);
+	genDP->setInitialValues(initApparentPower, smib.initMechPower);
 
 	//Grid bus as Slack
 	auto extnetDP = DP::Ph1::NetworkInjection::make("Slack", Logger::Level::debug);
-	extnetDP->setParameters(Vslack);
+	extnetDP->setParameters(smib.Vnom);
 	// Line
 	auto lineDP = DP::Ph1::PiLine::make("PiLine", Logger::Level::debug);
-	lineDP->setParameters(lineResistance, lineInductance, lineCapacitance, lineConductance);
+	lineDP->setParameters(smib.lineResistance, smib.lineInductance, smib.lineCapacitance, smib.lineConductance);
 
 	// Topology
 	genDP->connect({ n1DP });
@@ -159,15 +129,24 @@ void DP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTi
 int main(int argc, char* argv[]) {	
 		
 
-	//Simultion parameters
+	//Simulation parameters
 	String simName="DP_SynGenTrStab_SMIB_SteadyState";
-	Real finalTime = 10;
+	Real finalTime = 20;
 	Real timeStep = 0.001;
-	Bool startFaultEvent=false;
-	Bool endFaultEvent=false;
-	Real startTimeFault=10;
-	Real endTimeFault=10.1;
 	Real cmdInertia= 1.0;
+	Real cmdDamping=1.0;
 
-	DP_1ph_SynGenTrStab_SteadyState(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia);
+	CommandLineArgs args(argc, argv);
+	if (argc > 1) {
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+		if (args.name != "dpsim")
+			simName = args.name;
+		if (args.options.find("SCALEINERTIA") != args.options.end())
+			cmdInertia = args.options["SCALEINERTIA"];
+		if (args.options.find("SCALEDAMPING") != args.options.end())
+			cmdDamping = args.options["SCALEDAMPING"];
+	}
+	
+	DP_1ph_SynGenTrStab_SteadyState(simName, timeStep, finalTime, cmdInertia, cmdDamping);
 }

--- a/Examples/Cxx/Circuits/EMT_DP_SP_Slack_PiLine_PQLoad_FM.cpp
+++ b/Examples/Cxx/Circuits/EMT_DP_SP_Slack_PiLine_PQLoad_FM.cpp
@@ -231,7 +231,7 @@ void simulateEMT(SystemTopology& systemPF, String waveform) {
 	loggerEMT->addAttribute("f_src", extnetEMT->attribute("f_src"));
 
 	// load step sized in absolute terms
-	//std::shared_ptr<SwitchEvent3Ph> loadStepEvent = CIM::Examples::createEventAddPowerConsumption3Ph("n2", 0.1-timeStepEMT, 100e3, systemEMT, Domain::EMT, loggerEMT);
+	//std::shared_ptr<SwitchEvent3Ph> loadStepEvent = CIM::Examples::Events::createEventAddPowerConsumption3Ph("n2", 0.1-timeStepEMT, 100e3, systemEMT, Domain::EMT, loggerEMT);
 
 	// Simulation
 	Simulation sim(simNameEMT, Logger::Level::debug);

--- a/Examples/Cxx/Circuits/EMT_Slack_PiLine_PQLoad_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/EMT_Slack_PiLine_PQLoad_with_PF_Init.cpp
@@ -124,7 +124,7 @@ int main(int argc, char* argv[]) {
 	loggerEMT->addAttribute("f_src", extnetEMT->attribute("f_src"));
 
 	// load step sized in absolute terms
-	//std::shared_ptr<SwitchEvent3Ph> loadStepEvent = CIM::Examples::createEventAddPowerConsumption3Ph("n2", 0.1-timeStepEMT, 100e3, systemEMT, Domain::EMT, loggerEMT);
+	//std::shared_ptr<SwitchEvent3Ph> loadStepEvent = CIM::Examples::Events::createEventAddPowerConsumption3Ph("n2", 0.1-timeStepEMT, 100e3, systemEMT, Domain::EMT, loggerEMT);
 
 	// Simulation
 	Simulation sim(simNameEMT, Logger::Level::debug);

--- a/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
@@ -14,7 +14,7 @@ using namespace CPS;
 
 int main(int argc, char* argv[]) {
 
-	CIM::Examples::SGIB::ScenarioConfig scenario;
+	CIM::Examples::Grids::SGIB::ScenarioConfig scenario;
 	
 	Real finalTime = 2;
 	Real timeStep = 0.0001;
@@ -129,7 +129,7 @@ int main(int argc, char* argv[]) {
 	loggerEMT->addAttribute("f_src", extnetEMT->attribute("f_src"));
 	loggerEMT->addAttribute("sigOut", extnetEMT->attribute("sigOut"));
 
-	CIM::Examples::CIGREMV::logPVAttributes(loggerEMT, pv);
+	CIM::Examples::Grids::CIGREMV::logPVAttributes(loggerEMT, pv);
 
 	// load step sized in absolute terms
 	// std::shared_ptr<SwitchEvent3Ph> loadStepEvent = CIM::Examples::createEventAddPowerConsumption3Ph("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemEMT, Domain::EMT, loggerEMT);

--- a/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
@@ -132,7 +132,7 @@ int main(int argc, char* argv[]) {
 	CIM::Examples::Grids::CIGREMV::logPVAttributes(loggerEMT, pv);
 
 	// load step sized in absolute terms
-	// std::shared_ptr<SwitchEvent3Ph> loadStepEvent = CIM::Examples::createEventAddPowerConsumption3Ph("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemEMT, Domain::EMT, loggerEMT);
+	// std::shared_ptr<SwitchEvent3Ph> loadStepEvent = CIM::Examples::Events::createEventAddPowerConsumption3Ph("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemEMT, Domain::EMT, loggerEMT);
 
 	// Simulation
 	Simulation sim(simNameEMT, Logger::Level::debug);

--- a/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_with_PF_Init.cpp
@@ -14,7 +14,7 @@ using namespace CPS;
 
 int main(int argc, char* argv[]) {
 
-	CIM::Examples::SGIB::ScenarioConfig scenario;
+	CIM::Examples::Grids::SGIB::ScenarioConfig scenario;
 	
 	Real finalTime = 2;
 	Real timeStep = 0.0001;
@@ -126,7 +126,7 @@ int main(int argc, char* argv[]) {
 	loggerEMT->addAttribute("v2", n2EMT->attribute("v"));
 	loggerEMT->addAttribute("i12", lineEMT->attribute("i_intf"));
 
-	CIM::Examples::CIGREMV::logPVAttributes(loggerEMT, pv);
+	CIM::Examples::Grids::CIGREMV::logPVAttributes(loggerEMT, pv);
 
 	// load step sized in absolute terms
 	// std::shared_ptr<SwitchEvent3Ph> loadStepEvent = CIM::Examples::createEventAddPowerConsumption3Ph("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemEMT, Domain::EMT, loggerEMT);

--- a/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_with_PF_Init.cpp
@@ -129,7 +129,7 @@ int main(int argc, char* argv[]) {
 	CIM::Examples::Grids::CIGREMV::logPVAttributes(loggerEMT, pv);
 
 	// load step sized in absolute terms
-	// std::shared_ptr<SwitchEvent3Ph> loadStepEvent = CIM::Examples::createEventAddPowerConsumption3Ph("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemEMT, Domain::EMT, loggerEMT);
+	// std::shared_ptr<SwitchEvent3Ph> loadStepEvent = CIM::Examples::Events::createEventAddPowerConsumption3Ph("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemEMT, Domain::EMT, loggerEMT);
 
 	// Simulation
 	Simulation sim(simNameEMT, Logger::Level::debug);

--- a/Examples/Cxx/Circuits/EMT_SynGenDQ7odTrapez_DP_SynGenTrStab_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/EMT_SynGenDQ7odTrapez_DP_SynGenTrStab_SMIB_Fault.cpp
@@ -17,7 +17,7 @@ Real nomOmega= nomFreq* 2*PI;
 
 
 Examples::Components::SynchronousGeneratorKundur::MachineParameters syngenKundur;
-Examples::Components::CIGREHVAmerican::LineParameters lineCIGREHV;
+Examples::Grids::CIGREHVAmerican::LineParameters lineCIGREHV;
 
 // HV line parameters referred to MV side
 Real lineLength = 100;

--- a/Examples/Cxx/Circuits/EMT_SynGenDQ7odTrapez_OperationalParams_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/EMT_SynGenDQ7odTrapez_OperationalParams_SMIB_Fault.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) {
 	Real BreakerClosed = 0.001;
 
 	// Line 
-	const Examples::Components::CIGREHVAmerican::LineParameters lineCIGREHV;
+	const Examples::Grids::CIGREHVAmerican::LineParameters lineCIGREHV;
 	Real lineLength = 100;
 	Real lineResistance = lineCIGREHV.lineResistancePerKm*lineLength*std::pow(ratio,2); // HV parameters referred to MV side
 	Real lineInductance = lineCIGREHV.lineReactancePerKm*lineLength*std::pow(ratio,2)/nomOmega;

--- a/Examples/Cxx/Circuits/EMT_SynGenDQ7odTrapez_OperationalParams_SMIB_Fault_JsonSyngenParams.cpp
+++ b/Examples/Cxx/Circuits/EMT_SynGenDQ7odTrapez_OperationalParams_SMIB_Fault_JsonSyngenParams.cpp
@@ -7,6 +7,7 @@
 using namespace DPsim;
 using namespace CPS;
 using namespace CPS::CIM;
+using namespace Examples::Grids;
 using namespace Examples::Components;
 using json = nlohmann::json;
 using syngenParametersKundur = Examples::Components::SynchronousGeneratorKundur::MachineParameters;

--- a/Examples/Cxx/Circuits/EMT_SynGenDQ7odTrapez_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/EMT_SynGenDQ7odTrapez_SMIB_Fault.cpp
@@ -15,7 +15,7 @@ Real ratio = VnomMV/VnomHV;
 Real nomOmega= nomFreq* 2*PI;
 
 Examples::Components::SynchronousGeneratorKundur::MachineParameters syngenKundur;
-Examples::Components::CIGREHVAmerican::LineParameters lineCIGREHV;
+Examples::Grids::CIGREHVAmerican::LineParameters lineCIGREHV;
 
 // HV line parameters referred to MV side
 Real lineLength = 100;

--- a/Examples/Cxx/Circuits/SP_Slack_PiLine_VSI_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/SP_Slack_PiLine_VSI_with_PF_Init.cpp
@@ -131,7 +131,7 @@ int main(int argc, char* argv[]) {
 	CIM::Examples::Grids::CIGREMV::logPVAttributes(loggerSP, pv);
 
 	// load step sized in absolute terms
-	// std::shared_ptr<SwitchEvent> loadStepEvent = CIM::Examples::createEventAddPowerConsumption("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemSP, Domain::SP, loggerSP);
+	// std::shared_ptr<SwitchEvent> loadStepEvent = CIM::Examples::Events::createEventAddPowerConsumption("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemSP, Domain::SP, loggerSP);
 
 	// Simulation
 	Simulation sim(simNameSP, Logger::Level::debug);

--- a/Examples/Cxx/Circuits/SP_Slack_PiLine_VSI_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/SP_Slack_PiLine_VSI_with_PF_Init.cpp
@@ -14,7 +14,7 @@ using namespace CPS;
 
 int main(int argc, char* argv[]) {
 
-	CIM::Examples::SGIB::ScenarioConfig scenario;
+	CIM::Examples::Grids::SGIB::ScenarioConfig scenario;
 	
 	Real finalTime = 1;
 	Real timeStep = 0.0001;
@@ -128,7 +128,7 @@ int main(int argc, char* argv[]) {
 	loggerSP->addAttribute("v2", n2SP->attribute("v"));
 	loggerSP->addAttribute("i12", lineSP->attribute("i_intf"));
 
-	CIM::Examples::CIGREMV::logPVAttributes(loggerSP, pv);
+	CIM::Examples::Grids::CIGREMV::logPVAttributes(loggerSP, pv);
 
 	// load step sized in absolute terms
 	// std::shared_ptr<SwitchEvent> loadStepEvent = CIM::Examples::createEventAddPowerConsumption("n2", std::round(5.0/timeStep)*timeStep, 10e6, systemSP, Domain::SP, loggerSP);

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
@@ -1,76 +1,17 @@
 #include <DPsim.h>
-
+#include "../Examples.h"
 
 using namespace DPsim;
 using namespace CPS;
 
-
-//-----------Power system-----------//
-//Voltage level as Base Voltage
-Real Vnom = 230e3;
-
-//-----------Generator 1 (bus1)-----------//
-//Machine parameters
-Real nomPower_G1 = 300e6;
-Real nomPhPhVoltRMS_G1 = 25e3;
-Real nomFreq_G1 = 60;
-Real H_G1 = 6;
-Real Xpd_G1=0.3; //in p.u
-Real Rs_G1 = 0.003*0;
-Real Kd_G1 = 1.5;
-// Initialization parameters 
-Real initActivePower_G1 = 270e6;
-Real initMechPower_G1 = 270e6;
-Real setPointVoltage_G1=nomPhPhVoltRMS_G1+0.05*nomPhPhVoltRMS_G1;
-
-//-----------Generator 2 (bus2)-----------//
-//Machine parameters in per unit
-Real nomPower_G2 = 50e6;
-Real nomPhPhVoltRMS_G2 = 13.8e3;
-Real nomFreq_G2 = 60;
-Real H_G2 = 2;
-Real Xpd_G2=0.1; //in p.u
-Real Rs_G2 = 0.003*0;
-Real Kd_G2 =1.5;
-// Initialization parameters 
-Real initActivePower_G2 = 45e6;
-// Real initReactivePower_G2 = 106e6;
-Real initMechPower_G2 = 45e6;
-Real setPointVoltage_G2=nomPhPhVoltRMS_G2-0.05*nomPhPhVoltRMS_G2;
-
-//-----------Transformers-----------//
-Real t1_ratio=Vnom/nomPhPhVoltRMS_G1;
-Real t2_ratio=Vnom/nomPhPhVoltRMS_G2;
-
-//-----------Load (bus3)-----------
-Real activePower_L= 310e6;
-Real reactivePower_L= 150e6;
-
-//-----------Transmission Lines-----------//
-//PiLine parameters
-//line 1-2 (180km)
-Real lineResistance12 = 0.04*180;
-Real lineInductance12 = (0.4/377)*180;
-Real lineCapacitance12 = (4.3e-6/377)*180;
-// Real lineCapacitance12 =0;
-Real lineConductance12 =0;
-//line 1-3 (150km)
-Real lineResistance13 = 0.0267*150;
-Real lineInductance13 = (0.267/377)*150;
-Real lineCapacitance13 = (4.3e-6/377)*150;
-Real lineConductance13 =0;
-//line 2-3 (80km)
-Real lineResistance23 = 0.04*80;
-Real lineInductance23 = (0.267/377)*80;
-Real lineCapacitance23 = (4.3e-6/377)*80;
-Real lineConductance23 =0;
+CIM::Examples::Components::ThreeBus::ScenarioConfig ThreeBus;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e12;
 Real SwitchClosed = 0.1;
 
-void SP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, bool startFaultEvent, bool endFaultEvent, Real startTimeFault, Real endTimeFault, Real cmdInertia) {
-	//  // ----- POWERFLOW FOR INITIALIZATION -----
+void SP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, bool startFaultEvent, bool endFaultEvent, Real startTimeFault, Real endTimeFault, Real cmdInertia_G1, Real cmdInertia_G2, Real cmdDamping_G1, Real cmdDamping_G2) {
+	// ----- POWERFLOW FOR INITIALIZATION -----
 	Real timeStepPF = finalTime;
 	Real finalTimePF = finalTime+timeStepPF;
 	String simNamePF = simName + "_PF";
@@ -84,32 +25,32 @@ void SP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	//Synchronous generator 1
 	auto gen1PF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	gen1PF->setParameters(nomPower_G1, nomPhPhVoltRMS_G1, initActivePower_G1, setPointVoltage_G1*t1_ratio, PowerflowBusType::VD);
-	gen1PF->setBaseVoltage(Vnom);
+	gen1PF->setParameters(ThreeBus.nomPower_G1, ThreeBus.nomPhPhVoltRMS_G1, ThreeBus.initActivePower_G1, ThreeBus.setPointVoltage_G1*ThreeBus.t1_ratio, PowerflowBusType::VD);
+	gen1PF->setBaseVoltage(ThreeBus.Vnom);
 
 	//Synchronous generator 2
 	auto gen2PF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	gen2PF->setParameters(nomPower_G2, nomPhPhVoltRMS_G2, initActivePower_G2, setPointVoltage_G2*t2_ratio, PowerflowBusType::PV);
-	gen2PF->setBaseVoltage(Vnom);
+	gen2PF->setParameters(ThreeBus.nomPower_G2, ThreeBus.nomPhPhVoltRMS_G2, ThreeBus.initActivePower_G2, ThreeBus.setPointVoltage_G2*ThreeBus.t2_ratio, PowerflowBusType::PV);
+	gen2PF->setBaseVoltage(ThreeBus.Vnom);
 
 	//use Shunt as Load for powerflow
 	auto loadPF = SP::Ph1::Shunt::make("Load", Logger::Level::debug);
-	loadPF->setParameters(activePower_L / std::pow(Vnom, 2), - reactivePower_L / std::pow(Vnom, 2));
-	loadPF->setBaseVoltage(Vnom);
+	loadPF->setParameters(ThreeBus.activePower_L / std::pow(ThreeBus.Vnom, 2), - ThreeBus.reactivePower_L / std::pow(ThreeBus.Vnom, 2));
+	loadPF->setBaseVoltage(ThreeBus.Vnom);
 	
 	//Line12
 	auto line12PF = SP::Ph1::PiLine::make("PiLine12", Logger::Level::debug);
-	line12PF->setParameters(lineResistance12, lineInductance12, lineCapacitance12, lineConductance12);
-	line12PF->setBaseVoltage(Vnom);
+	line12PF->setParameters(ThreeBus.lineResistance12, ThreeBus.lineInductance12, ThreeBus.lineCapacitance12, ThreeBus.lineConductance12);
+	line12PF->setBaseVoltage(ThreeBus.Vnom);
 	//Line13
 	auto line13PF = SP::Ph1::PiLine::make("PiLine13", Logger::Level::debug);
-	line13PF->setParameters(lineResistance13, lineInductance13, lineCapacitance13, lineConductance13);
-	line13PF->setBaseVoltage(Vnom);
+	line13PF->setParameters(ThreeBus.lineResistance13, ThreeBus.lineInductance13, ThreeBus.lineCapacitance13, ThreeBus.lineConductance13);
+	line13PF->setBaseVoltage(ThreeBus.Vnom);
 	//Line23
 	auto line23PF = SP::Ph1::PiLine::make("PiLine23", Logger::Level::debug);
-	line23PF->setParameters(lineResistance23, lineInductance23, lineCapacitance23, lineConductance23);
-	line23PF->setBaseVoltage(Vnom);
+	line23PF->setParameters(ThreeBus.lineResistance23, ThreeBus.lineInductance23, ThreeBus.lineCapacitance23, ThreeBus.lineConductance23);
+	line23PF->setBaseVoltage(ThreeBus.Vnom);
 	//Switch
 	auto faultPF = CPS::SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	faultPF->setParameters(SwitchOpen, SwitchClosed);
@@ -159,46 +100,48 @@ void SP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	//Synchronous generator 1
 	auto gen1SP = SP::Ph1::SynchronGeneratorTrStab::make("SynGen", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	gen1SP->setStandardParametersPU(nomPower_G1, nomPhPhVoltRMS_G1, nomFreq_G1, Xpd_G1*std::pow(t1_ratio,2), cmdInertia*H_G1, Rs_G1, Kd_G1 );
+	gen1SP->setStandardParametersPU(ThreeBus.nomPower_G1, ThreeBus.nomPhPhVoltRMS_G1, ThreeBus.nomFreq_G1, ThreeBus.Xpd_G1*std::pow(ThreeBus.t1_ratio,2), cmdInertia_G1*ThreeBus.H_G1, ThreeBus.Rs_G1, cmdDamping_G1*ThreeBus.D_G1);
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower_G1= gen1PF->getApparentPower();
-	gen1SP->setInitialValues(initApparentPower_G1, initMechPower_G1);
+	gen1SP->setInitialValues(initApparentPower_G1, ThreeBus.initMechPower_G1);
 
 	//Synchronous generator 2
 	auto gen2SP = SP::Ph1::SynchronGeneratorTrStab::make("SynGen", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	gen2SP->setStandardParametersPU(nomPower_G2, nomPhPhVoltRMS_G2, nomFreq_G2, Xpd_G2*std::pow(t2_ratio,2), cmdInertia*H_G2, Rs_G2, Kd_G2 );
+	gen2SP->setStandardParametersPU(ThreeBus.nomPower_G2, ThreeBus.nomPhPhVoltRMS_G2, ThreeBus.nomFreq_G2, ThreeBus.Xpd_G2*std::pow(ThreeBus.t2_ratio,2), cmdInertia_G2*ThreeBus.H_G2, ThreeBus.Rs_G2, cmdDamping_G2*ThreeBus.D_G2);
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower_G2= gen2PF->getApparentPower();
-	gen2SP->setInitialValues(initApparentPower_G2, initMechPower_G2);
+	gen2SP->setInitialValues(initApparentPower_G2, ThreeBus.initMechPower_G2);
 
+	gen2SP->setModelFlags(true, true);
 	gen2SP->setReferenceOmega(gen1SP->attribute<Real>("w_r"), gen1SP->attribute<Real>("delta_r"));
 
 	//Load
 	auto loadSP = SP::Ph1::Load::make("Load", Logger::Level::debug);
-	loadSP->setParameters(activePower_L, reactivePower_L, Vnom);
+	loadSP->setParameters(ThreeBus.activePower_L, ThreeBus.reactivePower_L, ThreeBus.Vnom);
 	
 	//Line12
 	auto line12SP = SP::Ph1::PiLine::make("PiLine12", Logger::Level::debug);
-	line12SP->setParameters(lineResistance12, lineInductance12, lineCapacitance12, lineConductance12);
+	line12SP->setParameters(ThreeBus.lineResistance12, ThreeBus.lineInductance12, ThreeBus.lineCapacitance12, ThreeBus.lineConductance12);
 	//Line13
 	auto line13SP = SP::Ph1::PiLine::make("PiLine13", Logger::Level::debug);
-	line13SP->setParameters(lineResistance13, lineInductance13, lineCapacitance13, lineConductance13);
+	line13SP->setParameters(ThreeBus.lineResistance13, ThreeBus.lineInductance13, ThreeBus.lineCapacitance13, ThreeBus.lineConductance13);
 	//Line23
 	auto line23SP = SP::Ph1::PiLine::make("PiLine23", Logger::Level::debug);
-	line23SP->setParameters(lineResistance23, lineInductance23, lineCapacitance23, lineConductance23);
+	line23SP->setParameters(ThreeBus.lineResistance23, ThreeBus.lineInductance23, ThreeBus.lineCapacitance23, ThreeBus.lineConductance23);
+
 	// //Switch
 	// auto faultSP = SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	// faultSP->setParameters(SwitchOpen, SwitchClosed);
 	// faultSP->open();
 
-	//Switch
+	//Variable resistance Switch
 	auto faultSP = SP::Ph1::varResSwitch::make("Br_fault", Logger::Level::debug);
 	faultSP->setParameters(SwitchOpen, SwitchClosed);
 	faultSP->setInitParameters(timeStep);
 	faultSP->open();
 
-		// Topology
+	// Topology
 	gen1SP->connect({ n1SP });
 	gen2SP->connect({ n2SP });
 	loadSP->connect({ n3SP });
@@ -228,29 +171,23 @@ void SP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	loggerSP->addAttribute("v_line23", line23SP->attribute("v_intf"));
 	loggerSP->addAttribute("i_line23", line23SP->attribute("i_intf"));
 	loggerSP->addAttribute("Ep_gen1", gen1SP->attribute("Ep_mag"));
-	loggerSP->addAttribute("Ep_gen2", gen2SP->attribute("Ep_mag"));
 	loggerSP->addAttribute("v_gen1", gen1SP->attribute("v_intf"));
 	loggerSP->addAttribute("i_gen1", gen1SP->attribute("i_intf"));
 	loggerSP->addAttribute("wr_gen1", gen1SP->attribute("w_r"));
 	loggerSP->addAttribute("delta_gen1", gen1SP->attribute("delta_r"));
-
+	loggerSP->addAttribute("Ep_gen2", gen2SP->attribute("Ep_mag"));
 	loggerSP->addAttribute("v_gen2", gen2SP->attribute("v_intf"));
 	loggerSP->addAttribute("i_gen2", gen2SP->attribute("i_intf"));
 	loggerSP->addAttribute("wr_gen2", gen2SP->attribute("w_r"));
 	loggerSP->addAttribute("wref_gen2", gen2SP->attribute("w_ref"));
 	loggerSP->addAttribute("delta_gen2", gen2SP->attribute("delta_r"));
-	
+	loggerSP->addAttribute("i_fault", faultSP->attribute("i_intf"));	
 	loggerSP->addAttribute("v_load", loadSP->attribute("v_intf"));
-	loggerSP->addAttribute("i_load", loadSP->attribute("i_intf"));
-
-	loggerSP->addAttribute("i_fault", faultSP->attribute("i_intf"));
-	
+	loggerSP->addAttribute("i_load", loadSP->attribute("i_intf"));	
 	loggerSP->addAttribute("P_mech1", gen1SP->attribute("P_mech"));
 	loggerSP->addAttribute("P_mech2", gen2SP->attribute("P_mech"));
-
 	loggerSP->addAttribute("P_elec1", gen1SP->attribute("P_elec"));
 	loggerSP->addAttribute("P_elec2", gen2SP->attribute("P_elec"));
-
 
 	Simulation simSP(simNameSP, Logger::Level::debug);
 	simSP.setSystem(systemSP);
@@ -288,7 +225,10 @@ int main(int argc, char* argv[]) {
 	Bool endFaultEvent=true;
 	Real startTimeFault=10;
 	Real endTimeFault=10.2;
-	Real cmdInertia= 1.0;
+	Real cmdInertia_G1= 1.0;
+	Real cmdInertia_G2= 1.0;
+	Real cmdDamping_G1=1.0;
+	Real cmdDamping_G2=1.0;
 
 	CommandLineArgs args(argc, argv);
 	if (argc > 1) {
@@ -296,13 +236,19 @@ int main(int argc, char* argv[]) {
 		finalTime = args.duration;
 		if (args.name != "dpsim")
 			simName = args.name;
-		if (args.options.find("SCALEINERTIA") != args.options.end())
-			cmdInertia = args.options["SCALEINERTIA"];
+		if (args.options.find("SCALEINERTIA_G1") != args.options.end())
+			cmdInertia_G1 = args.options["SCALEINERTIA_G1"];
+		if (args.options.find("SCALEINERTIA_G2") != args.options.end())
+			cmdInertia_G2 = args.options["SCALEINERTIA_G2"];
+		if (args.options.find("SCALEDAMPING_G1") != args.options.end())
+			cmdDamping_G1 = args.options["SCALEDAMPING_G1"];
+		if (args.options.find("SCALEDAMPING_G2") != args.options.end())
+			cmdDamping_G2 = args.options["SCALEDAMPING_G2"];	
 		if (args.options.find("STARTTIMEFAULT") != args.options.end())
 			startTimeFault = args.options["STARTTIMEFAULT"];
 		if (args.options.find("ENDTIMEFAULT") != args.options.end())
 			endTimeFault = args.options["ENDTIMEFAULT"];	
 	}
 
-	SP_SynGenTrStab_3Bus_Fault(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia);
+	SP_SynGenTrStab_3Bus_Fault(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia_G1, cmdInertia_G2, cmdDamping_G1, cmdDamping_G2);
 }

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::Components::ThreeBus::ScenarioConfig ThreeBus;
+CIM::Examples::ThreeBus::ScenarioConfig ThreeBus;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e12;

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
@@ -3,8 +3,9 @@
 
 using namespace DPsim;
 using namespace CPS;
+using namespace CIM::Examples::Grids::ThreeBus;
 
-CIM::Examples::Grids::ThreeBus::ScenarioConfig ThreeBus;
+ScenarioConfig ThreeBus;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e12;

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::ThreeBus::ScenarioConfig ThreeBus;
+CIM::Examples::Grids::ThreeBus::ScenarioConfig ThreeBus;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e12;

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
@@ -3,8 +3,9 @@
 
 using namespace DPsim;
 using namespace CPS;
+using namespace CIM::Examples::Grids::ThreeBus;
 
-CIM::Examples::Grids::ThreeBus::ScenarioConfig ThreeBus;
+ScenarioConfig ThreeBus;
 
 void SP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia_G1, Real cmdInertia_G2, Real cmdDamping_G1, Real cmdDamping_G2) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::ThreeBus::ScenarioConfig ThreeBus;
+CIM::Examples::Grids::ThreeBus::ScenarioConfig ThreeBus;
 
 void SP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia_G1, Real cmdInertia_G2, Real cmdDamping_G1, Real cmdDamping_G2) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
@@ -1,73 +1,13 @@
 #include <DPsim.h>
-
+#include "../Examples.h"
 
 using namespace DPsim;
 using namespace CPS;
 
+CIM::Examples::Components::ThreeBus::ScenarioConfig ThreeBus;
 
-//-----------Power system-----------//
-//Voltage level as Base Voltage
-Real Vnom = 230e3;
-
-//-----------Generator 1 (bus1)-----------//
-//Machine parameters
-Real nomPower_G1 = 300e6;
-Real nomPhPhVoltRMS_G1 = 25e3;
-Real nomFreq_G1 = 60;
-Real H_G1 = 6;
-Real Xpd_G1=0.3; //in p.u
-Real Rs_G1 = 0.003*0;
-Real Kd_G1 = 1;
-// Initialization parameters 
-Real initActivePower_G1 = 270e6;
-//Real initReactivePower_G1 = 106e6;
-Real initMechPower_G1 = 270e6;
-Real setPointVoltage_G1=nomPhPhVoltRMS_G1+0.05*nomPhPhVoltRMS_G1;
-
-//-----------Generator 2 (bus2)-----------//
-//Machine parameters in per unit
-Real nomPower_G2 = 50e6;
-Real nomPhPhVoltRMS_G2 = 13.8e3;
-Real nomFreq_G2 = 60;
-Real H_G2 = 2;
-Real Xpd_G2=0.1; //in p.u
-Real Rs_G2 = 0.003*0;
-Real Kd_G2 =1;
-// Initialization parameters 
-Real initActivePower_G2 = 45e6;
-// Real initReactivePower_G2 = 106e6;
-Real initMechPower_G2 = 45e6;
-Real setPointVoltage_G2=nomPhPhVoltRMS_G2-0.05*nomPhPhVoltRMS_G2;
-
-//-----------Transformers-----------//
-Real t1_ratio=Vnom/nomPhPhVoltRMS_G1;
-Real t2_ratio=Vnom/nomPhPhVoltRMS_G2;
-
-//-----------Load (bus3)-----------
-Real activePower_L= 310e6;
-Real reactivePower_L= 150e6;
-
-//-----------Transmission Lines-----------//
-//PiLine parameters
-//line 1-2 (180km)
-Real lineResistance12 = 0.04*180;
-Real lineInductance12 = (0.4/377)*180;
-Real lineCapacitance12 = (4.3e-6/377)*180;
-// Real lineCapacitance12 =0;
-Real lineConductance12 =0;
-//line 1-3 (150km)
-Real lineResistance13 = 0.0267*150;
-Real lineInductance13 = (0.267/377)*150;
-Real lineCapacitance13 = (4.3e-6/377)*150;
-Real lineConductance13 =0;
-//line 2-3 (80km)
-Real lineResistance23 = 0.04*80;
-Real lineInductance23 = (0.267/377)*80;
-Real lineCapacitance23 = (4.3e-6/377)*80;
-Real lineConductance23 =0;
-
-void SP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalTime, bool startFaultEvent, bool endFaultEvent, Real startTimeFault, Real endTimeFault, Real cmdInertia) {
-	//  // ----- POWERFLOW FOR INITIALIZATION -----
+void SP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia_G1, Real cmdInertia_G2, Real cmdDamping_G1, Real cmdDamping_G2) {
+	// ----- POWERFLOW FOR INITIALIZATION -----
 	Real timeStepPF = finalTime;
 	Real finalTimePF = finalTime+timeStepPF;
 	String simNamePF = simName + "_PF";
@@ -81,32 +21,32 @@ void SP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalT
 	//Synchronous generator 1
 	auto gen1PF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	gen1PF->setParameters(nomPower_G1, nomPhPhVoltRMS_G1, initActivePower_G1, setPointVoltage_G1*t1_ratio, PowerflowBusType::VD);
-	gen1PF->setBaseVoltage(Vnom);
+	gen1PF->setParameters(ThreeBus.nomPower_G1, ThreeBus.nomPhPhVoltRMS_G1, ThreeBus.initActivePower_G1, ThreeBus.setPointVoltage_G1*ThreeBus.t1_ratio, PowerflowBusType::VD);
+	gen1PF->setBaseVoltage(ThreeBus.Vnom);
 
 	//Synchronous generator 2
 	auto gen2PF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	gen2PF->setParameters(nomPower_G2, nomPhPhVoltRMS_G2, initActivePower_G2, setPointVoltage_G2*t2_ratio, PowerflowBusType::PV);
-	gen2PF->setBaseVoltage(Vnom);
+	gen2PF->setParameters(ThreeBus.nomPower_G2, ThreeBus.nomPhPhVoltRMS_G2, ThreeBus.initActivePower_G2, ThreeBus.setPointVoltage_G2*ThreeBus.t2_ratio, PowerflowBusType::PV);
+	gen2PF->setBaseVoltage(ThreeBus.Vnom);
 
 	//use Shunt as Load for powerflow
 	auto loadPF = SP::Ph1::Shunt::make("Load", Logger::Level::debug);
-	loadPF->setParameters(activePower_L / std::pow(Vnom, 2), - reactivePower_L / std::pow(Vnom, 2));
-	loadPF->setBaseVoltage(Vnom);
+	loadPF->setParameters(ThreeBus.activePower_L / std::pow(ThreeBus.Vnom, 2), - ThreeBus.reactivePower_L / std::pow(ThreeBus.Vnom, 2));
+	loadPF->setBaseVoltage(ThreeBus.Vnom);
 	
 	//Line12
 	auto line12PF = SP::Ph1::PiLine::make("PiLine12", Logger::Level::debug);
-	line12PF->setParameters(lineResistance12, lineInductance12, lineCapacitance12, lineConductance12);
-	line12PF->setBaseVoltage(Vnom);
+	line12PF->setParameters(ThreeBus.lineResistance12, ThreeBus.lineInductance12, ThreeBus.lineCapacitance12, ThreeBus.lineConductance12);
+	line12PF->setBaseVoltage(ThreeBus.Vnom);
 	//Line13
 	auto line13PF = SP::Ph1::PiLine::make("PiLine13", Logger::Level::debug);
-	line13PF->setParameters(lineResistance13, lineInductance13, lineCapacitance13, lineConductance13);
-	line13PF->setBaseVoltage(Vnom);
+	line13PF->setParameters(ThreeBus.lineResistance13, ThreeBus.lineInductance13, ThreeBus.lineCapacitance13, ThreeBus.lineConductance13);
+	line13PF->setBaseVoltage(ThreeBus.Vnom);
 	//Line23
 	auto line23PF = SP::Ph1::PiLine::make("PiLine23", Logger::Level::debug);
-	line23PF->setParameters(lineResistance23, lineInductance23, lineCapacitance23, lineConductance23);
-	line23PF->setBaseVoltage(Vnom);
+	line23PF->setParameters(ThreeBus.lineResistance23, ThreeBus.lineInductance23, ThreeBus.lineCapacitance23, ThreeBus.lineConductance23);
+	line23PF->setBaseVoltage(ThreeBus.Vnom);
 
 	// Topology
 	gen1PF->connect({ n1PF });
@@ -149,34 +89,34 @@ void SP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalT
 	//Synchronous generator 1
 	auto gen1SP = SP::Ph1::SynchronGeneratorTrStab::make("SynGen", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	gen1SP->setStandardParametersPU(nomPower_G1, nomPhPhVoltRMS_G1, nomFreq_G1, Xpd_G1*std::pow(t1_ratio,2), cmdInertia*H_G1, Rs_G1, Kd_G1 );
+	gen1SP->setStandardParametersPU(ThreeBus.nomPower_G1, ThreeBus.nomPhPhVoltRMS_G1, ThreeBus.nomFreq_G1, ThreeBus.Xpd_G1*std::pow(ThreeBus.t1_ratio,2), cmdInertia_G1*ThreeBus.H_G1, ThreeBus.Rs_G1, cmdDamping_G1*ThreeBus.D_G1);
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower_G1= gen1PF->getApparentPower();
-	gen1SP->setInitialValues(initApparentPower_G1, initMechPower_G1);
+	gen1SP->setInitialValues(initApparentPower_G1, ThreeBus.initMechPower_G1);
 
 	//Synchronous generator 2
 	auto gen2SP = SP::Ph1::SynchronGeneratorTrStab::make("SynGen", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	gen2SP->setStandardParametersPU(nomPower_G2, nomPhPhVoltRMS_G2, nomFreq_G2, Xpd_G2*std::pow(t2_ratio,2), cmdInertia*H_G2, Rs_G2, Kd_G2 );
+	gen2SP->setStandardParametersPU(ThreeBus.nomPower_G2, ThreeBus.nomPhPhVoltRMS_G2, ThreeBus.nomFreq_G2, ThreeBus.Xpd_G2*std::pow(ThreeBus.t2_ratio,2), cmdInertia_G2*ThreeBus.H_G2, ThreeBus.Rs_G2, cmdDamping_G2*ThreeBus.D_G2);
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower_G2= gen2PF->getApparentPower();
-	gen2SP->setInitialValues(initApparentPower_G2, initMechPower_G2);
+	gen2SP->setInitialValues(initApparentPower_G2, ThreeBus.initMechPower_G2);
 
 	//Load
 	auto loadSP = SP::Ph1::Load::make("Load", Logger::Level::debug);
-	loadSP->setParameters(activePower_L, reactivePower_L, Vnom);
+	loadSP->setParameters(ThreeBus.activePower_L, ThreeBus.reactivePower_L, ThreeBus.Vnom);
 	
 	//Line12
 	auto line12SP = SP::Ph1::PiLine::make("PiLine12", Logger::Level::debug);
-	line12SP->setParameters(lineResistance12, lineInductance12, lineCapacitance12, lineConductance12);
+	line12SP->setParameters(ThreeBus.lineResistance12, ThreeBus.lineInductance12, ThreeBus.lineCapacitance12, ThreeBus.lineConductance12);
 	//Line13
 	auto line13SP = SP::Ph1::PiLine::make("PiLine13", Logger::Level::debug);
-	line13SP->setParameters(lineResistance13, lineInductance13, lineCapacitance13, lineConductance13);
+	line13SP->setParameters(ThreeBus.lineResistance13, ThreeBus.lineInductance13, ThreeBus.lineCapacitance13, ThreeBus.lineConductance13);
 	//Line23
 	auto line23SP = SP::Ph1::PiLine::make("PiLine23", Logger::Level::debug);
-	line23SP->setParameters(lineResistance23, lineInductance23, lineCapacitance23, lineConductance23);
+	line23SP->setParameters(ThreeBus.lineResistance23, ThreeBus.lineInductance23, ThreeBus.lineCapacitance23, ThreeBus.lineConductance23);
 
-		// Topology
+	// Topology
 	gen1SP->connect({ n1SP });
 	gen2SP->connect({ n2SP });
 	loadSP->connect({ n3SP });
@@ -202,20 +142,22 @@ void SP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalT
 	loggerSP->addAttribute("i_line13", line13SP->attribute("i_intf"));
 	loggerSP->addAttribute("v_line23", line23SP->attribute("v_intf"));
 	loggerSP->addAttribute("i_line23", line23SP->attribute("i_intf"));
+	loggerSP->addAttribute("Ep_gen1", gen1SP->attribute("Ep_mag"));
 	loggerSP->addAttribute("v_gen1", gen1SP->attribute("v_intf"));
 	loggerSP->addAttribute("i_gen1", gen1SP->attribute("i_intf"));
 	loggerSP->addAttribute("wr_gen1", gen1SP->attribute("w_r"));
 	loggerSP->addAttribute("delta_gen1", gen1SP->attribute("delta_r"));
-	loggerSP->addAttribute("Ep_gen1", gen1SP->attribute("Ep_mag"));
+	loggerSP->addAttribute("Ep_gen2", gen2SP->attribute("Ep_mag"));
 	loggerSP->addAttribute("v_gen2", gen2SP->attribute("v_intf"));
 	loggerSP->addAttribute("i_gen2", gen2SP->attribute("i_intf"));
-	loggerSP->addAttribute("wr_gen2", gen2SP->attribute("w_r"));
-	loggerSP->addAttribute("delta_gen2", gen2SP->attribute("delta_r"));
-	loggerSP->addAttribute("Ep_gen2", gen2SP->attribute("Ep_mag"));
-	////ADD LOAD v_intf & i_intf to log attributes
-	// loggerSP->addAttribute("v_load", loadSP->attribute("v_intf"));
-	// loggerSP->addAttribute("i_load", loadSP->attribute("i_intf"));
-
+	loggerSP->addAttribute("wr_gen2", gen2SP->attribute("w_r"));	
+	loggerSP->addAttribute("wref_gen2", gen2SP->attribute("w_ref"));
+	loggerSP->addAttribute("delta_gen2", gen2SP->attribute("delta_r"));	
+	loggerSP->addAttribute("v_load", loadSP->attribute("v_intf"));
+	loggerSP->addAttribute("i_load", loadSP->attribute("i_intf"));
+	loggerSP->addAttribute("P_mech1", gen1SP->attribute("P_mech"));
+	loggerSP->addAttribute("P_mech2", gen2SP->attribute("P_mech"));
+	loggerSP->addAttribute("P_elec1", gen1SP->attribute("P_elec"));
 	loggerSP->addAttribute("P_elec2", gen2SP->attribute("P_elec"));
 
 	Simulation sim(simNameSP, Logger::Level::debug);
@@ -233,13 +175,28 @@ int main(int argc, char* argv[]) {
 
 	//Simultion parameters
 	String simName="SP_SynGenTrStab_3Bus_SteadyState";
-	Real finalTime = 10;
+	Real finalTime = 30;
 	Real timeStep = 0.001;
-	Bool startFaultEvent=false;
-	Bool endFaultEvent=false;
-	Real startTimeFault=10;
-	Real endTimeFault=10.1;
-	Real cmdInertia= 1.0;
+	Real cmdInertia_G1= 1.0;
+	Real cmdInertia_G2= 1.0;
+	Real cmdDamping_G1=1.0;
+	Real cmdDamping_G2=1.0;
 
-	SP_SynGenTrStab_3Bus_SteadyState(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia);
+		CommandLineArgs args(argc, argv);
+	if (argc > 1) {
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+		if (args.name != "dpsim")
+			simName = args.name;
+		if (args.options.find("SCALEINERTIA_G1") != args.options.end())
+			cmdInertia_G1 = args.options["SCALEINERTIA_G1"];
+		if (args.options.find("SCALEINERTIA_G2") != args.options.end())
+			cmdInertia_G2 = args.options["SCALEINERTIA_G2"];
+		if (args.options.find("SCALEDAMPING_G1") != args.options.end())
+			cmdDamping_G1 = args.options["SCALEDAMPING_G1"];
+		if (args.options.find("SCALEDAMPING_G2") != args.options.end())
+			cmdDamping_G2 = args.options["SCALEDAMPING_G2"];
+	}
+
+	SP_SynGenTrStab_3Bus_SteadyState(simName, timeStep, finalTime, cmdInertia_G1, cmdInertia_G2, cmdDamping_G1, cmdDamping_G2);
 }

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::Components::ThreeBus::ScenarioConfig ThreeBus;
+CIM::Examples::ThreeBus::ScenarioConfig ThreeBus;
 
 void SP_SynGenTrStab_3Bus_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia_G1, Real cmdInertia_G2, Real cmdDamping_G1, Real cmdDamping_G2) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::Components::SMIB::ScenarioConfig smib;
+CIM::Examples::SMIB::ScenarioConfig smib;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e6;

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
@@ -3,8 +3,9 @@
 
 using namespace DPsim;
 using namespace CPS;
+using namespace CIM::Examples::Grids::SMIB;
 
-CIM::Examples::Grids::SMIB::ScenarioConfig smib;
+ScenarioConfig smib;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e6;

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::SMIB::ScenarioConfig smib;
+CIM::Examples::Grids::SMIB::ScenarioConfig smib;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e6;

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
@@ -1,47 +1,17 @@
 #include <DPsim.h>
-
+#include "../Examples.h"
 
 using namespace DPsim;
 using namespace CPS;
 
-
-//-----------Power system-----------//
-//Voltage level as Base Voltage
-Real Vnom = 230e3;
-
-//-----------Generator-----------//
-Real nomPower = 500e6;
-Real nomPhPhVoltRMS = 22e3;
-Real nomFreq = 60;
-Real nomOmega= nomFreq* 2*PI;
-Real H = 5;
-Real Xpd=0.31;
-Real Rs = 0.003*0;
-Real D = 1.5;
-// Initialization parameters
-Real initMechPower= 300e6;
-Real initActivePower = 300e6;
-Real setPointVoltage=nomPhPhVoltRMS + 0.05*nomPhPhVoltRMS;
-
-//-----------Transformer-----------//
-Real t_ratio=Vnom/nomPhPhVoltRMS;
-
-//PiLine parameters calculated from CIGRE Benchmark system
-Real lineResistance = 6.7;
-Real lineInductance = 47./nomOmega;
-Real lineCapacitance = 3.42e-4/nomOmega;
-Real lineConductance =0;
-
-// Parameters for powerflow initialization
-// Slack voltage: 1pu
-Real Vslack = Vnom;
+CIM::Examples::Components::SMIB::ScenarioConfig smib;
 
 //Switch to trigger fault at generator terminal
 Real SwitchOpen = 1e6;
 Real SwitchClosed = 0.1;
 
-void SP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bool startFaultEvent, bool endFaultEvent, Real startTimeFault, Real endTimeFault, Real cmdInertia) {
-	//  // ----- POWERFLOW FOR INITIALIZATION -----
+void SP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bool startFaultEvent, bool endFaultEvent, Real startTimeFault, Real endTimeFault, Real cmdInertia, Real cmdDamping) {
+	// ----- POWERFLOW FOR INITIALIZATION -----
 	Real timeStepPF = finalTime;
 	Real finalTimePF = finalTime+timeStepPF;
 	String simNamePF = simName + "_PF";
@@ -54,20 +24,20 @@ void SP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bo
 	//Synchronous generator ideal model
 	auto genPF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	genPF->setParameters(nomPower, nomPhPhVoltRMS, initActivePower, setPointVoltage*t_ratio, PowerflowBusType::PV);
-	genPF->setBaseVoltage(Vnom);
+	genPF->setParameters(smib.nomPower, smib.nomPhPhVoltRMS, smib.initActivePower, smib.setPointVoltage*smib.t_ratio, PowerflowBusType::PV);
+	genPF->setBaseVoltage(smib.Vnom);
 	genPF->modifyPowerFlowBusType(PowerflowBusType::PV);
 
 	//Grid bus as Slack
 	auto extnetPF = SP::Ph1::NetworkInjection::make("Slack", Logger::Level::debug);
-	extnetPF->setParameters(Vslack);
-	extnetPF->setBaseVoltage(Vnom);
+	extnetPF->setParameters(smib.Vnom);
+	extnetPF->setBaseVoltage(smib.Vnom);
 	extnetPF->modifyPowerFlowBusType(PowerflowBusType::VD);
 	
 	//Line
 	auto linePF = SP::Ph1::PiLine::make("PiLine", Logger::Level::debug);
-	linePF->setParameters(lineResistance, lineInductance, lineCapacitance, lineConductance);
-	linePF->setBaseVoltage(Vnom);
+	linePF->setParameters(smib.lineResistance, smib.lineInductance, smib.lineCapacitance, smib.lineConductance);
+	linePF->setBaseVoltage(smib.Vnom);
 
 	//Switch
 	auto faultPF = CPS::SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
@@ -110,23 +80,24 @@ void SP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bo
 	// Components
 	auto genSP = CPS::SP::Ph1::SynchronGeneratorTrStab::make("SynGen", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	genSP->setStandardParametersPU(nomPower, nomPhPhVoltRMS, nomFreq, Xpd*std::pow(t_ratio,2), cmdInertia*H, Rs, D );
+	genSP->setStandardParametersPU(smib.nomPower, smib.nomPhPhVoltRMS, smib.nomFreq, smib.Xpd*std::pow(smib.t_ratio,2), cmdInertia*smib.H, smib.Rs, cmdDamping*smib.D );
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower= genPF->getApparentPower();
-	genSP->setInitialValues(initApparentPower, initMechPower);
+	genSP->setInitialValues(initApparentPower, smib.initMechPower);
 
 	//Grid bus as Slack
 	auto extnetSP = SP::Ph1::NetworkInjection::make("Slack", Logger::Level::debug);
-	extnetSP->setParameters(Vslack);
+	extnetSP->setParameters(smib.Vnom);
 	// Line
 	auto lineSP = SP::Ph1::PiLine::make("PiLine", Logger::Level::debug);
-	lineSP->setParameters(lineResistance, lineInductance, lineCapacitance, lineConductance);
+	lineSP->setParameters(smib.lineResistance, smib.lineInductance, smib.lineCapacitance, smib.lineConductance);
+	
 	// //Switch
 	// auto faultSP = SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	// faultSP->setParameters(SwitchOpen, SwitchClosed);
 	// faultSP->open();
 
-	//Switch
+	// Variable resistance Switch
 	auto faultSP = SP::Ph1::varResSwitch::make("Br_fault", Logger::Level::debug);
 	faultSP->setParameters(SwitchOpen, SwitchClosed);
 	faultSP->setInitParameters(timeStep);
@@ -168,7 +139,6 @@ void SP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bo
 	loggerSP->addAttribute("i_slack", extnetSP->attribute("i_intf"));
 
 
-
 	Simulation simSP(simNameSP, Logger::Level::debug);
 	simSP.setSystem(systemSP);
 	simSP.setTimeStep(timeStep);
@@ -199,13 +169,14 @@ int main(int argc, char* argv[]) {
 
 	//Simultion parameters
 	String simName="SP_SynGenTrStab_SMIB_Fault";
-	Real finalTime = 20;
+	Real finalTime = 30;
 	Real timeStep = 0.001;
 	Bool startFaultEvent=true;
 	Bool endFaultEvent=true;
 	Real startTimeFault=10;
 	Real endTimeFault=10.2;
 	Real cmdInertia= 1.0;
+	Real cmdDamping=1.0;
 
 	CommandLineArgs args(argc, argv);
 	if (argc > 1) {
@@ -215,11 +186,13 @@ int main(int argc, char* argv[]) {
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA") != args.options.end())
 			cmdInertia = args.options["SCALEINERTIA"];
+		if (args.options.find("SCALEDAMPING") != args.options.end())
+			cmdDamping = args.options["SCALEDAMPING"];	
 		if (args.options.find("STARTTIMEFAULT") != args.options.end())
 			startTimeFault = args.options["STARTTIMEFAULT"];
 		if (args.options.find("ENDTIMEFAULT") != args.options.end())
 			endTimeFault = args.options["ENDTIMEFAULT"];
 	}
 
-	SP_1ph_SynGenTrStab_Fault(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia);
+	SP_1ph_SynGenTrStab_Fault(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia, cmdDamping);
 }

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault_KundurExample1.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault_KundurExample1.cpp
@@ -5,7 +5,7 @@
 using namespace DPsim;
 using namespace CPS;
 using namespace CPS::CIM;
-using namespace Examples::Components;
+using namespace Examples::Grids;
 
 // This example is taken from:
 // P. Kundur, "Power System Stability and Control", Example 13.2, pp. 864-869.

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp
@@ -3,8 +3,9 @@
 
 using namespace DPsim;
 using namespace CPS;
+using namespace CIM::Examples::Grids::SMIB;
 
-CIM::Examples::Grids::SMIB::ScenarioConfig smib;
+ScenarioConfig smib;
 
 void SP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia, Real cmdDamping) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::SMIB::ScenarioConfig smib;
+CIM::Examples::Grids::SMIB::ScenarioConfig smib;
 
 void SP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia, Real cmdDamping) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp
@@ -1,43 +1,13 @@
 #include <DPsim.h>
-
+#include "../Examples.h"
 
 using namespace DPsim;
 using namespace CPS;
 
+CIM::Examples::Components::SMIB::ScenarioConfig smib;
 
-//-----------Power system-----------//
-//Voltage level as Base Voltage
-Real Vnom = 230e3;
-
-//-----------Generator-----------//
-Real nomPower = 500e6;
-Real nomPhPhVoltRMS = 22e3;
-Real nomFreq = 60;
-Real nomOmega= nomFreq* 2*PI;
-Real H = 5;
-Real Xpd=0.31;
-Real Rs = 0.003*0;
-Real Kd = 1;
-// Initialization parameters
-Real initMechPower= 300e6;
-Real initActivePower = 300e6;
-Real setPointVoltage=nomPhPhVoltRMS + 0.05*nomPhPhVoltRMS;
-
-//-----------Transformer-----------//
-Real t_ratio=Vnom/nomPhPhVoltRMS;
-
-//PiLine parameters calculated from CIGRE Benchmark system
-Real lineResistance = 6.7;
-Real lineInductance = 47./nomOmega;
-Real lineCapacitance = 3.42e-4/nomOmega;
-Real lineConductance =0;
-
-// Parameters for powerflow initialization
-// Slack voltage: 1pu
-Real Vslack = Vnom;
-
-void SP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTime, bool startFaultEvent, bool endFaultEvent, Real startTimeFault, Real endTimeFault, Real cmdInertia) {
-	//  // ----- POWERFLOW FOR INITIALIZATION -----
+void SP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia, Real cmdDamping) {
+	// ----- POWERFLOW FOR INITIALIZATION -----
 	Real timeStepPF = finalTime;
 	Real finalTimePF = finalTime+timeStepPF;
 	String simNamePF = simName + "_PF";
@@ -50,20 +20,20 @@ void SP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTi
 	//Synchronous generator ideal model
 	auto genPF = SP::Ph1::SynchronGenerator::make("Generator", Logger::Level::debug);
 	// setPointVoltage is defined as the voltage at the transfomer primary side and should be transformed to network side
-	genPF->setParameters(nomPower, nomPhPhVoltRMS, initActivePower, setPointVoltage*t_ratio, PowerflowBusType::PV);
-	genPF->setBaseVoltage(Vnom);
+	genPF->setParameters(smib.nomPower, smib.nomPhPhVoltRMS, smib.initActivePower, smib.setPointVoltage*smib.t_ratio, PowerflowBusType::PV);
+	genPF->setBaseVoltage(smib.Vnom);
 	genPF->modifyPowerFlowBusType(PowerflowBusType::PV);
 
 	//Grid bus as Slack
 	auto extnetPF = SP::Ph1::NetworkInjection::make("Slack", Logger::Level::debug);
-	extnetPF->setParameters(Vslack);
-	extnetPF->setBaseVoltage(Vnom);
+	extnetPF->setParameters(smib.Vnom);
+	extnetPF->setBaseVoltage(smib.Vnom);
 	extnetPF->modifyPowerFlowBusType(PowerflowBusType::VD);
 	
 	//Line
 	auto linePF = SP::Ph1::PiLine::make("PiLine", Logger::Level::debug);
-	linePF->setParameters(lineResistance, lineInductance, lineCapacitance, lineConductance);
-	linePF->setBaseVoltage(Vnom);
+	linePF->setParameters(smib.lineResistance, smib.lineInductance, smib.lineCapacitance, smib.lineConductance);
+	linePF->setBaseVoltage(smib.Vnom);
 
 	// Topology
 	genPF->connect({ n1PF });
@@ -100,17 +70,17 @@ void SP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTi
 	// Components
 	auto genSP = SP::Ph1::SynchronGeneratorTrStab::make("SynGen", Logger::Level::debug);
 	// Xpd is given in p.u of generator base at transfomer primary side and should be transformed to network side
-	genSP->setStandardParametersPU(nomPower, nomPhPhVoltRMS, nomFreq, Xpd*std::pow(t_ratio,2), cmdInertia*H, Rs, Kd );
+	genSP->setStandardParametersPU(smib.nomPower, smib.nomPhPhVoltRMS, smib.nomFreq, smib.Xpd*std::pow(smib.t_ratio,2), cmdInertia*smib.H, smib.Rs, cmdDamping*smib.D );
 	// Get actual active and reactive power of generator's Terminal from Powerflow solution
 	Complex initApparentPower= genPF->getApparentPower();
-	genSP->setInitialValues(initApparentPower, initMechPower);
+	genSP->setInitialValues(initApparentPower, smib.initMechPower);
 
 	//Grid bus as Slack
 	auto extnetSP = SP::Ph1::NetworkInjection::make("Slack", Logger::Level::debug);
-	extnetSP->setParameters(Vslack);
+	extnetSP->setParameters(smib.Vnom);
 	// Line
 	auto lineSP = SP::Ph1::PiLine::make("PiLine", Logger::Level::debug);
-	lineSP->setParameters(lineResistance, lineInductance, lineCapacitance, lineConductance);
+	lineSP->setParameters(smib.lineResistance, smib.lineInductance, smib.lineCapacitance, smib.lineConductance);
 
 	// Topology
 	genSP->connect({ n1SP });
@@ -161,13 +131,22 @@ int main(int argc, char* argv[]) {
 
 	//Simultion parameters
 	String simName="SP_SynGenTrStab_SMIB_SteadyState";
-	Real finalTime = 10;
+	Real finalTime = 30;
 	Real timeStep = 0.001;
-	Bool startFaultEvent=false;
-	Bool endFaultEvent=false;
-	Real startTimeFault=10;
-	Real endTimeFault=10.1;
 	Real cmdInertia= 1.0;
+	Real cmdDamping=1.0;
 
-	SP_1ph_SynGenTrStab_SteadyState(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia);
+	CommandLineArgs args(argc, argv);
+	if (argc > 1) {
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+		if (args.name != "dpsim")
+			simName = args.name;
+		if (args.options.find("SCALEINERTIA") != args.options.end())
+			cmdInertia = args.options["SCALEINERTIA"];
+		if (args.options.find("SCALEDAMPING") != args.options.end())
+			cmdDamping = args.options["SCALEDAMPING"];
+	}
+
+	SP_1ph_SynGenTrStab_SteadyState(simName, timeStep, finalTime, cmdInertia, cmdDamping);
 }

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp
@@ -4,7 +4,7 @@
 using namespace DPsim;
 using namespace CPS;
 
-CIM::Examples::Components::SMIB::ScenarioConfig smib;
+CIM::Examples::SMIB::ScenarioConfig smib;
 
 void SP_1ph_SynGenTrStab_SteadyState(String simName, Real timeStep, Real finalTime, Real cmdInertia, Real cmdDamping) {
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -382,6 +382,9 @@ namespace CIGREMV {
     }
 
 }
+}
+
+namespace Events {
         std::shared_ptr<DPsim::SwitchEvent> createEventAddPowerConsumption(String nodeName, Real eventTime, Real additionalActivePower, SystemTopology& system, Domain domain, DPsim::DataLogger::Ptr logger) {
 
         // TODO: use base classes ph1

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -17,37 +17,6 @@ namespace CIM {
 namespace Examples {
 
 namespace Components {
-
-// P. Kundur, "Power System Stability and Control", Example 13.2, pp. 864-869.
-namespace KundurExample1 {
-    struct Network {
-        Real nomVoltage = 400e3;
-    };
-
-    struct Gen {
-        Real nomPower = 2220e6;
-        Real nomVoltage = 400e3;
-        Real H = 3.5;
-        Real XpdPU = 0.3;
-        Real RsPU = 0;
-        Real D = 1.0;
-    };
-    struct Line1 {
-        // Vnom = 400kV
-        Real lineResistance = 0.0721;
-        Real lineReactance = 36.0360; 
-        Real lineSusceptance = 0;
-        Real lineConductance =0;
-    };
-
-    struct Transf1 {
-	    Real nomVoltageHV = 400e3; 
-        Real nomVoltageMV = 400e3;
-        Real transformerResistance = 0; // referred to HV side
-        Real transformerReactance = 10.8108; // referred to HV side
-    };
-}
-
 namespace SynchronousGeneratorKundur {
     struct MachineParameters {
         // Define machine parameters in per unit
@@ -89,7 +58,9 @@ namespace SynchronousGeneratorKundur {
         Real fieldVoltage = 7.0821; //TODO: specify operating conditions
     };
 }
+}
 
+namespace Grids {
 namespace CIGREHVEuropean {
     struct LineParameters {
         // 220 kV
@@ -116,6 +87,35 @@ namespace CIGREHVAmerican {
         Real lineConductancePerKm = 0;
     };
 }
+
+// P. Kundur, "Power System Stability and Control", Example 13.2, pp. 864-869.
+namespace KundurExample1 {
+    struct Network {
+        Real nomVoltage = 400e3;
+    };
+
+    struct Gen {
+        Real nomPower = 2220e6;
+        Real nomVoltage = 400e3;
+        Real H = 3.5;
+        Real XpdPU = 0.3;
+        Real RsPU = 0;
+        Real D = 1.0;
+    };
+    struct Line1 {
+        // Vnom = 400kV
+        Real lineResistance = 0.0721;
+        Real lineReactance = 36.0360; 
+        Real lineSusceptance = 0;
+        Real lineConductance =0;
+    };
+
+    struct Transf1 {
+	    Real nomVoltageHV = 400e3; 
+        Real nomVoltageMV = 400e3;
+        Real transformerResistance = 0; // referred to HV side
+        Real transformerReactance = 10.8108; // referred to HV side
+    };
 }
 namespace SMIB {
     struct ScenarioConfig {
@@ -138,7 +138,7 @@ namespace SMIB {
         Real t_ratio=Vnom/nomPhPhVoltRMS;
         //-----------Transmission Line-----------//
         // CIGREHVAmerican (230 kV)
-        Components::CIGREHVAmerican::LineParameters lineCIGREHV;
+        Grids::CIGREHVAmerican::LineParameters lineCIGREHV;
         Real lineLeng=100;
         Real lineResistance = lineCIGREHV.lineResistancePerKm*lineLeng;
         Real lineInductance = lineCIGREHV.lineReactancePerKm/nomOmega*lineLeng;
@@ -191,7 +191,7 @@ namespace ThreeBus {
 
         // -----------Transmission Lines-----------//
         // CIGREHVAmerican (230 kV)
-        Components::CIGREHVAmerican::LineParameters lineCIGREHV;
+        Grids::CIGREHVAmerican::LineParameters lineCIGREHV;
         //line 1-2 (180km)
         Real lineResistance12 = lineCIGREHV.lineResistancePerKm*180;
         Real lineInductance12 = lineCIGREHV.lineReactancePerKm/nomOmega*180;
@@ -427,7 +427,7 @@ namespace CIGREMV {
             return nullptr;
         }
     }
-
+}
 }
 }
 }

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -48,63 +48,6 @@ namespace KundurExample1 {
     };
 }
 
-// The network transmission voltages used are 220 kV and 380 kV, which are
-// typical in European transmission systems. Generation bus voltages are 22 kV, and the
-// system frequency is 50 Hz.
-namespace CIGREHVEuropean {
-    struct LineParameters {
-        // 220 kV
-        Real lineResistancePerKm = 1.35e-4 * 484.0;
-        Real lineReactancePerKm = 8.22e-4 * 484.0;
-        Real lineSusceptancePerKm = 1.38e-3 / 484.0;
-        Real lineConductancePerKm = 0;
-    };
-
-    // All generators are rated at 22 kV, 50 Hz.
-    // Base power for p.u values: S_base=100 MVA 
-    struct GeneratorUnit_1 {
-        Real nomPower = 700e6;
-        Real nomVoltage = 22e3; // Phase-to-Phase RMS
-        Real nomFreq = 50;
-        Real setPointActivePower = 500e6;
-        Real setPointVoltage=1.03*nomVoltage;
-        Real Xd=1.25; //p.u
-        Real Xpd=0.333; //p.u
-        Real Rs=0; //p.u
-        Real H = 5; //p.u 
-        Real D = 1; //p.u
-    };
-
-    struct GeneratorUnit_2 {
-        Real nomPower = 500e6;
-        Real nomVoltage = 22e3; // Phase-to-Phase RMS
-        Real nomFreq = 50;
-        Real setPointActivePower = 300e6;
-        Real setPointVoltage=1.03*nomVoltage; 
-        Real Xd=1.25;
-        Real Xpd=0.333;
-        Real Rs=0; //p.u
-        Real H = 5;
-        Real D = 1;
-    };
-
-    struct RefBus {
-        // p.u
-        Real refVoltagePU= 1.03; //Bus voltage magnitude
-        Real refAngle= 0;    //Bus voltage angle
-        Real refFreq=50;
-    };
-}
-
-namespace CIGREHVAmerican {
-    struct LineParameters {
-        // 230 kV
-        Real lineResistancePerKm = 1.27e-4 * 529.0;
-        Real lineReactancePerKm = 9.05e-4 * 529.0;
-        Real lineSusceptancePerKm = 1.81e-3 / 529.0;
-    };
-}
-
 namespace SynchronousGeneratorKundur {
     struct MachineParameters {
         // Define machine parameters in per unit
@@ -146,6 +89,125 @@ namespace SynchronousGeneratorKundur {
         Real fieldVoltage = 7.0821; //TODO: specify operating conditions
     };
 }
+
+namespace CIGREHVEuropean {
+    struct LineParameters {
+        // 220 kV
+        Real Vnom = 220e3;
+        Real nomFreq = 50;
+        Real nomOmega= nomFreq* 2*PI;
+        //PiLine parameters (given in [p.u/km] with Z_base= 529ohm)
+        Real lineResistancePerKm = 1.35e-4  * 529;
+        Real lineReactancePerKm = 8.22e-4  * 529;
+        Real lineSusceptancePerKm = 1.38e-3  / 529;
+        Real lineConductancePerKm = 0;
+    };
+}
+namespace CIGREHVAmerican {
+    struct LineParameters {
+        // 230 kV
+        Real Vnom = 230e3;
+        Real nomFreq = 60;
+        Real nomOmega= nomFreq* 2*PI;
+        //PiLine parameters (given in [p.u/km] with Z_base= 529ohm)
+        Real lineResistancePerKm = 1.27e-4 * 529;
+        Real lineReactancePerKm = 9.05e-4 * 529;
+        Real lineSusceptancePerKm = 1.81e-3 / 529;
+        Real lineConductancePerKm = 0;
+    };
+}
+
+namespace SMIB {
+    struct ScenarioConfig {
+        //-----------Network-----------//
+        Real Vnom = 230e3;
+        Real nomFreq = 60;
+        Real nomOmega= nomFreq* 2*PI;
+        //-----------Generator-----------//
+        Real nomPower = 500e6;
+        Real nomPhPhVoltRMS = 22e3;
+        Real H = 5;
+        Real Xpd=0.31;
+        Real Rs = 0.003*0;
+        Real D = 1.5;
+        // Initialization parameters
+        Real initMechPower= 300e6;
+        Real initActivePower = 300e6;
+        Real setPointVoltage=nomPhPhVoltRMS + 0.05*nomPhPhVoltRMS;
+        //-----------Transformer-----------//
+        Real t_ratio=Vnom/nomPhPhVoltRMS;
+        //-----------Transmission Line-----------//
+        // CIGREHVAmerican (230 kV)
+        CIGREHVAmerican::LineParameters lineCIGREHV;
+        Real lineLeng=100;
+        Real lineResistance = lineCIGREHV.lineResistancePerKm*lineLeng;
+        Real lineInductance = lineCIGREHV.lineReactancePerKm/nomOmega*lineLeng;
+        Real lineCapacitance = lineCIGREHV.lineSusceptancePerKm/nomOmega*lineLeng;
+        Real lineConductance =lineCIGREHV.lineConductancePerKm*lineLeng;;
+    };
+}
+
+namespace ThreeBus {
+    struct ScenarioConfig {
+        
+        //-----------Network-----------//
+        Real Vnom = 230e3;
+        Real nomFreq = 60;
+        Real nomOmega= nomFreq* 2*PI;
+
+        //-----------Generator 1 (bus1)-----------//
+        Real nomPower_G1 = 300e6;
+        Real nomPhPhVoltRMS_G1 = 25e3;
+        Real nomFreq_G1 = 60;
+        Real H_G1 = 6; 
+        Real Xpd_G1=0.3; //in p.u
+        Real Rs_G1 = 0.003*0; //in p.u
+        Real D_G1 = 1.5; //in p.u 
+        // Initialization parameters 
+        Real initActivePower_G1 = 270e6;
+        Real initMechPower_G1 = 270e6;
+        Real setPointVoltage_G1=nomPhPhVoltRMS_G1+0.05*nomPhPhVoltRMS_G1;
+        
+        //-----------Generator 2 (bus2)-----------//
+        Real nomPower_G2 = 50e6;
+        Real nomPhPhVoltRMS_G2 = 13.8e3;
+        Real nomFreq_G2 = 60;
+        Real H_G2 = 2; 
+        Real Xpd_G2=0.1; //in p.u
+        Real Rs_G2 = 0.003*0; //in p.u
+        Real D_G2 =1.5; //in p.u
+        // Initialization parameters 
+        Real initActivePower_G2 = 45e6;
+        Real initMechPower_G2 = 45e6;
+        Real setPointVoltage_G2=nomPhPhVoltRMS_G2-0.05*nomPhPhVoltRMS_G2;
+
+        //-----------Transformers-----------//
+        Real t1_ratio=Vnom/nomPhPhVoltRMS_G1;
+        Real t2_ratio=Vnom/nomPhPhVoltRMS_G2;
+
+        //-----------Load (bus3)-----------
+        Real activePower_L= 310e6;
+        Real reactivePower_L= 150e6;
+
+        // -----------Transmission Lines-----------//
+        // CIGREHVAmerican (230 kV)
+        CIGREHVAmerican::LineParameters lineCIGREHV;
+        //line 1-2 (180km)
+        Real lineResistance12 = lineCIGREHV.lineResistancePerKm*180;
+        Real lineInductance12 = lineCIGREHV.lineReactancePerKm/nomOmega*180;
+        Real lineCapacitance12 = lineCIGREHV.lineSusceptancePerKm/nomOmega*180;
+        Real lineConductance12 = lineCIGREHV.lineConductancePerKm*180;
+        //line 1-3 (150km)
+        Real lineResistance13 = lineCIGREHV.lineResistancePerKm*150;
+        Real lineInductance13 = lineCIGREHV.lineReactancePerKm/nomOmega*150;
+        Real lineCapacitance13 = lineCIGREHV.lineSusceptancePerKm/nomOmega*150;
+        Real lineConductance13 = lineCIGREHV.lineConductancePerKm*150;
+        //line 2-3 (80km)
+        Real lineResistance23 = lineCIGREHV.lineResistancePerKm*80;
+        Real lineInductance23 = lineCIGREHV.lineReactancePerKm/nomOmega*80;
+        Real lineCapacitance23 = lineCIGREHV.lineSusceptancePerKm/nomOmega*80;
+        Real lineConductance23 = lineCIGREHV.lineConductancePerKm*80;
+    };
 }
 
 namespace SGIB {
@@ -366,6 +428,7 @@ namespace CIGREMV {
         }
     }
 
+}
 }
 }
 }

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -116,7 +116,7 @@ namespace CIGREHVAmerican {
         Real lineConductancePerKm = 0;
     };
 }
-
+}
 namespace SMIB {
     struct ScenarioConfig {
         //-----------Network-----------//
@@ -138,7 +138,7 @@ namespace SMIB {
         Real t_ratio=Vnom/nomPhPhVoltRMS;
         //-----------Transmission Line-----------//
         // CIGREHVAmerican (230 kV)
-        CIGREHVAmerican::LineParameters lineCIGREHV;
+        Components::CIGREHVAmerican::LineParameters lineCIGREHV;
         Real lineLeng=100;
         Real lineResistance = lineCIGREHV.lineResistancePerKm*lineLeng;
         Real lineInductance = lineCIGREHV.lineReactancePerKm/nomOmega*lineLeng;
@@ -191,7 +191,7 @@ namespace ThreeBus {
 
         // -----------Transmission Lines-----------//
         // CIGREHVAmerican (230 kV)
-        CIGREHVAmerican::LineParameters lineCIGREHV;
+        Components::CIGREHVAmerican::LineParameters lineCIGREHV;
         //line 1-2 (180km)
         Real lineResistance12 = lineCIGREHV.lineResistancePerKm*180;
         Real lineInductance12 = lineCIGREHV.lineReactancePerKm/nomOmega*180;
@@ -428,7 +428,6 @@ namespace CIGREMV {
         }
     }
 
-}
 }
 }
 }


### PR DESCRIPTION
Refactoring of SMIB and 3Bus transient stability examples by moving the scenario's global parameters to examples.h. For future work, scenario parameters (which are not imported) should be defined in examples.h for a better overview.