### PR TITLE
run autodoc on python submodules

### DIFF
--- a/docs/sphinx/Reference.rst
+++ b/docs/sphinx/Reference.rst
@@ -6,3 +6,39 @@ Reference
 .. automodule:: dpsimpy
     :members:
     :undoc-members:
+
+.. automodule:: dpsimpy.dp
+    :members:
+    :undoc-members:
+
+.. automodule:: dpsimpy.dp.ph1
+    :members:
+    :undoc-members:
+
+.. automodule:: dpsimpy.dp.ph1
+    :members:
+    :undoc-members:
+
+.. automodule:: dpsimpy.emt
+    :members:
+    :undoc-members:
+
+.. automodule:: dpsimpy.emt.ph1
+    :members:
+    :undoc-members:
+
+.. automodule:: dpsimpy.emt.ph1
+    :members:
+    :undoc-members:
+
+.. automodule:: dpsimpy.sp
+    :members:
+    :undoc-members:
+
+.. automodule:: dpsimpy.sp.ph1
+    :members:
+    :undoc-members:
+
+.. automodule:: dpsimpy.sp.ph1
+    :members:
+    :undoc-members:


### PR DESCRIPTION
Also include submodules in the automatically generated sphinx documentation.