### PR TITLE
Reduced order SG model continuation

### DIFF
--- a/Examples/Cxx/CIM/DP_WSCC9bus_SGReducedOrderVBR.cpp
+++ b/Examples/Cxx/CIM/DP_WSCC9bus_SGReducedOrderVBR.cpp
@@ -1,0 +1,179 @@
+/* Copyright 2017-2020 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <iostream>
+#include <list>
+
+#include <DPsim.h>
+#include "../../dpsim/Examples/Cxx/Examples.h"
+
+using namespace DPsim;
+using namespace CPS::DP;
+using namespace CPS::CIM;
+
+
+int main(int argc, char *argv[]) {
+
+	// Simulation parameters
+	String simName = "DP_WSCC9bus_SGReducedOrderVBR";
+	Real timeStep = 10e-6;
+	Real finalTime = 0.1;
+	String sgType = "4";
+	Bool withFault = true;
+	Real startTimeFault = 0.2;
+	Real endTimeFault = 0.3;
+	String faultBusName= "BUS6";
+	Real inertiaScalingFactor = 1.0;
+	String logDirectory = "logs";
+
+	// Find CIM files
+	std::list<fs::path> filenames;
+	CommandLineArgs args(argc, argv);
+	if (argc <= 1) {
+		filenames = Utils::findFiles({
+			"WSCC-09_Dyn_Full_DI.xml",
+			"WSCC-09_Dyn_Full_EQ.xml",
+			"WSCC-09_Dyn_Full_SV.xml",
+			"WSCC-09_Dyn_Full_TP.xml"
+		}, "WSCC-09_Dyn_Full", "CIMPATH");
+	}
+	else {
+		filenames = args.positionalPaths();
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+
+		if (args.name != "dpsim")
+			simName = args.name;
+
+		if (args.options.find("sgType") != args.options.end())
+			sgType = args.getOptionString("sgType");
+
+		if (args.options.find("withFault") != args.options.end())
+			withFault = args.getOptionBool("withFault");
+
+		if (args.options.find("startTimeFault") != args.options.end())
+			startTimeFault = args.getOptionReal("startTimeFault");
+		
+		if (args.options.find("endTimeFault") != args.options.end())
+			endTimeFault = args.getOptionReal("endTimeFault");
+		
+		if (args.options.find("faultBus") != args.options.end())
+			faultBusName = args.getOptionString("faultBus");
+		
+		if (args.options.find("inertiaScalingFactor") != args.options.end())
+			inertiaScalingFactor = args.getOptionReal("inertiaScalingFactor");
+		
+		if (args.options.find("logDirectory") != args.options.end())
+			logDirectory = args.getOptionString("logDirectory");
+	}
+
+	// Configure logging
+	Logger::Level logLevel = Logger::Level::info;
+
+	// apply downsampling for simulation step sizes lower than 10us
+	Real logDownSampling;
+	if (timeStep < 10e-6)
+		logDownSampling = floor((10e-6) / timeStep);
+	else
+		logDownSampling = 1.0;
+
+	// ----- POWERFLOW FOR INITIALIZATION -----
+	// read original network topology
+	String simNamePF = simName + "_PF";
+	Logger::setLogDir(logDirectory + "/" + simNamePF);
+    CPS::CIM::Reader reader(simNamePF, logLevel, logLevel);
+    SystemTopology systemPF = reader.loadCIM(60, filenames, Domain::SP, PhaseType::Single, CPS::GeneratorType::PVNode);
+	systemPF.component<CPS::SP::Ph1::SynchronGenerator>("GEN1")->modifyPowerFlowBusType(CPS::PowerflowBusType::VD);
+
+	// define logging
+    auto loggerPF = DPsim::DataLogger::make(simNamePF);
+    for (auto node : systemPF.mNodes)
+        loggerPF->addAttribute(node->name() + ".V", node->attribute("v"));
+
+	// run powerflow
+    Simulation simPF(simNamePF, logLevel);
+	simPF.setSystem(systemPF);
+	simPF.setTimeStep(finalTime);
+	simPF.setFinalTime(2*finalTime);
+	simPF.setDomain(Domain::SP);
+	simPF.setSolverType(Solver::Type::NRP);
+	simPF.setSolverAndComponentBehaviour(Solver::Behaviour::Initialization);
+	simPF.doInitFromNodesAndTerminals(true);
+    simPF.addLogger(loggerPF);
+    simPF.run();
+
+	// ----- DYNAMIC SIMULATION -----
+	Logger::setLogDir(logDirectory + "/" + simName);
+
+	CPS::CIM::Reader reader2(simName, logLevel, logLevel);
+	SystemTopology sys;
+	if (sgType=="3")
+		sys = reader2.loadCIM(60, filenames, Domain::DP, PhaseType::Single, CPS::GeneratorType::SG3OrderVBR);
+	else if (sgType=="4") 
+		sys = reader2.loadCIM(60, filenames, Domain::DP, PhaseType::Single, CPS::GeneratorType::SG4OrderVBR);
+	else if (sgType=="6b") 
+		sys = reader2.loadCIM(60, filenames, Domain::DP, PhaseType::Single, CPS::GeneratorType::SG6bOrderVBR);
+	else 
+		throw CPS::SystemError("Unsupported reduced-order SG type!");
+	
+	// Optionally extend topology with switch
+	auto faultDP = Ph1::Switch::make("Fault", logLevel);
+	if (withFault) {
+		faultDP->setParameters(1e12,0.02*529);
+		faultDP->connect({ SimNode::GND, sys.node<SimNode>(faultBusName) });
+		faultDP->open();
+		sys.addComponent(faultDP);
+	}
+
+	sys.initWithPowerflow(systemPF);
+	for (auto comp : sys.mComponents) {
+		if (auto genReducedOrder = std::dynamic_pointer_cast<CPS::Base::ReducedOrderSynchronGenerator<Complex>>(comp)) {
+			auto genPF = systemPF.component<CPS::SP::Ph1::SynchronGenerator>(comp->name());
+			genReducedOrder->terminal(0)->setPower(-genPF->getApparentPower());
+			genReducedOrder->scaleInertiaConstant(inertiaScalingFactor);
+		}
+	}
+
+	// Logging
+	// log node voltage
+	auto logger = DataLogger::make(simName, true, logDownSampling);
+		for (auto node : sys.mNodes)
+			logger->addAttribute(node->name() + ".V", node->attribute("v"));
+
+	// log generator vars
+	for (auto comp : sys.mComponents) {
+		if (auto genReducedOrder = std::dynamic_pointer_cast<CPS::Base::ReducedOrderSynchronGenerator<Complex>>(comp)){
+			logger->addAttribute(genReducedOrder->name() + ".Tm", genReducedOrder->attribute("Tm"));
+			logger->addAttribute(genReducedOrder->name() + ".Te", genReducedOrder->attribute("Te"));
+			logger->addAttribute(genReducedOrder->name() + ".omega", genReducedOrder->attribute("w_r"));
+			logger->addAttribute(genReducedOrder->name() + ".delta", genReducedOrder->attribute("delta"));
+		}
+	}
+
+	Simulation sim(simName, logLevel);
+	sim.setSystem(sys);
+	sim.setDomain(Domain::DP);
+	sim.setSolverType(Solver::Type::MNA);
+	sim.setTimeStep(timeStep);
+	sim.setFinalTime(finalTime);
+	sim.doSystemMatrixRecomputation(true);
+	sim.setMnaSolverImplementation(MnaSolverFactory::MnaSolverImpl::EigenSparse);
+	sim.addLogger(logger);
+
+		// Optionally add switch event
+	if (withFault) {
+		auto faultEvent1 = SwitchEvent::make(startTimeFault, faultDP, true);
+		auto faultEvent2 = SwitchEvent::make(endTimeFault, faultDP, false);
+		sim.addEvent(faultEvent1);
+		sim.addEvent(faultEvent2);
+	}
+
+	sim.run();
+
+	return 0;
+}

--- a/Examples/Cxx/CIM/DP_WSCC9bus_SGReducedOrderVBR.cpp
+++ b/Examples/Cxx/CIM/DP_WSCC9bus_SGReducedOrderVBR.cpp
@@ -10,7 +10,6 @@
 #include <list>
 
 #include <DPsim.h>
-#include "../../dpsim/Examples/Cxx/Examples.h"
 
 using namespace DPsim;
 using namespace CPS::DP;

--- a/Examples/Cxx/CIM/EMT_WSCC-9bus_VBR.cpp
+++ b/Examples/Cxx/CIM/EMT_WSCC-9bus_VBR.cpp
@@ -95,8 +95,11 @@ int main(int argc, char *argv[]) {
 
 	// log generator's current
 	for (auto comp : sys.mComponents) {
-		if (std::dynamic_pointer_cast<CPS::EMT::Ph3::SynchronGeneratorVBR>(comp))
+		if (std::dynamic_pointer_cast<CPS::EMT::Ph3::SynchronGeneratorVBR>(comp)){
 			logger->addAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+			logger->addAttribute(comp->name() + ".omega", comp->attribute("w_r"));
+			logger->addAttribute(comp->name() + ".delta", comp->attribute("delta_r"));
+		}
 	}
 
 	Simulation sim(simName, Logger::Level::info);

--- a/Examples/Cxx/CIM/EMT_WSCC9bus_SGReducedOrderVBR.cpp
+++ b/Examples/Cxx/CIM/EMT_WSCC9bus_SGReducedOrderVBR.cpp
@@ -1,0 +1,179 @@
+/* Copyright 2017-2020 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <iostream>
+#include <list>
+
+#include <DPsim.h>
+#include "../../dpsim/Examples/Cxx/Examples.h"
+
+using namespace DPsim;
+using namespace CPS::EMT;
+using namespace CPS::CIM;
+
+
+int main(int argc, char *argv[]) {
+
+	// Simulation parameters
+	String simName = "EMT_WSCC9bus_SGReducedOrderVBR";
+	Real timeStep = 10e-6;
+	Real finalTime = 0.1;
+	String sgType = "4";
+	Bool withFault = true;
+	Real startTimeFault = 0.2;
+	Real endTimeFault = 0.3;
+	String faultBusName= "BUS6";
+	Real inertiaScalingFactor = 1.0;
+	String logDirectory = "logs";
+
+	// Find CIM files
+	std::list<fs::path> filenames;
+	CommandLineArgs args(argc, argv);
+	if (argc <= 1) {
+		filenames = Utils::findFiles({
+			"WSCC-09_Dyn_Full_DI.xml",
+			"WSCC-09_Dyn_Full_EQ.xml",
+			"WSCC-09_Dyn_Full_SV.xml",
+			"WSCC-09_Dyn_Full_TP.xml"
+		}, "WSCC-09_Dyn_Full", "CIMPATH");
+	}
+	else {
+		filenames = args.positionalPaths();
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+
+		if (args.name != "dpsim")
+			simName = args.name;
+
+		if (args.options.find("sgType") != args.options.end())
+			sgType = args.getOptionString("sgType");
+		
+		if (args.options.find("withFault") != args.options.end())
+			withFault = args.getOptionBool("withFault");
+
+		if (args.options.find("startTimeFault") != args.options.end())
+			startTimeFault = args.getOptionReal("startTimeFault");
+		
+		if (args.options.find("endTimeFault") != args.options.end())
+			endTimeFault = args.getOptionReal("endTimeFault");
+		
+		if (args.options.find("faultBus") != args.options.end())
+			faultBusName = args.getOptionString("faultBus");
+		
+		if (args.options.find("inertiaScalingFactor") != args.options.end())
+			inertiaScalingFactor = args.getOptionReal("inertiaScalingFactor");
+
+		if (args.options.find("logDirectory") != args.options.end())
+			logDirectory = args.getOptionString("logDirectory");
+	}
+
+	// Configure logging
+	Logger::Level logLevel = Logger::Level::info;
+
+	// apply downsampling for simulation step sizes lower than 10us
+	Real logDownSampling;
+	if (timeStep < 10e-6)
+		logDownSampling = floor((10e-6) / timeStep);
+	else
+		logDownSampling = 1.0;
+
+	// ----- POWERFLOW FOR INITIALIZATION -----
+	// read original network topology
+	String simNamePF = simName + "_PF";
+	Logger::setLogDir(logDirectory + "/" + simNamePF);
+    CPS::CIM::Reader reader(simNamePF, logLevel, logLevel);
+    SystemTopology systemPF = reader.loadCIM(60, filenames, Domain::SP, PhaseType::Single, CPS::GeneratorType::PVNode);
+	systemPF.component<CPS::SP::Ph1::SynchronGenerator>("GEN1")->modifyPowerFlowBusType(CPS::PowerflowBusType::VD);
+
+	// define logging
+    auto loggerPF = DPsim::DataLogger::make(simNamePF);
+    for (auto node : systemPF.mNodes)
+        loggerPF->addAttribute(node->name() + ".V", node->attribute("v"));
+
+	// run powerflow
+    Simulation simPF(simNamePF, logLevel);
+	simPF.setSystem(systemPF);
+	simPF.setTimeStep(finalTime);
+	simPF.setFinalTime(2*finalTime);
+	simPF.setDomain(Domain::SP);
+	simPF.setSolverType(Solver::Type::NRP);
+	simPF.setSolverAndComponentBehaviour(Solver::Behaviour::Initialization);
+	simPF.doInitFromNodesAndTerminals(true);
+    simPF.addLogger(loggerPF);
+    simPF.run();
+
+	// ----- DYNAMIC SIMULATION -----
+	Logger::setLogDir(logDirectory + "/" + simName);
+
+	CPS::CIM::Reader reader2(simName, logLevel, logLevel);
+	SystemTopology sys;
+	if (sgType=="3")
+		sys = reader2.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC, CPS::GeneratorType::SG3OrderVBR);
+	else if (sgType=="4") 
+		sys = reader2.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC, CPS::GeneratorType::SG4OrderVBR);
+	else if (sgType=="6b") 
+		sys = reader2.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC, CPS::GeneratorType::SG6bOrderVBR);
+	else 
+		throw CPS::SystemError("Unsupported reduced-order SG type!");
+
+	// Optionally extend topology with switch
+	auto sw = Ph3::Switch::make("Fault", logLevel);
+	if (withFault) {
+		sw->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1e12), CPS::Math::singlePhaseParameterToThreePhase(0.02*529));
+		sw->connect({ SimNode::GND, sys.node<SimNode>(faultBusName) });
+		sw->openSwitch();
+		sys.addComponent(sw);
+	}
+
+	sys.initWithPowerflow(systemPF);
+	for (auto comp : sys.mComponents) {
+		if (auto genReducedOrder = std::dynamic_pointer_cast<CPS::Base::ReducedOrderSynchronGenerator<Real>>(comp)) {
+			auto genPF = systemPF.component<CPS::SP::Ph1::SynchronGenerator>(comp->name());
+			genReducedOrder->terminal(0)->setPower(-genPF->getApparentPower());
+			genReducedOrder->scaleInertiaConstant(inertiaScalingFactor);
+		}
+	}
+
+	// Logging
+	// log node voltage
+	auto logger = DataLogger::make(simName, true, logDownSampling);
+		for (auto node : sys.mNodes)
+			logger->addAttribute(node->name() + ".V", node->attribute("v"));
+
+	// log generator vars
+	for (auto comp : sys.mComponents) {
+		if (auto genReducedOrder = std::dynamic_pointer_cast<CPS::Base::ReducedOrderSynchronGenerator<Real>>(comp)){
+			logger->addAttribute(genReducedOrder->name() + ".Tm", genReducedOrder->attribute("Tm"));
+			logger->addAttribute(genReducedOrder->name() + ".Te", genReducedOrder->attribute("Te"));
+			logger->addAttribute(genReducedOrder->name() + ".omega", genReducedOrder->attribute("w_r"));
+			logger->addAttribute(genReducedOrder->name() + ".delta", genReducedOrder->attribute("delta"));
+		}
+	}
+
+	Simulation sim(simName, logLevel);
+	sim.setSystem(sys);
+	sim.setDomain(Domain::EMT);
+	sim.setSolverType(Solver::Type::MNA);
+	sim.setTimeStep(timeStep);
+	sim.setFinalTime(finalTime);
+	sim.doSystemMatrixRecomputation(true);
+	sim.setMnaSolverImplementation(MnaSolverFactory::MnaSolverImpl::EigenSparse);
+	sim.addLogger(logger);
+
+	// Optionally add switch event
+	if (withFault) {
+		auto faultEvent1 = SwitchEvent3Ph::make(startTimeFault, sw, true);
+		auto faultEvent2 = SwitchEvent3Ph::make(endTimeFault, sw, false);
+		sim.addEvent(faultEvent1);
+		sim.addEvent(faultEvent2);
+	}
+
+	sim.run();
+
+	return 0;
+}

--- a/Examples/Cxx/CIM/EMT_WSCC9bus_SGReducedOrderVBR.cpp
+++ b/Examples/Cxx/CIM/EMT_WSCC9bus_SGReducedOrderVBR.cpp
@@ -10,7 +10,6 @@
 #include <list>
 
 #include <DPsim.h>
-#include "../../dpsim/Examples/Cxx/Examples.h"
 
 using namespace DPsim;
 using namespace CPS::EMT;

--- a/Examples/Cxx/CIM/SP_WSCC9bus_SGReducedOrderVBR.cpp
+++ b/Examples/Cxx/CIM/SP_WSCC9bus_SGReducedOrderVBR.cpp
@@ -1,0 +1,179 @@
+/* Copyright 2017-2020 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <iostream>
+#include <list>
+
+#include <DPsim.h>
+#include "../../dpsim/Examples/Cxx/Examples.h"
+
+using namespace DPsim;
+using namespace CPS::SP;
+using namespace CPS::CIM;
+
+
+int main(int argc, char *argv[]) {
+
+	// Simulation parameters
+	String simName = "SP_WSCC9bus_SGReducedOrderVBR";
+	Real timeStep = 10e-6;
+	Real finalTime = 0.1;
+	String sgType = "4";
+	Bool withFault = true;
+	Real startTimeFault = 0.2;
+	Real endTimeFault = 0.3;
+	String faultBusName= "BUS6";
+	Real inertiaScalingFactor = 1.0;
+	String logDirectory = "logs";
+
+	// Find CIM files
+	std::list<fs::path> filenames;
+	CommandLineArgs args(argc, argv);
+	if (argc <= 1) {
+		filenames = Utils::findFiles({
+			"WSCC-09_Dyn_Full_DI.xml",
+			"WSCC-09_Dyn_Full_EQ.xml",
+			"WSCC-09_Dyn_Full_SV.xml",
+			"WSCC-09_Dyn_Full_TP.xml"
+		}, "WSCC-09_Dyn_Full", "CIMPATH");
+	}
+	else {
+		filenames = args.positionalPaths();
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+
+		if (args.name != "dpsim")
+			simName = args.name;
+
+		if (args.options.find("sgType") != args.options.end())
+			sgType = args.getOptionString("sgType");
+		
+		if (args.options.find("withFault") != args.options.end())
+			withFault = args.getOptionBool("withFault");
+
+		if (args.options.find("startTimeFault") != args.options.end())
+			startTimeFault = args.getOptionReal("startTimeFault");
+		
+		if (args.options.find("endTimeFault") != args.options.end())
+			endTimeFault = args.getOptionReal("endTimeFault");
+		
+		if (args.options.find("faultBus") != args.options.end())
+			faultBusName = args.getOptionString("faultBus");
+
+		if (args.options.find("inertiaScalingFactor") != args.options.end())
+			inertiaScalingFactor = args.getOptionReal("inertiaScalingFactor");
+
+		if (args.options.find("logDirectory") != args.options.end())
+			logDirectory = args.getOptionString("logDirectory");
+	}
+
+	// Configure logging
+	Logger::Level logLevel = Logger::Level::info;
+
+	// apply downsampling for simulation step sizes lower than 10us
+	Real logDownSampling;
+	if (timeStep < 10e-6)
+		logDownSampling = floor((10e-6) / timeStep);
+	else
+		logDownSampling = 1.0;
+
+	// ----- POWERFLOW FOR INITIALIZATION -----
+	// read original network topology
+	String simNamePF = simName + "_PF";
+	Logger::setLogDir(logDirectory + "/" + simNamePF);
+    CPS::CIM::Reader reader(simNamePF, logLevel, logLevel);
+    SystemTopology systemPF = reader.loadCIM(60, filenames, Domain::SP, PhaseType::Single, CPS::GeneratorType::PVNode);
+	systemPF.component<CPS::SP::Ph1::SynchronGenerator>("GEN1")->modifyPowerFlowBusType(CPS::PowerflowBusType::VD);
+
+	// define logging
+    auto loggerPF = DPsim::DataLogger::make(simNamePF);
+    for (auto node : systemPF.mNodes)
+        loggerPF->addAttribute(node->name() + ".V", node->attribute("v"));
+
+	// run powerflow
+    Simulation simPF(simNamePF, logLevel);
+	simPF.setSystem(systemPF);
+	simPF.setTimeStep(finalTime);
+	simPF.setFinalTime(2*finalTime);
+	simPF.setDomain(Domain::SP);
+	simPF.setSolverType(Solver::Type::NRP);
+	simPF.setSolverAndComponentBehaviour(Solver::Behaviour::Initialization);
+	simPF.doInitFromNodesAndTerminals(true);
+    simPF.addLogger(loggerPF);
+    simPF.run();
+
+	// ----- DYNAMIC SIMULATION -----
+	Logger::setLogDir(logDirectory + "/" + simName);
+
+	CPS::CIM::Reader reader2(simName, logLevel, logLevel);
+	SystemTopology sys;
+	if (sgType=="3")
+		sys = reader2.loadCIM(60, filenames, Domain::SP, PhaseType::Single, CPS::GeneratorType::SG3OrderVBR);
+	else if (sgType=="4") 
+		sys = reader2.loadCIM(60, filenames, Domain::SP, PhaseType::Single, CPS::GeneratorType::SG4OrderVBR);
+	else if (sgType=="6b") 
+		sys = reader2.loadCIM(60, filenames, Domain::SP, PhaseType::Single, CPS::GeneratorType::SG6bOrderVBR);
+	else 
+		throw CPS::SystemError("Unsupported reduced-order SG type!");
+
+	// Optionally extend topology with switch
+	auto faultSP = Ph1::Switch::make("Fault", logLevel);
+	if (withFault) {
+		faultSP->setParameters(1e12,0.02*529);
+		faultSP->connect({ SimNode::GND, sys.node<SimNode>(faultBusName) });
+		faultSP->open();
+		sys.addComponent(faultSP);
+	}
+
+	sys.initWithPowerflow(systemPF);
+	for (auto comp : sys.mComponents) {
+		if (auto genReducedOrder = std::dynamic_pointer_cast<CPS::Base::ReducedOrderSynchronGenerator<Complex>>(comp)) {
+			auto genPF = systemPF.component<CPS::SP::Ph1::SynchronGenerator>(comp->name());
+			genReducedOrder->terminal(0)->setPower(-genPF->getApparentPower());
+			genReducedOrder->scaleInertiaConstant(inertiaScalingFactor);
+		}
+	}
+
+	// Logging
+	// log node voltage
+	auto logger = DataLogger::make(simName, true, logDownSampling);
+		for (auto node : sys.mNodes)
+			logger->addAttribute(node->name() + ".V", node->attribute("v"));
+
+	// log generator vars
+	for (auto comp : sys.mComponents) {
+		if (auto genReducedOrder = std::dynamic_pointer_cast<CPS::Base::ReducedOrderSynchronGenerator<Complex>>(comp)){
+			logger->addAttribute(genReducedOrder->name() + ".Tm", genReducedOrder->attribute("Tm"));
+			logger->addAttribute(genReducedOrder->name() + ".Te", genReducedOrder->attribute("Te"));
+			logger->addAttribute(genReducedOrder->name() + ".omega", genReducedOrder->attribute("w_r"));
+			logger->addAttribute(genReducedOrder->name() + ".delta", genReducedOrder->attribute("delta"));
+		}
+	}
+
+	Simulation sim(simName, logLevel);
+	sim.setSystem(sys);
+	sim.setDomain(Domain::SP);
+	sim.setSolverType(Solver::Type::MNA);
+	sim.setTimeStep(timeStep);
+	sim.setFinalTime(finalTime);
+	sim.doSystemMatrixRecomputation(true);
+	sim.setMnaSolverImplementation(MnaSolverFactory::MnaSolverImpl::EigenSparse);
+	sim.addLogger(logger);
+
+	// Optionally add switch event
+	if (withFault) {
+		auto faultEvent1 = SwitchEvent::make(startTimeFault, faultSP, true);
+		auto faultEvent2 = SwitchEvent::make(endTimeFault, faultSP, false);
+		sim.addEvent(faultEvent1);
+		sim.addEvent(faultEvent2);
+	}
+
+	sim.run();
+
+	return 0;
+}

--- a/Examples/Cxx/CIM/SP_WSCC9bus_SGReducedOrderVBR.cpp
+++ b/Examples/Cxx/CIM/SP_WSCC9bus_SGReducedOrderVBR.cpp
@@ -10,7 +10,6 @@
 #include <list>
 
 #include <DPsim.h>
-#include "../../dpsim/Examples/Cxx/Examples.h"
 
 using namespace DPsim;
 using namespace CPS::SP;

--- a/Examples/Cxx/CMakeLists.txt
+++ b/Examples/Cxx/CMakeLists.txt
@@ -75,6 +75,11 @@ set(CIRCUIT_SOURCES
 	Circuits/EMT_ReducedOrderSG_VBR_Load_Fault.cpp
 	Circuits/SP_SynGen4OrderDCIM_SMIB_Fault.cpp
 
+	# SMIB Reduced Order - Load step
+	Circuits/SP_SMIB_ReducedOrderSG_LoadStep.cpp
+	Circuits/DP_SMIB_ReducedOrderSG_LoadStep.cpp
+	Circuits/EMT_SMIB_ReducedOrderSG_LoadStep.cpp
+
 	#3Bus System
 	Circuits/SP_SynGenTrStab_3Bus_SteadyState.cpp
 	Circuits/DP_SynGenTrStab_3Bus_SteadyState.cpp

--- a/Examples/Cxx/CMakeLists.txt
+++ b/Examples/Cxx/CMakeLists.txt
@@ -140,6 +140,11 @@ if(WITH_CIM)
 		CIM/EMT_WSCC-9bus_VBR.cpp
 		CIM/DP_WSCC-9bus_IdealVS.cpp
 
+		# WSCC Reduced Order
+		CIM/SP_WSCC9bus_SGReducedOrderVBR.cpp
+		CIM/EMT_WSCC9bus_SGReducedOrderVBR.cpp	
+		CIM/DP_WSCC9bus_SGReducedOrderVBR.cpp
+
 		# PF(Power Flow) example
 		CIM/Slack_Trafo_Load.cpp
 		CIM/Slack_TrafoTapChanger_Load.cpp

--- a/Examples/Cxx/Circuits/DP_ReducedOrderSG_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/DP_ReducedOrderSG_SMIB_Fault.cpp
@@ -6,7 +6,7 @@ using namespace CPS;
 using namespace CPS::CIM;
 
 // Grid parameters
-Examples::Grids::SMIB::ScenarioConfig4 GridParams;
+Examples::Grids::SMIB::ReducedOrderSynchronGenerator::Scenario4::GridParams GridParams;
 
 // Generator parameters
 Examples::Components::SynchronousGeneratorKundur::MachineParameters syngenKundur;

--- a/Examples/Cxx/Circuits/DP_SMIB_ReducedOrderSG_LoadStep.cpp
+++ b/Examples/Cxx/Circuits/DP_SMIB_ReducedOrderSG_LoadStep.cpp
@@ -1,0 +1,207 @@
+#include <DPsim.h>
+#include "../Examples.h"
+
+using namespace DPsim;
+using namespace CPS;
+using namespace CPS::CIM;
+using namespace Examples::Grids::SMIB::ReducedOrderSynchronGenerator;
+
+// Default configuration of scenario
+Scenario6::Config defaultConfig;
+
+// Grid parameters
+Scenario6::GridParams gridParams;
+
+// Generator parameters
+Examples::Components::SynchronousGeneratorKundur::MachineParameters syngenKundur;
+
+int main(int argc, char* argv[]) {	
+
+	// Simulation parameters
+	String simName = "DP_SMIB_ReducedOrderSG_LoadStep";
+	Real timeStep = 100e-6;
+	Real finalTime = 35;
+
+	// Default configuration
+	String sgType = defaultConfig.sgType;
+	Real loadStepEventTime = defaultConfig.loadStepEventTime;
+	Real H = syngenKundur.H;
+
+	// Command line args processing
+	CommandLineArgs args(argc, argv);
+	if (argc > 1) {
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+		if (args.name != "dpsim")
+			simName = args.name;
+		if (args.options.find("sgType") != args.options.end())
+			sgType = args.getOptionString("sgType");
+		if (args.options.find("loadStepEventTime") != args.options.end())
+			loadStepEventTime = args.getOptionReal("loadStepEventTime");
+		if (args.options.find("inertia") != args.options.end())
+			H = args.getOptionReal("inertia");
+	}
+
+	// Configure logging
+	Logger::Level logLevel = Logger::Level::info;
+
+	// apply downsampling for simulation step sizes lower than 10us
+	Real logDownSampling;
+	if (timeStep < 10e-6)
+		logDownSampling = floor((10e-6) / timeStep);
+	else
+		logDownSampling = 1.0;
+
+	// ----- POWERFLOW FOR INITIALIZATION -----
+	String simNamePF = simName + "_PF";
+	Logger::setLogDir("logs/" + simNamePF);
+
+	// Components
+	auto n1PF = SimNode<Complex>::make("n1", PhaseType::Single);
+	auto n2PF = SimNode<Complex>::make("n2", PhaseType::Single);
+
+	//Synchronous generator ideal model
+	auto genPF = SP::Ph1::SynchronGenerator::make("Generator", logLevel);
+	genPF->setParameters(syngenKundur.nomPower, gridParams.VnomMV, gridParams.setPointActivePower, 
+						 gridParams.setPointVoltage, PowerflowBusType::PV);
+    genPF->setBaseVoltage(gridParams.VnomMV);
+	genPF->modifyPowerFlowBusType(PowerflowBusType::PV);
+
+	//Grid bus as Slack
+	auto extnetPF = SP::Ph1::NetworkInjection::make("Slack", logLevel);
+	extnetPF->setParameters(gridParams.VnomMV);
+	extnetPF->setBaseVoltage(gridParams.VnomMV);
+	extnetPF->modifyPowerFlowBusType(PowerflowBusType::VD);
+	
+	//Line
+	auto linePF = SP::Ph1::PiLine::make("PiLine", logLevel);
+	linePF->setParameters(gridParams.lineResistance, gridParams.lineInductance, 
+						  gridParams.lineCapacitance, gridParams.lineConductance);
+	linePF->setBaseVoltage(gridParams.VnomMV);
+
+	// Topology
+	genPF->connect({ n1PF });
+	linePF->connect({ n1PF, n2PF });
+	extnetPF->connect({ n2PF });
+	auto systemPF = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1PF, n2PF},
+			SystemComponentList{genPF, linePF, extnetPF});
+
+	// Logging
+	auto loggerPF = DataLogger::make(simNamePF);
+	loggerPF->addAttribute("v1", n1PF->attribute("v"));
+	loggerPF->addAttribute("v2", n2PF->attribute("v"));
+
+	// Simulation
+	Simulation simPF(simNamePF, logLevel);
+	simPF.setSystem(systemPF);
+	simPF.setTimeStep(0.1);
+	simPF.setFinalTime(0.1);
+	simPF.setDomain(Domain::SP);
+	simPF.setSolverType(Solver::Type::NRP);
+	simPF.setSolverAndComponentBehaviour(Solver::Behaviour::Initialization);
+	simPF.doInitFromNodesAndTerminals(false);
+	simPF.addLogger(loggerPF);
+	simPF.run();
+
+
+	// ----- Dynamic simulation ------
+	String simNameDP = simName;
+	Logger::setLogDir("logs/" + simNameDP);
+	
+	// Extract relevant powerflow results
+	Real initActivePower = genPF->getApparentPower().real();
+	Real initReactivePower = genPF->getApparentPower().imag();
+	Complex initElecPower = Complex(initActivePower, initReactivePower);
+	Real initMechPower = initActivePower;
+
+	// Nodes
+	std::vector<Complex> initialVoltage_n1{ n1PF->voltage()(0,0)};
+	std::vector<Complex> initialVoltage_n2{ n2PF->voltage()(0,0)};
+	auto n1DP = SimNode<Complex>::make("n1DP", PhaseType::Single, initialVoltage_n1);
+	auto n2DP = SimNode<Complex>::make("n2DP", PhaseType::Single, initialVoltage_n2);
+
+	// Synchronous generator
+	std::shared_ptr<DP::Ph1::SynchronGeneratorVBR> genDP = nullptr;
+	if (sgType=="3") {
+		genDP = DP::Ph1::SynchronGenerator3OrderVBR::make("SynGen", logLevel);
+		std::dynamic_pointer_cast<DP::Ph1::SynchronGenerator3OrderVBR>(genDP)->setOperationalParametersPerUnit(
+			syngenKundur.nomPower, syngenKundur.nomVoltage, 
+			syngenKundur.nomFreq, H, 
+			syngenKundur.Ld, syngenKundur.Lq, syngenKundur.Ll, syngenKundur.Ld_t, syngenKundur.Td0_t);
+	} else if (sgType=="4") {
+		genDP = DP::Ph1::SynchronGenerator4OrderVBR::make("SynGen", logLevel);
+		std::dynamic_pointer_cast<DP::Ph1::SynchronGenerator4OrderVBR>(genDP)->setOperationalParametersPerUnit(
+			syngenKundur.nomPower, syngenKundur.nomVoltage, 
+			syngenKundur.nomFreq, H, 
+			syngenKundur.Ld, syngenKundur.Lq, syngenKundur.Ll,
+			syngenKundur.Ld_t, syngenKundur.Lq_t, syngenKundur.Td0_t, syngenKundur.Tq0_t); 
+	} else if (sgType=="6b") {
+		genDP = DP::Ph1::SynchronGenerator6bOrderVBR::make("SynGen", logLevel);
+		std::dynamic_pointer_cast<DP::Ph1::SynchronGenerator6bOrderVBR>(genDP)->setOperationalParametersPerUnit(
+			syngenKundur.nomPower, syngenKundur.nomVoltage,
+			syngenKundur.nomFreq, H,
+	 		syngenKundur.Ld, syngenKundur.Lq, syngenKundur.Ll, 
+			syngenKundur.Ld_t, syngenKundur.Lq_t, syngenKundur.Td0_t, syngenKundur.Tq0_t,
+			syngenKundur.Ld_s, syngenKundur.Lq_s, syngenKundur.Td0_s, syngenKundur.Tq0_s); 
+	} else 
+		throw CPS::SystemError("Unsupported reduced-order SG type!");	
+    genDP->setInitialValues(initElecPower, initMechPower, n1PF->voltage()(0,0));
+
+	//Grid bus as Slack
+	auto extnetDP = DP::Ph1::NetworkInjection::make("Slack", logLevel);
+	extnetDP->setParameters(gridParams.VnomMV);
+
+    // Line
+	auto lineDP = DP::Ph1::PiLine::make("PiLine", logLevel);
+	lineDP->setParameters(gridParams.lineResistance, gridParams.lineInductance, 
+						  gridParams.lineCapacitance, gridParams.lineConductance);
+	
+	// Topology
+	genDP->connect({ n1DP });
+	lineDP->connect({ n1DP, n2DP });
+	extnetDP->connect({ n2DP });
+	SystemTopology systemDP;
+	if (sgType=="3")
+		systemDP = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1DP, n2DP},
+			SystemComponentList{std::dynamic_pointer_cast<DP::Ph1::SynchronGenerator3OrderVBR>(genDP), lineDP, extnetDP});
+	else if (sgType=="4")
+		systemDP = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1DP, n2DP},
+			SystemComponentList{std::dynamic_pointer_cast<DP::Ph1::SynchronGenerator4OrderVBR>(genDP), lineDP, extnetDP});
+	else if (sgType=="6b")
+		systemDP = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1DP, n2DP},
+			SystemComponentList{std::dynamic_pointer_cast<DP::Ph1::SynchronGenerator6bOrderVBR>(genDP), lineDP, extnetDP});
+
+	// Logging
+	// log node voltage
+	auto logger = DataLogger::make(simName, true, logDownSampling);
+		for (auto node : systemDP.mNodes)
+			logger->addAttribute(node->name() + ".V", node->attribute("v"));
+
+	// log generator vars
+	logger->addAttribute(genDP->name() + ".Tm", genDP->attribute("Tm"));
+	logger->addAttribute(genDP->name() + ".Te", genDP->attribute("Te"));
+	logger->addAttribute(genDP->name() + ".omega", genDP->attribute("w_r"));
+	logger->addAttribute(genDP->name() + ".delta", genDP->attribute("delta"));
+
+	// load step event
+	std::shared_ptr<SwitchEvent> loadStepEvent = Examples::Events::createEventAddPowerConsumption("n1DP", std::round(loadStepEventTime/timeStep)*timeStep, gridParams.loadStepActivePower, systemDP, Domain::DP, logger);
+
+	Simulation simDP(simNameDP, logLevel);
+	simDP.doInitFromNodesAndTerminals(true);
+	simDP.setSystem(systemDP);
+	simDP.setTimeStep(timeStep);
+	simDP.setFinalTime(finalTime);
+	simDP.setDomain(Domain::DP);
+	simDP.setMnaSolverImplementation(DPsim::MnaSolverFactory::EigenSparse);
+	simDP.addLogger(logger);
+	simDP.doSystemMatrixRecomputation(true);
+
+	// Events
+	simDP.addEvent(loadStepEvent);
+	
+	simDP.run();
+}

--- a/Examples/Cxx/Circuits/EMT_ReducedOrderSG_SMIB_Fault.cpp
+++ b/Examples/Cxx/Circuits/EMT_ReducedOrderSG_SMIB_Fault.cpp
@@ -6,7 +6,7 @@ using namespace CPS;
 using namespace CPS::CIM;
 
 // Grid parameters
-Examples::Grids::SMIB::ScenarioConfig4 GridParams;
+Examples::Grids::SMIB::ReducedOrderSynchronGenerator::Scenario4::GridParams GridParams;
 
 // Generator parameters
 Examples::Components::SynchronousGeneratorKundur::MachineParameters syngenKundur;

--- a/Examples/Cxx/Circuits/EMT_SMIB_ReducedOrderSG_LoadStep.cpp
+++ b/Examples/Cxx/Circuits/EMT_SMIB_ReducedOrderSG_LoadStep.cpp
@@ -1,0 +1,214 @@
+#include <DPsim.h>
+#include "../Examples.h"
+
+using namespace DPsim;
+using namespace CPS;
+using namespace CPS::CIM;
+using namespace Examples::Grids::SMIB::ReducedOrderSynchronGenerator;
+
+// Default configuration of scenario
+Scenario6::Config defaultConfig;
+
+// Grid parameters
+Scenario6::GridParams gridParams;
+
+// Generator parameters
+Examples::Components::SynchronousGeneratorKundur::MachineParameters syngenKundur;
+
+int main(int argc, char* argv[]) {	
+
+	// Simulation parameters
+	String simName = "EMT_SMIB_ReducedOrderSG_LoadStep";
+	Real timeStep = 100e-6;
+	Real finalTime = 35;
+
+	// Default configuration
+	String sgType = defaultConfig.sgType;
+	Real loadStepEventTime = defaultConfig.loadStepEventTime;
+	Real H = syngenKundur.H;
+
+	// Command line args processing
+	CommandLineArgs args(argc, argv);
+	if (argc > 1) {
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+		if (args.name != "dpsim")
+			simName = args.name;
+		if (args.options.find("sgType") != args.options.end())
+			sgType = args.getOptionString("sgType");
+		if (args.options.find("loadStepEventTime") != args.options.end())
+			loadStepEventTime = args.getOptionReal("loadStepEventTime");
+		if (args.options.find("inertia") != args.options.end())
+			H = args.getOptionReal("inertia");
+	}
+
+	// Configure logging
+	Logger::Level logLevel = Logger::Level::info;
+
+	// apply downsampling for simulation step sizes lower than 10us
+	Real logDownSampling;
+	if (timeStep < 10e-6)
+		logDownSampling = floor((10e-6) / timeStep);
+	else
+		logDownSampling = 1.0;
+
+	// ----- POWERFLOW FOR INITIALIZATION -----
+	String simNamePF = simName + "_PF";
+	Logger::setLogDir("logs/" + simNamePF);
+
+	// Components
+	auto n1PF = SimNode<Complex>::make("n1", PhaseType::Single);
+	auto n2PF = SimNode<Complex>::make("n2", PhaseType::Single);
+
+	//Synchronous generator ideal model
+	auto genPF = SP::Ph1::SynchronGenerator::make("Generator", logLevel);
+	genPF->setParameters(syngenKundur.nomPower, gridParams.VnomMV, gridParams.setPointActivePower, 
+						 gridParams.setPointVoltage, PowerflowBusType::PV);
+    genPF->setBaseVoltage(gridParams.VnomMV);
+	genPF->modifyPowerFlowBusType(PowerflowBusType::PV);
+
+	//Grid bus as Slack
+	auto extnetPF = SP::Ph1::NetworkInjection::make("Slack", logLevel);
+	extnetPF->setParameters(gridParams.VnomMV);
+	extnetPF->setBaseVoltage(gridParams.VnomMV);
+	extnetPF->modifyPowerFlowBusType(PowerflowBusType::VD);
+	
+	//Line
+	auto linePF = SP::Ph1::PiLine::make("PiLine", logLevel);
+	linePF->setParameters(gridParams.lineResistance, gridParams.lineInductance, 
+						  gridParams.lineCapacitance, gridParams.lineConductance);
+	linePF->setBaseVoltage(gridParams.VnomMV);
+
+	// Topology
+	genPF->connect({ n1PF });
+	linePF->connect({ n1PF, n2PF });
+	extnetPF->connect({ n2PF });
+	auto systemPF = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1PF, n2PF},
+			SystemComponentList{genPF, linePF, extnetPF});
+
+	// Logging
+	auto loggerPF = DataLogger::make(simNamePF);
+	loggerPF->addAttribute("v1", n1PF->attribute("v"));
+	loggerPF->addAttribute("v2", n2PF->attribute("v"));
+
+	// Simulation
+	Simulation simPF(simNamePF, logLevel);
+	simPF.setSystem(systemPF);
+	simPF.setTimeStep(0.1);
+	simPF.setFinalTime(0.1);
+	simPF.setDomain(Domain::SP);
+	simPF.setSolverType(Solver::Type::NRP);
+	simPF.setSolverAndComponentBehaviour(Solver::Behaviour::Initialization);
+	simPF.doInitFromNodesAndTerminals(false);
+	simPF.addLogger(loggerPF);
+	simPF.run();
+
+
+	// ----- Dynamic simulation ------
+	String simNameEMT = simName;
+	Logger::setLogDir("logs/" + simNameEMT);
+	
+	// Extract relevant powerflow results
+	Real initActivePower = genPF->getApparentPower().real();
+	Real initReactivePower = genPF->getApparentPower().imag();
+	Complex initElecPower = Complex(initActivePower, initReactivePower);
+	Real initMechPower = initActivePower;
+
+	// Nodes
+	std::vector<Complex> initialVoltage_n1{ n1PF->voltage()(0,0), 
+											n1PF->voltage()(0,0) * SHIFT_TO_PHASE_B,
+											n1PF->voltage()(0,0) * SHIFT_TO_PHASE_C
+										  };
+	auto n1EMT = SimNode<Real>::make("n1EMT", PhaseType::ABC, initialVoltage_n1);
+	std::vector<Complex> initialVoltage_n2{ n2PF->voltage()(0,0), 
+											n2PF->voltage()(0,0) * SHIFT_TO_PHASE_B,
+											n2PF->voltage()(0,0) * SHIFT_TO_PHASE_C
+										  };
+	auto n2EMT = SimNode<Real>::make("n2EMT", PhaseType::ABC, initialVoltage_n2);
+
+	// Synchronous generator
+	std::shared_ptr<EMT::Ph3::ReducedOrderSynchronGeneratorVBR> genEMT = nullptr;
+	if (sgType=="3") {
+		genEMT = EMT::Ph3::SynchronGenerator3OrderVBR::make("SynGen", logLevel);
+		std::dynamic_pointer_cast<EMT::Ph3::SynchronGenerator3OrderVBR>(genEMT)->setOperationalParametersPerUnit(
+			syngenKundur.nomPower, syngenKundur.nomVoltage, 
+			syngenKundur.nomFreq, H, 
+			syngenKundur.Ld, syngenKundur.Lq, syngenKundur.Ll, syngenKundur.Ld_t, syngenKundur.Td0_t);
+	} else if (sgType=="4") {
+		genEMT = EMT::Ph3::SynchronGenerator4OrderVBR::make("SynGen", logLevel);
+		std::dynamic_pointer_cast<EMT::Ph3::SynchronGenerator4OrderVBR>(genEMT)->setOperationalParametersPerUnit(
+			syngenKundur.nomPower, syngenKundur.nomVoltage, 
+			syngenKundur.nomFreq, H, 
+			syngenKundur.Ld, syngenKundur.Lq, syngenKundur.Ll,
+			syngenKundur.Ld_t, syngenKundur.Lq_t, syngenKundur.Td0_t, syngenKundur.Tq0_t); 
+	} else if (sgType=="6b") {
+		genEMT = EMT::Ph3::SynchronGenerator6bOrderVBR::make("SynGen", logLevel);
+		std::dynamic_pointer_cast<EMT::Ph3::SynchronGenerator6bOrderVBR>(genEMT)->setOperationalParametersPerUnit(
+			syngenKundur.nomPower, syngenKundur.nomVoltage,
+			syngenKundur.nomFreq, H,
+	 		syngenKundur.Ld, syngenKundur.Lq, syngenKundur.Ll, 
+			syngenKundur.Ld_t, syngenKundur.Lq_t, syngenKundur.Td0_t, syngenKundur.Tq0_t,
+			syngenKundur.Ld_s, syngenKundur.Lq_s, syngenKundur.Td0_s, syngenKundur.Tq0_s); 
+	} else 
+		throw CPS::SystemError("Unsupported reduced-order SG type!");	
+    genEMT->setInitialValues(initElecPower, initMechPower, n1PF->voltage()(0,0));
+
+	//Grid bus as Slack
+	auto extnetEMT = EMT::Ph3::NetworkInjection::make("Slack", logLevel);
+
+    // Line
+	auto lineEMT = EMT::Ph3::PiLine::make("PiLine", logLevel);
+	lineEMT->setParameters(Math::singlePhaseParameterToThreePhase(gridParams.lineResistance), 
+	                      Math::singlePhaseParameterToThreePhase(gridParams.lineInductance), 
+					      Math::singlePhaseParameterToThreePhase(gridParams.lineCapacitance),
+						  Math::singlePhaseParameterToThreePhase(gridParams.lineConductance));
+	
+	// Topology
+	genEMT->connect({ n1EMT });
+	lineEMT->connect({ n1EMT, n2EMT });
+	extnetEMT->connect({ n2EMT });
+	SystemTopology systemEMT;
+	if (sgType=="3")
+		systemEMT = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1EMT, n2EMT},
+			SystemComponentList{std::dynamic_pointer_cast<EMT::Ph3::SynchronGenerator3OrderVBR>(genEMT), lineEMT, extnetEMT});
+	else if (sgType=="4")
+		systemEMT = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1EMT, n2EMT},
+			SystemComponentList{std::dynamic_pointer_cast<EMT::Ph3::SynchronGenerator4OrderVBR>(genEMT), lineEMT, extnetEMT});
+	else if (sgType=="6b")
+		systemEMT = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1EMT, n2EMT},
+			SystemComponentList{std::dynamic_pointer_cast<EMT::Ph3::SynchronGenerator6bOrderVBR>(genEMT), lineEMT, extnetEMT});
+
+	// Logging
+	// log node voltage
+	auto logger = DataLogger::make(simName, true, logDownSampling);
+		for (auto node : systemEMT.mNodes)
+			logger->addAttribute(node->name() + ".V", node->attribute("v"));
+
+	// log generator vars
+	logger->addAttribute(genEMT->name() + ".Tm", genEMT->attribute("Tm"));
+	logger->addAttribute(genEMT->name() + ".Te", genEMT->attribute("Te"));
+	logger->addAttribute(genEMT->name() + ".omega", genEMT->attribute("w_r"));
+	logger->addAttribute(genEMT->name() + ".delta", genEMT->attribute("delta"));
+
+	// load step event
+	std::shared_ptr<SwitchEvent3Ph> loadStepEvent = Examples::Events::createEventAddPowerConsumption3Ph("n1EMT", std::round(loadStepEventTime/timeStep)*timeStep, gridParams.loadStepActivePower, systemEMT, Domain::EMT, logger);
+
+	Simulation simEMT(simNameEMT, logLevel);
+	simEMT.doInitFromNodesAndTerminals(true);
+	simEMT.setSystem(systemEMT);
+	simEMT.setTimeStep(timeStep);
+	simEMT.setFinalTime(finalTime);
+	simEMT.setDomain(Domain::EMT);
+	simEMT.setMnaSolverImplementation(DPsim::MnaSolverFactory::EigenSparse);
+	simEMT.addLogger(logger);
+	simEMT.doSystemMatrixRecomputation(true);
+
+	// Events
+	simEMT.addEvent(loadStepEvent);
+	
+	simEMT.run();
+}

--- a/Examples/Cxx/Circuits/SP_SMIB_ReducedOrderSG_LoadStep.cpp
+++ b/Examples/Cxx/Circuits/SP_SMIB_ReducedOrderSG_LoadStep.cpp
@@ -1,0 +1,207 @@
+#include <DPsim.h>
+#include "../Examples.h"
+
+using namespace DPsim;
+using namespace CPS;
+using namespace CPS::CIM;
+using namespace Examples::Grids::SMIB::ReducedOrderSynchronGenerator;
+
+// Default configuration of scenario
+Scenario6::Config defaultConfig;
+
+// Grid parameters
+Scenario6::GridParams gridParams;
+
+// Generator parameters
+Examples::Components::SynchronousGeneratorKundur::MachineParameters syngenKundur;
+
+int main(int argc, char* argv[]) {	
+
+	// Simulation parameters
+	String simName = "SP_SMIB_ReducedOrderSG_LoadStep";
+	Real timeStep = 100e-6;
+	Real finalTime = 35;
+
+	// Default configuration
+	String sgType = defaultConfig.sgType;
+	Real loadStepEventTime = defaultConfig.loadStepEventTime;
+	Real H = syngenKundur.H;
+
+	// Command line args processing
+	CommandLineArgs args(argc, argv);
+	if (argc > 1) {
+		timeStep = args.timeStep;
+		finalTime = args.duration;
+		if (args.name != "dpsim")
+			simName = args.name;
+		if (args.options.find("sgType") != args.options.end())
+			sgType = args.getOptionString("sgType");
+		if (args.options.find("loadStepEventTime") != args.options.end())
+			loadStepEventTime = args.getOptionReal("loadStepEventTime");
+		if (args.options.find("inertia") != args.options.end())
+			H = args.getOptionReal("inertia");
+	}
+
+	// Configure logging
+	Logger::Level logLevel = Logger::Level::info;
+
+	// apply downsampling for simulation step sizes lower than 10us
+	Real logDownSampling;
+	if (timeStep < 10e-6)
+		logDownSampling = floor((10e-6) / timeStep);
+	else
+		logDownSampling = 1.0;
+
+	// ----- POWERFLOW FOR INITIALIZATION -----
+	String simNamePF = simName + "_PF";
+	Logger::setLogDir("logs/" + simNamePF);
+
+	// Components
+	auto n1PF = SimNode<Complex>::make("n1", PhaseType::Single);
+	auto n2PF = SimNode<Complex>::make("n2", PhaseType::Single);
+
+	//Synchronous generator ideal model
+	auto genPF = SP::Ph1::SynchronGenerator::make("Generator", logLevel);
+	genPF->setParameters(syngenKundur.nomPower, gridParams.VnomMV, gridParams.setPointActivePower, 
+						 gridParams.setPointVoltage, PowerflowBusType::PV);
+    genPF->setBaseVoltage(gridParams.VnomMV);
+	genPF->modifyPowerFlowBusType(PowerflowBusType::PV);
+
+	//Grid bus as Slack
+	auto extnetPF = SP::Ph1::NetworkInjection::make("Slack", logLevel);
+	extnetPF->setParameters(gridParams.VnomMV);
+	extnetPF->setBaseVoltage(gridParams.VnomMV);
+	extnetPF->modifyPowerFlowBusType(PowerflowBusType::VD);
+	
+	//Line
+	auto linePF = SP::Ph1::PiLine::make("PiLine", logLevel);
+	linePF->setParameters(gridParams.lineResistance, gridParams.lineInductance, 
+						  gridParams.lineCapacitance, gridParams.lineConductance);
+	linePF->setBaseVoltage(gridParams.VnomMV);
+
+	// Topology
+	genPF->connect({ n1PF });
+	linePF->connect({ n1PF, n2PF });
+	extnetPF->connect({ n2PF });
+	auto systemPF = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1PF, n2PF},
+			SystemComponentList{genPF, linePF, extnetPF});
+
+	// Logging
+	auto loggerPF = DataLogger::make(simNamePF);
+	loggerPF->addAttribute("v1", n1PF->attribute("v"));
+	loggerPF->addAttribute("v2", n2PF->attribute("v"));
+
+	// Simulation
+	Simulation simPF(simNamePF, logLevel);
+	simPF.setSystem(systemPF);
+	simPF.setTimeStep(0.1);
+	simPF.setFinalTime(0.1);
+	simPF.setDomain(Domain::SP);
+	simPF.setSolverType(Solver::Type::NRP);
+	simPF.setSolverAndComponentBehaviour(Solver::Behaviour::Initialization);
+	simPF.doInitFromNodesAndTerminals(false);
+	simPF.addLogger(loggerPF);
+	simPF.run();
+
+
+	// ----- Dynamic simulation ------
+	String simNameSP = simName;
+	Logger::setLogDir("logs/" + simNameSP);
+	
+	// Extract relevant powerflow results
+	Real initActivePower = genPF->getApparentPower().real();
+	Real initReactivePower = genPF->getApparentPower().imag();
+	Complex initElecPower = Complex(initActivePower, initReactivePower);
+	Real initMechPower = initActivePower;
+
+	// Nodes
+	std::vector<Complex> initialVoltage_n1{ n1PF->voltage()(0,0)};
+	std::vector<Complex> initialVoltage_n2{ n2PF->voltage()(0,0)};
+	auto n1SP = SimNode<Complex>::make("n1SP", PhaseType::Single, initialVoltage_n1);
+	auto n2SP = SimNode<Complex>::make("n2SP", PhaseType::Single, initialVoltage_n2);
+
+	// Synchronous generator
+	std::shared_ptr<SP::Ph1::SynchronGeneratorVBR> genSP = nullptr;
+	if (sgType=="3") {
+		genSP = SP::Ph1::SynchronGenerator3OrderVBR::make("SynGen", logLevel);
+		std::dynamic_pointer_cast<SP::Ph1::SynchronGenerator3OrderVBR>(genSP)->setOperationalParametersPerUnit(
+			syngenKundur.nomPower, syngenKundur.nomVoltage, 
+			syngenKundur.nomFreq, H, 
+			syngenKundur.Ld, syngenKundur.Lq, syngenKundur.Ll, syngenKundur.Ld_t, syngenKundur.Td0_t);
+	} else if (sgType=="4") {
+		genSP = SP::Ph1::SynchronGenerator4OrderVBR::make("SynGen", logLevel);
+		std::dynamic_pointer_cast<SP::Ph1::SynchronGenerator4OrderVBR>(genSP)->setOperationalParametersPerUnit(
+			syngenKundur.nomPower, syngenKundur.nomVoltage, 
+			syngenKundur.nomFreq, H, 
+			syngenKundur.Ld, syngenKundur.Lq, syngenKundur.Ll,
+			syngenKundur.Ld_t, syngenKundur.Lq_t, syngenKundur.Td0_t, syngenKundur.Tq0_t); 
+	} else if (sgType=="6b") {
+		genSP = SP::Ph1::SynchronGenerator6bOrderVBR::make("SynGen", logLevel);
+		std::dynamic_pointer_cast<SP::Ph1::SynchronGenerator6bOrderVBR>(genSP)->setOperationalParametersPerUnit(
+			syngenKundur.nomPower, syngenKundur.nomVoltage,
+			syngenKundur.nomFreq, H,
+	 		syngenKundur.Ld, syngenKundur.Lq, syngenKundur.Ll, 
+			syngenKundur.Ld_t, syngenKundur.Lq_t, syngenKundur.Td0_t, syngenKundur.Tq0_t,
+			syngenKundur.Ld_s, syngenKundur.Lq_s, syngenKundur.Td0_s, syngenKundur.Tq0_s); 
+	} else 
+		throw CPS::SystemError("Unsupported reduced-order SG type!");	
+    genSP->setInitialValues(initElecPower, initMechPower, n1PF->voltage()(0,0));
+
+	//Grid bus as Slack
+	auto extnetSP = SP::Ph1::NetworkInjection::make("Slack", logLevel);
+	extnetSP->setParameters(gridParams.VnomMV);
+
+    // Line
+	auto lineSP = SP::Ph1::PiLine::make("PiLine", logLevel);
+	lineSP->setParameters(gridParams.lineResistance, gridParams.lineInductance, 
+						  gridParams.lineCapacitance, gridParams.lineConductance);
+	
+	// Topology
+	genSP->connect({ n1SP });
+	lineSP->connect({ n1SP, n2SP });
+	extnetSP->connect({ n2SP });
+	SystemTopology systemSP;
+	if (sgType=="3")
+		systemSP = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1SP, n2SP},
+			SystemComponentList{std::dynamic_pointer_cast<SP::Ph1::SynchronGenerator3OrderVBR>(genSP), lineSP, extnetSP});
+	else if (sgType=="4")
+		systemSP = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1SP, n2SP},
+			SystemComponentList{std::dynamic_pointer_cast<SP::Ph1::SynchronGenerator4OrderVBR>(genSP), lineSP, extnetSP});
+	else if (sgType=="6b")
+		systemSP = SystemTopology(gridParams.nomFreq,
+			SystemNodeList{n1SP, n2SP},
+			SystemComponentList{std::dynamic_pointer_cast<SP::Ph1::SynchronGenerator6bOrderVBR>(genSP), lineSP, extnetSP});
+
+	// Logging
+	// log node voltage
+	auto logger = DataLogger::make(simName, true, logDownSampling);
+		for (auto node : systemSP.mNodes)
+			logger->addAttribute(node->name() + ".V", node->attribute("v"));
+
+	// log generator vars
+	logger->addAttribute(genSP->name() + ".Tm", genSP->attribute("Tm"));
+	logger->addAttribute(genSP->name() + ".Te", genSP->attribute("Te"));
+	logger->addAttribute(genSP->name() + ".omega", genSP->attribute("w_r"));
+	logger->addAttribute(genSP->name() + ".delta", genSP->attribute("delta"));
+
+		// load step event
+	std::shared_ptr<SwitchEvent> loadStepEvent = Examples::Events::createEventAddPowerConsumption("n1SP", std::round(loadStepEventTime/timeStep)*timeStep, gridParams.loadStepActivePower, systemSP, Domain::SP, logger);
+
+	Simulation simSP(simNameSP, logLevel);
+	simSP.doInitFromNodesAndTerminals(true);
+	simSP.setSystem(systemSP);
+	simSP.setTimeStep(timeStep);
+	simSP.setFinalTime(finalTime);
+	simSP.setDomain(Domain::SP);
+	simSP.setMnaSolverImplementation(DPsim::MnaSolverFactory::EigenSparse);
+	simSP.addLogger(logger);
+	simSP.doSystemMatrixRecomputation(true);
+
+	// Events
+	simSP.addEvent(loadStepEvent);
+	
+	simSP.run();
+}

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -232,9 +232,19 @@ namespace SMIB {
 	    Real SwitchOpen = 1e6;
     };
 
-    struct ScenarioConfig4 {
-        //Scenario used to compare DP against SP accuracy in Martin's thesis
+namespace ReducedOrderSynchronGenerator {
+namespace Scenario4 {
+    //Scenario used to compare DP against SP accuracy in Martin's thesis
 
+    struct Config {
+        // default configuration of scenario
+        // adjustable using applyCommandLineArgsOptions
+        String sgType = "4";
+        Real startTimeFault = 30.0;
+	    Real endTimeFault = 30.1;
+    };
+
+    struct GridParams {
         // General grid parameters
         Real VnomMV = 24e3;
         Real VnomHV = 230e3;
@@ -258,6 +268,7 @@ namespace SMIB {
         Real SwitchClosed = 0.1;
 	    Real SwitchOpen = 1e6;
     };
+}
   
 }
 

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -269,7 +269,52 @@ namespace Scenario4 {
 	    Real SwitchOpen = 1e6;
     };
 }
-  
+
+namespace Scenario5 {
+    // SMIB scenario including trafo
+    struct Config {
+        // default configuration of scenario
+        // adjustable using applyCommandLineArgsOptions
+        String sgType = "4";
+        Real startTimeFault = 1.0;
+	    Real endTimeFault = 1.1;
+    };
+
+    struct GridParams {
+
+        // General grid parameters
+        Real VnomMV = 24e3;
+        Real VnomHV = 230e3;
+        Real nomFreq = 60;
+        Real ratio = VnomMV/VnomHV;
+        Real nomOmega= nomFreq * 2 * PI;
+
+        // Generator parameters
+        Real setPointActivePower = 300e6;
+        Real setPointVoltage = 1.05*VnomMV;
+
+        // CIGREHVAmerican (230 kV)
+        Grids::CIGREHVAmerican::LineParameters lineCIGREHV;
+        Real lineLength = 100;
+        Real lineResistance = lineCIGREHV.lineResistancePerKm * lineLength;
+        Real lineInductance = lineCIGREHV.lineReactancePerKm * lineLength / nomOmega;
+        Real lineCapacitance = lineCIGREHV.lineSusceptancePerKm * lineLength / nomOmega;
+        Real lineConductance = 1e-15;
+
+        // Fault resistance 10 Ohms at 230kV
+        Real SwitchClosed = 10;
+	    Real SwitchOpen = 1e6;
+    };
+
+    struct Transf1 {
+	    Real nomVoltageHV = 230e3;
+        Real nomVoltageMV = 24e3;
+        Real transformerResistance = 0; // referred to HV side
+        Real transformerReactance = 5.2900; // referred to HV side
+    };
+}
+
+}
 }
 
 namespace ThreeBus {

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -311,6 +311,7 @@ namespace Scenario5 {
         Real nomVoltageMV = 24e3;
         Real transformerResistance = 0; // referred to HV side
         Real transformerReactance = 5.2900; // referred to HV side
+        Real transformerNominalPower = 555e6;
     };
 }
 

--- a/Examples/Cxx/Examples.h
+++ b/Examples/Cxx/Examples.h
@@ -18,8 +18,10 @@ namespace Examples {
 
 namespace Components {
 namespace SynchronousGeneratorKundur {
+    // P. Kundur, "Power System Stability and Control", Example 3.2, pp. 102
+    // and Example 3.5, pp. 134f.
     struct MachineParameters {
-        // Define machine parameters in per unit
+        // Thermal generating unit, 3600r/min, 2-pole
         Real nomPower = 555e6;
         Real nomVoltage = 24e3; // Phase-to-Phase RMS
         Real nomFreq = 60;
@@ -27,6 +29,7 @@ namespace SynchronousGeneratorKundur {
         Int poleNum = 2;
         Real H = 3.7;
 
+        // Define machine parameters in per unit
         // Fundamental parameters
         Real Rs = 0.003;
         Real Ll = 0.15;
@@ -125,8 +128,8 @@ namespace CIGREHVAmerican {
     };
 }
 
-// P. Kundur, "Power System Stability and Control", Example 13.2, pp. 864-869.
 namespace KundurExample1 {
+    // P. Kundur, "Power System Stability and Control", Example 13.2, pp. 864-869.
     struct Network {
         Real nomVoltage = 400e3;
     };
@@ -271,7 +274,7 @@ namespace Scenario4 {
 }
 
 namespace Scenario5 {
-    // SMIB scenario including trafo
+    // SMIB scenario with RX trafo and load step as event
     struct Config {
         // default configuration of scenario
         // adjustable using applyCommandLineArgsOptions
@@ -299,11 +302,11 @@ namespace Scenario5 {
         Real lineResistance = lineCIGREHV.lineResistancePerKm * lineLength;
         Real lineInductance = lineCIGREHV.lineReactancePerKm * lineLength / nomOmega;
         Real lineCapacitance = lineCIGREHV.lineSusceptancePerKm * lineLength / nomOmega;
-        Real lineConductance = 1e-15;
+        Real lineConductance = 1.0491e-05; // Psnub 0.1% of 555MW
 
-        // Fault resistance 10 Ohms at 230kV
-        Real SwitchClosed = 10;
-	    Real SwitchOpen = 1e6;
+        // Switch for load step
+        Real SwitchClosed = 529; // 100 MW load step
+	    Real SwitchOpen = 9.1840e+07; // corresponds to 1e6 Ohms at MV level of 24kV
     };
 
     struct Transf1 {
@@ -312,6 +315,41 @@ namespace Scenario5 {
         Real transformerResistance = 0; // referred to HV side
         Real transformerReactance = 5.2900; // referred to HV side
         Real transformerNominalPower = 555e6;
+    };
+}
+
+namespace Scenario6 {
+    // SMIB scenario with ideal trafo and load step as event 
+
+    struct Config {
+        // default configuration of scenario
+        // adjustable using applyCommandLineArgsOptions
+        String sgType = "4";
+        Real loadStepEventTime = 10.0;
+    };
+
+    struct GridParams {
+        // General grid parameters
+        Real VnomMV = 24e3;
+        Real VnomHV = 230e3;
+        Real nomFreq = 60;
+        Real ratio = VnomMV/VnomHV;
+        Real nomOmega= nomFreq * 2 * PI;
+
+        // Generator parameters
+        Real setPointActivePower = 300e6;
+        Real setPointVoltage = 1.05*VnomMV;
+
+        // CIGREHVAmerican (230 kV)
+        Grids::CIGREHVAmerican::LineParameters lineCIGREHV;
+        Real lineLength = 100;
+        Real lineResistance = lineCIGREHV.lineResistancePerKm * lineLength * std::pow(ratio,2);
+        Real lineInductance = lineCIGREHV.lineReactancePerKm * lineLength * std::pow(ratio,2) / nomOmega;
+        Real lineCapacitance = lineCIGREHV.lineSusceptancePerKm * lineLength / std::pow(ratio,2) / nomOmega;
+        Real lineConductance = 0.0048; // Psnub 0.5% of 555MW
+
+        // Load step
+        Real loadStepActivePower = 100e6; 
     };
 }
 

--- a/Source/Event.cpp
+++ b/Source/Event.cpp
@@ -21,10 +21,11 @@ void EventQueue::handleEvents(Real currentTime) {
 	while (!mEvents.empty()) {
 		e = mEvents.top();
 		// if current time larger or equal to event time, execute event
-		if ( currentTime > e->mTime || (e->mTime - currentTime) < 1e-12) {
+		if ( currentTime > e->mTime || (e->mTime - currentTime) < 100e-9) {
 			e->execute();
 			std::cout << std::scientific << currentTime << ": Handle event time" << std::endl;
 			//std::cout << std::scientific << e->mTime << ": Original event time" << std::endl;
+			//std::cout << std::scientific << (e->mTime - currentTime)*1e9 << ": Difference to specified event time in ns" << std::endl;
 			mEvents.pop();
 		} else {
 			break;

--- a/Source/PFSolver.cpp
+++ b/Source/PFSolver.cpp
@@ -231,34 +231,34 @@ void PFSolver::determineNodeBaseVoltages() {
 		for (auto comp : mSystem.mComponentsAtNode[node]) {
             if (std::shared_ptr<CPS::SP::Ph1::AvVoltageSourceInverterDQ> vsi = std::dynamic_pointer_cast<CPS::SP::Ph1::AvVoltageSourceInverterDQ>(comp)) {
 				baseVoltage_=Math::abs(vsi->attribute<CPS::Complex>("vnom")->get());
-                mSLog->info("Choose base voltage of {} to convert pu-solution of {}.", vsi->name(), node->name());
+                mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, vsi->name(), node->name());
                 break;
 			}
             else if (std::shared_ptr<CPS::SP::Ph1::RXLine> rxline = std::dynamic_pointer_cast<CPS::SP::Ph1::RXLine>(comp)) {
 				baseVoltage_ = rxline->attribute<CPS::Real>("base_Voltage")->get();
-                mSLog->info("Choose base voltage of {} to convert pu-solution of {}.", rxline->name(), node->name());
+                mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, rxline->name(), node->name());
                 break;
 			}
             else if (std::shared_ptr<CPS::SP::Ph1::PiLine> line = std::dynamic_pointer_cast<CPS::SP::Ph1::PiLine>(comp)) {
 				baseVoltage_ = line->attribute<CPS::Real>("base_Voltage")->get();
-                mSLog->info("Choose base voltage of {} to convert pu-solution of {}.", line->name(), node->name());
+                mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, line->name(), node->name());
                 break;
 			}
 			else if (std::shared_ptr<CPS::SP::Ph1::Transformer> trans = std::dynamic_pointer_cast<CPS::SP::Ph1::Transformer>(comp)) {
 				if (trans->terminal(0)->node()->name() == node->name()){
                     baseVoltage_ = trans->attribute<CPS::Real>("nominal_voltage_end1")->get();
-                    mSLog->info("Choose base voltage of {} to convert pu-solution of {}.", trans->name(), node->name());
+                    mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, trans->name(), node->name());
                     break;
                 }
 				else if (trans->terminal(1)->node()->name() == node->name()){
                     baseVoltage_ = trans->attribute<CPS::Real>("nominal_voltage_end2")->get();
-                    mSLog->info("Choose base voltage of {} to convert pu-solution of {}.", trans->name(), node->name());
+                    mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, trans->name(), node->name());
                     break;
                 }
             }
             else if (std::shared_ptr<CPS::SP::Ph1::SynchronGenerator> gen = std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(comp)) {
                     baseVoltage_ = gen->attribute<CPS::Real>("base_Voltage")->get();
-                    mSLog->info("Choose base voltage of {} to convert pu-solution of {}.", gen->name(), node->name());
+                    mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, gen->name(), node->name());
                     break;
                 }
             else {

--- a/models/Include/cps/Base/Base_ReducedOrderSynchronGenerator.h
+++ b/models/Include/cps/Base/Base_ReducedOrderSynchronGenerator.h
@@ -175,7 +175,7 @@ namespace Base {
 				Real initMechanicalPower, Complex initTerminalVoltage);
 
 			/// ### Setters ###
-			void reduceInertiaConstant(Real porcent) {mH = mH * (1.-porcent);}
+			void scaleInertiaConstant(Real scalingFactor); 
 
 			/// ### Mna Section ###
 			class MnaPreStep : public Task {

--- a/models/Include/cps/DP/DP_Ph1_SynchronGenerator3OrderVBR.h
+++ b/models/Include/cps/DP/DP_Ph1_SynchronGenerator3OrderVBR.h
@@ -52,6 +52,10 @@ namespace Ph1 {
 		void calculateAuxiliarConstants();
 		///
 		void stepInPerUnit();
+		/// Setter 3rd order parameters - extending base class setter by logging
+		void setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Td0_t);
 	};
 }
 }

--- a/models/Include/cps/DP/DP_Ph1_SynchronGenerator4OrderVBR.h
+++ b/models/Include/cps/DP/DP_Ph1_SynchronGenerator4OrderVBR.h
@@ -56,6 +56,10 @@ namespace Ph1 {
 		void calculateAuxiliarConstants();
 		///
 		void stepInPerUnit();
+		/// Setter 4th order parameters - extending base class setter by logging
+		void setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t);
 	};
 }
 }

--- a/models/Include/cps/DP/DP_Ph1_SynchronGenerator6bOrderVBR.h
+++ b/models/Include/cps/DP/DP_Ph1_SynchronGenerator6bOrderVBR.h
@@ -75,6 +75,11 @@ namespace Ph1 {
 		void calculateAuxiliarConstants();
 		///
 		void stepInPerUnit();
+		/// Setter 6th order parameters - extending base class setter by logging
+		void setOperationalParametersPerUnit(Real nomPower, 
+				Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+				Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t,
+				Real Ld_s, Real Lq_s, Real Td0_s, Real Tq0_s);
 	};
 }
 }

--- a/models/Include/cps/DP/DP_Ph1_SynchronGeneratorVBR.h
+++ b/models/Include/cps/DP/DP_Ph1_SynchronGeneratorVBR.h
@@ -67,6 +67,7 @@ namespace Ph1 {
 		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
         void mnaApplyRightSideVectorStamp(Matrix& rightVector);
 		void mnaPostStep(const Matrix& leftVector);
+		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
 
     public:
         virtual ~SynchronGeneratorVBR();

--- a/models/Include/cps/EMT/EMT_Ph3_ReducedOrderSynchronGeneratorVBR.h
+++ b/models/Include/cps/EMT/EMT_Ph3_ReducedOrderSynchronGeneratorVBR.h
@@ -51,6 +51,7 @@ namespace Ph3 {
         void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
         void mnaApplyRightSideVectorStamp(Matrix& rightVector);
 		void mnaPostStep(const Matrix& leftVector);
+        void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
 
     public:
         virtual ~ReducedOrderSynchronGeneratorVBR();

--- a/models/Include/cps/EMT/EMT_Ph3_SynchronGenerator3OrderVBR.h
+++ b/models/Include/cps/EMT/EMT_Ph3_SynchronGenerator3OrderVBR.h
@@ -46,6 +46,10 @@ namespace Ph3 {
 		void calculateAuxiliarConstants();
 		///
 		void stepInPerUnit();
+		/// Setter 3rd order parameters - extending base class setter by logging
+		void setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Td0_t);
 	};
 }
 }

--- a/models/Include/cps/EMT/EMT_Ph3_SynchronGenerator4OrderVBR.h
+++ b/models/Include/cps/EMT/EMT_Ph3_SynchronGenerator4OrderVBR.h
@@ -50,6 +50,10 @@ namespace Ph3 {
 		void calculateAuxiliarConstants();
 		///
 		void stepInPerUnit();
+		/// Setter 4th order parameters - extending base class setter by logging
+		void setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t);
 	};
 }
 }

--- a/models/Include/cps/EMT/EMT_Ph3_SynchronGenerator6bOrderVBR.h
+++ b/models/Include/cps/EMT/EMT_Ph3_SynchronGenerator6bOrderVBR.h
@@ -69,6 +69,11 @@ namespace Ph3 {
 		void calculateAuxiliarConstants();
 		///
 		void stepInPerUnit();
+		/// Setter 6th order parameters - extending base class setter by logging
+		void setOperationalParametersPerUnit(Real nomPower, 
+				Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+				Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t,
+				Real Ld_s, Real Lq_s, Real Td0_s, Real Tq0_s);
 	};
 }
 }

--- a/models/Include/cps/SP/SP_Ph1_SynchronGenerator3OrderVBR.h
+++ b/models/Include/cps/SP/SP_Ph1_SynchronGenerator3OrderVBR.h
@@ -46,6 +46,10 @@ namespace Ph1 {
 		void calculateAuxiliarConstants();
 		///
 		void stepInPerUnit();
+		/// Setter 3rd order parameters - extending base class setter by logging
+		void setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Td0_t);
 	};
 }
 }

--- a/models/Include/cps/SP/SP_Ph1_SynchronGenerator4OrderVBR.h
+++ b/models/Include/cps/SP/SP_Ph1_SynchronGenerator4OrderVBR.h
@@ -50,6 +50,10 @@ namespace Ph1 {
 		void calculateAuxiliarConstants();
 		///
 		void stepInPerUnit();
+		/// Setter 4th order parameters - extending base class setter by logging
+		void setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t);
 	};
 }
 }

--- a/models/Include/cps/SP/SP_Ph1_SynchronGenerator6bOrderVBR.h
+++ b/models/Include/cps/SP/SP_Ph1_SynchronGenerator6bOrderVBR.h
@@ -69,6 +69,11 @@ namespace Ph1 {
 		void calculateAuxiliarConstants();
 		///
 		void stepInPerUnit();
+		/// Setter 6th order parameters - extending base class setter by logging
+		void setOperationalParametersPerUnit(Real nomPower, 
+				Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+				Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t,
+				Real Ld_s, Real Lq_s, Real Td0_s, Real Tq0_s);
 	};
 }
 }

--- a/models/Include/cps/SP/SP_Ph1_Transformer.h
+++ b/models/Include/cps/SP/SP_Ph1_Transformer.h
@@ -65,12 +65,8 @@ namespace Ph1 {
 		/// Reactance [Ohm]
 		Real mReactance;
 
-		/// Magnetizing reactance [Ohm]
-		Real mMagnetizingReactance=1e9;
 		/// Leakage
 		Complex mLeakage;
-		/// Magnetizing impedance
-		Complex mMagnetizing;
 
 		/// base apparent power[VA]
 		Real mBaseApparentPower;

--- a/models/Source/Base/Base_ReducedOrderSynchronGenerator.cpp
+++ b/models/Source/Base/Base_ReducedOrderSynchronGenerator.cpp
@@ -154,7 +154,7 @@ void Base::ReducedOrderSynchronGenerator<Real>::initializeFromNodesAndTerminals(
 	this->updateMatrixNodeIndices();
 
 	if(!mInitialValuesSet)
-		this->setInitialValues(-this->terminal(0)->singlePower(), mInitMechPower, this->initialSingleVoltage(0));
+		this->setInitialValues(-this->terminal(0)->singlePower(), -this->terminal(0)->singlePower().real(), this->initialSingleVoltage(0));
 
 	// Initialize mechanical torque
 	mMechTorque = mInitMechPower / mNomPower;
@@ -217,7 +217,7 @@ void Base::ReducedOrderSynchronGenerator<Complex>::initializeFromNodesAndTermina
 	this->updateMatrixNodeIndices();
 
 	if(!mInitialValuesSet)
-		this->setInitialValues(-this->terminal(0)->singlePower(), mInitMechPower, this->initialSingleVoltage(0));
+		this->setInitialValues(-this->terminal(0)->singlePower(), -this->terminal(0)->singlePower().real(), this->initialSingleVoltage(0));
 
 	// Initialize mechanical torque
 	mMechTorque = mInitMechPower / mNomPower;

--- a/models/Source/Base/Base_ReducedOrderSynchronGenerator.cpp
+++ b/models/Source/Base/Base_ReducedOrderSynchronGenerator.cpp
@@ -22,7 +22,8 @@ Base::ReducedOrderSynchronGenerator<Real>::ReducedOrderSynchronGenerator(
 	mIdq0 = Matrix::Zero(3,1);
 
     // Register attributes
-	addAttribute<Real>("Etorque", &mElecTorque, Flags::read);
+	addAttribute<Real>("Tm", &mMechTorque, Flags::read);
+	addAttribute<Real>("Te", &mElecTorque, Flags::read);
 	addAttribute<Real>("delta", &mDelta, Flags::read);
 	addAttribute<Real>("Theta", &mThetaMech, Flags::read);
     addAttribute<Real>("w_r", &mOmMech, Flags::read);
@@ -42,7 +43,8 @@ Base::ReducedOrderSynchronGenerator<Complex>::ReducedOrderSynchronGenerator(
 	mIdq = Matrix::Zero(2,1);
 
     // Register attributes
-	addAttribute<Real>("Etorque", &mElecTorque, Flags::read);
+	addAttribute<Real>("Tm", &mMechTorque, Flags::read);
+	addAttribute<Real>("Te", &mElecTorque, Flags::read);
 	addAttribute<Real>("delta", &mDelta, Flags::read);
 	addAttribute<Real>("Theta", &mThetaMech, Flags::read);
     addAttribute<Real>("w_r", &mOmMech, Flags::read);

--- a/models/Source/Base/Base_ReducedOrderSynchronGenerator.cpp
+++ b/models/Source/Base/Base_ReducedOrderSynchronGenerator.cpp
@@ -131,6 +131,18 @@ void Base::ReducedOrderSynchronGenerator<VarType>::setOperationalParametersPerUn
 	mH = H;
 }
 
+template <>
+void Base::ReducedOrderSynchronGenerator<Real>::scaleInertiaConstant(Real scalingFactor) {
+	mH = mH * scalingFactor;
+	mSLog->info("Scaling inertia with factor {:e}:\n resulting inertia: {:e}\n", scalingFactor, mH); 
+}
+
+template <>
+void Base::ReducedOrderSynchronGenerator<Complex>::scaleInertiaConstant(Real scalingFactor) {
+	mH = mH * scalingFactor;
+	mSLog->info("Scaling inertia with factor {:e}:\n resulting inertia: {:e}\n", scalingFactor, mH); 
+}
+
 template <typename VarType>
 void Base::ReducedOrderSynchronGenerator<VarType>::setInitialValues(
 	Complex initComplexElectricalPower, Real initMechanicalPower, Complex initTerminalVoltage) {

--- a/models/Source/CIM/Reader.cpp
+++ b/models/Source/CIM/Reader.cpp
@@ -580,7 +580,11 @@ TopologicalPowerComp::Ptr Reader::mapSynchronousMachine(CIMPP::SynchronousMachin
 		}
 	} else if (mDomain == Domain::SP) {
 		mSLog->info("    Create generator in SP domain.");
-		if (mGeneratorType == GeneratorType::TransientStability || mGeneratorType == GeneratorType::SG4OrderVBR) {
+		if (mGeneratorType == GeneratorType::TransientStability 
+			|| mGeneratorType == GeneratorType::SG6aOrderVBR
+			|| mGeneratorType == GeneratorType::SG6bOrderVBR
+			|| mGeneratorType == GeneratorType::SG4OrderVBR
+			|| mGeneratorType == GeneratorType::SG3OrderVBR) {
 
 			Real ratedPower = unitValue(machine->ratedS.value, UnitMultiplier::M);
 			Real ratedVoltage = unitValue(machine->ratedU.value, UnitMultiplier::k);

--- a/models/Source/CIM/Reader.cpp
+++ b/models/Source/CIM/Reader.cpp
@@ -496,7 +496,11 @@ TopologicalPowerComp::Ptr Reader::mapSynchronousMachine(CIMPP::SynchronousMachin
 
 	if (mDomain == Domain::DP) {
 		mSLog->info("    Create generator in DP domain.");
-		if (mGeneratorType == GeneratorType::TransientStability || mGeneratorType == GeneratorType::SG4OrderVBR) {
+		if (mGeneratorType == GeneratorType::TransientStability 
+			|| mGeneratorType == GeneratorType::SG6aOrderVBR
+			|| mGeneratorType == GeneratorType::SG6bOrderVBR
+			|| mGeneratorType == GeneratorType::SG4OrderVBR
+			|| mGeneratorType == GeneratorType::SG3OrderVBR) {
 
 			Real ratedPower = unitValue(machine->ratedS.value, UnitMultiplier::M);
 			Real ratedVoltage = unitValue(machine->ratedU.value, UnitMultiplier::k);

--- a/models/Source/DP/DP_Ph1_Switch.cpp
+++ b/models/Source/DP/DP_Ph1_Switch.cpp
@@ -68,14 +68,14 @@ void DP::Ph1::Switch::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
 		Math::addToMatrixElement(systemMatrix, matrixNodeIndex(1), matrixNodeIndex(0), -conductance);
 	}
 
-	mSLog->info("-- Stamp ---");
+	SPDLOG_LOGGER_TRACE(mSLog, "-- Stamp ---");
 	if (terminalNotGrounded(0))
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(0), matrixNodeIndex(0));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(0), matrixNodeIndex(0));
 	if (terminalNotGrounded(1))
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(1), matrixNodeIndex(1));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(1), matrixNodeIndex(1));
 	if (terminalNotGrounded(0) && terminalNotGrounded(1)) {
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(0), matrixNodeIndex(1));
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(1), matrixNodeIndex(0));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(0), matrixNodeIndex(1));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(1), matrixNodeIndex(0));
 	}
 }
 
@@ -96,14 +96,14 @@ void DP::Ph1::Switch::mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& syste
 		Math::addToMatrixElement(systemMatrix, matrixNodeIndex(1), matrixNodeIndex(0), -conductance);
 	}
 
-	mSLog->info("-- Stamp ---");
+	SPDLOG_LOGGER_TRACE(mSLog, "-- Stamp ---");
 	if (terminalNotGrounded(0))
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(0), matrixNodeIndex(0));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(0), matrixNodeIndex(0));
 	if (terminalNotGrounded(1))
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(1), matrixNodeIndex(1));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(1), matrixNodeIndex(1));
 	if (terminalNotGrounded(0) && terminalNotGrounded(1)) {
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(0), matrixNodeIndex(1));
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(1), matrixNodeIndex(0));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(0), matrixNodeIndex(1));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(1), matrixNodeIndex(0));
 	}
 }
 

--- a/models/Source/DP/DP_Ph1_SynchronGenerator3OrderVBR.cpp
+++ b/models/Source/DP/DP_Ph1_SynchronGenerator3OrderVBR.cpp
@@ -33,6 +33,26 @@ SimPowerComp<Complex>::Ptr DP::Ph1::SynchronGenerator3OrderVBR::clone(String nam
 	return copy;
 }
 
+void DP::Ph1::SynchronGenerator3OrderVBR::setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Td0_t) {
+
+	Base::ReducedOrderSynchronGenerator<Complex>::setOperationalParametersPerUnit(nomPower, 
+		nomVolt, nomFreq, H, Ld, Lq, L0,
+		Ld_t, Td0_t);
+	
+	mSLog->info("Set base parameters: \n"
+				"nomPower: {:e}\nnomVolt: {:e}\nnomFreq: {:e}\n",
+				nomPower, nomVolt, nomFreq);
+
+	mSLog->info("Set operational parameters in per unit: \n"
+			"inertia: {:e}\n"
+			"Ld: {:e}\nLq: {:e}\nL0: {:e}\n"
+			"Ld_t: {:e}\nTd0_t: {:e}\n",
+			H, Ld, Lq, L0, 
+			Ld_t, Td0_t);
+}
+
 void DP::Ph1::SynchronGenerator3OrderVBR::specificInitialization() {
 
 	// initial voltage behind the transient reactance in the dq reference frame

--- a/models/Source/DP/DP_Ph1_SynchronGenerator4OrderVBR.cpp
+++ b/models/Source/DP/DP_Ph1_SynchronGenerator4OrderVBR.cpp
@@ -33,6 +33,28 @@ SimPowerComp<Complex>::Ptr DP::Ph1::SynchronGenerator4OrderVBR::clone(String nam
 	return copy;
 }
 
+void DP::Ph1::SynchronGenerator4OrderVBR::setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t) {
+
+	Base::ReducedOrderSynchronGenerator<Complex>::setOperationalParametersPerUnit(nomPower, 
+			nomVolt, nomFreq, H, Ld, Lq, L0,
+			Ld_t, Lq_t, Td0_t, Tq0_t);
+	
+	mSLog->info("Set base parameters: \n"
+				"nomPower: {:e}\nnomVolt: {:e}\nnomFreq: {:e}\n",
+				nomPower, nomVolt, nomFreq);
+
+	mSLog->info("Set operational parameters in per unit: \n"
+			"inertia: {:e}\n"
+			"Ld: {:e}\nLq: {:e}\nL0: {:e}\n"
+			"Ld_t: {:e}\nLq_t: {:e}\n"
+			"Td0_t: {:e}\nTq0_t: {:e}\n",
+			H, Ld, Lq, L0, 
+			Ld_t, Lq_t,
+			Td0_t, Tq0_t);
+};
+
 void DP::Ph1::SynchronGenerator4OrderVBR::specificInitialization() {
 
 	// initial voltage behind the transient reactance in the dq reference frame

--- a/models/Source/DP/DP_Ph1_SynchronGenerator6bOrderVBR.cpp
+++ b/models/Source/DP/DP_Ph1_SynchronGenerator6bOrderVBR.cpp
@@ -36,6 +36,34 @@ SimPowerComp<Complex>::Ptr DP::Ph1::SynchronGenerator6bOrderVBR::clone(String na
 	return copy;
 }
 
+void DP::Ph1::SynchronGenerator6bOrderVBR::setOperationalParametersPerUnit(Real nomPower, 
+		Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+		Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t,
+		Real Ld_s, Real Lq_s, Real Td0_s, Real Tq0_s) {
+
+	Base::ReducedOrderSynchronGenerator<Complex>::setOperationalParametersPerUnit(nomPower, 
+		nomVolt, nomFreq, H, Ld, Lq, L0,
+		Ld_t, Lq_t, Td0_t, Tq0_t,
+		Ld_s, Lq_s, Td0_s, Tq0_s);
+	
+	mSLog->info("Set base parameters: \n"
+				"nomPower: {:e}\nnomVolt: {:e}\nnomFreq: {:e}\n",
+				nomPower, nomVolt, nomFreq);
+
+	mSLog->info("Set operational parameters in per unit: \n"
+			"inertia: {:e}\n"
+			"Ld: {:e}\nLq: {:e}\nL0: {:e}\n"
+			"Ld_t: {:e}\nLq_t: {:e}\n"
+			"Td0_t: {:e}\nTq0_t: {:e}\n"
+			"Ld_s: {:e}\nLq_s: {:e}\n"
+			"Td0_s: {:e}\nTq0_s: {:e}\n",
+			H, Ld, Lq, L0, 
+			Ld_t, Lq_t,
+			Td0_t, Tq0_t,
+			Ld_s, Lq_s,
+			Td0_s, Tq0_s);
+};
+
 void DP::Ph1::SynchronGenerator6bOrderVBR::specificInitialization() {
 
 	// initial voltage behind the transient reactance in the dq reference frame

--- a/models/Source/DP/DP_Ph1_SynchronGeneratorVBR.cpp
+++ b/models/Source/DP/DP_Ph1_SynchronGeneratorVBR.cpp
@@ -67,6 +67,27 @@ void DP::Ph1::SynchronGeneratorVBR::calculateAuxiliarVariables() {
 	mKvbr(0,1) = -Complex(cos(mThetaMech - mBase_OmMech * mSimTime - PI/2.), sin(mThetaMech - mBase_OmMech * mSimTime - PI/2.));
 }
 
+void DP::Ph1::SynchronGeneratorVBR::mnaInitialize(Real omega, 
+		Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+
+	Base::ReducedOrderSynchronGenerator<Complex>::mnaInitialize(omega, timeStep, leftVector);
+
+	// upper left
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(), mVirtualNodes[0]->matrixNodeIndex()));
+
+	// buttom right
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 0), matrixNodeIndex(0, 0)));
+
+	// off diagonal
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(), matrixNodeIndex(0, 0)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 0), mVirtualNodes[0]->matrixNodeIndex()));
+	
+	mSLog->info("List of index pairs of varying matrix entries: ");
+	for (auto indexPair : mVariableSystemMatrixEntries)
+		mSLog->info("({}, {})", indexPair.first, indexPair.second);
+
+}
+
 void DP::Ph1::SynchronGeneratorVBR::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
 	// Stamp voltage source
 	Math::setMatrixElement(systemMatrix, mVirtualNodes[0]->matrixNodeIndex(), mVirtualNodes[1]->matrixNodeIndex(), Complex(-1, 0));

--- a/models/Source/EMT/EMT_Ph3_ReducedOrderSynchronGeneratorVBR.cpp
+++ b/models/Source/EMT/EMT_Ph3_ReducedOrderSynchronGeneratorVBR.cpp
@@ -41,6 +41,59 @@ void EMT::Ph3::ReducedOrderSynchronGeneratorVBR::calculateResistanceMatrix() {
 	mConductanceMatrix = resistanceMatrix.inverse();
 }
 
+void EMT::Ph3::ReducedOrderSynchronGeneratorVBR::mnaInitialize(Real omega, 
+		Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+
+	Base::ReducedOrderSynchronGenerator<Real>::mnaInitialize(omega, timeStep, leftVector);
+
+	// upper left block
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::A), mVirtualNodes[0]->matrixNodeIndex(PhaseType::A)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::A), mVirtualNodes[0]->matrixNodeIndex(PhaseType::B)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::A), mVirtualNodes[0]->matrixNodeIndex(PhaseType::C)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::B), mVirtualNodes[0]->matrixNodeIndex(PhaseType::A)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::B), mVirtualNodes[0]->matrixNodeIndex(PhaseType::B)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::B), mVirtualNodes[0]->matrixNodeIndex(PhaseType::C)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::C), mVirtualNodes[0]->matrixNodeIndex(PhaseType::A)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::C), mVirtualNodes[0]->matrixNodeIndex(PhaseType::B)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::C), mVirtualNodes[0]->matrixNodeIndex(PhaseType::C)));
+	
+	// buttom right block
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 0), matrixNodeIndex(0, 0)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 0), matrixNodeIndex(0, 1)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 0), matrixNodeIndex(0, 2)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 1), matrixNodeIndex(0, 0)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 1), matrixNodeIndex(0, 1)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 1), matrixNodeIndex(0, 2)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 2), matrixNodeIndex(0, 0)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 2), matrixNodeIndex(0, 1)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 2), matrixNodeIndex(0, 2)));
+
+	// off diagonal blocks
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::A), matrixNodeIndex(0, 0)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::A), matrixNodeIndex(0, 1)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::A), matrixNodeIndex(0, 2)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::B), matrixNodeIndex(0, 0)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::B), matrixNodeIndex(0, 1)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::B), matrixNodeIndex(0, 2)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::C), matrixNodeIndex(0, 0)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::C), matrixNodeIndex(0, 1)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(mVirtualNodes[0]->matrixNodeIndex(PhaseType::C), matrixNodeIndex(0, 2)));
+
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 0), mVirtualNodes[0]->matrixNodeIndex(PhaseType::A)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 0), mVirtualNodes[0]->matrixNodeIndex(PhaseType::B)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 0), mVirtualNodes[0]->matrixNodeIndex(PhaseType::C)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 1), mVirtualNodes[0]->matrixNodeIndex(PhaseType::A)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 1), mVirtualNodes[0]->matrixNodeIndex(PhaseType::B)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 1), mVirtualNodes[0]->matrixNodeIndex(PhaseType::C)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 2), mVirtualNodes[0]->matrixNodeIndex(PhaseType::A)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 2), mVirtualNodes[0]->matrixNodeIndex(PhaseType::B)));
+	mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, 2), mVirtualNodes[0]->matrixNodeIndex(PhaseType::C)));
+
+	mSLog->info("List of index pairs of varying matrix entries: ");
+	for (auto indexPair : mVariableSystemMatrixEntries)
+		mSLog->info("({}, {})", indexPair.first, indexPair.second);
+}
+
 void EMT::Ph3::ReducedOrderSynchronGeneratorVBR::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
 
 	// Stamp voltage source

--- a/models/Source/EMT/EMT_Ph3_Switch.cpp
+++ b/models/Source/EMT/EMT_Ph3_Switch.cpp
@@ -112,7 +112,7 @@ void EMT::Ph3::Switch::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
 		Math::addToMatrixElement(systemMatrix, matrixNodeIndex(1, 2), matrixNodeIndex(0, 1), -conductance(2, 1));
 		Math::addToMatrixElement(systemMatrix, matrixNodeIndex(1, 2), matrixNodeIndex(0, 2), -conductance(2, 2));
 	}
-	mSLog->info(
+	SPDLOG_LOGGER_TRACE(mSLog, 
 		"\nConductance matrix: {:s}",
 		Logger::matrixToString(conductance));
 }
@@ -170,7 +170,7 @@ void EMT::Ph3::Switch::mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& syst
 		Math::addToMatrixElement(systemMatrix, matrixNodeIndex(1, 2), matrixNodeIndex(0, 2), -conductance(2, 2));
 	}
 
-	mSLog->info(
+	SPDLOG_LOGGER_TRACE(mSLog, 
 		"\nConductance matrix: {:s}",
 		Logger::matrixToString(conductance));
 }

--- a/models/Source/EMT/EMT_Ph3_SynchronGenerator3OrderVBR.cpp
+++ b/models/Source/EMT/EMT_Ph3_SynchronGenerator3OrderVBR.cpp
@@ -33,6 +33,26 @@ SimPowerComp<Real>::Ptr EMT::Ph3::SynchronGenerator3OrderVBR::clone(String name)
 	return copy;
 }
 
+void EMT::Ph3::SynchronGenerator3OrderVBR::setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Td0_t) {
+
+	Base::ReducedOrderSynchronGenerator<Real>::setOperationalParametersPerUnit(nomPower, 
+		nomVolt, nomFreq, H, Ld, Lq, L0,
+		Ld_t, Td0_t);
+	
+	mSLog->info("Set base parameters: \n"
+				"nomPower: {:e}\nnomVolt: {:e}\nnomFreq: {:e}\n",
+				nomPower, nomVolt, nomFreq);
+
+	mSLog->info("Set operational parameters in per unit: \n"
+			"inertia: {:e}\n"
+			"Ld: {:e}\nLq: {:e}\nL0: {:e}\n"
+			"Ld_t: {:e}\nTd0_t: {:e}\n",
+			H, Ld, Lq, L0, 
+			Ld_t, Td0_t);
+}
+
 void EMT::Ph3::SynchronGenerator3OrderVBR::specificInitialization() {
 	// initial voltage behind the transient reactance in the dq0 reference frame
 	mEdq0_t(1,0) = mVdq0(1,0) + mIdq0(0,0) * mLd_t;

--- a/models/Source/EMT/EMT_Ph3_SynchronGenerator4OrderVBR.cpp
+++ b/models/Source/EMT/EMT_Ph3_SynchronGenerator4OrderVBR.cpp
@@ -33,6 +33,28 @@ SimPowerComp<Real>::Ptr EMT::Ph3::SynchronGenerator4OrderVBR::clone(String name)
 	return copy;
 }
 
+void EMT::Ph3::SynchronGenerator4OrderVBR::setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t) {
+
+	Base::ReducedOrderSynchronGenerator<Real>::setOperationalParametersPerUnit(nomPower, 
+			nomVolt, nomFreq, H, Ld, Lq, L0,
+			Ld_t, Lq_t, Td0_t, Tq0_t);
+	
+	mSLog->info("Set base parameters: \n"
+				"nomPower: {:e}\nnomVolt: {:e}\nnomFreq: {:e}\n",
+				nomPower, nomVolt, nomFreq);
+
+	mSLog->info("Set operational parameters in per unit: \n"
+			"inertia: {:e}\n"
+			"Ld: {:e}\nLq: {:e}\nL0: {:e}\n"
+			"Ld_t: {:e}\nLq_t: {:e}\n"
+			"Td0_t: {:e}\nTq0_t: {:e}\n",
+			H, Ld, Lq, L0, 
+			Ld_t, Lq_t,
+			Td0_t, Tq0_t);
+};
+
 void EMT::Ph3::SynchronGenerator4OrderVBR::specificInitialization() {
 	// initial voltage behind the transient reactance in the dq0 reference frame
 	mEdq0_t(0,0) = mVdq0(0,0) - mIdq0(1,0) * mLq_t;

--- a/models/Source/EMT/EMT_Ph3_SynchronGenerator6bOrderVBR.cpp
+++ b/models/Source/EMT/EMT_Ph3_SynchronGenerator6bOrderVBR.cpp
@@ -36,6 +36,34 @@ SimPowerComp<Real>::Ptr EMT::Ph3::SynchronGenerator6bOrderVBR::clone(String name
 	return copy;
 }
 
+void EMT::Ph3::SynchronGenerator6bOrderVBR::setOperationalParametersPerUnit(Real nomPower, 
+		Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+		Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t,
+		Real Ld_s, Real Lq_s, Real Td0_s, Real Tq0_s) {
+
+	Base::ReducedOrderSynchronGenerator<Real>::setOperationalParametersPerUnit(nomPower, 
+		nomVolt, nomFreq, H, Ld, Lq, L0,
+		Ld_t, Lq_t, Td0_t, Tq0_t,
+		Ld_s, Lq_s, Td0_s, Tq0_s);
+	
+	mSLog->info("Set base parameters: \n"
+				"nomPower: {:e}\nnomVolt: {:e}\nnomFreq: {:e}\n",
+				nomPower, nomVolt, nomFreq);
+
+	mSLog->info("Set operational parameters in per unit: \n"
+			"inertia: {:e}\n"
+			"Ld: {:e}\nLq: {:e}\nL0: {:e}\n"
+			"Ld_t: {:e}\nLq_t: {:e}\n"
+			"Td0_t: {:e}\nTq0_t: {:e}\n"
+			"Ld_s: {:e}\nLq_s: {:e}\n"
+			"Td0_s: {:e}\nTq0_s: {:e}\n",
+			H, Ld, Lq, L0, 
+			Ld_t, Lq_t,
+			Td0_t, Tq0_t,
+			Ld_s, Lq_s,
+			Td0_s, Tq0_s);
+};
+
 void EMT::Ph3::SynchronGenerator6bOrderVBR::specificInitialization() {
 	// initial voltage behind the transient reactance in the dq reference frame
 	mEdq0_t(0,0) = (mLq - mLq_t) * mIdq0(1,0);

--- a/models/Source/SP/SP_Ph1_Capacitor.cpp
+++ b/models/Source/SP/SP_Ph1_Capacitor.cpp
@@ -151,7 +151,7 @@ void SP::Ph1::Capacitor::pfApplyAdmittanceMatrixStamp(SparseMatrixCompRow & Y) {
 	if (std::isinf(mAdmittancePerUnit.real()) || std::isinf(mAdmittancePerUnit.imag())) {
 		std::cout << "Y:" << mAdmittancePerUnit << std::endl;
 		std::stringstream ss;
-		ss << "Resistor >>" << this->name() << ": infinite or nan values at node: " << bus1;
+		ss << "Capacitor >>" << this->name() << ": infinite or nan values at node: " << bus1;
 		throw std::invalid_argument(ss.str());
 	}
 

--- a/models/Source/SP/SP_Ph1_Switch.cpp
+++ b/models/Source/SP/SP_Ph1_Switch.cpp
@@ -68,14 +68,14 @@ void SP::Ph1::Switch::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
 		Math::addToMatrixElement(systemMatrix, matrixNodeIndex(1), matrixNodeIndex(0), -conductance);
 	}
 
-	mSLog->info("-- Stamp ---");
+	SPDLOG_LOGGER_TRACE(mSLog, "-- Stamp ---");
 	if (terminalNotGrounded(0))
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(0), matrixNodeIndex(0));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(0), matrixNodeIndex(0));
 	if (terminalNotGrounded(1))
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(1), matrixNodeIndex(1));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(1), matrixNodeIndex(1));
 	if (terminalNotGrounded(0) && terminalNotGrounded(1)) {
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(0), matrixNodeIndex(1));
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(1), matrixNodeIndex(0));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(0), matrixNodeIndex(1));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(1), matrixNodeIndex(0));
 	}
 }
 
@@ -96,14 +96,14 @@ void SP::Ph1::Switch::mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& syste
 		Math::addToMatrixElement(systemMatrix, matrixNodeIndex(1), matrixNodeIndex(0), -conductance);
 	}
 
-	mSLog->info("-- Stamp ---");
+	SPDLOG_LOGGER_TRACE(mSLog, "-- Stamp ---");
 	if (terminalNotGrounded(0))
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(0), matrixNodeIndex(0));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(0), matrixNodeIndex(0));
 	if (terminalNotGrounded(1))
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(1), matrixNodeIndex(1));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(conductance), matrixNodeIndex(1), matrixNodeIndex(1));
 	if (terminalNotGrounded(0) && terminalNotGrounded(1)) {
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(0), matrixNodeIndex(1));
-		mSLog->info("Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(1), matrixNodeIndex(0));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(0), matrixNodeIndex(1));
+		SPDLOG_LOGGER_TRACE(mSLog, "Add {:s} to system at ({:d},{:d})", Logger::complexToString(-conductance), matrixNodeIndex(1), matrixNodeIndex(0));
 	}
 }
 

--- a/models/Source/SP/SP_Ph1_SynchronGenerator3OrderVBR.cpp
+++ b/models/Source/SP/SP_Ph1_SynchronGenerator3OrderVBR.cpp
@@ -32,6 +32,26 @@ SimPowerComp<Complex>::Ptr SP::Ph1::SynchronGenerator3OrderVBR::clone(String nam
 	return copy;
 }
 
+void SP::Ph1::SynchronGenerator3OrderVBR::setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Td0_t) {
+
+	Base::ReducedOrderSynchronGenerator<Complex>::setOperationalParametersPerUnit(nomPower, 
+		nomVolt, nomFreq, H, Ld, Lq, L0,
+		Ld_t, Td0_t);
+	
+	mSLog->info("Set base parameters: \n"
+				"nomPower: {:e}\nnomVolt: {:e}\nnomFreq: {:e}\n",
+				nomPower, nomVolt, nomFreq);
+
+	mSLog->info("Set operational parameters in per unit: \n"
+			"inertia: {:e}\n"
+			"Ld: {:e}\nLq: {:e}\nL0: {:e}\n"
+			"Ld_t: {:e}\nTd0_t: {:e}\n",
+			H, Ld, Lq, L0, 
+			Ld_t, Td0_t);
+}
+
 void SP::Ph1::SynchronGenerator3OrderVBR::specificInitialization() {
 
 	// initial voltage behind the transient reactance in the dq reference frame

--- a/models/Source/SP/SP_Ph1_SynchronGenerator4OrderVBR.cpp
+++ b/models/Source/SP/SP_Ph1_SynchronGenerator4OrderVBR.cpp
@@ -32,6 +32,29 @@ SimPowerComp<Complex>::Ptr SP::Ph1::SynchronGenerator4OrderVBR::clone(String nam
 	return copy;
 }
 
+void SP::Ph1::SynchronGenerator4OrderVBR::setOperationalParametersPerUnit(Real nomPower, 
+			Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+			Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t) {
+
+	Base::ReducedOrderSynchronGenerator<Complex>::setOperationalParametersPerUnit(nomPower, 
+			nomVolt, nomFreq, H, Ld, Lq, L0,
+			Ld_t, Lq_t, Td0_t, Tq0_t);
+	
+	mSLog->info("Set base parameters: \n"
+				"nomPower: {:e}\nnomVolt: {:e}\nnomFreq: {:e}\n",
+				nomPower, nomVolt, nomFreq);
+
+	mSLog->info("Set operational parameters in per unit: \n"
+			"inertia: {:e}\n"
+			"Ld: {:e}\nLq: {:e}\nL0: {:e}\n"
+			"Ld_t: {:e}\nLq_t: {:e}\n"
+			"Td0_t: {:e}\nTq0_t: {:e}\n",
+			H, Ld, Lq, L0, 
+			Ld_t, Lq_t,
+			Td0_t, Tq0_t);
+};
+
+
 void SP::Ph1::SynchronGenerator4OrderVBR::specificInitialization() {
 
 	// initial voltage behind the transient reactance in the dq reference frame

--- a/models/Source/SP/SP_Ph1_SynchronGenerator6bOrderVBR.cpp
+++ b/models/Source/SP/SP_Ph1_SynchronGenerator6bOrderVBR.cpp
@@ -35,6 +35,34 @@ SimPowerComp<Complex>::Ptr SP::Ph1::SynchronGenerator6bOrderVBR::clone(String na
 	return copy;
 }
 
+void SP::Ph1::SynchronGenerator6bOrderVBR::setOperationalParametersPerUnit(Real nomPower, 
+		Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
+		Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t,
+		Real Ld_s, Real Lq_s, Real Td0_s, Real Tq0_s) {
+
+	Base::ReducedOrderSynchronGenerator<Complex>::setOperationalParametersPerUnit(nomPower, 
+		nomVolt, nomFreq, H, Ld, Lq, L0,
+		Ld_t, Lq_t, Td0_t, Tq0_t,
+		Ld_s, Lq_s, Td0_s, Tq0_s);
+	
+	mSLog->info("Set base parameters: \n"
+				"nomPower: {:e}\nnomVolt: {:e}\nnomFreq: {:e}\n",
+				nomPower, nomVolt, nomFreq);
+
+	mSLog->info("Set operational parameters in per unit: \n"
+			"inertia: {:e}\n"
+			"Ld: {:e}\nLq: {:e}\nL0: {:e}\n"
+			"Ld_t: {:e}\nLq_t: {:e}\n"
+			"Td0_t: {:e}\nTq0_t: {:e}\n"
+			"Ld_s: {:e}\nLq_s: {:e}\n"
+			"Td0_s: {:e}\nTq0_s: {:e}\n",
+			H, Ld, Lq, L0, 
+			Ld_t, Lq_t,
+			Td0_t, Tq0_t,
+			Ld_s, Lq_s,
+			Td0_s, Tq0_s);
+};
+
 void SP::Ph1::SynchronGenerator6bOrderVBR::specificInitialization() {
 
 	// initial voltage behind the transient reactance in the dq reference frame

--- a/models/Source/SP/SP_Ph1_Transformer.cpp
+++ b/models/Source/SP/SP_Ph1_Transformer.cpp
@@ -217,11 +217,9 @@ void SP::Ph1::Transformer::calculatePerUnitParameters(Real baseApparentPower, Re
 
 	mBaseInductance = mBaseImpedance / mBaseOmega;
 	mInductancePerUnit = mInductance / mBaseInductance;
-	mMagnetizing = mMagnetizingReactance / mBaseImpedance;
 	// omega per unit=1, hence 1.0*mInductancePerUnit.
 	mLeakagePerUnit = Complex(mResistancePerUnit,1.*mInductancePerUnit);
-	mMagnetizingPerUnit = mMagnetizing / mBaseImpedance;
-	mSLog->info("Leakage Impedance Per Unit={} [Ohm] ", mLeakagePerUnit);
+	mSLog->info("Leakage Impedance={} [pu] ", mLeakagePerUnit);
 
     mRatioAbsPerUnit = mRatioAbs / mNominalVoltageEnd1 * mNominalVoltageEnd2;
     mSLog->info("Tap Ratio={} [pu]", mRatioAbsPerUnit);
@@ -241,18 +239,17 @@ void SP::Ph1::Transformer::pfApplyAdmittanceMatrixStamp(SparseMatrixCompRow & Y)
 	// calculate matrix stamp
 	mY_element = MatrixComp(2, 2);
 	Complex y = Complex(1, 0) / mLeakagePerUnit;
-	Complex ys = Complex(1, 0) / mMagnetizingPerUnit;
-	mY_element(0, 0) = (y + ys);
+
+	mY_element(0, 0) = y;
 	mY_element(0, 1) = -y*mRatioAbsPerUnit;
 	mY_element(1, 0) = -y*mRatioAbsPerUnit;
-	mY_element(1, 1) = (y + ys)*std::pow(mRatioAbsPerUnit, 2);
+	mY_element(1, 1) = y*std::pow(mRatioAbsPerUnit, 2);
 
 	//check for inf or nan
 	for (int i = 0; i < 2; i++)
 		for (int j = 0; j < 2; j++)
 			if (std::isinf(mY_element.coeff(i, j).real()) || std::isinf(mY_element.coeff(i, j).imag())) {
 				std::cout << mY_element << std::endl;
-				std::cout << "Zm:" << mMagnetizing << std::endl;
 				std::cout << "Zl:" << mLeakage << std::endl;
 				std::cout << "tap:" << mRatioAbsPerUnit << std::endl;
 				std::stringstream ss;


### PR DESCRIPTION
This PR provides further examples with reduced-order synchronous generators: a SMIB system with a load step event and the WSCC benchmark system. Besides, it includes the following:
- The logging of the indices of the variable matrix entries for reduced-order VBR models.
- The removal of the uncofigurable magnetizing reactance from the powerflow transformer model to align the model with the ones used in dynamic simulations.
- The use of the SG's initial active power from the terminals as initial mechanical input power instead of the predefined mechanical power when this value is set by means of initializeFromNodesAndTerminals.
- The reduction of the required accuracy for an time event from 1000ns to 100ns.