### PR TITLE
Refactor cli options

### DIFF
--- a/Examples/Cxx/CIM/WSCC_9bus_mult_coupled.cpp
+++ b/Examples/Cxx/CIM/WSCC_9bus_mult_coupled.cpp
@@ -120,9 +120,20 @@ int main(int argc, char *argv[]) {
 	//		simulateCoupled(filenames, copies, threads);
 	//}
 
-	std::cout << "Simulate with " << Int(args.options["copies"]) << " copies, "
-		<< Int(args.options["threads"]) << " threads, sequence number "
-		<< Int(args.options["seq"]) << std::endl;
-	simulateCoupled(filenames, args, Int(args.options["copies"]),
-		Int(args.options["threads"]), Int(args.options["seq"]));
+	Int numCopies = 0;
+	Int numThreads = 0;
+	Int numSeq = 0;
+
+	if (args.options.find("copies") != args.options.end())
+		numCopies = args.getOptionInt("copies");
+	if (args.options.find("threads") != args.options.end())
+		numThreads = args.getOptionInt("threads");
+	if (args.options.find("seq") != args.options.end())
+		numSeq = args.getOptionInt("seq");
+
+	std::cout << "Simulate with " << numCopies << " copies, "
+		<< numThreads << " threads, sequence number "
+		<< numSeq << std::endl;
+	
+	simulateCoupled(filenames, args, numCopies,	numThreads, numSeq);
 }

--- a/Examples/Cxx/CIM/WSCC_9bus_mult_decoupled.cpp
+++ b/Examples/Cxx/CIM/WSCC_9bus_mult_decoupled.cpp
@@ -103,9 +103,20 @@ int main(int argc, char *argv[]) {
 	//		simulateDecoupled(filenames, copies, threads);
 	//}
 	//simulateDecoupled(filenames, 19, 8);
-	std::cout << "Simulate with " << Int(args.options["copies"]) << " copies, "
-		<< Int(args.options["threads"]) << " threads, sequence number "
-		<< Int(args.options["seq"]) << std::endl;
-	simulateDecoupled(filenames, Int(args.options["copies"]),
-		Int(args.options["threads"]), Int(args.options["seq"]));
+
+	Int numCopies = 0;
+	Int numThreads = 0;
+	Int numSeq = 0;
+
+	if (args.options.find("copies") != args.options.end())
+		numCopies = args.getOptionInt("copies");
+	if (args.options.find("threads") != args.options.end())
+		numThreads = args.getOptionInt("threads");
+	if (args.options.find("seq") != args.options.end())
+		numSeq = args.getOptionInt("seq");
+
+	std::cout << "Simulate with " << numCopies << " copies, "
+		<< numThreads << " threads, sequence number "
+		<< numSeq << std::endl;
+	simulateDecoupled(filenames, numCopies,	numThreads, numSeq);
 }

--- a/Examples/Cxx/CIM/WSCC_9bus_mult_diakoptics.cpp
+++ b/Examples/Cxx/CIM/WSCC_9bus_mult_diakoptics.cpp
@@ -121,10 +121,23 @@ int main(int argc, char *argv[]) {
 	//}
 	//simulateDiakoptics(filenames, 19, 8, 0);
 
-	std::cout << "Simulate with " << Int(args.options["copies"]) << " copies, "
-		<< Int(args.options["threads"]) << " threads, "
-		<< UInt(args.options["splits"]) << " splits, sequence number "
-		<< Int(args.options["seq"]) << std::endl;
-	simulateDiakoptics(filenames, Int(args.options["copies"]),
-		Int(args.options["threads"]), UInt(args.options["splits"]), Int(args.options["seq"]));
+	Int numCopies = 0;
+	Int numThreads = 0;
+	Int numSeq = 0;
+	Int numSplits = 0;
+
+	if (args.options.find("copies") != args.options.end())
+		numCopies = args.getOptionInt("copies");
+	if (args.options.find("threads") != args.options.end())
+		numThreads = args.getOptionInt("threads");
+	if (args.options.find("seq") != args.options.end())
+		numSeq = args.getOptionInt("seq");
+	if (args.options.find("splits") != args.options.end())
+		numSplits = args.getOptionInt("splits");
+
+	std::cout << "Simulate with " << numCopies << " copies, "
+		<< numThreads << " threads, "
+		<< numSplits << " splits, sequence number "
+		<< numSeq << std::endl;
+	simulateDiakoptics(filenames, numCopies, numThreads, numSplits, numSeq);
 }

--- a/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
@@ -30,12 +30,12 @@ int main(int argc, char* argv[]) {
 
 		if (args.name != "dpsim")
 			simName = args.name;
-		if (args.options_bool.find("control") != args.options_bool.end())
-			pvWithControl = args.options_bool["control"];
+		if (args.options.find("control") != args.options.end())
+			pvWithControl = args.getOptionBool("control");
 		if (args.options.find("scale_kp") != args.options.end())
-			cmdScaleI = args.options["scale_kp"];
+			cmdScaleI = args.getOptionReal("scale_kp");
 		if (args.options.find("scale_ki") != args.options.end())
-			cmdScaleI = args.options["scale_ki"];
+			cmdScaleI = args.getOptionReal("scale_ki");
 	}
 
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/DP_Slack_PiLine_VSI_with_PF_Init.cpp
@@ -30,12 +30,12 @@ int main(int argc, char* argv[]) {
 
 		if (args.name != "dpsim")
 			simName = args.name;
-		if (args.options_bool.find("control") != args.options_bool.end())
-			pvWithControl = args.options_bool["control"];
+		if (args.options.find("control") != args.options.end())
+			pvWithControl = args.getOptionBool("control");
 		if (args.options.find("scale_kp") != args.options.end())
-			cmdScaleI = args.options["scale_kp"];
+			cmdScaleI = args.getOptionReal("scale_kp");
 		if (args.options.find("scale_ki") != args.options.end())
-			cmdScaleI = args.options["scale_ki"];
+			cmdScaleI = args.getOptionReal("scale_ki");
 	}
 
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
@@ -247,17 +247,17 @@ int main(int argc, char* argv[]) {
 		if (args.name != "dpsim")
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA_G1") != args.options.end())
-			cmdInertia_G1 = args.options["SCALEINERTIA_G1"];
+			cmdInertia_G1 = args.getOptionReal("SCALEINERTIA_G1");
 		if (args.options.find("SCALEINERTIA_G2") != args.options.end())
-			cmdInertia_G2 = args.options["SCALEINERTIA_G2"];
+			cmdInertia_G2 = args.getOptionReal("SCALEINERTIA_G2");
 		if (args.options.find("SCALEDAMPING_G1") != args.options.end())
-			cmdDamping_G1 = args.options["SCALEDAMPING_G1"];
+			cmdDamping_G1 = args.getOptionReal("SCALEDAMPING_G1");
 		if (args.options.find("SCALEDAMPING_G2") != args.options.end())
-			cmdDamping_G2 = args.options["SCALEDAMPING_G2"];
+			cmdDamping_G2 = args.getOptionReal("SCALEDAMPING_G2");
 		if (args.options.find("STARTTIMEFAULT") != args.options.end())
-			startTimeFault = args.options["STARTTIMEFAULT"];
+			startTimeFault = args.getOptionReal("STARTTIMEFAULT");
 		if (args.options.find("ENDTIMEFAULT") != args.options.end())
-			endTimeFault = args.options["ENDTIMEFAULT"];
+			endTimeFault = args.getOptionReal("ENDTIMEFAULT");
 	}
 
 	DP_SynGenTrStab_3Bus_Fault(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia_G1, cmdInertia_G2, cmdDamping_G1, cmdDamping_G2);

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_3Bus_SteadyState.cpp
@@ -198,13 +198,13 @@ int main(int argc, char* argv[]) {
 		if (args.name != "dpsim")
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA_G1") != args.options.end())
-			cmdInertia_G1 = args.options["SCALEINERTIA_G1"];
+			cmdInertia_G1 = args.getOptionReal("SCALEINERTIA_G1");
 		if (args.options.find("SCALEINERTIA_G2") != args.options.end())
-			cmdInertia_G2 = args.options["SCALEINERTIA_G2"];
+			cmdInertia_G2 = args.getOptionReal("SCALEINERTIA_G2");
 		if (args.options.find("SCALEDAMPING_G1") != args.options.end())
-			cmdDamping_G1 = args.options["SCALEDAMPING_G1"];
+			cmdDamping_G1 = args.getOptionReal("SCALEDAMPING_G1");
 		if (args.options.find("SCALEDAMPING_G2") != args.options.end())
-			cmdDamping_G2 = args.options["SCALEDAMPING_G2"];
+			cmdDamping_G2 = args.getOptionReal("SCALEDAMPING_G2");
 	}
 
 	DP_SynGenTrStab_3Bus_SteadyState(simName, timeStep, finalTime, cmdInertia_G1, cmdInertia_G2, cmdDamping_G1, cmdDamping_G2);

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
@@ -195,13 +195,13 @@ int main(int argc, char* argv[]) {
 		if (args.name != "dpsim")
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA") != args.options.end())
-			cmdInertia = args.options["SCALEINERTIA"];
+			cmdInertia = args.getOptionReal("SCALEINERTIA");
 		if (args.options.find("SCALEDAMPING") != args.options.end())
-			cmdDamping = args.options["SCALEDAMPING"];
+			cmdDamping = args.getOptionReal("SCALEDAMPING");
 		if (args.options.find("STARTTIMEFAULT") != args.options.end())
-			startTimeFault = args.options["STARTTIMEFAULT"];
+			startTimeFault = args.getOptionReal("STARTTIMEFAULT");
 		if (args.options.find("ENDTIMEFAULT") != args.options.end())
-			endTimeFault = args.options["ENDTIMEFAULT"];
+			endTimeFault = args.getOptionReal("ENDTIMEFAULT");
 	}
 
 	DP_1ph_SynGenTrStab_Fault(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia, cmdDamping);

--- a/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/DP_SynGenTrStab_SMIB_SteadyState.cpp
@@ -152,9 +152,9 @@ int main(int argc, char* argv[]) {
 		if (args.name != "dpsim")
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA") != args.options.end())
-			cmdInertia = args.options["SCALEINERTIA"];
+			cmdInertia = args.getOptionReal("SCALEINERTIA");
 		if (args.options.find("SCALEDAMPING") != args.options.end())
-			cmdDamping = args.options["SCALEDAMPING"];
+			cmdDamping = args.getOptionReal("SCALEDAMPING");
 	}
 
 	DP_1ph_SynGenTrStab_SteadyState(simName, timeStep, finalTime, cmdInertia, cmdDamping);

--- a/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
@@ -30,12 +30,12 @@ int main(int argc, char* argv[]) {
 
 		if (args.name != "dpsim")
 			simName = args.name;
-		if (args.options_bool.find("control") != args.options_bool.end())
-			pvWithControl = args.options_bool["control"];
+		if (args.options.find("control") != args.options.end())
+			pvWithControl = args.getOptionBool("control");
 		if (args.options.find("scale_kp") != args.options.end())
-			cmdScaleI = args.options["scale_kp"];
+			cmdScaleI = args.getOptionReal("scale_kp");
 		if (args.options.find("scale_ki") != args.options.end())
-			cmdScaleI = args.options["scale_ki"];
+			cmdScaleI = args.getOptionReal("scale_ki");
 	}
 
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/EMT_Slack_PiLine_VSI_with_PF_Init.cpp
@@ -30,12 +30,12 @@ int main(int argc, char* argv[]) {
 
 		if (args.name != "dpsim")
 			simName = args.name;
-		if (args.options_bool.find("control") != args.options_bool.end())
-			pvWithControl = args.options_bool["control"];
+		if (args.options.find("control") != args.options.end())
+			pvWithControl = args.getOptionBool("control");
 		if (args.options.find("scale_kp") != args.options.end())
-			cmdScaleI = args.options["scale_kp"];
+			cmdScaleI = args.getOptionReal("scale_kp");
 		if (args.options.find("scale_ki") != args.options.end())
-			cmdScaleI = args.options["scale_ki"];
+			cmdScaleI = args.getOptionReal("scale_ki");
 	}
 
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/EMT_SynGenDQ7odTrapez_OperationalParams_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/EMT_SynGenDQ7odTrapez_OperationalParams_SMIB_Fault.cpp
@@ -72,31 +72,31 @@ int main(int argc, char* argv[]) {
 
 		// Machine parameters
 		if (args.options.find("H") != args.options.end())
-			H = args.options["H"];
+			H = args.getOptionReal("H");
 		if (args.options.find("Rs") != args.options.end())
-			Rs = args.options["Rs"];
+			Rs = args.getOptionReal("Rs");
 		if (args.options.find("Ld") != args.options.end())
-			Ld = args.options["Ld"];
+			Ld = args.getOptionReal("Ld");
 		if (args.options.find("Lq") != args.options.end())
-			Lq = args.options["Lq"];
+			Lq = args.getOptionReal("Lq");
 		if (args.options.find("Ld_t") != args.options.end())
-			Ld_t = args.options["Ld_t"];
+			Ld_t = args.getOptionReal("Ld_t");
 		if (args.options.find("Lq_t") != args.options.end())
-			Lq_t = args.options["Lq_t"];
+			Lq_t = args.getOptionReal("Lq_t");
 		if (args.options.find("Ld_s") != args.options.end())
-			Ld_s = args.options["Ld_s"];
+			Ld_s = args.getOptionReal("Ld_s");
 		if (args.options.find("Lq_s") != args.options.end())
-			Lq_s = args.options["Lq_s"];
+			Lq_s = args.getOptionReal("Lq_s");
 		if (args.options.find("Ll") != args.options.end())
-			Ll = args.options["Ll"];
+			Ll = args.getOptionReal("Ll");
 		if (args.options.find("Td0_t") != args.options.end())
-			Td0_t = args.options["Td0_t"];
+			Td0_t = args.getOptionReal("Td0_t");
 		if (args.options.find("Tq0_t") != args.options.end())
-			Tq0_t = args.options["Tq0_t"];
+			Tq0_t = args.getOptionReal("Tq0_t");
 		if (args.options.find("Td0_s") != args.options.end())
-			Td0_s = args.options["Td0_s"];
+			Td0_s = args.getOptionReal("Td0_s");
 		if (args.options.find("Tq0_s") != args.options.end())
-			Tq0_s = args.options["Tq0_s"];
+			Tq0_s = args.getOptionReal("Tq0_s");
 	}
 
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/SP_Slack_PiLine_VSI_with_PF_Init.cpp
+++ b/Examples/Cxx/Circuits/SP_Slack_PiLine_VSI_with_PF_Init.cpp
@@ -30,12 +30,12 @@ int main(int argc, char* argv[]) {
 
 		if (args.name != "dpsim")
 			simName = args.name;
-		if (args.options_bool.find("control") != args.options_bool.end())
-			pvWithControl = args.options_bool["control"];
+		if (args.options.find("control") != args.options.end())
+			pvWithControl = args.getOptionBool("control");
 		if (args.options.find("scale_kp") != args.options.end())
-			cmdScaleI = args.options["scale_kp"];
+			cmdScaleI = args.getOptionReal("scale_kp");
 		if (args.options.find("scale_ki") != args.options.end())
-			cmdScaleI = args.options["scale_ki"];
+			cmdScaleI = args.getOptionReal("scale_ki");
 	}
 
 	// ----- POWERFLOW FOR INITIALIZATION -----

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
@@ -247,17 +247,17 @@ int main(int argc, char* argv[]) {
 		if (args.name != "dpsim")
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA_G1") != args.options.end())
-			cmdInertia_G1 = args.options["SCALEINERTIA_G1"];
+			cmdInertia_G1 = args.getOptionReal("SCALEINERTIA_G1");
 		if (args.options.find("SCALEINERTIA_G2") != args.options.end())
-			cmdInertia_G2 = args.options["SCALEINERTIA_G2"];
+			cmdInertia_G2 = args.getOptionReal("SCALEINERTIA_G2");
 		if (args.options.find("SCALEDAMPING_G1") != args.options.end())
-			cmdDamping_G1 = args.options["SCALEDAMPING_G1"];
+			cmdDamping_G1 = args.getOptionReal("SCALEDAMPING_G1");
 		if (args.options.find("SCALEDAMPING_G2") != args.options.end())
-			cmdDamping_G2 = args.options["SCALEDAMPING_G2"];
+			cmdDamping_G2 = args.getOptionReal("SCALEDAMPING_G2");
 		if (args.options.find("STARTTIMEFAULT") != args.options.end())
-			startTimeFault = args.options["STARTTIMEFAULT"];
+			startTimeFault = args.getOptionReal("STARTTIMEFAULT");
 		if (args.options.find("ENDTIMEFAULT") != args.options.end())
-			endTimeFault = args.options["ENDTIMEFAULT"];
+			endTimeFault = args.getOptionReal("ENDTIMEFAULT");
 	}
 
 	SP_SynGenTrStab_3Bus_Fault(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia_G1, cmdInertia_G2, cmdDamping_G1, cmdDamping_G2);

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
@@ -198,13 +198,13 @@ int main(int argc, char* argv[]) {
 		if (args.name != "dpsim")
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA_G1") != args.options.end())
-			cmdInertia_G1 = args.options["SCALEINERTIA_G1"];
+			cmdInertia_G1 = args.getOptionReal("SCALEINERTIA_G1");
 		if (args.options.find("SCALEINERTIA_G2") != args.options.end())
-			cmdInertia_G2 = args.options["SCALEINERTIA_G2"];
+			cmdInertia_G2 = args.getOptionReal("SCALEINERTIA_G2");
 		if (args.options.find("SCALEDAMPING_G1") != args.options.end())
-			cmdDamping_G1 = args.options["SCALEDAMPING_G1"];
+			cmdDamping_G1 = args.getOptionReal("SCALEDAMPING_G1");
 		if (args.options.find("SCALEDAMPING_G2") != args.options.end())
-			cmdDamping_G2 = args.options["SCALEDAMPING_G2"];
+			cmdDamping_G2 = args.getOptionReal("SCALEDAMPING_G2");
 	}
 
 	SP_SynGenTrStab_3Bus_SteadyState(simName, timeStep, finalTime, cmdInertia_G1, cmdInertia_G2, cmdDamping_G1, cmdDamping_G2);

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
@@ -195,13 +195,13 @@ int main(int argc, char* argv[]) {
 		if (args.name != "dpsim")
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA") != args.options.end())
-			cmdInertia = args.options["SCALEINERTIA"];
+			cmdInertia = args.getOptionReal("SCALEINERTIA");
 		if (args.options.find("SCALEDAMPING") != args.options.end())
-			cmdDamping = args.options["SCALEDAMPING"];
+			cmdDamping = args.getOptionReal("SCALEDAMPING");
 		if (args.options.find("STARTTIMEFAULT") != args.options.end())
-			startTimeFault = args.options["STARTTIMEFAULT"];
+			startTimeFault = args.getOptionReal("STARTTIMEFAULT");
 		if (args.options.find("ENDTIMEFAULT") != args.options.end())
-			endTimeFault = args.options["ENDTIMEFAULT"];
+			endTimeFault = args.getOptionReal("ENDTIMEFAULT");
 	}
 
 	SP_1ph_SynGenTrStab_Fault(simName, timeStep, finalTime, startFaultEvent, endFaultEvent, startTimeFault, endTimeFault, cmdInertia, cmdDamping);

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault_KundurExample1.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_Fault_KundurExample1.cpp
@@ -242,11 +242,11 @@ int main(int argc, char* argv[]) {
 		if (args.name != "dpsim")
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA") != args.options.end())
-			cmdInertiaFactor = args.options["SCALEINERTIA"];
+			cmdInertiaFactor = args.getOptionReal("SCALEINERTIA");
 		if (args.options.find("STARTTIMEFAULT") != args.options.end())
-			startTimeFault = args.options["STARTTIMEFAULT"];
+			startTimeFault = args.getOptionReal("STARTTIMEFAULT");
 		if (args.options.find("ENDTIMEFAULT") != args.options.end())
-			endTimeFault = args.options["ENDTIMEFAULT"];
+			endTimeFault = args.getOptionReal("ENDTIMEFAULT");
 	}
 
 	SP_1ph_SynGenTrStab_Fault(simName, timeStep, finalTime, startTimeFault, endTimeFault, cmdInertiaFactor);

--- a/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp
+++ b/Examples/Cxx/Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp
@@ -152,9 +152,9 @@ int main(int argc, char* argv[]) {
 		if (args.name != "dpsim")
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA") != args.options.end())
-			cmdInertia = args.options["SCALEINERTIA"];
+			cmdInertia = args.getOptionReal("SCALEINERTIA");
 		if (args.options.find("SCALEDAMPING") != args.options.end())
-			cmdDamping = args.options["SCALEDAMPING"];
+			cmdDamping = args.getOptionReal("SCALEDAMPING");
 	}
 
 	SP_1ph_SynGenTrStab_SteadyState(simName, timeStep, finalTime, cmdInertia, cmdDamping);

--- a/Examples/Cxx/Components/DP_Inverter_Grid_Parallel_FreqSplit.cpp
+++ b/Examples/Cxx/Components/DP_Inverter_Grid_Parallel_FreqSplit.cpp
@@ -15,15 +15,15 @@ using namespace CPS::DP::Ph1;
 
 int main(int argc, char* argv[]) {
 	CommandLineArgs args(argc, argv);
-	std::cout 	<< "Simulate with " << Int(args.options["threads"]) << " threads, sequence "
-				<< Int(args.options["seq"]) << std::endl;
+	std::cout 	<< "Simulate with " << args.getOptionInt("threads") << " threads, sequence "
+				<< args.getOptionInt("seq") << std::endl;
 
 	// Define simulation scenario
 	Real timeStep = 0.000001;
 	Real finalTime = 0.05;
-	String simName = "DP_Inverter_Grid_Parallel_FreqSplit_t" + std::to_string(Int(args.options["threads"])) + "_s" + std::to_string(Int(args.options["seq"]));
+	String simName = "DP_Inverter_Grid_Parallel_FreqSplit_t" + std::to_string(args.getOptionInt("threads")) + "_s" + std::to_string(args.getOptionInt("seq"));
 	Logger::setLogDir("logs/"+simName);
-	Int threads = Int(args.options["threads"]);
+	Int threads = args.getOptionInt("threads");
 
 	// Set system frequencies
 	//Matrix frequencies(5,1);

--- a/Examples/Cxx/Components/DP_Inverter_Grid_Sequential_FreqSplit.cpp
+++ b/Examples/Cxx/Components/DP_Inverter_Grid_Sequential_FreqSplit.cpp
@@ -15,12 +15,12 @@ using namespace CPS::DP::Ph1;
 
 int main(int argc, char* argv[]) {
 	CommandLineArgs args(argc, argv);
-	std::cout << "Simulate sequence " << Int(args.options["seq"]) << std::endl;
+	std::cout << "Simulate sequence " << args.getOptionInt("seq") << std::endl;
 
 	// Define simulation scenario
 	Real timeStep = 0.000001;
 	Real finalTime = 0.05;
-	String simName = "DP_Inverter_Grid_Sequential_FreqSplit_s" + std::to_string(Int(args.options["seq"]));
+	String simName = "DP_Inverter_Grid_Sequential_FreqSplit_s" + std::to_string(args.getOptionInt("seq"));
 	Logger::setLogDir("logs/"+simName);
 
 	// Set system frequencies

--- a/Examples/Cxx/Components/DP_Multimachine_DQ_Parallel.cpp
+++ b/Examples/Cxx/Components/DP_Multimachine_DQ_Parallel.cpp
@@ -124,8 +124,8 @@ void doSim(int threads, int generators, int repNumber) {
 int main(int argc, char* argv[]) {
 	CommandLineArgs args(argc, argv);
 
-	std::cout << "Simulate with " << Int(args.options["gen"]) << " generators, "
-		<< Int(args.options["threads"]) << " threads, sequence number "
-		<< Int(args.options["seq"]) << std::endl;
-	doSim(Int(args.options["threads"]), Int(args.options["gen"]), Int(args.options["seq"]));
+	std::cout << "Simulate with " << args.getOptionInt("gen") << " generators, "
+		<< args.getOptionInt("threads") << " threads, sequence number "
+		<< args.getOptionInt("seq") << std::endl;
+	doSim(args.getOptionInt("threads"), args.getOptionInt("gen"), args.getOptionInt("seq"));
 }

--- a/Examples/Cxx/Components/EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter.cpp
+++ b/Examples/Cxx/Components/EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter.cpp
@@ -50,15 +50,15 @@ int main(int argc, char* argv[]) {
 		if (args.name != "dpsim")
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA") != args.options.end())
-			cmdInertiaFactor = args.options["SCALEINERTIA"];
-		if (args.options_bool.find("WITHGOVERNOR") != args.options_bool.end())
-			withGovernor = args.options_bool["WITHGOVERNOR"];
-		if (args.options_bool.find("WITHEXCITER") != args.options_bool.end())
-			withExciter = args.options_bool["WITHEXCITER"];
+			cmdInertiaFactor = args.getOptionReal("SCALEINERTIA");
+		if (args.options.find("WITHGOVERNOR") != args.options.end())
+			withGovernor = args.getOptionBool("WITHGOVERNOR");
+		if (args.options.find("WITHEXCITER") != args.options.end())
+			withExciter = args.getOptionBool("WITHEXCITER");
 		if (args.options.find("TIMESTEPEVENT") != args.options.end())
-			timeStepEvent = args.options["TIMESTEPEVENT"];
+			timeStepEvent = args.getOptionReal("TIMESTEPEVENT");
 		if (args.options.find("LOADFACTOR") != args.options.end())
-			cmdLoadFactor = args.options["LOADFACTOR"];
+			cmdLoadFactor = args.getOptionReal("LOADFACTOR");
 	}
 
 	// Calculate grid parameters

--- a/Examples/Cxx/Components/EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter.cpp
+++ b/Examples/Cxx/Components/EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter.cpp
@@ -50,15 +50,15 @@ int main(int argc, char* argv[]) {
 		if (args.name != "dpsim")
 			simName = args.name;
 		if (args.options.find("SCALEINERTIA") != args.options.end())
-			cmdInertiaFactor = args.options["SCALEINERTIA"];
-		if (args.options_bool.find("WITHGOVERNOR") != args.options_bool.end())
-			withGovernor = args.options_bool["WITHGOVERNOR"];
-		if (args.options_bool.find("WITHEXCITER") != args.options_bool.end())
-			withExciter = args.options_bool["WITHEXCITER"];
+			cmdInertiaFactor = args.getOptionReal("SCALEINERTIA");
+		if (args.options.find("WITHGOVERNOR") != args.options.end())
+			withGovernor = args.getOptionBool("WITHGOVERNOR");
+		if (args.options.find("WITHEXCITER") != args.options.end())
+			withExciter = args.getOptionBool("WITHEXCITER");
 		if (args.options.find("TIMESTEPEVENT") != args.options.end())
-			timeStepEvent = args.options["TIMESTEPEVENT"];
+			timeStepEvent = args.getOptionReal("TIMESTEPEVENT");
 		if (args.options.find("LOADFACTOR") != args.options.end())
-			cmdLoadFactor = args.options["LOADFACTOR"];
+			cmdLoadFactor = args.getOptionReal("LOADFACTOR");
 	}
 
 	// Calculate grid parameters

--- a/Include/dpsim/Utils.h
+++ b/Include/dpsim/Utils.h
@@ -113,8 +113,40 @@ public:
 	std::list<String> positional;
 	std::list<fs::path> positionalPaths() const;
 
-	std::map<String, Real> options;
-	std::map<String, Bool> options_bool;
+	std::map<String, String> options;
+
+	Int getOptionInt(String optionName) {
+		// try to convert to integer number
+		try{
+			return std::stoi(options[optionName]);
+		} catch(...) {
+			throw CPS::TypeException();
+		} 
+	}
+
+	Real getOptionReal(String optionName) {
+		// try to convert to real number
+		try{
+			return std::stod(options[optionName]);
+		} catch(...) {
+			throw CPS::TypeException();
+		} 
+	}
+
+	Bool getOptionBool(String optionName) {
+		// try to convert to boolean
+		if (options[optionName] == "true")
+			return true;
+		else if (options[optionName] == "false")
+			return false;
+		else 
+			throw CPS::TypeException();
+	}
+
+	String getOptionString(String optionName){
+		return options[optionName];
+	}
+
 };
 
 namespace Utils {

--- a/Source/Utils.cpp
+++ b/Source/Utils.cpp
@@ -179,27 +179,10 @@ void CommandLineArgs::parseArguments(int argc, char *argv[])
 				auto p = arg.find("=");
 				auto key = arg.substr(0, p);
 				auto value = arg.substr(p + 1);
-
-				if (p != String::npos) {
-
-					// try to convert to real number
-					try {
-						options[key] = std::stod(value);
-					}
-					catch (...) {}
-
-					// try to convert to boolean
-					if (value == "true")
-						options_bool[key] = true;
-					else if (value == "false")
-					 	options_bool[key] = false;
-
-					// check if at least one conversion was successful
-					if ((options.find(key) == options.end()) && (options_bool.find(key) == options_bool.end()))
-						std::cerr << "Value " << value << " of option with key " << key << " could not be converted.";
+				if (p != String::npos)
+					options[key] = value;
 
 				break;
-				}
 			}
 
 			case 'l': {


### PR DESCRIPTION
Refactor `options` of `CommandLineArgs`. There is now a single `options` map, which stores the provided `options` as `string`. Type-specific access to these `options` is enabled by additional methods `getOptionInt`, `getOptionReal`, `getOptionBool` and `getOptionString`. 

Closes #77