### PR TITLE
Voltage Profile for NetworkInjection with CSVreader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.11...3.23)
+set(CMAKE_SYSTEM_VERSION "10.0")
 project(DPsim
 		VERSION 1.1.0
 		DESCRIPTION "C++ Power System Simulation Library"

--- a/dpsim-models/include/dpsim-models/CSVReader.h
+++ b/dpsim-models/include/dpsim-models/CSVReader.h
@@ -19,6 +19,7 @@
 #include <dpsim-models/SystemTopology.h>
 #include <dpsim-models/SP/SP_Ph1_Load.h>
 #include <dpsim-models/DP/DP_Ph1_PQLoadCS.h>
+#include <dpsim-models/DP/DP_Ph1_NetworkInjection.h>
 #include <dpsim-models/DP/DP_Ph1_AvVoltageSourceInverterDQ.h>
 #include <dpsim-models/SP/SP_Ph1_AvVoltageSourceInverterDQ.h>
 
@@ -97,6 +98,11 @@ namespace CPS {
 		std::vector<Real> readPQData (fs::path file,
 			Real start_time = -1, Real time_step = 1, Real end_time = -1,
 			CSVReader::DataFormat format = CSVReader::DataFormat::SECONDS);
+		///
+		VoltageProfile readVoltageProfile(fs::path file,
+			Real start_time = -1, Real time_step = 1, Real end_time = -1,
+			CSVReader::DataFormat format = CSVReader::DataFormat::SECONDS);
+
 		/// assign load profile to corresponding load object
 		void assignLoadProfile(SystemTopology& sys,
 			Real start_time = -1, Real time_step = 1, Real end_time = -1,
@@ -106,9 +112,17 @@ namespace CPS {
 		void assignPVGeneration(SystemTopology& sys,
 			Real start_time = -1, Real time_step = 1, Real end_time = -1,
 			CSVReader::Mode mode = CSVReader::Mode::AUTO);
+		/// assign voltage source profile to corresponding source object
+		void assignSourceProfile(std::vector<std::shared_ptr<CPS::DP::Ph1::NetworkInjection>>& sources,
+			Real start_time = -1, Real time_step = 1, Real end_time = -1,
+			CSVReader::Mode mode = CSVReader::Mode::AUTO,
+			CSVReader::DataFormat format = CSVReader::DataFormat::SECONDS);
 
 		/// interpolation for PQ data points
 		PQData interpol_linear(std::map<Real, PQData>& data_PQ, Real x);
+
+		/// interpolation for Voltage data points
+		VData interpol_linear(std::map<Real, VData>& vData, Real x);
 
 		/// interpolation for weighting factor data points
 		Real interpol_linear(std::map<Real, Real>& data_wf, Real x);

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_NetworkInjection.h
@@ -12,6 +12,7 @@
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Solver/DAEInterface.h>
 #include <dpsim-models/DP/DP_Ph1_VoltageSource.h>
+#include <dpsim-models/PowerProfile.h>
 
 namespace CPS {
 namespace DP {
@@ -34,6 +35,12 @@ namespace Ph1 {
 		std::vector<const Matrix*> mRightVectorStamps;
 
 	public:
+		// ### Source profile as time series ###
+		/// Source profile data
+		VoltageProfile mSourceProfile;
+		/// Use the assigned load profile
+		bool use_profile = false;
+
 		const Attribute<Complex>::Ptr mVoltageRef;
 		const Attribute<Real>::Ptr mSrcFreq; 
 
@@ -70,7 +77,7 @@ namespace Ph1 {
 		/// Returns current through the component
 		void mnaUpdateCurrent(const Matrix& leftVector);
 		/// Updates voltage across component
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaUpdateVoltage(Real time, const Matrix& leftVector);
 		/// MNA pre step operations
 		void mnaPreStep(Real time, Int timeStepCount);
 		/// MNA post step operations

--- a/dpsim-models/include/dpsim-models/PowerProfile.h
+++ b/dpsim-models/include/dpsim-models/PowerProfile.h
@@ -19,4 +19,13 @@ namespace CPS {
 		std::map<Real, PQData> pqData;
 		std::map<Real, Real> weightingFactors;
 	};
+
+	struct VData {
+		Complex v;
+	};
+
+	struct VoltageProfile {
+		std::map<Real, VData> vData;
+		std::map<Real, Real> weightingFactors;
+	};
 }

--- a/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
@@ -157,10 +157,17 @@ void DP::Ph1::NetworkInjection::mnaPostStep(Real time, Int timeStepCount, Attrib
 			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
 	// post-step of component itself
 	mnaUpdateCurrent(**leftVector);
-	mnaUpdateVoltage(**leftVector);
+	mnaUpdateVoltage(time, **leftVector);
 }
 
-void DP::Ph1::NetworkInjection::mnaUpdateVoltage(const Matrix& leftVector) {
+void DP::Ph1::NetworkInjection::mnaUpdateVoltage(Real time, const Matrix& leftVector) {
+	if (mSourceProfile.vData.size() > 0) {
+		std::map<Real, VData>::iterator it;
+		it = mSourceProfile.vData.lower_bound(time);
+		if (it != mSourceProfile.vData.end()) {
+			mSubVoltageSource->setParameters(it->second.v);
+		}
+	}
 	**mIntfVoltage = **mSubVoltageSource->mIntfVoltage;
 }
 

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CIRCUIT_SOURCES
 	Circuits/DP_Circuits.cpp
 	Circuits/DP_Basics_DP_Sims.cpp
 	Circuits/DP_PiLine.cpp
+	Circuits/DP_PiLine_SourceProfile.cpp
 	Circuits/DP_DecouplingLine.cpp
 	Circuits/DP_Diakoptics.cpp
 	Circuits/DP_VSI.cpp

--- a/dpsim/examples/cxx/Circuits/DP_PiLine_SourceProfile.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_PiLine_SourceProfile.cpp
@@ -1,0 +1,83 @@
+/* Copyright 2017-2021 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <DPsim.h>
+#include <dpsim-models/CSVReader.h>
+
+using namespace DPsim;
+using namespace CPS::DP;
+
+void simPiLineSource() {
+
+#ifdef _WIN32
+	String loadProfilePath("build\\_deps\\profile-data-src\\NetworkInjektion_Voltage\\");
+#elif defined(__linux__) || defined(__APPLE__)
+	String loadProfilePath("build/_deps/profile-data-src/NetworkInjektion_Voltage/");
+#endif
+
+	Real timeStep = 0.00005;
+	Real finalTime = 1;
+	String simName = "DP_PiLine_Source";
+	Logger::setLogDir("logs/"+simName);
+
+	// read csv
+	String ni_name = "vs_test";
+	CPS::CSVReader csvreader(ni_name + ".csv", loadProfilePath, Logger::Level::debug);
+
+	// Nodes
+	auto n1 = SimNode::make("n1");
+	auto n2 = SimNode::make("n2");
+
+	// Components
+	auto vs = Ph1::NetworkInjection::make(ni_name);
+	vs->setParameters(CPS::Math::polar(100000, 0));
+	
+	// Parametrization of components
+	Real resistance = 5;
+	Real inductance = 0.16;
+	Real capacitance = 1.0e-6;
+	Real conductance = 1e-6;
+
+	auto line = Ph1::PiLine::make("Line");
+	line->setParameters(resistance, inductance, capacitance, conductance);
+
+	auto load = Ph1::Resistor::make("R_load");
+	load->setParameters(10000);
+
+	// Topology
+	vs->connect({ n1 });
+	line->connect({ n1, n2 });
+	load->connect({ n2, SimNode::GND });
+
+	auto sys = SystemTopology(50,
+		SystemNodeList{n1, n2},
+		SystemComponentList{vs, line, load});
+
+	// Logging
+	auto logger = DataLogger::make(simName);
+	logger->logAttribute("v1", n1->attribute("v"));
+	logger->logAttribute("v2", n2->attribute("v"));
+	logger->logAttribute("iline", line->attribute("i_intf"));
+
+	Simulation sim(simName);
+	sim.setSystem(sys);
+	sim.setTimeStep(timeStep);
+	sim.setFinalTime(finalTime);
+	sim.addLogger(logger);
+
+	std::vector<std::shared_ptr<CPS::DP::Ph1::NetworkInjection>> networkinjections;
+	networkinjections.push_back(vs);
+	csvreader.assignSourceProfile(networkinjections, sim.time(), sim.timeStep(), sim.finalTime(), CPS::CSVReader::Mode::AUTO);
+
+	sim.run();
+}
+
+
+int main(int argc, char* argv[]) {
+	simPiLineSource();
+}


### PR DESCRIPTION
Changes to CSVReader, NetworkInjection and PowerProfile to enable reading a voltage profile

- Structured similar to powerprofiles for loads
- added an example (Circuits/DP_PiLine_SourceProfile.cpp)

Signed-off-by: cwirtz <Christoph.Wirtz@fgh-ma.de>
![Explanation_Vprofile](https://user-images.githubusercontent.com/67785000/196744021-c543ae07-e6ec-45c3-a3ab-f8ddd4eed79c.JPG)
