### PR TITLE
Fix attribute relationships for reference voltages

### DIFF
--- a/.github/workflows/build_test_linux_fedora.yaml
+++ b/.github/workflows/build_test_linux_fedora.yaml
@@ -269,8 +269,9 @@ jobs:
     with:
       compose_file_path: examples/villas/docker-compose-tests
       container_commands: |
+        docker exec dpsim-compose_dpsim_1 /bin/bash -c "pip install paho-mqtt"
         docker exec dpsim-compose_mqtt_1 mosquitto_sub -t "/dpsim-mqtt" -u wildcard -v&
-        docker exec dpsim-compose_mqtt_1 /bin/sh -c "while true; do mosquitto_pub -t '/mqtt-dpsim' -m '[{\"ts\": {}, \"data\": [{\"real\": 10.0,\"imag\":0.0}]}]'; sleep 0.05; done"&
+        docker exec dpsim-compose_dpsim_1 /bin/bash -c "cd /dpsim && python /dpsim/examples/villas/dpsim-mqtt-producer.py"&
         docker exec dpsim-compose_dpsim_1 /bin/bash -c "cd /dpsim && python /dpsim/examples/villas/dpsim-mqtt.py"
 
   test-villas-examples-2:

--- a/dpsim-models/include/dpsim-models/Attribute.h
+++ b/dpsim-models/include/dpsim-models/Attribute.h
@@ -595,6 +595,7 @@ namespace CPS {
 				this->addTask(UpdateTaskKind::UPDATE_ONCE, AttributeUpdateTask<T, T>::make(UpdateTaskKind::UPDATE_ONCE, getter, reference));
 			} else {
 				this->addTask(UpdateTaskKind::UPDATE_ON_GET, AttributeUpdateTask<T, T>::make(UpdateTaskKind::UPDATE_ON_GET, getter, reference));
+				this->addTask(UpdateTaskKind::UPDATE_ONCE, AttributeUpdateTask<T, T>::make(UpdateTaskKind::UPDATE_ONCE, getter, reference));
 			}
 		}
 

--- a/dpsim-models/include/dpsim-models/Attribute.h
+++ b/dpsim-models/include/dpsim-models/Attribute.h
@@ -595,7 +595,6 @@ namespace CPS {
 				this->addTask(UpdateTaskKind::UPDATE_ONCE, AttributeUpdateTask<T, T>::make(UpdateTaskKind::UPDATE_ONCE, getter, reference));
 			} else {
 				this->addTask(UpdateTaskKind::UPDATE_ON_GET, AttributeUpdateTask<T, T>::make(UpdateTaskKind::UPDATE_ON_GET, getter, reference));
-				this->addTask(UpdateTaskKind::UPDATE_ONCE, AttributeUpdateTask<T, T>::make(UpdateTaskKind::UPDATE_ONCE, getter, reference));
 			}
 		}
 

--- a/dpsim-models/include/dpsim-models/Attribute.h
+++ b/dpsim-models/include/dpsim-models/Attribute.h
@@ -306,7 +306,7 @@ namespace CPS {
 		 * Exposing the underlying shared_ptr for this attribute's data. Used to create reference relations between two attributes.
 		 * @return The shared_ptr to this attribute's underlying data
 		 * */
-		virtual const std::shared_ptr<T> asRawPointer() = 0;
+		virtual std::shared_ptr<T> asRawPointer() = 0;
 
 		/// Fallback method for all attribute types not covered by the specifications in Attribute.cpp
 		virtual String toString() override {
@@ -507,7 +507,7 @@ namespace CPS {
 			throw TypeException();
 		}
 
-		virtual const std::shared_ptr<T> asRawPointer() {
+		virtual std::shared_ptr<T> asRawPointer() {
 			return this->mData;
 		}
 
@@ -598,7 +598,7 @@ namespace CPS {
 			}
 		}
 
-		virtual const std::shared_ptr<T> asRawPointer() {
+		virtual std::shared_ptr<T> asRawPointer() {
 			for(typename AttributeUpdateTaskBase<T>::Ptr task : updateTasksOnGet) {
 				task->executeUpdate(this->mData);
 			}

--- a/dpsim-models/include/dpsim-models/Attribute.h
+++ b/dpsim-models/include/dpsim-models/Attribute.h
@@ -306,9 +306,7 @@ namespace CPS {
 		 * Exposing the underlying shared_ptr for this attribute's data. Used to create reference relations between two attributes.
 		 * @return The shared_ptr to this attribute's underlying data
 		 * */
-		virtual const std::shared_ptr<T> asRawPointer() {
-			return this->mData;
-		}
+		virtual const std::shared_ptr<T> asRawPointer() = 0;
 
 		/// Fallback method for all attribute types not covered by the specifications in Attribute.cpp
 		virtual String toString() override {
@@ -509,6 +507,10 @@ namespace CPS {
 			throw TypeException();
 		}
 
+		virtual const std::shared_ptr<T> asRawPointer() {
+			return this->mData;
+		}
+
 		virtual void appendDependencies(AttributeBase::Set *deps) override {
 			deps->insert(this->shared_from_this());
 		}
@@ -594,6 +596,13 @@ namespace CPS {
 			} else {
 				this->addTask(UpdateTaskKind::UPDATE_ON_GET, AttributeUpdateTask<T, T>::make(UpdateTaskKind::UPDATE_ON_GET, getter, reference));
 			}
+		}
+
+		virtual const std::shared_ptr<T> asRawPointer() {
+			for(typename AttributeUpdateTaskBase<T>::Ptr task : updateTasksOnGet) {
+				task->executeUpdate(this->mData);
+			}
+			return this->mData;
 		}
 
 		virtual void set(T value) override {

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSource.h
@@ -116,9 +116,9 @@ namespace Ph1 {
 			MnaPreStepHarm(VoltageSource& voltageSource) :
 				Task(**voltageSource.mName + ".MnaPreStepHarm"),
 				mVoltageSource(voltageSource) {
-				mAttributeDependencies.push_back(voltageSource.attribute("V_ref"));
-				mModifiedAttributes.push_back(mVoltageSource.attribute("right_vector"));
-				mModifiedAttributes.push_back(mVoltageSource.attribute("v_intf"));
+				mAttributeDependencies.push_back(mVoltageSource.mVoltageRef);
+				mModifiedAttributes.push_back(mVoltageSource.mRightVector);
+				mModifiedAttributes.push_back(mVoltageSource.mIntfVoltage);
 			}
 			void execute(Real time, Int timeStepCount);
 		private:
@@ -132,7 +132,7 @@ namespace Ph1 {
 				mVoltageSource(voltageSource), mLeftVectors(leftVectors) {
 				for (UInt i = 0; i < mLeftVectors.size(); i++)
 					mAttributeDependencies.push_back(mLeftVectors[i]);
-				mModifiedAttributes.push_back(mVoltageSource.attribute("i_intf"));
+				mModifiedAttributes.push_back(mVoltageSource.mIntfCurrent);
 			}
 			void execute(Real time, Int timeStepCount);
 		private:

--- a/dpsim-models/include/dpsim-models/Signal/SineWaveGenerator.h
+++ b/dpsim-models/include/dpsim-models/Signal/SineWaveGenerator.h
@@ -16,13 +16,12 @@ namespace Signal {
 		public SignalGenerator,
         public SharedFactory<SineWaveGenerator>  {
     private:
-		/// initial signal phasor with magnitude and phase
-		Real mMagnitude;
+		/// initial signal phasor phase
 		Real mInitialPhase;
     public:
+		const Attribute<Real>::Ptr mMagnitude;
 		/// init the identified object
-        SineWaveGenerator(String name, Logger::Level logLevel = Logger::Level::off)
-			: SignalGenerator(name, logLevel) { }
+        SineWaveGenerator(String name, Logger::Level logLevel = Logger::Level::off);
 		/// set the source's parameters
 		void setParameters(Complex initialPhasor, Real frequency = 0.0);
 		/// implementation of inherited method step to update and return the current signal value

--- a/dpsim-models/include/dpsim-models/Signal/SineWaveGenerator.h
+++ b/dpsim-models/include/dpsim-models/Signal/SineWaveGenerator.h
@@ -18,8 +18,9 @@ namespace Signal {
     private:
 		/// initial signal phasor phase
 		Real mInitialPhase;
+		Attribute<Real>::Ptr mMagnitude;
     public:
-		const Attribute<Real>::Ptr mMagnitude;
+		const Attribute<Complex>::Ptr mVoltageRef;
 		/// init the identified object
         SineWaveGenerator(String name, Logger::Level logLevel = Logger::Level::off);
 		/// set the source's parameters

--- a/dpsim-models/include/dpsim-models/Signal/SineWaveGenerator.h
+++ b/dpsim-models/include/dpsim-models/Signal/SineWaveGenerator.h
@@ -17,7 +17,7 @@ namespace Signal {
         public SharedFactory<SineWaveGenerator>  {
     private:
 		/// initial signal phasor phase
-		Real mInitialPhase;
+		Attribute<Real>::Ptr mPhase;
 		Attribute<Real>::Ptr mMagnitude;
     public:
 		const Attribute<Complex>::Ptr mVoltageRef;

--- a/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
@@ -28,8 +28,8 @@ DP::Ph1::NetworkInjection::NetworkInjection(String uid, String name, Logger::Lev
 	for (auto subcomp: mSubComponents)
 		mSLog->info("- {}", subcomp->name());
 
-	mVoltageRef->setReference(mSubVoltageSource->mVoltageRef);
-	mSrcFreq->setReference(mSubVoltageSource->mSrcFreq);
+	mSubVoltageSource->mVoltageRef->setReference(mVoltageRef);
+	mSubVoltageSource->mSrcFreq->setReference(mSrcFreq);
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph1::NetworkInjection::clone(String name) {
@@ -43,10 +43,6 @@ void DP::Ph1::NetworkInjection::setParameters(Complex voltageRef, Real srcFreq) 
 
 	mSubVoltageSource->setParameters(voltageRef, srcFreq);
 
-	///FIXME: This should not be necessary, because the reference is already set in the constructor
-	mVoltageRef->setReference(mSubVoltageSource->mVoltageRef);
-	mSrcFreq->setReference(mSubVoltageSource->mSrcFreq);
-
 	mSLog->info("\nVoltage Ref={:s} [V]"
 				"\nFrequency={:s} [Hz]",
 				Logger::phasorToString(voltageRef),
@@ -58,10 +54,6 @@ void DP::Ph1::NetworkInjection::setParameters(Complex initialPhasor, Real freqSt
 
 	mSubVoltageSource->setParameters(initialPhasor, freqStart, rocof, timeStart, duration, useAbsoluteCalc);
 
-	///FIXME: This should not be necessary, because the reference is already set in the constructor
-	mVoltageRef->setReference(mSubVoltageSource->mVoltageRef);
-	mSrcFreq->setReference(mSubVoltageSource->mSrcFreq);
-
 	mSLog->info("\nVoltage Ref={:s} [V]"
 				"\nFrequency={:s} [Hz]",
 				Logger::phasorToString(initialPhasor),
@@ -72,10 +64,6 @@ void DP::Ph1::NetworkInjection::setParameters(Complex initialPhasor, Real modula
 	mParametersSet = true;
 
 	mSubVoltageSource->setParameters(initialPhasor, modulationFrequency, modulationAmplitude, baseFrequency, zigzag);
-
-	/// FIXME: This should not be necessary, because the reference is already set in the constructor
-	mVoltageRef->setReference(mSubVoltageSource->mVoltageRef);
-	mSrcFreq->setReference(mSubVoltageSource->mSrcFreq);
 
 	mSLog->info("\nVoltage Ref={:s} [V]"
 				"\nFrequency={:s} [Hz]",

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
@@ -32,12 +32,11 @@ SimPowerComp<Complex>::Ptr DP::Ph1::SynchronGeneratorIdeal::clone(String name) {
 void DP::Ph1::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real frequency) {
 	mSubVoltageSource = DP::Ph1::VoltageSource::make(**mName + "_src", mLogLevel);
 	mSubComponents.push_back(mSubVoltageSource);
+	mSubComponents[0]->attribute<Complex>("V_ref")->setReference(mVoltageRef);
 	mSubComponents[0]->connect({ SimNode::GND, node(0) });
 	mSubComponents[0]->setVirtualNodeAt(mVirtualNodes[0], 0);
 	mSubComponents[0]->initialize(mFrequencies);
 	mSubComponents[0]->initializeFromNodesAndTerminals(frequency);
-
-	mVoltageRef->setReference(mSubComponents[0]->attribute<Complex>("V_ref"));
 
 	mSLog->info(
 		"\n--- Initialization from powerflow ---"

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
@@ -288,13 +288,13 @@ void DP::Ph1::SynchronGeneratorTrStab::mnaApplyRightSideVectorStamp(Matrix& righ
 void DP::Ph1::SynchronGeneratorTrStab::MnaPreStep::execute(Real time, Int timeStepCount) {
 	mGenerator.step(time);
 	//change V_ref of subvoltage source
-	mGenerator.mSubVoltageSource->attribute<Complex>("V_ref")->set(**mGenerator.mEp);
+	mGenerator.mSubVoltageSource->mVoltageRef->set(**mGenerator.mEp);
 }
 
 void DP::Ph1::SynchronGeneratorTrStab::AddBStep::execute(Real time, Int timeStepCount) {
 	**mGenerator.mRightVector =
-		mGenerator.mSubInductor->attribute<Matrix>("right_vector")->get()
-		+ mGenerator.mSubVoltageSource->attribute<Matrix>("right_vector")->get();
+		mGenerator.mSubInductor->mRightVector->get()
+		+ mGenerator.mSubVoltageSource->mRightVector->get();
 }
 
 void DP::Ph1::SynchronGeneratorTrStab::MnaPostStep::execute(Real time, Int timeStepCount) {

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
@@ -310,7 +310,7 @@ void DP::Ph1::SynchronGeneratorTrStab::mnaUpdateVoltage(const Matrix& leftVector
 void DP::Ph1::SynchronGeneratorTrStab::mnaUpdateCurrent(const Matrix& leftVector) {
 	SPDLOG_LOGGER_DEBUG(mSLog, "Read current from {:d}", matrixNodeIndex(0));
 	//Current flowing out of component
-	**mIntfCurrent = mSubInductor->attribute<MatrixComp>("i_intf")->get();
+	**mIntfCurrent = mSubInductor->mIntfCurrent->get();
 }
 
 void DP::Ph1::SynchronGeneratorTrStab::setReferenceOmega(Attribute<Real>::Ptr refOmegaPtr, Attribute<Real>::Ptr refDeltaPtr) {

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
@@ -31,18 +31,16 @@ SimPowerComp<Complex>::Ptr DP::Ph1::VoltageSource::clone(String name) {
 
 void DP::Ph1::VoltageSource::setParameters(Complex voltageRef, Real srcFreq) {
 	auto srcSigSine = Signal::SineWaveGenerator::make(**mName + "_sw");
-	srcSigSine->setParameters(voltageRef, srcFreq);
 	srcSigSine->mMagnitude->setReference(mVoltageRef->deriveMag());
 	srcSigSine->mFreq->setReference(mSrcFreq);
+	srcSigSine->setParameters(voltageRef, srcFreq);
 	mSrcSig = srcSigSine;
-
 	mParametersSet = true;
 }
 
 void DP::Ph1::VoltageSource::setParameters(Complex initialPhasor, Real freqStart, Real rocof, Real timeStart, Real duration, bool useAbsoluteCalc) {
 	auto srcSigFreqRamp = Signal::FrequencyRampGenerator::make(**mName + "_fr");
 	srcSigFreqRamp->setParameters(initialPhasor, freqStart, rocof, timeStart, duration, useAbsoluteCalc);
-	srcSigFreqRamp->mFreq->setReference(mSrcFreq);
 	mSrcSig = srcSigFreqRamp;
 
 	mParametersSet = true;
@@ -51,21 +49,21 @@ void DP::Ph1::VoltageSource::setParameters(Complex initialPhasor, Real freqStart
 void DP::Ph1::VoltageSource::setParameters(Complex initialPhasor, Real modulationFrequency, Real modulationAmplitude, Real baseFrequency /*= 0.0*/, bool zigzag /*= false*/) {
     auto srcSigFm = Signal::CosineFMGenerator::make(**mName + "_fm");
 	srcSigFm->setParameters(initialPhasor, modulationFrequency, modulationAmplitude, baseFrequency, zigzag);
-	srcSigFm->mFreq->setReference(mSrcFreq);
 	mSrcSig = srcSigFm;
 
 	mParametersSet = true;
 }
 
 void DP::Ph1::VoltageSource::initializeFromNodesAndTerminals(Real frequency) {
+	//CHECK: The frequency parameter is unused
 	if (**mVoltageRef == Complex(0, 0))
 		**mVoltageRef = initialSingleVoltage(1) - initialSingleVoltage(0);
 
 	if (mSrcSig == nullptr) {
 		auto srcSigSine = Signal::SineWaveGenerator::make(**mName);
-		srcSigSine->setParameters(**mVoltageRef);
 		srcSigSine->mMagnitude->setReference(mVoltageRef->deriveMag());
 		srcSigSine->mFreq->setReference(mSrcFreq);
+		srcSigSine->setParameters(**mVoltageRef);
 		mSrcSig = srcSigSine;
 	}
 

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
@@ -31,9 +31,10 @@ SimPowerComp<Complex>::Ptr DP::Ph1::VoltageSource::clone(String name) {
 
 void DP::Ph1::VoltageSource::setParameters(Complex voltageRef, Real srcFreq) {
 	auto srcSigSine = Signal::SineWaveGenerator::make(**mName + "_sw");
-	srcSigSine->mMagnitude->setReference(mVoltageRef->deriveMag());
+	srcSigSine->mVoltageRef->setReference(mVoltageRef);
 	srcSigSine->mFreq->setReference(mSrcFreq);
 	srcSigSine->setParameters(voltageRef, srcFreq);
+
 	mSrcSig = srcSigSine;
 	mParametersSet = true;
 }
@@ -61,7 +62,7 @@ void DP::Ph1::VoltageSource::initializeFromNodesAndTerminals(Real frequency) {
 
 	if (mSrcSig == nullptr) {
 		auto srcSigSine = Signal::SineWaveGenerator::make(**mName);
-		srcSigSine->mMagnitude->setReference(mVoltageRef->deriveMag());
+		srcSigSine->mVoltageRef->setReference(mVoltageRef);
 		srcSigSine->mFreq->setReference(mSrcFreq);
 		srcSigSine->setParameters(**mVoltageRef);
 		mSrcSig = srcSigSine;

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
@@ -82,7 +82,7 @@ void DP::Ph1::VoltageSource::initializeFromNodesAndTerminals(Real frequency) {
 // #### MNA functions ####
 
 void DP::Ph1::VoltageSource::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	attributeDependencies.push_back(mSrcSig->mSigOut);
+	attributeDependencies.push_back(mVoltageRef);
 	modifiedAttributes.push_back(mRightVector);
 	modifiedAttributes.push_back(mIntfVoltage);
 }

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
@@ -56,7 +56,7 @@ void DP::Ph1::VoltageSource::setParameters(Complex initialPhasor, Real modulatio
 }
 
 void DP::Ph1::VoltageSource::initializeFromNodesAndTerminals(Real frequency) {
-	//CHECK: The frequency parameter is unused
+	///CHECK: The frequency parameter is unused
 	if (**mVoltageRef == Complex(0, 0))
 		**mVoltageRef = initialSingleVoltage(1) - initialSingleVoltage(0);
 

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
@@ -58,19 +58,15 @@ void DP::Ph1::VoltageSource::setParameters(Complex initialPhasor, Real modulatio
 }
 
 void DP::Ph1::VoltageSource::initializeFromNodesAndTerminals(Real frequency) {
-	Complex voltageRef = **mVoltageRef;
-
-	if (voltageRef == Complex(0, 0))
-		voltageRef = initialSingleVoltage(1) - initialSingleVoltage(0);
+	if (**mVoltageRef == Complex(0, 0))
+		**mVoltageRef = initialSingleVoltage(1) - initialSingleVoltage(0);
 
 	if (mSrcSig == nullptr) {
 		auto srcSigSine = Signal::SineWaveGenerator::make(**mName);
-		srcSigSine->setParameters(voltageRef);
+		srcSigSine->setParameters(**mVoltageRef);
 		srcSigSine->mMagnitude->setReference(mVoltageRef->deriveMag());
 		srcSigSine->mFreq->setReference(mSrcFreq);
 		mSrcSig = srcSigSine;
-	} else {
-		**mVoltageRef = voltageRef;
 	}
 
 	mSLog->info(

--- a/dpsim-models/src/EMT/EMT_Ph3_AvVoltSourceInverterStateSpace.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_AvVoltSourceInverterStateSpace.cpp
@@ -278,7 +278,7 @@ Matrix EMT::Ph3::AvVoltSourceInverterStateSpace::getInverseParkTransformMatrix(R
 void EMT::Ph3::AvVoltSourceInverterStateSpace::mnaInitialize(Real omega, Real timeStep,
 	Attribute<Matrix>::Ptr leftVector){
 	updateMatrixNodeIndices();
-	Complex voltageRef = attribute<Complex>("V_ref")->get();
+	Complex voltageRef = mVoltageRef->get();
 	(**mIntfVoltage)(0, 0) = voltageRef.real() * cos(Math::phase(voltageRef));
 	(**mIntfVoltage)(1, 0) = voltageRef.real() * cos(Math::phase(voltageRef) - 2. / 3. * M_PI);
 	(**mIntfVoltage)(2, 0) = voltageRef.real() * cos(Math::phase(voltageRef) + 2. / 3. * M_PI);

--- a/dpsim-models/src/EMT/EMT_Ph3_VoltageSourceNorton.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_VoltageSourceNorton.cpp
@@ -41,7 +41,7 @@ SimPowerComp<Real>::Ptr EMT::Ph3::VoltageSourceNorton::clone(String name) {
 
 void EMT::Ph3::VoltageSourceNorton::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	updateMatrixNodeIndices();
-	Complex voltageRef = attribute<Complex>("V_ref")->get();
+	Complex voltageRef = mVoltageRef->get();
 	(**mIntfVoltage)(0, 0) = voltageRef.real() * cos(Math::phase(voltageRef));
 	(**mIntfVoltage)(1, 0) = voltageRef.real() * cos(Math::phase(voltageRef) - 2. / 3. * M_PI);
 	(**mIntfVoltage)(2, 0) = voltageRef.real() * cos(Math::phase(voltageRef) + 2. / 3. * M_PI);

--- a/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -346,7 +346,7 @@ void SP::Ph1::AvVoltageSourceInverterDQ::mnaAddPreStepDependencies(AttributeBase
 void SP::Ph1::AvVoltageSourceInverterDQ::mnaPreStep(Real time, Int timeStepCount) {
 	// pre-steo of subcomponents - controlled source
 	if (mWithControl)
-		mSubCtrledVoltageSource->attribute<Complex>("V_ref")->set((**mVsref)(0,0));
+		mSubCtrledVoltageSource->mVoltageRef->set((**mVsref)(0,0));
 	// pre-step of subcomponents - others
 	for (auto subcomp: mSubComponents)
 		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))

--- a/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
@@ -35,8 +35,8 @@ SP::Ph1::NetworkInjection::NetworkInjection(String uid, String name,
 		mSLog->info("- {}", subcomp->name());
 
 	// MNA attributes
-	mVoltageRef->setReference(mSubVoltageSource->mVoltageRef);
-	mSrcFreq->setReference(mSubVoltageSource->mSrcFreq);
+	mSubVoltageSource->mVoltageRef->setReference(mVoltageRef);
+	mSubVoltageSource->mSrcFreq->setReference(mSrcFreq);
 }
 
 // #### Powerflow section ####
@@ -55,10 +55,6 @@ void SP::Ph1::NetworkInjection::setParameters(Complex initialPhasor, Real freqSt
 
 	mSubVoltageSource->setParameters(initialPhasor, freqStart, rocof, timeStart, duration, useAbsoluteCalc);
 
-	///FIXME: This should not be necessary, because the reference is already set in the constructor
-	mVoltageRef->setReference(mSubVoltageSource->mVoltageRef);
-	mSrcFreq->setReference(mSubVoltageSource->mSrcFreq);
-
 	mSLog->info("\nVoltage Ref={:s} [V]"
 				"\nFrequency={:s} [Hz]",
 				Logger::phasorToString(initialPhasor),
@@ -69,10 +65,6 @@ void SP::Ph1::NetworkInjection::setParameters(Complex initialPhasor, Real modula
 	mParametersSet = true;
 
 	mSubVoltageSource->setParameters(initialPhasor, modulationFrequency, modulationAmplitude, baseFrequency, zigzag);
-
-	///FIXME: This should not be necessary, because the reference is already set in the constructor
-	mVoltageRef->setReference(mSubVoltageSource->mVoltageRef);
-	mSrcFreq->setReference(mSubVoltageSource->mSrcFreq);
 
 	mSLog->info("\nVoltage Ref={:s} [V]"
 				"\nFrequency={:s} [Hz]",

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
@@ -297,13 +297,13 @@ void SP::Ph1::SynchronGeneratorTrStab::mnaApplyRightSideVectorStamp(Matrix& righ
 void SP::Ph1::SynchronGeneratorTrStab::MnaPreStep::execute(Real time, Int timeStepCount) {
 	mGenerator.step(time);
 	//change V_ref of subvoltage source
-	mGenerator.mSubVoltageSource->attribute<Complex>("V_ref")->set(**mGenerator.mEp);
+	mGenerator.mSubVoltageSource->mVoltageRef->set(**mGenerator.mEp);
 }
 
 void SP::Ph1::SynchronGeneratorTrStab::AddBStep::execute(Real time, Int timeStepCount) {
 	**mGenerator.mRightVector =
-		mGenerator.mSubInductor->attribute<Matrix>("right_vector")->get()
-		+ mGenerator.mSubVoltageSource->attribute<Matrix>("right_vector")->get();
+		mGenerator.mSubInductor->mRightVector->get()
+		+ mGenerator.mSubVoltageSource->mRightVector->get();
 }
 
 void SP::Ph1::SynchronGeneratorTrStab::MnaPostStep::execute(Real time, Int timeStepCount) {
@@ -319,7 +319,7 @@ void SP::Ph1::SynchronGeneratorTrStab::mnaUpdateVoltage(const Matrix& leftVector
 void SP::Ph1::SynchronGeneratorTrStab::mnaUpdateCurrent(const Matrix& leftVector) {
 	SPDLOG_LOGGER_DEBUG(mSLog, "Read current from {:d}", matrixNodeIndex(0));
 	//Current flowing out of component
-	**mIntfCurrent = mSubInductor->attribute<MatrixComp>("i_intf")->get();
+	**mIntfCurrent = mSubInductor->mIntfCurrent->get();
 }
 
 void SP::Ph1::SynchronGeneratorTrStab::setReferenceOmega(Attribute<Real>::Ptr refOmegaPtr, Attribute<Real>::Ptr refDeltaPtr) {

--- a/dpsim-models/src/SP/SP_Ph1_VoltageSource.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_VoltageSource.cpp
@@ -55,7 +55,7 @@ void SP::Ph1::VoltageSource::setParameters(Complex initialPhasor, Real modulatio
 }
 
 void SP::Ph1::VoltageSource::initializeFromNodesAndTerminals(Real frequency) {
-	//CHECK: The frequency parameter is unused
+	///CHECK: The frequency parameter is unused
 	if (**mVoltageRef == Complex(0, 0))
 		**mVoltageRef = initialSingleVoltage(1) - initialSingleVoltage(0);
 

--- a/dpsim-models/src/SP/SP_Ph1_VoltageSource.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_VoltageSource.cpp
@@ -31,7 +31,7 @@ SimPowerComp<Complex>::Ptr SP::Ph1::VoltageSource::clone(String name) {
 
 void SP::Ph1::VoltageSource::setParameters(Complex voltageRef, Real srcFreq) {
 	auto srcSigSine = Signal::SineWaveGenerator::make(**mName + "_sw");
-	srcSigSine->mMagnitude->setReference(mVoltageRef->deriveMag());
+	srcSigSine->mVoltageRef->setReference(mVoltageRef);
 	srcSigSine->mFreq->setReference(mSrcFreq);
 	srcSigSine->setParameters(voltageRef, srcFreq);
 	mSrcSig = srcSigSine;
@@ -61,7 +61,7 @@ void SP::Ph1::VoltageSource::initializeFromNodesAndTerminals(Real frequency) {
 
 	if (mSrcSig == nullptr) {
 		auto srcSigSine = Signal::SineWaveGenerator::make(**mName);
-		srcSigSine->mMagnitude->setReference(mVoltageRef->deriveMag());
+		srcSigSine->mVoltageRef->setReference(mVoltageRef);
 		srcSigSine->mFreq->setReference(mSrcFreq);
 		srcSigSine->setParameters(**mVoltageRef);
 		mSrcSig = srcSigSine;

--- a/dpsim-models/src/SP/SP_Ph1_VoltageSource.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_VoltageSource.cpp
@@ -31,12 +31,10 @@ SimPowerComp<Complex>::Ptr SP::Ph1::VoltageSource::clone(String name) {
 
 void SP::Ph1::VoltageSource::setParameters(Complex voltageRef, Real srcFreq) {
 	auto srcSigSine = Signal::SineWaveGenerator::make(**mName + "_sw");
+	srcSigSine->mMagnitude->setReference(mVoltageRef->deriveMag());
+	srcSigSine->mFreq->setReference(mSrcFreq);
 	srcSigSine->setParameters(voltageRef, srcFreq);
 	mSrcSig = srcSigSine;
-
-	mVoltageRef->setReference(mSrcSig->mSigOut);
-	mSrcFreq->setReference(mSrcSig->mFreq);
-
 	mParametersSet = true;
 }
 
@@ -44,9 +42,6 @@ void SP::Ph1::VoltageSource::setParameters(Complex initialPhasor, Real freqStart
 	auto srcSigFreqRamp = Signal::FrequencyRampGenerator::make(**mName + "_fr");
 	srcSigFreqRamp->setParameters(initialPhasor, freqStart, rocof, timeStart, duration, useAbsoluteCalc);
 	mSrcSig = srcSigFreqRamp;
-
-	mVoltageRef->setReference(mSrcSig->mSigOut);
-	mSrcFreq->setReference(mSrcSig->mFreq);
 
 	mParametersSet = true;
 }
@@ -56,27 +51,20 @@ void SP::Ph1::VoltageSource::setParameters(Complex initialPhasor, Real modulatio
 	srcSigFm->setParameters(initialPhasor, modulationFrequency, modulationAmplitude, baseFrequency, zigzag);
 	mSrcSig = srcSigFm;
 
-	mVoltageRef->setReference(mSrcSig->mSigOut);
-	mSrcFreq->setReference(mSrcSig->mFreq);
-
 	mParametersSet = true;
 }
 
 void SP::Ph1::VoltageSource::initializeFromNodesAndTerminals(Real frequency) {
-	Complex voltageRef = **mVoltageRef;
-
-	if (voltageRef == Complex(0, 0))
-		voltageRef = initialSingleVoltage(1) - initialSingleVoltage(0);
+	//CHECK: The frequency parameter is unused
+	if (**mVoltageRef == Complex(0, 0))
+		**mVoltageRef = initialSingleVoltage(1) - initialSingleVoltage(0);
 
 	if (mSrcSig == nullptr) {
-		Signal::SineWaveGenerator srcSigSine(**mName);
-		srcSigSine.setParameters(voltageRef);
-		mSrcSig = std::make_shared<Signal::SineWaveGenerator>(srcSigSine);
-
-		mVoltageRef->setReference(mSrcSig->mSigOut);
-	mSrcFreq->setReference(mSrcSig->mFreq);
-	} else {
-		**mVoltageRef = voltageRef;
+		auto srcSigSine = Signal::SineWaveGenerator::make(**mName);
+		srcSigSine->mMagnitude->setReference(mVoltageRef->deriveMag());
+		srcSigSine->mFreq->setReference(mSrcFreq);
+		srcSigSine->setParameters(**mVoltageRef);
+		mSrcSig = srcSigSine;
 	}
 
 	mSLog->info(

--- a/dpsim-models/src/Signal/SignalGenerator.cpp
+++ b/dpsim-models/src/Signal/SignalGenerator.cpp
@@ -13,7 +13,7 @@ using namespace CPS;
 Signal::SignalGenerator::SignalGenerator(String uid, String name, Logger::Level logLevel) 
     : SimSignalComp(name, logLevel),
     mSigOut(Attribute<Complex>::create("sigOut", mAttributes)),
-    mFreq(Attribute<Real>::create("freq", mAttributes)) {
+    mFreq(Attribute<Real>::createDynamic("freq", mAttributes)) {
 
     mSLog->info("Create {} {}", type(), name);
 }

--- a/dpsim-models/src/Signal/SineWaveGenerator.cpp
+++ b/dpsim-models/src/Signal/SineWaveGenerator.cpp
@@ -10,8 +10,12 @@
 
 using namespace CPS;
 
+Signal::SineWaveGenerator::SineWaveGenerator(String name, Logger::Level logLevel)
+			: SignalGenerator(name, logLevel),
+			mMagnitude(Attribute<Real>::createDynamic("V_max", mAttributes)) { }
+
 void Signal::SineWaveGenerator::setParameters(Complex initialPhasor, Real frequency /*= -1*/) {
-    mMagnitude = Math::abs(initialPhasor);
+    **mMagnitude = Math::abs(initialPhasor);
     mInitialPhase = Math::phase(initialPhasor);
 	**mFreq = frequency;
 	**mSigOut = initialPhasor;
@@ -20,13 +24,11 @@ void Signal::SineWaveGenerator::setParameters(Complex initialPhasor, Real freque
 					 "Sine wave magnitude: {} [V] \n"
 					 "Sine wave initial phase: {} [rad] \n"
 					 "Sine wave frequency: {} [Hz] \n",
-					mMagnitude, mInitialPhase, **mFreq);				 
+					**mMagnitude, mInitialPhase, **mFreq);				 
 }
 
 void Signal::SineWaveGenerator::step(Real time) {
-	if (**mFreq != 0.0) {
-		**mSigOut = Complex(
-			mMagnitude * cos(time * 2.*PI* **mFreq + mInitialPhase),
-			mMagnitude * sin(time * 2.*PI* **mFreq + mInitialPhase));
-	}
+	**mSigOut = Complex(
+		**mMagnitude * cos(time * 2.*PI* **mFreq + mInitialPhase),
+		**mMagnitude * sin(time * 2.*PI* **mFreq + mInitialPhase));
 }

--- a/dpsim-models/src/Signal/SineWaveGenerator.cpp
+++ b/dpsim-models/src/Signal/SineWaveGenerator.cpp
@@ -17,7 +17,7 @@ Signal::SineWaveGenerator::SineWaveGenerator(String name, Logger::Level logLevel
 void Signal::SineWaveGenerator::setParameters(Complex initialPhasor, Real frequency /*= -1*/) {
     **mVoltageRef = initialPhasor;
 	mMagnitude = mVoltageRef->deriveMag(); 
-    mInitialPhase = Math::phase(initialPhasor);
+    mPhase = mVoltageRef->derivePhase();
 	**mFreq = frequency;
 	**mSigOut = initialPhasor;
 
@@ -25,11 +25,11 @@ void Signal::SineWaveGenerator::setParameters(Complex initialPhasor, Real freque
 					 "Sine wave magnitude: {} [V] \n"
 					 "Sine wave initial phase: {} [rad] \n"
 					 "Sine wave frequency: {} [Hz] \n",
-					**mMagnitude, mInitialPhase, **mFreq);				 
+					**mMagnitude, **mPhase, **mFreq);				 
 }
 
 void Signal::SineWaveGenerator::step(Real time) {
 	**mSigOut = Complex(
-		**mMagnitude * cos(time * 2.*PI* **mFreq + mInitialPhase),
-		**mMagnitude * sin(time * 2.*PI* **mFreq + mInitialPhase));
+		**mMagnitude * cos(time * 2.*PI* **mFreq + **mPhase),
+		**mMagnitude * sin(time * 2.*PI* **mFreq + **mPhase));
 }

--- a/dpsim-models/src/Signal/SineWaveGenerator.cpp
+++ b/dpsim-models/src/Signal/SineWaveGenerator.cpp
@@ -12,10 +12,11 @@ using namespace CPS;
 
 Signal::SineWaveGenerator::SineWaveGenerator(String name, Logger::Level logLevel)
 			: SignalGenerator(name, logLevel),
-			mMagnitude(Attribute<Real>::createDynamic("V_max", mAttributes)) { }
+			mVoltageRef(Attribute<Complex>::createDynamic("V_ref", mAttributes)) { }
 
 void Signal::SineWaveGenerator::setParameters(Complex initialPhasor, Real frequency /*= -1*/) {
-    **mMagnitude = Math::abs(initialPhasor);
+    **mVoltageRef = initialPhasor;
+	mMagnitude = mVoltageRef->deriveMag(); 
     mInitialPhase = Math::phase(initialPhasor);
 	**mFreq = frequency;
 	**mSigOut = initialPhasor;

--- a/examples/villas/dpsim-mqtt-producer.py
+++ b/examples/villas/dpsim-mqtt-producer.py
@@ -1,0 +1,29 @@
+import paho.mqtt.publish as publish
+import json
+import time
+
+def build_message(sequence, v_ref):
+    ts_field = {"origin":[int(elem) for elem in str(time.time()).split('.')]}
+    # ts_field = {"origin": ts}
+    data_field = [v_ref]
+    message = {"ts": ts_field, "sequence": sequence, "data": data_field}
+
+    return "[" + json.dumps(message) + "]"
+
+if __name__ == '__main__':
+    time.sleep(5)
+    seq = 0
+    T_s = 0.01
+    tf = 10.0
+    num_samples = int(tf/T_s) + 2
+    for n in range(0, num_samples):
+        # ts = [0, n*1000000]
+        if n < int(num_samples/2):
+            m_v_ref = {"real":5.0, "imag":0.0}
+        else:
+            m_v_ref = {"real":7.0, "imag":0.0}
+        m_message = build_message(sequence=seq, v_ref=m_v_ref)
+        print(m_message)
+        publish.single(topic="/mqtt-dpsim", payload=m_message, hostname="mqtt")
+        seq += 1
+        time.sleep(T_s)

--- a/examples/villas/dpsim-mqtt-producer.py
+++ b/examples/villas/dpsim-mqtt-producer.py
@@ -4,7 +4,6 @@ import time
 
 def build_message(sequence, v_ref):
     ts_field = {"origin":[int(elem) for elem in str(time.time()).split('.')]}
-    # ts_field = {"origin": ts}
     data_field = [v_ref]
     message = {"ts": ts_field, "sequence": sequence, "data": data_field}
 
@@ -17,7 +16,6 @@ if __name__ == '__main__':
     tf = 10.0
     num_samples = int(tf/T_s) + 2
     for n in range(0, num_samples):
-        # ts = [0, n*1000000]
         if n < int(num_samples/2):
             m_v_ref = {"real":5.0, "imag":0.0}
         else:

--- a/examples/villas/dpsim-mqtt.py
+++ b/examples/villas/dpsim-mqtt.py
@@ -57,10 +57,8 @@ intf = dpsimpyvillas.InterfaceVillas(name='dpsim-mqtt', config=mqtt_config)
 sim.add_interface(intf, True)
 
 sim.import_attribute(evs.attr('V_ref'), 0)
-sim.export_attribute(evs.attr('i_intf').derive_coeff(0, 0), 0)
+sim.export_attribute(r12.attr('i_intf').derive_coeff(0, 0), 0)
 
 sim.add_logger(logger)
-
-evs.set_intf_current([[complex(5, 0)]])
 
 sim.run(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pybind11[global]
 
 villas-dataprocessing>=0.2.6
 villas-node
+
+paho-mqtt==1.1


### PR DESCRIPTION
This PR fixes multiple bugs regarding the import of the `mVoltageRef` attribute of the `DP_Ph1_VoltageSource`. For this, the reference relationship with voltageRef attributes in components that include voltage sources is reversed. Additionally, the update function for multiple chained dynamic referencing attributes is fixed to allow proper updating of the data pointers.