### PR TITLE
add pillow dependencies to centos dockerfile

### DIFF
--- a/Packaging/Docker/Dockerfile.dev-centos
+++ b/Packaging/Docker/Dockerfile.dev-centos
@@ -59,7 +59,9 @@ RUN dnf -y install \
     libnl3-devel \
     libcurl-devel \
     jansson-devel \
-    mosquitto-devel
+    mosquitto-devel \
+    libjpeg-devel \
+    zlib-devel
 
 # CUDARPC and dependencies
 RUN dnf install -y make bash git gcc autoconf libtool automake \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 sphinx
-nbsphinx
 sphinx_rtd_theme
 
 pytest-runner
@@ -9,4 +8,3 @@ pybind11[global]
 
 villas-dataprocessing>=0.2.6
 villas-node
-progressbar2


### PR DESCRIPTION
Add additional dependencies to the CentOS Dockerfile to correctly build the Python pillow library.