### PR TITLE
use new villas version

### DIFF
--- a/Packaging/Docker/Dockerfile.dev
+++ b/Packaging/Docker/Dockerfile.dev
@@ -102,7 +102,7 @@ RUN cd /tmp && \
 RUN cd /tmp && \
 	git -c submodule.fpga.update=none clone --recursive https://git.rwth-aachen.de/acs/public/villas/node.git villasnode && \	
 	mkdir -p villasnode/build && cd villasnode/build && \
-	git -c submodule.fpga.update=none checkout dpsim-villas && git -c submodule.fpga.update=none submodule update --recursive && \
+	git -c submodule.fpga.update=none checkout a98ab9f1726476fdaa8966da63744794b691bf54 && git -c submodule.fpga.update=none submodule update --recursive && \
 	cmake -DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 .. && make -j$(nproc) install && \
 	rm -rf /tmp/villasnode
 

--- a/Packaging/Docker/Dockerfile.dev-debian
+++ b/Packaging/Docker/Dockerfile.dev-debian
@@ -104,7 +104,7 @@ RUN cd /tmp && \
 RUN cd /tmp && \
 	git -c submodule.fpga.update=none clone --recursive https://git.rwth-aachen.de/acs/public/villas/node.git villasnode && \	
 	mkdir -p villasnode/build && cd villasnode/build && \
-	git checkout 5f6a28ca && git -c submodule.fpga.update=none submodule update --recursive && \
+	git -c submodule.fpga.update=none checkout a98ab9f1726476fdaa8966da63744794b691bf54 && git -c submodule.fpga.update=none submodule update --recursive && \
 	cmake -DCMAKE_INSTALL_LIBDIR=/usr/local/lib .. && make install && \
 	rm -rf /tmp/villasnode
 

--- a/cmake/GetVillasDPsim.cmake
+++ b/cmake/GetVillasDPsim.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 FetchContent_Declare(
   dpsim-villas
   GIT_REPOSITORY https://github.com/sogno-platform/dpsim-villas.git
-  GIT_TAG        main
+  GIT_TAG        v0.11.0
 )
 
 if(${CMAKE_VERSION} VERSION_LESS "3.14.0")


### PR DESCRIPTION
This PR updates the version of VILLASnode used in the Docker installations to match the [changes to dpsim-villas](https://github.com/sogno-platform/dpsim-villas/pull/6). To provide security for future updates, the version of dpsim-villas that is downloaded in GetVillasDPsim.cmake should be fixed to the new merge commit. 