### PR TITLE
New iec60870-104 example

### DIFF
--- a/examples/villas/dpsim-iec104-cigre-mv-pf-profiles.py
+++ b/examples/villas/dpsim-iec104-cigre-mv-pf-profiles.py
@@ -1,0 +1,97 @@
+# Adapted from shmem_cigre_mv_pf_profiles using the new attribute system
+
+import glob
+import logging
+import os
+import sys
+
+import dpsimpy
+import dpsimpyvillas
+
+# setup
+name = 'CIGRE-MV-Profiles'
+time_step = 1
+final_time = float('inf')
+
+# setup stdout logger
+base = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+log = logging.getLogger(base)
+
+# read topology from CIM
+files = glob.glob('build/_deps/cim-data-src/CIGRE_MV/NEPLAN/CIGRE_MV_no_tapchanger_With_LoadFlow_Results/*.xml') # downloaded by CMake
+log.info('CIM files: %s', files)
+reader = dpsimpy.CIMReader(name)
+system = reader.loadCIM(50, files, dpsimpy.Domain.SP, dpsimpy.PhaseType.Single, dpsimpy.GeneratorType.PVNode)
+
+# map from CSV to simulation names
+assignList = {
+    'LOAD-H-1': 'Load_H_1',
+    'LOAD-H-3': 'Load_H_3',
+    'LOAD-H-4': 'Load_H_4',
+    'LOAD-H-5': 'Load_H_5',
+    'LOAD-H-6': 'Load_H_6',
+    'LOAD-H-8': 'Load_H_8',
+    'LOAD-H-10': 'Load_H_10',
+    'LOAD-H-11': 'Load_H_11',
+    'LOAD-H-12': 'Load_H_12',
+    'LOAD-H-14': 'Load_H_14',
+    'LOAD-I-1': 'Load_I_1',
+    'LOAD-I-3': 'Load_I_3',
+    'LOAD-I-7': 'Load_I_7',
+    'LOAD-I-9': 'Load_I_9',
+    'LOAD-I-10': 'Load_I_10',
+    'LOAD-I-12': 'Load_I_12',
+    'LOAD-I-13': 'Load_I_13',
+    'LOAD-I-14': 'Load_I_14'
+}
+
+# read profiles from CSV
+csv_files = 'build/_deps/profile-data-src/CIGRE_MV_NoTap/load_profiles/'
+log.info('CSV files: %s', csv_files)
+csvreader = dpsimpy.CSVReader(name, csv_files, assignList, dpsimpy.LogLevel.info)
+csvreader.assignLoadProfile(system, 0, 1, 300, dpsimpy.CSVReaderMode.MANUAL, dpsimpy.CSVReaderFormat.SECONDS)
+
+# instantiate logger
+logger = dpsimpy.Logger(name)
+
+intf_iec104 = dpsimpyvillas.InterfaceVillas(name='IEC104', config='''{
+    "type": "iec60870-5-104",
+    "address": "0.0.0.0",
+    "ca": 41025,
+    "out": {
+        "duplicate_ioa_is_sequence": true,
+        "signals": {
+            "count": 30,
+            "asdu_type_id": "M_ME_TF_1",
+            "ioa": 4202832
+        }
+    }
+}''')
+
+# setup simulation
+sim = dpsimpy.RealTimeSimulation(name)
+sim.set_system(system)
+sim.set_domain(dpsimpy.Domain.SP)
+sim.set_solver(dpsimpy.Solver.NRP)
+sim.set_time_step(time_step)
+sim.set_final_time(final_time)
+sim.add_logger(logger)
+sim.add_interface(intf_iec104, False)
+
+# setup exports
+for i in range(15):
+    objname = 'N'+str(i)
+    sim.export_attribute(sim \
+        .get_idobj_attr(objname, 'v') \
+        .derive_coeff(0,0) \
+        .derive_mag(), 2*i)
+    sim.export_attribute(sim \
+        .get_idobj_attr(objname, 'v') \
+        .derive_coeff(0,0) \
+        .derive_phase(), 2*i+1)
+
+# log exports
+for node in system.nodes:
+    sim.log_idobj_attribute(node.name(), 'v')
+
+sim.run(1)

--- a/packaging/Docker/Dockerfile.dev-iec104
+++ b/packaging/Docker/Dockerfile.dev-iec104
@@ -1,0 +1,107 @@
+# base with basic dependencies (no build dependencies)
+FROM fedora:34 AS base
+
+LABEL \
+	org.label-schema.schema-version = "1.0.0" \
+	org.label-schema.name = "DPsim" \
+	org.label-schema.license = "MPL 2.0" \
+	org.label-schema.url = "http://dpsim.fein-aachen.org/" \
+	org.label-schema.vcs-url = "https://github.com/sogno-platform/dpsim"
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
+
+RUN dnf -y update
+
+# Toolchain
+RUN dnf -y install \
+	gcc gcc-c++ clang \
+	git \
+	rpmdevtools rpm-build \
+	make cmake pkgconfig \
+	python3-pip \
+	cppcheck
+
+# Tools needed for developement
+RUN dnf -y install \
+	doxygen graphviz \
+	gdb \
+	procps-ng
+
+# Dependencies
+RUN dnf --refresh -y install \
+	python3-devel \
+	eigen3-devel \
+	libxml2-devel \
+	graphviz-devel \
+	spdlog-devel \
+	fmt-devel
+
+# Install some debuginfos
+RUN dnf -y debuginfo-install \
+	python3
+
+# Build & Install sundials
+RUN cd /tmp && \
+	git clone --recursive https://github.com/LLNL/sundials.git && \
+	mkdir -p sundials/build && cd sundials/build && \
+	git checkout v3.2.1 && \
+	cmake -DCMAKE_BUILD_TYPE=Release ..  && \
+	make -j$(nproc) install
+
+# minimal VILLAS dependencies (+ go or cmake would download it)
+RUN dnf -y install \
+    openssl-devel \
+    libuuid-devel \
+    libcurl-devel \
+    jansson-devel \
+    libwebsockets-devel
+
+# optional VILLAS dependencies
+RUN dnf -y install \
+	mosquitto-devel \
+	libconfig-devel \
+	libnl3-devel
+
+# Install lib60870 from fork with pkg-config file
+RUN cd /tmp && \
+	git clone https://github.com/mz-automation/lib60870.git && \
+	mkdir -p lib60870/build && cd lib60870/build && \
+	cmake -DCMAKE_INSTALL_DIR=/usr/local ../lib60870-C && make -j$(nproc) install && \
+	rm -rf /tmp/lib60870
+
+# Python dependencies
+ADD requirements.txt .
+RUN pip3 install --upgrade wheel build
+RUN pip3 install -r requirements.txt
+
+# Install CIMpp from source
+RUN cd /tmp && \
+	git clone --recursive https://github.com/cim-iec/libcimpp.git && \
+	mkdir -p libcimpp/build && cd libcimpp/build && \
+	cmake -DCMAKE_INSTALL_DIR=/usr/local -DUSE_CIM_VERSION=CGMES_2.4.15_16FEB2016 -DBUILD_SHARED_LIBS=ON -DBUILD_ARABICA_EXAMPLES=OFF .. && make -j$(nproc) install && \
+	rm -rf /tmp/libcimpp
+
+# Install VILLAS from source
+RUN cd /tmp && \
+	git clone --recursive https://git.rwth-aachen.de/acs/public/villas/node.git villasnode && \
+	mkdir -p villasnode/build && cd villasnode/build && \
+	cmake -DCMAKE_INSTALL_DIR=/usr/local .. && make -j$(nproc) install && \
+	rm -rf /tmp/villasnode
+
+# target for vscode dev container
+FROM base AS dev-vscode
+
+# create a non-root user for vscode to use
+ARG USERNAME=dpsim
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+	&& useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+	&& echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+	&& chmod 0440 /etc/sudoers.d/$USERNAME
+
+# use base image when no target is specified
+FROM base


### PR DESCRIPTION
Create an example which distributes the `cigre-mv-pf-profiles` simulation results using IEC104.

Resolves #95

## Problems
- [ ] Licensing: The [`lib60870`](https://github.com/mz-automation/lib60870) needed for the `VILLASnode` iec104 node type and used in the `Dockerfile.dev-iec104` is licensed under GPL3. Where and how should this be noted.
- [x] VILLASnode iec104 node is not yet in the master branch: see the [merge request](https://git.rwth-aachen.de/acs/public/villas/node/-/merge_requests/304) for progress.
- [ ] Remove unrelated VScode devcontainer commits

