### PR TITLE
Sg controllers

### DIFF
--- a/Examples/Cxx/CMakeLists.txt
+++ b/Examples/Cxx/CMakeLists.txt
@@ -66,6 +66,7 @@ set(CIRCUIT_SOURCES
 	Circuits/EMT_SynGenTrStab_SMIB_Fault.cpp
 	Circuits/SP_SynGenTrStab_SMIB_Fault_KundurExample1.cpp
 	Circuits/EMT_SynGenVBR_OperationalParams_SMIB_Fault.cpp
+	Circuits/EMT_SynGenVBR_SMIB_Fault.cpp
 
 	#3Bus System
 	Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
@@ -150,10 +151,6 @@ if(WITH_CIM)
 		CIM/EMT_CIGRE_MV_withoutDG.cpp
 		CIM/EMT_CIGRE_MV_withDG.cpp
 		CIM/EMT_CIGRE_MV_withDG_withLoadStep.cpp
-
-		# SMIB example 
-		# TODO: does not read CIM files, but currently requires CIM reader
-		Circuits/EMT_SynGenVBR_SMIB_Fault.cpp
 	)
 
 	if(WITH_RT)

--- a/Examples/Cxx/CMakeLists.txt
+++ b/Examples/Cxx/CMakeLists.txt
@@ -65,7 +65,6 @@ set(CIRCUIT_SOURCES
 	Circuits/EMT_SynGenDQ7odTrapez_DP_SynGenTrStab_SMIB_Fault.cpp
 	Circuits/EMT_SynGenTrStab_SMIB_Fault.cpp
 	Circuits/SP_SynGenTrStab_SMIB_Fault_KundurExample1.cpp
-	Circuits/EMT_SynGenVBR_SMIB_Fault.cpp
 	Circuits/EMT_SynGenVBR_OperationalParams_SMIB_Fault.cpp
 
 	#3Bus System
@@ -151,6 +150,10 @@ if(WITH_CIM)
 		CIM/EMT_CIGRE_MV_withoutDG.cpp
 		CIM/EMT_CIGRE_MV_withDG.cpp
 		CIM/EMT_CIGRE_MV_withDG_withLoadStep.cpp
+
+		# SMIB example 
+		# TODO: does not read CIM files, but currently requires CIM reader
+		Circuits/EMT_SynGenVBR_SMIB_Fault.cpp
 	)
 
 	if(WITH_RT)

--- a/Examples/Cxx/CMakeLists.txt
+++ b/Examples/Cxx/CMakeLists.txt
@@ -86,6 +86,8 @@ set(SYNCGEN_SOURCES
 	Components/DP_EMT_SynGenDq7odTrapez_LoadStep.cpp
 	Components/DP_SP_SynGenTrStab_testModels.cpp
 	Components/DP_SP_SynGenTrStab_testModels_doubleLine.cpp
+	Components/EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter.cpp
+	Components/EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter.cpp
 )
 
 set(INVERTER_SOURCES

--- a/Examples/Cxx/Circuits/EMT_SynGenVBR_OperationalParams_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/EMT_SynGenVBR_OperationalParams_SMIB_Fault.cpp
@@ -144,7 +144,6 @@ int main(int argc, char* argv[]) {
 			SystemComponentList{gen, line, fault, extnet});
 
 	// Initialization of dynamic topology
-	CIM::Reader reader(simName, Logger::Level::debug);
 	system.initWithPowerflow(systemPF);
 	gen->terminal(0)->setPower(-genPF->getApparentPower());
 

--- a/Examples/Cxx/Circuits/EMT_SynGenVBR_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/EMT_SynGenVBR_SMIB_Fault.cpp
@@ -144,7 +144,6 @@ int main(int argc, char* argv[]) {
 			SystemComponentList{gen, line, fault, extnet});
 
 	// Initialization of dynamic topology
-	CIM::Reader reader(simName, Logger::Level::debug);
 	system.initWithPowerflow(systemPF);
 	gen->terminal(0)->setPower(-genPF->getApparentPower());
 

--- a/Examples/Cxx/Components/EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter.cpp
+++ b/Examples/Cxx/Components/EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter.cpp
@@ -1,0 +1,115 @@
+/* Copyright 2017-2021 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <DPsim.h>
+#include "../Examples.h"
+
+using namespace DPsim;
+using namespace CPS;
+using namespace CPS::CIM;
+
+// Machine parameters synchronous generator
+const Examples::Components::SynchronousGeneratorKundur::MachineParameters syngenKundur;
+
+// Initialization parameters
+Real nominalVoltage = 24e3;
+Real initActivePower = 300e6;
+Real initReactivePower = 0;
+Real initMechPower = 300e6;
+Real initTerminalVoltageMagnitude = nominalVoltage*RMS3PH_TO_PEAK1PH;
+Real initTerminalVoltageAngle = -PI / 2;
+Complex initTerminalVoltage = CPS::Math::polar(initTerminalVoltageMagnitude, initTerminalVoltageAngle);
+
+// Define load parameters
+Real PloadOriginal = 300e6;
+
+int main(int argc, char* argv[]) {
+
+	//Simulation parameters
+	String simName="EMT_Ph3_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter";
+	Real timeStep = 50e-6;
+	Real finalTime = 1.0;
+	Real cmdInertiaFactor= 1.0;
+	Bool withGovernor = false;
+	Bool withExciter = false;
+	Real timeStepEvent = 30.0;
+	Real cmdLoadFactor = 1.5;
+	
+
+	CommandLineArgs args(argc, argv);
+	if (argc > 1) {
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+		if (args.name != "dpsim")
+			simName = args.name;
+		if (args.options.find("SCALEINERTIA") != args.options.end())
+			cmdInertiaFactor = args.options["SCALEINERTIA"];
+		if (args.options_bool.find("WITHGOVERNOR") != args.options_bool.end())
+			withGovernor = args.options_bool["WITHGOVERNOR"];
+		if (args.options_bool.find("WITHEXCITER") != args.options_bool.end())
+			withExciter = args.options_bool["WITHEXCITER"];
+		if (args.options.find("TIMESTEPEVENT") != args.options.end())
+			timeStepEvent = args.options["TIMESTEPEVENT"];
+		if (args.options.find("LOADFACTOR") != args.options.end())
+			cmdLoadFactor = args.options["LOADFACTOR"];
+	}
+
+	// Calculate grid parameters
+	Real RloadOriginal = std::pow(nominalVoltage,2)/PloadOriginal;
+	Real RloadNew = std::pow(nominalVoltage,2)/(cmdLoadFactor*PloadOriginal);
+
+	// Set logger directory
+	Logger::setLogDir("logs/"+simName);
+
+	// Nodes
+	auto n1 = CPS::EMT::SimNode::make("n1", PhaseType::ABC);
+
+	// Components
+	auto gen = CPS::EMT::Ph3::SynchronGeneratorDQTrapez::make("SynGen", CPS::Logger::Level::info);
+	gen->setParametersFundamentalPerUnit(syngenKundur.nomPower, syngenKundur.nomVoltage, syngenKundur.nomFreq, syngenKundur.poleNum, syngenKundur.nomFieldCurr,
+		syngenKundur.Rs, syngenKundur.Ll, syngenKundur.Ld, syngenKundur.Lq, syngenKundur.Rfd, syngenKundur.Llfd, syngenKundur.Rkd, syngenKundur.Llkd, syngenKundur.Rkq1, syngenKundur.Llkq1, syngenKundur.Rkq2, syngenKundur.Llkq2, cmdInertiaFactor*syngenKundur.H,
+		initActivePower, initReactivePower, initTerminalVoltageMagnitude,
+		initTerminalVoltageAngle, initMechPower);
+
+	if (withGovernor) 
+		gen->addGovernor(syngenKundur.Ta_t, syngenKundur.Tb, syngenKundur.Tc, syngenKundur.Fa, syngenKundur.Fb, syngenKundur.Fc, syngenKundur.Kg, syngenKundur.Tsr, syngenKundur.Tsm, initActivePower / syngenKundur.nomPower, initMechPower / syngenKundur.nomPower);
+	
+	if (withExciter)
+		gen->addExciter(syngenKundur.Ta, syngenKundur.Ka, syngenKundur.Te, syngenKundur.Ke, syngenKundur.Tf, syngenKundur.Kf, syngenKundur.Tr);
+
+	auto fault = CPS::EMT::Ph3::Switch::make("Br_fault", CPS::Logger::Level::info);
+	fault->setParameters(Math::singlePhaseParameterToThreePhase(RloadOriginal), 
+						 Math::singlePhaseParameterToThreePhase(RloadNew));
+	fault->openSwitch();
+
+
+	// Connections
+	gen->connect({n1});
+	fault->connect({CPS::EMT::SimNode::GND, n1});
+
+	auto sys = SystemTopology(60, SystemNodeList{n1}, SystemComponentList{gen, fault});
+
+	// Logging
+	auto logger = DataLogger::make(simName);
+	logger->addAttribute("v1", n1->attribute("v"));
+	logger->addAttribute("i_gen", gen->attribute("i_intf"));
+	logger->addAttribute("wr_gen", gen->attribute("w_r"));
+
+	Simulation sim(simName, Logger::Level::info);
+	sim.setSystem(sys);
+	sim.setTimeStep(timeStep);
+	sim.setFinalTime(finalTime);
+	sim.setDomain(Domain::EMT);
+	sim.addLogger(logger);
+
+	// Events
+	auto sw1 = SwitchEvent3Ph::make(timeStepEvent, fault, true);
+	sim.addEvent(sw1);
+
+	sim.run();
+}

--- a/Examples/Cxx/Components/EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter.cpp
+++ b/Examples/Cxx/Components/EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter.cpp
@@ -13,8 +13,10 @@ using namespace DPsim;
 using namespace CPS;
 using namespace CPS::CIM;
 
-// Machine parameters synchronous generator
+// Parameters synchronous generator
 const Examples::Components::SynchronousGeneratorKundur::MachineParameters syngenKundur;
+const Examples::Components::GovernorKundur::Parameters govKundur;
+const Examples::Components::ExcitationSystemEremia::Parameters excEremia;
 
 // Initialization parameters
 Real nominalVoltage = 24e3;
@@ -77,10 +79,10 @@ int main(int argc, char* argv[]) {
 		initTerminalVoltageAngle, initMechPower);
 
 	if (withGovernor) 
-		gen->addGovernor(syngenKundur.Ta_t, syngenKundur.Tb, syngenKundur.Tc, syngenKundur.Fa, syngenKundur.Fb, syngenKundur.Fc, syngenKundur.Kg, syngenKundur.Tsr, syngenKundur.Tsm, initActivePower / syngenKundur.nomPower, initMechPower / syngenKundur.nomPower);
+		gen->addGovernor(govKundur.Ta_t, govKundur.Tb, govKundur.Tc, govKundur.Fa, govKundur.Fb, govKundur.Fc, govKundur.Kg, govKundur.Tsr, govKundur.Tsm, initActivePower / syngenKundur.nomPower, initMechPower / syngenKundur.nomPower);
 	
 	if (withExciter)
-		gen->addExciter(syngenKundur.Ta, syngenKundur.Ka, syngenKundur.Te, syngenKundur.Ke, syngenKundur.Tf, syngenKundur.Kf, syngenKundur.Tr);
+		gen->addExciter(excEremia.Ta, excEremia.Ka, excEremia.Te, excEremia.Ke, excEremia.Tf, excEremia.Kf, excEremia.Tr);
 
 	auto fault = CPS::EMT::Ph3::Switch::make("Br_fault", CPS::Logger::Level::info);
 	fault->setParameters(Math::singlePhaseParameterToThreePhase(RloadOriginal), 

--- a/Examples/Cxx/Components/EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter.cpp
+++ b/Examples/Cxx/Components/EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter.cpp
@@ -13,8 +13,10 @@ using namespace DPsim;
 using namespace CPS;
 using namespace CPS::CIM;
 
-// Machine parameters synchronous generator
+// Parameters synchronous generator
 const Examples::Components::SynchronousGeneratorKundur::MachineParameters syngenKundur;
+const Examples::Components::GovernorKundur::Parameters govKundur;
+const Examples::Components::ExcitationSystemEremia::Parameters excEremia;
 
 // Initialization parameters
 Real nominalVoltage = 24e3;
@@ -78,10 +80,10 @@ int main(int argc, char* argv[]) {
 		initTerminalVoltageAngle, initMechPower);
 
 	if (withGovernor) 
-		gen->addGovernor(syngenKundur.Ta_t, syngenKundur.Tb, syngenKundur.Tc, syngenKundur.Fa, syngenKundur.Fb, syngenKundur.Fc, syngenKundur.Kg, syngenKundur.Tsr, syngenKundur.Tsm, initActivePower / syngenKundur.nomPower, initMechPower / syngenKundur.nomPower);
+		gen->addGovernor(govKundur.Ta_t, govKundur.Tb, govKundur.Tc, govKundur.Fa, govKundur.Fb, govKundur.Fc, govKundur.Kg, govKundur.Tsr, govKundur.Tsm, initActivePower / syngenKundur.nomPower, initMechPower / syngenKundur.nomPower);
 
 	if (withExciter)
-		gen->addExciter(syngenKundur.Ta, syngenKundur.Ka, syngenKundur.Te, syngenKundur.Ke, syngenKundur.Tf, syngenKundur.Kf, syngenKundur.Tr);
+		gen->addExciter(excEremia.Ta, excEremia.Ka, excEremia.Te, excEremia.Ke, excEremia.Tf, excEremia.Kf, excEremia.Tr);
 
 	auto fault = CPS::EMT::Ph3::Switch::make("Br_fault", CPS::Logger::Level::info);
 	fault->setParameters(Math::singlePhaseParameterToThreePhase(RloadOriginal), 

--- a/Examples/Cxx/Components/EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter.cpp
+++ b/Examples/Cxx/Components/EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter.cpp
@@ -1,0 +1,125 @@
+/* Copyright 2017-2021 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <DPsim.h>
+#include "../Examples.h"
+
+using namespace DPsim;
+using namespace CPS;
+using namespace CPS::CIM;
+
+// Machine parameters synchronous generator
+const Examples::Components::SynchronousGeneratorKundur::MachineParameters syngenKundur;
+
+// Initialization parameters
+Real nominalVoltage = 24e3;
+Real initActivePower = 300e6;
+Real initReactivePower = 0;
+Real initMechPower = 300e6;
+Real initTerminalVoltageMagnitude = nominalVoltage*RMS3PH_TO_PEAK1PH;
+Real initTerminalVoltageAngle = -PI / 2;
+Complex initTerminalVoltage = CPS::Math::polar(initTerminalVoltageMagnitude, initTerminalVoltageAngle);
+
+// Define load parameters
+Real PloadOriginal = 300e6;
+
+int main(int argc, char* argv[]) {
+
+	//Simulation parameters
+	String simName="EMT_Ph3_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter";
+	Real timeStep = 50e-6;
+	Real finalTime = 1.0;
+	Real cmdInertiaFactor= 1.0;
+	Bool withGovernor = false;
+	Bool withExciter = false;
+	Real timeStepEvent = 30.0;
+	Real cmdLoadFactor = 1.5;
+	
+
+	CommandLineArgs args(argc, argv);
+	if (argc > 1) {
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+		if (args.name != "dpsim")
+			simName = args.name;
+		if (args.options.find("SCALEINERTIA") != args.options.end())
+			cmdInertiaFactor = args.options["SCALEINERTIA"];
+		if (args.options_bool.find("WITHGOVERNOR") != args.options_bool.end())
+			withGovernor = args.options_bool["WITHGOVERNOR"];
+		if (args.options_bool.find("WITHEXCITER") != args.options_bool.end())
+			withExciter = args.options_bool["WITHEXCITER"];
+		if (args.options.find("TIMESTEPEVENT") != args.options.end())
+			timeStepEvent = args.options["TIMESTEPEVENT"];
+		if (args.options.find("LOADFACTOR") != args.options.end())
+			cmdLoadFactor = args.options["LOADFACTOR"];
+	}
+
+	// Calculate grid parameters
+	Real RloadOriginal = std::pow(nominalVoltage,2)/PloadOriginal;
+	Real RloadNew = std::pow(nominalVoltage,2)/(cmdLoadFactor*PloadOriginal);
+
+	// Set logger directory
+	Logger::setLogDir("logs/"+simName);
+
+	// Nodes
+	auto n1 = CPS::EMT::SimNode::make("n1", PhaseType::ABC);
+
+	// Components
+	auto gen = CPS::EMT::Ph3::SynchronGeneratorVBR::make("SynGen", CPS::Logger::Level::info);
+	gen->setBaseAndFundamentalPerUnitParameters(syngenKundur.nomPower, syngenKundur.nomVoltage, syngenKundur.nomFreq, syngenKundur.poleNum, syngenKundur.nomFieldCurr,
+												syngenKundur.Rs, syngenKundur.Ll, syngenKundur.Ld, syngenKundur.Lq, syngenKundur.Rfd, syngenKundur.Llfd,
+												syngenKundur.Rkd, syngenKundur.Llkd, syngenKundur.Rkq1, syngenKundur.Llkq1, syngenKundur.Rkq2, syngenKundur.Llkq2, cmdInertiaFactor*syngenKundur.H);
+	gen->setInitialValues(initActivePower, initReactivePower, initTerminalVoltageMagnitude,
+		initTerminalVoltageAngle, initMechPower);
+
+	if (withGovernor) 
+		gen->addGovernor(syngenKundur.Ta_t, syngenKundur.Tb, syngenKundur.Tc, syngenKundur.Fa, syngenKundur.Fb, syngenKundur.Fc, syngenKundur.Kg, syngenKundur.Tsr, syngenKundur.Tsm, initActivePower / syngenKundur.nomPower, initMechPower / syngenKundur.nomPower);
+
+	if (withExciter)
+		gen->addExciter(syngenKundur.Ta, syngenKundur.Ka, syngenKundur.Te, syngenKundur.Ke, syngenKundur.Tf, syngenKundur.Kf, syngenKundur.Tr);
+
+	auto fault = CPS::EMT::Ph3::Switch::make("Br_fault", CPS::Logger::Level::info);
+	fault->setParameters(Math::singlePhaseParameterToThreePhase(RloadOriginal), 
+						 Math::singlePhaseParameterToThreePhase(RloadNew));
+	fault->openSwitch();
+
+
+	// Connections
+	gen->connect({n1});
+	fault->connect({CPS::EMT::SimNode::GND, n1});
+
+	auto sys = SystemTopology(60, SystemNodeList{n1}, SystemComponentList{gen, fault});
+
+	// Logging
+	auto logger = DataLogger::make(simName);
+	logger->addAttribute("v1", n1->attribute("v"));
+	logger->addAttribute("i_gen", gen->attribute("i_intf"));
+	logger->addAttribute("wr_gen", gen->attribute("w_r"));
+
+	// Log further variables if exciter connected
+	if (withExciter) {
+		logger->addAttribute("vh_exc_gen", gen->mExciter->attribute("Vh"));
+		logger->addAttribute("vr_exc_gen", gen->mExciter->attribute("Vr"));
+		logger->addAttribute("vf_exc_gen", gen->mExciter->attribute("Vf"));
+	}
+
+	Simulation sim(simName, Logger::Level::info);
+	sim.setSystem(sys);
+	sim.setTimeStep(timeStep);
+	sim.setFinalTime(finalTime);
+	sim.doSystemMatrixRecomputation(true);
+	sim.setMnaSolverImplementation(MnaSolverFactory::MnaSolverImpl::EigenSparse);
+	sim.setDomain(Domain::EMT);
+	sim.addLogger(logger);
+
+	// Events
+	auto sw1 = SwitchEvent3Ph::make(timeStepEvent, fault, true);
+	sim.addEvent(sw1);
+
+	sim.run();
+}

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -54,7 +54,11 @@ namespace SynchronousGeneratorKundur {
         Real Lq_s = 0.2500;
         Real Ld = 1.8099;
         Real Lq = 1.7600;
+    };
+}
 
+namespace GovernorKundur {
+    struct Parameters {
         // Turbine model parameters (tandem compound single reheat steam turbine, fossil-fuelled)
         // from P. Kundur, "Power System Stability and Control", 1994, p. 427
         Real Ta_t = 0.3;    // T_CH
@@ -69,7 +73,11 @@ namespace SynchronousGeneratorKundur {
         Real Kg = 20;       // 5% droop
         Real Tsr = 0.1;
         Real Tsm = 0.3;
+    };
+}
 
+namespace ExcitationSystemEremia {
+    struct Parameters {
         // Excitation system parameters (IEEE Type DC1A)
         // from M. Eremia, "Handbook of Electrical Power System Dynamics", 2013, p.96 and 106
         // voltage-regulator
@@ -84,7 +92,9 @@ namespace SynchronousGeneratorKundur {
         // voltage transducer
         Real Tr = 0.02;
     };
+
 }
+
 }
 
 namespace Grids {

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -55,14 +55,14 @@ namespace SynchronousGeneratorKundur {
         Real Ld = 1.8099;
         Real Lq = 1.7600;
 
-        // Turbine model parameters (tandem compound single reheat turbine)
+        // Turbine model parameters (tandem compound single reheat steam turbine, fossil-fuelled)
         // from P. Kundur, "Power System Stability and Control", 1994, p. 427
-        Real Ta_t = 0.3;    // fossil-fuelled or nuclear
-        Real Fa = 0.3;      // fossil-fuelled or nuclear
-        Real Tb = 7.0;      // fossil-fuelled
-        Real Fb = 0.3;      // fossil-fuelled
-        Real Tc = 0.2;      // nuclear
-        Real Fc = 0.4;      // fossil-fuelled
+        Real Ta_t = 0.3;    // T_CH
+        Real Fa = 0.3;      // F_HP
+        Real Tb = 7.0;      // T_RH
+        Real Fb = 0.3;      // F_IP
+        Real Tc = 0.5;      // T_CO
+        Real Fc = 0.4;      // F_LP
 
         // Governor parameters (mechanical-hydraulic control)
         // from P. Kundur, "Power System Stability and Control", 1994, p. 437
@@ -70,14 +70,18 @@ namespace SynchronousGeneratorKundur {
         Real Tsr = 0.1;
         Real Tsm = 0.3;
 
-        // Exciter parameters (IEEE Type DC1A)
-        // from M. Eremia, "Handbook of Electrical Power System Dynamics", 2013, p. 125
+        // Excitation system parameters (IEEE Type DC1A)
+        // from M. Eremia, "Handbook of Electrical Power System Dynamics", 2013, p.96 and 106
+        // voltage-regulator
         Real Ka = 46;
         Real Ta = 0.06;
+        // exciter
         Real Ke = -0.0435;
         Real Te = 0.46;
+        // stabilizing feedback
         Real Kf = 0.1;
         Real Tf = 1;
+        // voltage transducer
         Real Tr = 0.02;
     };
 }

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -54,6 +54,22 @@ namespace SynchronousGeneratorKundur {
         Real Lq_s = 0.2500;
         Real Ld = 1.8099;
         Real Lq = 1.7600;
+
+        // Turbine model parameters (tandem compound single reheat turbine)
+        // from P. Kundur, "Power System Stability and Control", 1994, p. 427
+        Real Ta_t = 0.3;    // fossil-fuelled or nuclear
+        Real Fa = 0.3;      // fossil-fuelled or nuclear
+        Real Tb = 7.0;      // fossil-fuelled
+        Real Fb = 0.3;      // fossil-fuelled
+        Real Tc = 0.2;      // nuclear
+        Real Fc = 0.4;      // fossil-fuelled
+
+        // Governor parameters (mechanical-hydraulic control)
+        // from P. Kundur, "Power System Stability and Control", 1994, p. 437
+        Real Kg = 20;       // 5% droop
+        Real Tsr = 0.1;
+        Real Tsm = 0.3;
+
     };
 }
 }

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -70,6 +70,15 @@ namespace SynchronousGeneratorKundur {
         Real Tsr = 0.1;
         Real Tsm = 0.3;
 
+        // Exciter parameters (IEEE Type DC1A)
+        // from M. Eremia, "Handbook of Electrical Power System Dynamics", 2013, p. 125
+        Real Ka = 46;
+        Real Ta = 0.06;
+        Real Ke = -0.0435;
+        Real Te = 0.46;
+        Real Kf = 0.1;
+        Real Tf = 1;
+        Real Tr = 0.02;
     };
 }
 }

--- a/Examples/Cxx/signals/Exciter.cpp
+++ b/Examples/Cxx/signals/Exciter.cpp
@@ -37,7 +37,7 @@ int main(int argc, char* argv[]) {
 	Real Vref = 1;
 
 	Signal::Exciter exciter("exciter");
-	exciter.setParameters(Ta, Ka, Te, Ke, Tf, Kf, Tr, Lmd, Rfd);
+	exciter.setParameters(Ta, Ka, Te, Ke, Tf, Kf, Tr);
 
 	// Variables to read input
 	std::string line_vd;
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
 			exciter.initialize(Vh_init, Vf_init);
 		}
 
-		vt = exciter.step(mVd, mVq, Vref, dt);
+		vt = (Rfd / Lmd)*exciter.step(mVd, mVq, Vref, dt);
 
 		log << t << "," << vt * 257198.07031934269 << std::endl;
 	}

--- a/Examples/Notebooks/Components/Syngen_9Order_DCIM_VBR_Governor_Exciter.ipynb
+++ b/Examples/Notebooks/Components/Syngen_9Order_DCIM_VBR_Governor_Exciter.ipynb
@@ -22,7 +22,7 @@
     "import os\n",
     "import subprocess\n",
     "\n",
-    "%matplotlib widget\n",
+    "#%matplotlib widget\n",
     "\n",
     "PEAK1PH_TO_RMS3PH=np.sqrt(3./2.)\n",
     "\n",

--- a/Examples/Notebooks/Components/Syngen_9Order_DCIM_VBR_Governor_Exciter.ipynb
+++ b/Examples/Notebooks/Components/Syngen_9Order_DCIM_VBR_Governor_Exciter.ipynb
@@ -1,0 +1,474 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# EMT Syngen LoadStep - 9th Order DCIM versus VBR - Controller Tests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from villas.dataprocessing.readtools import *\n",
+    "from villas.dataprocessing.timeseries import *\n",
+    "import matplotlib.pyplot as plt\n",
+    "import re\n",
+    "import numpy as np\n",
+    "import math\n",
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "%matplotlib widget\n",
+    "\n",
+    "PEAK1PH_TO_RMS3PH=np.sqrt(3./2.)\n",
+    "\n",
+    "root_path = subprocess.Popen(['git', 'rev-parse', '--show-toplevel'], stdout=subprocess.PIPE).communicate()[0].rstrip().decode('utf-8')\n",
+    "\n",
+    "path_exec = root_path + '/build/Examples/Cxx/'\n",
+    "\n",
+    "finalTime = 30.0\n",
+    "\n",
+    "timeStepDCIM = 100e-6\n",
+    "timeStepVBR = 500e-6\n",
+    "\n",
+    "loadStepEventTime = 5.0\n",
+    "loadFactor = 1.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run simulation and read results of DCIM without controllers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name_exec = 'EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter'\n",
+    "\n",
+    "model_name = name_exec\n",
+    "\n",
+    "sim = subprocess.Popen([path_exec+name_exec, '--name', model_name, '--timestep', str(timeStepDCIM), '--duration', str(finalTime), '--option', 'TIMESTEPEVENT='+str(loadStepEventTime), '--option', 'LOADFACTOR='+str(loadFactor)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)\n",
+    "print(sim.communicate()[0].decode())\n",
+    "\n",
+    "path = 'logs/' + model_name + '/'\n",
+    "dpsim_result_file = path  + model_name + '.csv'\n",
+    "ts_dpsim_emt_dcim = read_timeseries_csv(dpsim_result_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run simulation and read results of VBR without controllers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name_exec = 'EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter'\n",
+    "\n",
+    "model_name = name_exec\n",
+    "\n",
+    "sim = subprocess.Popen([path_exec+name_exec, '--name', model_name, '--timestep', str(timeStepVBR), '--duration', str(finalTime), '--option', 'TIMESTEPEVENT='+str(loadStepEventTime), '--option', 'LOADFACTOR='+str(loadFactor)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)\n",
+    "print(sim.communicate()[0].decode())\n",
+    "\n",
+    "path = 'logs/' + model_name + '/'\n",
+    "dpsim_result_file = path  + model_name + '.csv'\n",
+    "ts_dpsim_emt_vbr = read_timeseries_csv(dpsim_result_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generator bus voltages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12,8))\n",
+    "name = 'v1_0'\n",
+    "plt.plot(ts_dpsim_emt_dcim[name].time, PEAK1PH_TO_RMS3PH*ts_dpsim_emt_dcim[name].values, label='dcim')\n",
+    "plt.plot(ts_dpsim_emt_vbr[name].time, PEAK1PH_TO_RMS3PH*ts_dpsim_emt_vbr[name].values, label='vbr', linestyle='--')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generator current"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12,8))\n",
+    "name = 'i_gen_0'\n",
+    "plt.plot(ts_dpsim_emt_dcim[name].time, ts_dpsim_emt_dcim[name].values, label='dcim')\n",
+    "plt.plot(ts_dpsim_emt_vbr[name].time, ts_dpsim_emt_vbr[name].values, label='vbr', linestyle='--')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generator omega"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12,8))\n",
+    "name = 'wr_gen'\n",
+    "plt.plot(ts_dpsim_emt_dcim[name].time, ts_dpsim_emt_dcim[name].values, label='dcim')\n",
+    "plt.plot(ts_dpsim_emt_vbr[name].time, ts_dpsim_emt_vbr[name].values, label='vbr', linestyle='--')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assertion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = 'wr_gen'\n",
+    "rmse = ts_dpsim_emt_dcim[name].rmse(ts_dpsim_emt_dcim[name], ts_dpsim_emt_vbr[name].interpolate(timeStepDCIM))\n",
+    "print(rmse)\n",
+    "assert(rmse < 4e-4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Run simulation and read results of DCIM with governor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name_exec = 'EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter'\n",
+    "\n",
+    "model_name = name_exec\n",
+    "\n",
+    "sim = subprocess.Popen([path_exec+name_exec, '--name', model_name, '--timestep', str(timeStepDCIM), '--duration', str(finalTime), '--option', 'WITHGOVERNOR=true', '--option', 'TIMESTEPEVENT='+str(loadStepEventTime), '--option', 'LOADFACTOR='+str(loadFactor)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)\n",
+    "print(sim.communicate()[0].decode())\n",
+    "\n",
+    "path = 'logs/' + model_name + '/'\n",
+    "dpsim_result_file = path  + model_name + '.csv'\n",
+    "ts_dpsim_emt_dcim = read_timeseries_csv(dpsim_result_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run simulation and read results of VBR with governor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name_exec = 'EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter'\n",
+    "\n",
+    "model_name = name_exec\n",
+    "\n",
+    "sim = subprocess.Popen([path_exec+name_exec, '--name', model_name, '--timestep', str(timeStepVBR), '--duration', str(finalTime), '--option', 'WITHGOVERNOR=true', '--option', 'TIMESTEPEVENT='+str(loadStepEventTime), '--option', 'LOADFACTOR='+str(loadFactor)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)\n",
+    "print(sim.communicate()[0].decode())\n",
+    "\n",
+    "path = 'logs/' + model_name + '/'\n",
+    "dpsim_result_file = path  + model_name + '.csv'\n",
+    "ts_dpsim_emt_vbr = read_timeseries_csv(dpsim_result_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generator bus voltages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12,8))\n",
+    "name = 'v1_0'\n",
+    "plt.plot(ts_dpsim_emt_dcim[name].time, PEAK1PH_TO_RMS3PH*ts_dpsim_emt_dcim[name].values, label='dcim - with governor')\n",
+    "plt.plot(ts_dpsim_emt_vbr[name].time, PEAK1PH_TO_RMS3PH*ts_dpsim_emt_vbr[name].values, label='vbr - with governor', linestyle='--')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generator current"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12,8))\n",
+    "name = 'i_gen_0'\n",
+    "plt.plot(ts_dpsim_emt_dcim[name].time, ts_dpsim_emt_dcim[name].values, label='dcim - with governor')\n",
+    "plt.plot(ts_dpsim_emt_vbr[name].time, ts_dpsim_emt_vbr[name].values, label='vbr - with governor', linestyle='--')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generator omega"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12,8))\n",
+    "name = 'wr_gen'\n",
+    "plt.plot(ts_dpsim_emt_dcim[name].time, ts_dpsim_emt_dcim[name].values, label='dcim - with governor')\n",
+    "plt.plot(ts_dpsim_emt_vbr[name].time, ts_dpsim_emt_vbr[name].values, label='vbr - with governor', linestyle='--')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assertion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = 'wr_gen'\n",
+    "rmse = ts_dpsim_emt_dcim[name].rmse(ts_dpsim_emt_dcim[name], ts_dpsim_emt_vbr[name].interpolate(timeStepDCIM))\n",
+    "print(rmse)\n",
+    "assert(rmse < 2.1e-5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Run simulation and read results of DCIM with governor and exciter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name_exec = 'EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter'\n",
+    "\n",
+    "model_name = name_exec\n",
+    "\n",
+    "sim = subprocess.Popen([path_exec+name_exec, '--name', model_name, '--timestep', str(timeStepDCIM), '--duration', str(finalTime), '--option', 'WITHGOVERNOR=true', '--option', 'WITHEXCITER=true', '--option', 'TIMESTEPEVENT='+str(loadStepEventTime), '--option', 'LOADFACTOR='+str(loadFactor)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)\n",
+    "print(sim.communicate()[0].decode())\n",
+    "\n",
+    "path = 'logs/' + model_name + '/'\n",
+    "dpsim_result_file = path  + model_name + '.csv'\n",
+    "ts_dpsim_emt_dcim = read_timeseries_csv(dpsim_result_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run simulation and read results of VBR with governor and exciter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name_exec = 'EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter'\n",
+    "\n",
+    "model_name = name_exec\n",
+    "\n",
+    "sim = subprocess.Popen([path_exec+name_exec, '--name', model_name, '--timestep', str(timeStepVBR), '--duration', str(finalTime), '--option', 'WITHGOVERNOR=true', '--option', 'WITHEXCITER=true', '--option', 'TIMESTEPEVENT='+str(loadStepEventTime), '--option', 'LOADFACTOR='+str(loadFactor)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)\n",
+    "print(sim.communicate()[0].decode())\n",
+    "\n",
+    "path = 'logs/' + model_name + '/'\n",
+    "dpsim_result_file = path  + model_name + '.csv'\n",
+    "ts_dpsim_emt_vbr = read_timeseries_csv(dpsim_result_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generator bus voltages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12,8))\n",
+    "name = 'v1_0'\n",
+    "plt.plot(ts_dpsim_emt_dcim[name].time, PEAK1PH_TO_RMS3PH*ts_dpsim_emt_dcim[name].values, label='dcim - with governor and exciter')\n",
+    "plt.plot(ts_dpsim_emt_vbr[name].time, PEAK1PH_TO_RMS3PH*ts_dpsim_emt_vbr[name].values, label='vbr - with governor and exciter', linestyle='--')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generator current"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12,8))\n",
+    "name = 'i_gen_0'\n",
+    "plt.plot(ts_dpsim_emt_dcim[name].time, ts_dpsim_emt_dcim[name].values, label='dcim - with governor and exciter')\n",
+    "plt.plot(ts_dpsim_emt_vbr[name].time, ts_dpsim_emt_vbr[name].values, label='vbr - with governor and exciter', linestyle='--')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generator omega"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12,8))\n",
+    "name = 'wr_gen'\n",
+    "plt.plot(ts_dpsim_emt_dcim[name].time, ts_dpsim_emt_dcim[name].values, label='dcim - with governor and exciter')\n",
+    "plt.plot(ts_dpsim_emt_vbr[name].time, ts_dpsim_emt_vbr[name].values, label='vbr - with governor and exciter', linestyle='--')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assertion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = 'wr_gen'\n",
+    "rmse = ts_dpsim_emt_dcim[name].rmse(ts_dpsim_emt_dcim[name], ts_dpsim_emt_vbr[name].interpolate(timeStepDCIM))\n",
+    "print(rmse)\n",
+    "assert(rmse < 7e-6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  },
+  "tests": {
+   "skip": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/models/Include/cps/Base/Base_SynchronGenerator.h
+++ b/models/Include/cps/Base/Base_SynchronGenerator.h
@@ -255,10 +255,6 @@ namespace Base {
 		Bool mHasTurbineGovernor = false;
 		/// Determines if Exciter is activated
 		Bool mHasExciter = false;
-		/// Signal component modelling governor control and steam turbine
-		std::shared_ptr<Signal::TurbineGovernor> mTurbineGovernor;
-		/// Signal component modelling voltage regulator and exciter
-		std::shared_ptr<Signal::Exciter> mExciter;
 
 		// Deprecated
 		Real mInitTerminalVoltage = 0;
@@ -328,6 +324,11 @@ namespace Base {
 
 		/// Switch to determine the integration method for the machine model.
 		void setNumericalMethod(NumericalMethod method) { mNumericalMethod = method; }
+
+		/// Signal component modelling governor control and steam turbine
+		std::shared_ptr<Signal::TurbineGovernor> mTurbineGovernor;
+		/// Signal component modelling voltage regulator and exciter
+		std::shared_ptr<Signal::Exciter> mExciter;
 	};
 }
 }

--- a/models/Include/cps/Base/Base_SynchronGenerator.h
+++ b/models/Include/cps/Base/Base_SynchronGenerator.h
@@ -30,6 +30,10 @@ namespace Base {
 		enum class StateType { perUnit, statorReferred, rotorReferred };
 		/// \brief Machine parameters type.
 		enum class ParameterType { perUnit, statorReferred, operational };
+		
+		/// Add governor and turbine
+		void addGovernor(Real Ta, Real Tb, Real Tc, Real Fa,
+			Real Fb, Real Fc, Real K, Real Tsr, Real Tsm, Real Tm_init, Real PmRef);
 	protected:
 		///
 		NumericalMethod mNumericalMethod; //not needed if sundials used; could instead determine implicit / explicit solve
@@ -247,6 +251,8 @@ namespace Base {
 		Bool mHasExciter = false;
 		/// Determines if Turbine and Governor are activated
 		Bool mHasTurbineGovernor = false;
+		/// Signal component modelling governor control and steam turbine
+		std::shared_ptr<Signal::TurbineGovernor> mTurbineGovernor;
 		// Deprecated
 		Real mInitTerminalVoltage = 0;
 		Real mInitVoltAngle = 0;
@@ -262,9 +268,6 @@ namespace Base {
 		///
 		void addExciter(Real Ta, Real Ka, Real Te, Real Ke,
 			Real Tf, Real Kf, Real Tr, Real Lad, Real Rfd);
-		///
-		void addGovernor(Real Ta, Real Tb, Real Tc, Real Fa,
-			Real Fb, Real Fc, Real K, Real Tsr, Real Tsm, Real Tm_init, Real PmRef);
 
 		///
 		void calcStateSpaceMatrixDQ();

--- a/models/Include/cps/Base/Base_SynchronGenerator.h
+++ b/models/Include/cps/Base/Base_SynchronGenerator.h
@@ -34,6 +34,10 @@ namespace Base {
 		/// Add governor and turbine
 		void addGovernor(Real Ta, Real Tb, Real Tc, Real Fa,
 			Real Fb, Real Fc, Real K, Real Tsr, Real Tsm, Real Tm_init, Real PmRef);
+		/// Add voltage regulator and exciter
+		void addExciter(Real Ta, Real Ka, Real Te, Real Ke,
+			Real Tf, Real Kf, Real Tr);
+
 	protected:
 		///
 		NumericalMethod mNumericalMethod; //not needed if sundials used; could instead determine implicit / explicit solve
@@ -246,13 +250,16 @@ namespace Base {
 		/// Function parameters have to be given in real units.
 		void initPerUnitStates();
 
-		// #### Controllers - to be removed ####
-		/// Determines if Exciter is activated
-		Bool mHasExciter = false;
+		// #### Controllers ####
 		/// Determines if Turbine and Governor are activated
 		Bool mHasTurbineGovernor = false;
+		/// Determines if Exciter is activated
+		Bool mHasExciter = false;
 		/// Signal component modelling governor control and steam turbine
 		std::shared_ptr<Signal::TurbineGovernor> mTurbineGovernor;
+		/// Signal component modelling voltage regulator and exciter
+		std::shared_ptr<Signal::Exciter> mExciter;
+
 		// Deprecated
 		Real mInitTerminalVoltage = 0;
 		Real mInitVoltAngle = 0;
@@ -263,11 +270,6 @@ namespace Base {
 		void setBaseParameters(Real nomPower, Real nomVolt, Real nomFreq);
 		///
 		void setBaseParameters(Real nomPower, Real nomVolt, Real nomFreq, Real nomFieldCur);
-
-		// ### Deprecated ####
-		///
-		void addExciter(Real Ta, Real Ka, Real Te, Real Ke,
-			Real Tf, Real Kf, Real Tr, Real Lad, Real Rfd);
 
 		///
 		void calcStateSpaceMatrixDQ();

--- a/models/Include/cps/EMT/EMT_Ph3_SynchronGeneratorVBR.h
+++ b/models/Include/cps/EMT/EMT_Ph3_SynchronGeneratorVBR.h
@@ -33,16 +33,6 @@ namespace Ph3 {
 		public Base::SynchronGenerator,
 		public SharedFactory<SynchronGeneratorVBR> {
 	protected:
-		/// Exciter Model
-		//Signal::Exciter mExciter;
-		/// Determine if Exciter is activated
-		bool WithExciter = false;
-
-		/// Governor Model
-		//Signal::TurbineGovernor mTurbineGovernor;
-		/// Determine if Turbine and Governor are activated
-		bool WithTurbineGovernor = false;
-
 		/// d dynamic inductance
 		Real mDLmd;
 		/// q dynamic inductance
@@ -222,9 +212,6 @@ namespace Ph3 {
 
 		/// Initialize states according to desired initial electrical powerflow and mechanical input power
 		void setInitialValues(Real initActivePower, Real initReactivePower, Real initTerminalVolt, Real initVoltAngle, Real initMechPower);
-
-		/// Function to initialize Exciter
-		void addExciter(Real Ta, Real Ka, Real Te, Real Ke, Real Tf, Real Kf, Real Tr, Real Lad, Real Rfd);
 
 		/// Initialize components with correct network frequencies
 		void initialize(Matrix frequencies) override {

--- a/models/Include/cps/EMT/EMT_Ph3_SynchronGeneratorVBR.h
+++ b/models/Include/cps/EMT/EMT_Ph3_SynchronGeneratorVBR.h
@@ -225,8 +225,6 @@ namespace Ph3 {
 
 		/// Function to initialize Exciter
 		void addExciter(Real Ta, Real Ka, Real Te, Real Ke, Real Tf, Real Kf, Real Tr, Real Lad, Real Rfd);
-		/// Function to initialize Governor and Turbine
-		void addGovernor(Real Ta, Real Tb, Real Tc, Real Fa, Real Fb, Real Fc, Real K, Real Tsr, Real Tsm, Real Tm_init, Real PmRef);
 
 		/// Initialize components with correct network frequencies
 		void initialize(Matrix frequencies) override {

--- a/models/Include/cps/Signal/Exciter.h
+++ b/models/Include/cps/Signal/Exciter.h
@@ -53,7 +53,7 @@ namespace Signal {
 		Exciter(String name) : SimSignalComp(name, name) { }
 
 		/// Constructor with log level
-		Exciter(String name, CPS::Logger::Level logLevel) : SimSignalComp(name, name, logLevel) { }
+		Exciter(String name, CPS::Logger::Level logLevel);
 
 		/// Initializes exciter parameters
 		void setParameters(Real Ta, Real Ka, Real Te, Real Ke, Real Tf, Real Kf, Real Tr);

--- a/models/Include/cps/Signal/Exciter.h
+++ b/models/Include/cps/Signal/Exciter.h
@@ -8,13 +8,15 @@
 
 #pragma once
 
-#include <cps/IdentifiedObject.h>
+#include <cps/SimSignalComp.h>
 #include <cps/Logger.h>
 
 namespace CPS {
 namespace Signal {
 	/// Exciter model
-	class Exciter : public IdentifiedObject {
+	class Exciter :
+		public SimSignalComp,
+		public SharedFactory<Exciter> {
 	protected:
 		Real mTa;
 		Real mKa;
@@ -48,10 +50,13 @@ namespace Signal {
 
 	public:
 		///
-		Exciter(String name) : IdentifiedObject(name) { }
+		Exciter(String name) : SimSignalComp(name, name) { }
+
+		/// Constructor with log level
+		Exciter(String name, CPS::Logger::Level logLevel) : SimSignalComp(name, name, logLevel) { }
 
 		/// Initializes exciter parameters
-		void setParameters(Real Ta, Real Ka, Real Te, Real Ke, Real Tf, Real Kf, Real Tr, Real Lad, Real Rfd);
+		void setParameters(Real Ta, Real Ka, Real Te, Real Ke, Real Tf, Real Kf, Real Tr);
 		/// Initializes exciter variables
 		void initialize(Real Vh_init, Real Vf_init);
 		/// Performs an step to update field voltage value

--- a/models/Include/cps/Signal/TurbineGovernor.h
+++ b/models/Include/cps/Signal/TurbineGovernor.h
@@ -8,14 +8,16 @@
 
 #pragma once
 
-#include <cps/IdentifiedObject.h>
+#include <cps/SimSignalComp.h>
 #include <cps/Logger.h>
 
 namespace CPS {
 namespace Signal {
 
 	/// Turbine governor model to be used with synchronous generator
-	class TurbineGovernor : public IdentifiedObject {
+	class TurbineGovernor :
+		public SimSignalComp,
+		public SharedFactory<TurbineGovernor> {
 	protected:
 		// ### Steam Turbine Parameters ####
 		/// Time constant of main inlet volume and steam chest
@@ -71,8 +73,11 @@ namespace Signal {
 		Real T2;
 
 	public:
-		///
-		TurbineGovernor(String name) : IdentifiedObject(name) { }
+		/// 
+		TurbineGovernor(String name) : SimSignalComp(name, name) { }
+
+		/// Constructor with log level
+		TurbineGovernor(String name, CPS::Logger::Level logLevel) : SimSignalComp(name, name, logLevel) { }
 
 		/// Initializes exciter parameters
 		void setParameters(Real Ta, Real Tb, Real Tc, Real Fa, Real Fb, Real Fc, Real K, Real Tsr, Real Tsm);

--- a/models/Source/Base/Base_SynchronGenerator.cpp
+++ b/models/Source/Base/Base_SynchronGenerator.cpp
@@ -381,9 +381,10 @@ Real Base::SynchronGenerator::calcHfromJ(Real J, Real omegaNominal, Int polePair
 }
 
 void Base::SynchronGenerator::addExciter(Real Ta, Real Ka, Real Te, Real Ke,
-	Real Tf, Real Kf, Real Tr, Real Lad, Real Rfd) {
-	//mExciter = Signal::Exciter(Ta, Ka, Te, Ke, Tf, Kf, Tr, Lad, Rfd);
-	//mExciter.initialize(1, 1);
+	Real Tf, Real Kf, Real Tr) {
+	mExciter = Signal::Exciter::make("Exciter", CPS::Logger::Level::info);
+	mExciter->setParameters(Ta, Ka, Te, Ke, Tf, Kf, Tr);
+	mExciter->initialize(1, 1);
 	mHasExciter = true;
 }
 

--- a/models/Source/Base/Base_SynchronGenerator.cpp
+++ b/models/Source/Base/Base_SynchronGenerator.cpp
@@ -302,6 +302,13 @@ void Base::SynchronGenerator::initPerUnitStates() {
 	}
 
 	mElecTorque = (mPsisr(3,0)*mIsr(0,0) - mPsisr(0,0)*mIsr(3,0));
+
+	// Initialize controllers
+	if (mHasExciter){
+		// Note: field voltage scaled by Lmd/Rfd to transform from synchronous generator pu system
+		// to the exciter pu system
+		mExciter->initialize(init_vt_abs, (mLmd / mRfd)*init_vfd);
+	}
 }
 
 void Base::SynchronGenerator::calcStateSpaceMatrixDQ() {
@@ -384,7 +391,6 @@ void Base::SynchronGenerator::addExciter(Real Ta, Real Ka, Real Te, Real Ke,
 	Real Tf, Real Kf, Real Tr) {
 	mExciter = Signal::Exciter::make("Exciter", CPS::Logger::Level::info);
 	mExciter->setParameters(Ta, Ka, Te, Ke, Tf, Kf, Tr);
-	mExciter->initialize(1, 1);
 	mHasExciter = true;
 }
 

--- a/models/Source/Base/Base_SynchronGenerator.cpp
+++ b/models/Source/Base/Base_SynchronGenerator.cpp
@@ -389,7 +389,8 @@ void Base::SynchronGenerator::addExciter(Real Ta, Real Ka, Real Te, Real Ke,
 
 void Base::SynchronGenerator::addGovernor(Real Ta, Real Tb, Real Tc, Real Fa,
 	Real Fb, Real Fc, Real K, Real Tsr, Real Tsm, Real Tm_init, Real PmRef) {
-	//mTurbineGovernor = Signal::TurbineGovernor(Ta, Tb, Tc, Fa, Fb, Fc, K, Tsr, Tsm);
-	//mTurbineGovernor.initialize(PmRef, Tm_init);
+	mTurbineGovernor = Signal::TurbineGovernor::make("TurbineGovernor", CPS::Logger::Level::info);
+	mTurbineGovernor->setParameters(Ta, Tb, Tc, Fa, Fb, Fc, K, Tsr, Tsm);
+	mTurbineGovernor->initialize(PmRef, Tm_init);
 	mHasTurbineGovernor = true;
 }

--- a/models/Source/EMT/EMT_Ph3_SynchronGeneratorDQTrapez.cpp
+++ b/models/Source/EMT/EMT_Ph3_SynchronGeneratorDQTrapez.cpp
@@ -58,9 +58,8 @@ void EMT::Ph3::SynchronGeneratorDQTrapez::stepInPerUnit(Real time) {
 	}
 
 	// Update of mechanical torque from turbine governor
-	if (mHasTurbineGovernor == true) {
-		//mMechTorque = mTurbineGovernor.step(mOmMech, 1, 300e6 / 555e6, mTimeStep);
-	}
+	if (mHasTurbineGovernor)
+		mMechTorque = mTurbineGovernor->step(mOmMech, 1,  mInitElecPower.real() / mNomPower, mTimeStep);
 
 	// Calculation of electrical torque
 	mElecTorque = (mPsisr(3,0)*mIsr(0,0) - mPsisr(0,0)*mIsr(3,0));

--- a/models/Source/EMT/EMT_Ph3_SynchronGeneratorDQTrapez.cpp
+++ b/models/Source/EMT/EMT_Ph3_SynchronGeneratorDQTrapez.cpp
@@ -54,7 +54,10 @@ void EMT::Ph3::SynchronGeneratorDQTrapez::stepInPerUnit(Real time) {
 
 	// Update of fd winding voltage from exciter
 	if (mHasExciter) {
-		//mVsr(1,0) = mExciter.step(mVsr(0,0), mVsr(3,0), 1, mTimeStep);
+		// Get exciter output voltage
+		// Note: scaled by Rfd/Lmd to transform from exciter pu system
+		// to the synchronous generator pu system
+		mVsr(1,0) = (mRfd / mLmd)*mExciter->step(mVsr(0,0), mVsr(3,0), 1.0, mTimeStep);
 	}
 
 	// Update of mechanical torque from turbine governor

--- a/models/Source/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
+++ b/models/Source/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
@@ -131,12 +131,6 @@ void EMT::Ph3::SynchronGeneratorVBR::initializeFromNodesAndTerminals(Real freque
 	}
 }
 
-void EMT::Ph3::SynchronGeneratorVBR::addExciter(Real Ta, Real Ka, Real Te, Real Ke, Real Tf, Real Kf, Real Tr, Real Lad, Real Rfd) {
-	// mExciter = Exciter(Ta, Ka, Te, Ke, Tf, Kf, Tr, Lad, Rfd);
-	// mExciter.initialize(1, 1);
-	WithExciter = true;
-}
-
 void EMT::Ph3::SynchronGeneratorVBR::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
@@ -360,10 +354,8 @@ void EMT::Ph3::SynchronGeneratorVBR::mnaPostStep(Real time, Int timeStepCount, A
 	mVd = parkTransform(mThetaMech, mVa, mVb, mVc)(1);
 	mV0 = parkTransform(mThetaMech, mVa, mVb, mVc)(2);
 
-	/*
-	if (WithExciter == true) {
-		mVfd = mExciter.step(mVd, mVq, 1, mTimeStep);
-	}*/
+	if (mHasExciter)
+		mVfd = (mRfd / mLmd)*mExciter->step(mVd, mVq, 1.0, mTimeStep);
 
 	mIabc = R_eq_vbr.inverse()*(mVabc - E_eq_vbr);
 

--- a/models/Source/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
+++ b/models/Source/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
@@ -354,8 +354,12 @@ void EMT::Ph3::SynchronGeneratorVBR::mnaPostStep(Real time, Int timeStepCount, A
 	mVd = parkTransform(mThetaMech, mVa, mVb, mVc)(1);
 	mV0 = parkTransform(mThetaMech, mVa, mVb, mVc)(2);
 
-	if (mHasExciter)
+	if (mHasExciter){
+		// Get exciter output voltage
+		// Note: scaled by Rfd/Lmd to transform from exciter pu system
+		// to the synchronous generator pu system
 		mVfd = (mRfd / mLmd)*mExciter->step(mVd, mVq, 1.0, mTimeStep);
+	}
 
 	mIabc = R_eq_vbr.inverse()*(mVabc - E_eq_vbr);
 

--- a/models/Source/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
+++ b/models/Source/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
@@ -137,12 +137,6 @@ void EMT::Ph3::SynchronGeneratorVBR::addExciter(Real Ta, Real Ka, Real Te, Real 
 	WithExciter = true;
 }
 
-void EMT::Ph3::SynchronGeneratorVBR::addGovernor(Real Ta, Real Tb, Real Tc, Real Fa, Real Fb, Real Fc, Real K, Real Tsr, Real Tsm, Real Tm_init, Real PmRef) {
-	// mTurbineGovernor = TurbineGovernor(Ta, Tb, Tc, Fa, Fb, Fc, K, Tsr, Tsm);
-	// mTurbineGovernor.initialize(PmRef, Tm_init);
-	WithTurbineGovernor = true;
-}
-
 void EMT::Ph3::SynchronGeneratorVBR::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
@@ -305,10 +299,9 @@ void EMT::Ph3::SynchronGeneratorVBR::mnaApplyRightSideVectorStamp(Matrix& rightV
 
 void EMT::Ph3::SynchronGeneratorVBR::stepInPerUnit() {	
 
-	// TODO: fix hard-coded numerical values, for this reason commented out
-	/* if (WithTurbineGovernor == true) {
-		mMechTorque = -mTurbineGovernor.step(mOmMech, 1, 300e6 / 555e6, mTimeStep);
-	}*/
+	// Update of mechanical torque from turbine governor
+	if (mHasTurbineGovernor)
+		mMechTorque = -mTurbineGovernor->step(mOmMech, 1,  mInitElecPower.real() / mNomPower, mTimeStep);
 
 	// Estimate mechanical variables with euler
 	mElecTorque = (mPsimd*mIq - mPsimq*mId);

--- a/models/Source/Signal/Exciter.cpp
+++ b/models/Source/Signal/Exciter.cpp
@@ -12,7 +12,7 @@
 using namespace CPS;
 
 void Signal::Exciter::setParameters(Real Ta, Real Ka, Real Te, Real Ke,
-	Real Tf, Real Kf, Real Tr, Real Lad, Real Rfd) {
+	Real Tf, Real Kf, Real Tr) {
 	mTa = Ta;
 	mKa = Ka;
 	mTe = Te;
@@ -20,8 +20,16 @@ void Signal::Exciter::setParameters(Real Ta, Real Ka, Real Te, Real Ke,
 	mTf = Tf;
 	mKf = Kf;
 	mTr = Tr;
-	mLad = Lad;
-	mRfd = Rfd;
+
+	mSLog->info("Exciter parameters: \n"
+				"Ta: {:e}\nKa: {:e}\n"
+				"Te: {:e}\nKe: {:e}\n"
+				"Tf: {:e}\nKf: {:e}\n"
+				"Tr: {:e}\n",
+				mTa, mKa, 
+				mTe, mKe,
+				mTf, mKf,
+				mTr);
 }
 
 void Signal::Exciter::initialize(Real Vh_init, Real Vf_init) {
@@ -56,5 +64,5 @@ Real Signal::Exciter::step(Real mVd, Real mVq, Real Vref, Real dt) {
 	mVse = mVse*mVf;
 	mVf = Math::StateSpaceEuler(mVf, -mKe, 1, dt / mTe, mVr - mVse);
 
-	return (mRfd / mLad)*mVf;
+	return mVf;
 }

--- a/models/Source/Signal/Exciter.cpp
+++ b/models/Source/Signal/Exciter.cpp
@@ -11,6 +11,13 @@
 
 using namespace CPS;
 
+Signal::Exciter::Exciter(String name, CPS::Logger::Level logLevel) 
+	: SimSignalComp(name, name, logLevel) { 
+	addAttribute<Real>("Vh", &mVh, Flags::read | Flags::write);
+	addAttribute<Real>("Vr", &mVr, Flags::read | Flags::write);
+	addAttribute<Real>("Vf", &mVf, Flags::read | Flags::write);
+}
+
 void Signal::Exciter::setParameters(Real Ta, Real Ka, Real Te, Real Ke,
 	Real Tf, Real Kf, Real Tr) {
 	mTa = Ta;
@@ -33,36 +40,65 @@ void Signal::Exciter::setParameters(Real Ta, Real Ka, Real Te, Real Ke,
 }
 
 void Signal::Exciter::initialize(Real Vh_init, Real Vf_init) {
-	mVf = 1;
+	
+	mSLog->info("Initially set excitation system initial values: \n"
+				"Vh_init: {:e}\nVf_init: {:e}\n",
+				Vh_init, Vf_init);
+
+	mVf = Vf_init;
 	mVse = mVf <= 2.3 ? 0.1 / 2.3 : 0.33 / 3.1;
 	mVse *= mVf;
 
 	mVr = mVse + mKe*mVf;
 	mVf_init = mVr/mKa;
-	mVh = 1;
+
+	mVh = Vh_init;
 	mVm = mVh;
 	mVis = 0;
+
+	mSLog->info("Actually applied excitation system initial values: \n"
+				"init_Vf: {:e}\ninit_Vse: {:e}\n"
+				"init_Vr: {:e}\ninit_Vf_init: {:e}\n"
+				"init_Vh: {:e}\ninit_Vm: {:e}\ninit_Vis: {:e}\n",
+				mVf, mVse, 
+				mVr, mVf_init,
+				mVh, mVm, mVis);
 }
 
 Real Signal::Exciter::step(Real mVd, Real mVq, Real Vref, Real dt) {
+	// Voltage magnitude calculation
 	mVh = sqrt(pow(mVd, 2.) + pow(mVq, 2.));
+	
 	// Voltage Transducer equation
-	mVm = Math::StateSpaceEuler(mVm, -1, 1, dt / mTr, mVh);
+	mVm = Math::StateSpaceEuler(mVm, -1 / mTr, 1 / mTr, dt, mVh);
+	
 	// Stabilizing feedback equation
-	mVis = Math::StateSpaceEuler(mVis, -1, mKf, dt / mTf, ((mVr - mVse) - mVf*mKe)/mTe);
-	// Amplifier equation
-	mVr = Math::StateSpaceEuler(mVr, -1, mKa, dt / mTa, Vref - mVm - mVis + mVf_init);
+	mVis = Math::StateSpaceEuler(mVis, -1 / mTf, mKf / mTe / mTf, dt, mVr - mVse - mVf*mKe);
+
+	// Voltage regulator equation
+	mVr = Math::StateSpaceEuler(mVr, -1 / mTa, mKa / mTa, dt, Vref - mVm - mVis + mVf_init);
+
+	// Voltage regulator limiter
+	// Vr,max and Vr,min parameters 
+	// from M. Eremia, "Handbook of Electrical Power System Dynamics", 2013, p.96
+	// TODO: fix hard-coded limiter values
 	if (mVr > 1)
-			mVr = 1;
+		mVr = 1;
 	else if (mVr < -0.9)
-			mVr = -0.9;
-	// Exciter
+		mVr = -0.9;
+	
+	// Exciter saturation
+	// Se(Ef1), Ef1, Se(Ef2) and Ef2
+	// from M. Eremia, "Handbook of Electrical Power System Dynamics", 2013, p.96
+	// TODO: fix hard-coded saturation values
 	if (mVf <= 2.3)
-			mVse = (0.1 / 2.3)*mVf;
+		mVse = (0.1 / 2.3)*mVf;
 	else
-			mVse = (0.33 / 3.1)*mVf;
+		mVse = (0.33 / 3.1)*mVf;
 	mVse = mVse*mVf;
-	mVf = Math::StateSpaceEuler(mVf, -mKe, 1, dt / mTe, mVr - mVse);
+
+	// Exciter equation
+	mVf = Math::StateSpaceEuler(mVf, - mKe / mTe, 1 / mTe, dt, mVr - mVse);
 
 	return mVf;
 }

--- a/models/Source/Signal/TurbineGovernor.cpp
+++ b/models/Source/Signal/TurbineGovernor.cpp
@@ -10,8 +10,9 @@
 #include <cps/MathUtils.h>
 
 using namespace CPS;
+using namespace CPS::Signal;
 
-void Signal::TurbineGovernor::setParameters(Real Ta, Real Tb, Real Tc, Real Fa,
+void TurbineGovernor::setParameters(Real Ta, Real Tb, Real Tc, Real Fa,
 	Real Fb, Real Fc, Real K, Real Tsr, Real Tsm) {
 	mTa = Ta;
 	mTb = Tb;
@@ -19,45 +20,73 @@ void Signal::TurbineGovernor::setParameters(Real Ta, Real Tb, Real Tc, Real Fa,
 	mFa = Fa;
 	mFb = Fb;
 	mFc = Fc;
+
 	mK = K;
 	mTsr = Tsr;
 	mTsm = Tsm;
+
+	mSLog->info("Turbine parameters: \n"
+				"Ta: {:e}\nTb: {:e}\nTc: {:e}\n"
+				"Fa: {:e}\nFb: {:e}\nFc: {:e}\n",
+				mTa, mTb, mTc,
+				mFa, mFb, mFc);
+
+	mSLog->info("Governor parameters: \n"
+				"K: {:e}\nTsr: {:e}\nTsm: {:e}\n",
+				mK, mTsr, mTsm);
 }
 
-void Signal::TurbineGovernor::initialize(Real PmRef, Real Tm_init) {
+void TurbineGovernor::initialize(Real PmRef, Real Tm_init) {
 	mTm = Tm_init;
+	T1 = (1 - mFa)*PmRef;
+	T2 = mFa*PmRef;
+
+	mSLog->info("Turbine initial values: \n"
+				"init_Tm: {:e}\ninit_T1: {:e}\ninit_T2: {:e}\n",
+				mTm, T1, T2);
+
 	mVcv = PmRef;
 	mpVcv = 0;
 	Psm_in = PmRef;
-	T1 = (1 - mFa)*PmRef;
-	T2 = mFa*PmRef;
+
+	mSLog->info("Governor initial values: \n"
+				"init_Vcv: {:e}\ninit_pVcv: {:e}\ninit_Psm_in: {:e}\n",
+				mVcv, mpVcv, Psm_in);
 }
 
-Real Signal::TurbineGovernor::step(Real Om, Real OmRef, Real PmRef, Real dt) {
+Real TurbineGovernor::step(Real Om, Real OmRef, Real PmRef, Real dt) {
 	// ### Governing ###
+	// Modelled according to V. Sapucaia-Gunzenhauser, "Modeling and Simulation of Rotating Machines", p.45
+	
 	// Input of speed relay
 	Psr_in = PmRef + (OmRef - Om)*mK;
+	
 	// Input of servor motor
-	Psm_in = Math::StateSpaceEuler(Psm_in, -1, 1, dt / mTsr, Psr_in);
+	Psm_in = Math::StateSpaceEuler(Psm_in, -1 / mTsr, 1 / mTsr, dt, Psr_in);
+	
 	// rate of change of valve
+	// including limiter with upper bound 0.1pu/s and lower bound -1.0pu/s
 	mpVcv = (Psm_in - mVcv) / mTsm;
 	if (mpVcv >= 0.1)
 		mpVcv = 0.1;
 	else if (mpVcv <= -1)
 		mpVcv = -1;
-	//Valve position
+	
+	// valve position
+	// including limiter with upper bound 1 and lower bound 0
 	mVcv = mVcv + dt*mpVcv;
 	if (mVcv >= 1)
 		mVcv = 1;
 	else if (mVcv <= 0)
 		mVcv = 0;
 
-	//### Turbine ###
-	// Simplified equation
+	// ### Turbine ###
+	// Simplified Single Reheat Tandem-Compound Steam Turbine
+	// Modelled according to V. Sapucaia-Gunzenhauser, "Modeling and Simulation of Rotating Machines", p.44
 
-	T1 = Math::StateSpaceEuler(T1, -1, (1 - mFa), dt / mTa, mVcv);
+	T1 = Math::StateSpaceEuler(T1, -1 / mTb, 1 / mTb, dt , mVcv);
 	T2 = mVcv*mFa;
-	mTm = T1 + T2;
+	mTm = (mFb + mFc)*T1 + T2;
 
 	return mTm;
 }


### PR DESCRIPTION
Fixes the former implementations of excitation system (IEEE DC1A) and turbine governor (mechanical-hydraulic control). So far, the two control systems are supported by the 9th order synchronous generator models (DCIM and VBR implementation). They are tested within an additional notebook.