### PR TITLE
Add a basic VS Code devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+	"name": "DPsim",
+	"build": {
+		"dockerfile": "../Packaging/Docker/Dockerfile.dev",
+		"target": "dev-vscode",
+		"context": ".."
+	},
+	"remoteUser": "dpsim",
+	"runArgs": [
+		"--privileged",
+		"--security-opt=seccomp=unconfined"
+	]
+}

--- a/Packaging/Docker/Dockerfile.dev
+++ b/Packaging/Docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:34 AS base
 
 LABEL \
 	org.label-schema.schema-version = "1.0.0" \
@@ -88,3 +88,18 @@ RUN dnf -y --refresh install npm
 RUN pip3 install jupyter jupyterlab jupyter_contrib_nbextensions nbconvert nbformat
 
 EXPOSE 8888
+
+# target for vscode dev container
+FROM base AS dev-vscode
+
+# create a non-root user for vscode to use
+ARG USERNAME=dpsim
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+	&& useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+	&& echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+	&& chmod 0440 /etc/sudoers.d/$USERNAME
+
+FROM base


### PR DESCRIPTION
A devcontainer allows new developers, foreign to the project, to easily
setup a working environment with the needed dependencies to start
developing. The devcontainer is based on `Dockerfile.dev`.
See: https://code.visualstudio.com/docs/remote/containers

This adds a new build stage to `Dockerfile.dev` which adds a non root
user. Devcontainers without a non root user suffer from permission
problems on Linux hosts. This buildstage does not affect existing users
of the `Dockerfile.dev` at all.
See https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user

Signed-off-by: Philipp Jungkamp <philipp.jungkamp@rwth-aachen.de>