### PR TITLE
Added EMT_Ph1_Switch

### DIFF
--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Switch.h
@@ -22,20 +22,20 @@ namespace Ph1 {
 		/// Resistance if switch is closed [ohm]
 		Attribute<Real>::Ptr mClosedResistance;
 		/// Defines if Switch is open or closed
-		Attribute<Bool>::Ptr mIsClosed;
+		Attribute<Bool>::Ptr mSwitchClosed;
 		///
 		void setParameters(Real openResistance, Real closedResistance, Bool closed = false) {
 			**mOpenResistance = openResistance;
 			**mClosedResistance = closedResistance;
-			**mIsClosed = closed;
+			**mSwitchClosed = closed;
 		}
 
 		/// Close switch
-		void close() { **mIsClosed = true; }
+		void closeSwitch() { **mSwitchClosed = true; }
 		/// Open switch
-		void open() { **mIsClosed = false; }
+		void openSwitch() { **mSwitchClosed = false; }
 		/// Check if switch is closed
-		Bool isClosed() { return **mIsClosed; }
+		Bool isClosed() { return **mSwitchClosed; }
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -81,6 +81,7 @@
 #include <dpsim-models/EMT/EMT_Ph1_CurrentSource.h>
 #include <dpsim-models/EMT/EMT_Ph1_Inductor.h>
 #include <dpsim-models/EMT/EMT_Ph1_Resistor.h>
+#include <dpsim-models/EMT/EMT_Ph1_Switch.h>
 #include <dpsim-models/EMT/EMT_Ph1_VoltageSource.h>
 #include <dpsim-models/EMT/EMT_Ph1_VoltageSourceRamp.h>
 #include <dpsim-models/EMT/EMT_Ph1_VoltageSourceNorton.h>

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesSwitch.h
@@ -52,7 +52,7 @@ namespace Ph3 {
 
 		// #### MNA section for switches ####
 		/// Check if switch is closed
-		Bool mnaIsClosed() { return **mIsClosed; }
+		Bool mnaIsClosed() { return **mSwitchClosed; }
 		/// Stamps system matrix considering the defined switch position
 		void mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& systemMatrix, Int freqIdx);
 

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_Switch.h
@@ -1,0 +1,81 @@
+/* Copyright 2017-2021 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#pragma once
+
+#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Definitions.h>
+#include <dpsim-models/Logger.h>
+#include <dpsim-models/Base/Base_Ph1_Switch.h>
+
+namespace CPS {
+namespace EMT {
+namespace Ph1 {
+	/// \brief Dynamic phasor switch
+	///
+	/// The switch can be opened and closed.
+	/// Each state has a specific resistance value.
+	class Switch :
+		public Base::Ph1::Switch,
+		public SimPowerComp<Real>,
+		public SharedFactory<Switch>,
+		public MNASwitchInterface {
+	protected:
+	public:
+		/// Defines UID, name, component parameters and logging level
+		Switch(String uid, String name,	Logger::Level loglevel = Logger::Level::off);
+		/// Defines name, component parameters and logging level
+		Switch(String name, Logger::Level logLevel = Logger::Level::off)
+			: Switch(name, name, logLevel) { }
+
+		SimPowerComp<Real>::Ptr clone(String name);
+
+		// #### General ####
+		/// Initializes component from power flow data
+		void initializeFromNodesAndTerminals(Real frequency);
+
+		// #### General MNA section ####
+		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
+		/// Stamps system matrix
+		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
+		/// Stamps right side (source) vector
+		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+		/// Update interface voltage from MNA system result
+		void mnaUpdateVoltage(const Matrix& leftVector);
+		/// Update interface current from MNA system result
+		void mnaUpdateCurrent(const Matrix& leftVector);
+		/// MNA post step operations
+		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		/// Add MNA post step dependencies
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
+			AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes,
+			Attribute<Matrix>::Ptr &leftVector);
+
+		class MnaPostStep : public Task {
+		public:
+			MnaPostStep(Switch& switchRef, Attribute<Matrix>::Ptr leftSideVector) :
+				Task(**switchRef.mName + ".MnaPostStep"), mSwitch(switchRef), mLeftVector(leftSideVector) {
+				mSwitch.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
+			}
+			void execute(Real time, Int timeStepCount) { mSwitch.mnaPostStep(time, timeStepCount, mLeftVector); }
+
+		private:
+			Switch& mSwitch;
+			Attribute<Matrix>::Ptr mLeftVector;
+		};
+
+		// #### MNA section for switches ####
+		/// Check if switch is closed
+		Bool mnaIsClosed() { return **mSwitchClosed; }
+		/// Stamps system matrix considering the defined switch position
+		void mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& systemMatrix, Int freqIdx);
+	};
+}
+}
+}

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SeriesSwitch.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SeriesSwitch.h
@@ -52,7 +52,7 @@ namespace Ph3 {
 
 		// #### Switch specific MNA section ####
 		/// Check if switch is closed
-		Bool mnaIsClosed() { return **mIsClosed; }
+		Bool mnaIsClosed() { return **mSwitchClosed; }
 		/// Stamps system matrix considering the defined switch position
 		void mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& systemMatrix, Int freqIdx);
 

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -58,6 +58,7 @@ list(APPEND MODELS_SOURCES
 	EMT/EMT_Ph1_CurrentSource.cpp
 	EMT/EMT_Ph1_Inductor.cpp
 	EMT/EMT_Ph1_Resistor.cpp
+	EMT/EMT_Ph1_Switch.cpp
 	EMT/EMT_Ph1_VoltageSource.cpp
 	EMT/EMT_Ph1_VoltageSourceRamp.cpp
 	EMT/EMT_Ph1_VoltageSourceNorton.cpp

--- a/dpsim-models/src/CSVReader.cpp
+++ b/dpsim-models/src/CSVReader.cpp
@@ -8,6 +8,7 @@
 
 
 #include <dpsim-models/CSVReader.h>
+#include <cctype>  // we'll use the non-locale <cctype>'s std::isdigit
 
 using namespace CPS;
 

--- a/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
@@ -151,7 +151,7 @@ void DP::Ph1::RXLoadSwitch::updateSwitchState(Real time) {
 		Real deltaV = Math::abs((V - VRef) / VRef);
 
 		if (deltaV > 0.1) {
-			mSubSwitch->open();
+			mSubSwitch->openSwitch();
 			mSLog->info("Opened Switch at {}", (float)time);
 		}
 	}

--- a/dpsim-models/src/DP/DP_Ph1_varResSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_varResSwitch.cpp
@@ -18,12 +18,12 @@ DP::Ph1::varResSwitch::varResSwitch(String uid, String name, Logger::Level logLe
 
 	mOpenResistance = Attribute<Real>::create("R_open", mAttributes);
 	mClosedResistance = Attribute<Real>::create("R_closed", mAttributes);
-	mIsClosed = Attribute<Bool>::create("is_closed", mAttributes);
+	mSwitchClosed = Attribute<Bool>::create("is_closed", mAttributes);
 	}
 
 SimPowerComp<Complex>::Ptr DP::Ph1::varResSwitch::clone(String name) {
 	auto copy = varResSwitch::make(name, mLogLevel);
-	copy->setParameters(**mOpenResistance, **mClosedResistance, **mIsClosed);
+	copy->setParameters(**mOpenResistance, **mClosedResistance, **mSwitchClosed);
 	return copy;
 }
 
@@ -32,7 +32,7 @@ void DP::Ph1::varResSwitch::initializeFromNodesAndTerminals(Real frequency) {
 	// // This function is not used!!!!!!
 
 	//Switch Resistance
-	Real impedance = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
+	Real impedance = (**mSwitchClosed) ? **mClosedResistance : **mOpenResistance;
 
 	(**mIntfVoltage)(0,0) = initialSingleVoltage(1) - initialSingleVoltage(0);
 	(**mIntfCurrent)(0,0)  = (**mIntfVoltage)(0,0) / impedance;
@@ -48,7 +48,7 @@ void DP::Ph1::varResSwitch::mnaInitialize(Real omega, Real timeStep, Attribute<M
 }
 
 void DP::Ph1::varResSwitch::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	Complex conductance = (**mIsClosed) ?
+	Complex conductance = (**mSwitchClosed) ?
 		Complex( 1. / **mClosedResistance, 0 ) : Complex( 1. / **mOpenResistance, 0 );
 
 	// Set diagonal entries
@@ -115,7 +115,7 @@ void DP::Ph1::varResSwitch::mnaUpdateVoltage(const Matrix& leftVector) {
 }
 
 void DP::Ph1::varResSwitch::mnaUpdateCurrent(const Matrix& leftVector) {
-	(**mIntfCurrent)(0,0) = (**mIsClosed) ?
+	(**mIntfCurrent)(0,0) = (**mSwitchClosed) ?
 		(**mIntfVoltage)(0,0) / **mClosedResistance :
 		(**mIntfVoltage)(0,0) / **mOpenResistance;
 }
@@ -161,8 +161,8 @@ void DP::Ph1::varResSwitch::setInitParameters(Real timestep) {
 	mDeltaResClosed= 0;
 	// mDeltaResOpen = 1.5; // assumption for 1ms step size
 	mDeltaResOpen= 0.5*timestep/0.001 + 1;
-	mPrevState= **mIsClosed;
-	mPrevRes= (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
+	mPrevState= **mSwitchClosed;
+	mPrevRes= (**mSwitchClosed) ? **mClosedResistance : **mOpenResistance;
 	mInitClosedRes = **mClosedResistance;
 	mInitOpenRes = **mOpenResistance;
 }

--- a/dpsim-models/src/DP/DP_Ph3_SeriesSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_SeriesSwitch.cpp
@@ -18,12 +18,12 @@ DP::Ph3::SeriesSwitch::SeriesSwitch(String uid, String name, Logger::Level logLe
 
 	mOpenResistance = Attribute<Real>::create("R_open", mAttributes);
 	mClosedResistance = Attribute<Real>::create("R_closed", mAttributes);
-	mIsClosed = Attribute<Bool>::create("is_closed", mAttributes);
+	mSwitchClosed = Attribute<Bool>::create("is_closed", mAttributes);
 }
 
 void DP::Ph3::SeriesSwitch::initializeFromNodesAndTerminals(Real frequency) {
 
-	Real impedance = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
+	Real impedance = (**mSwitchClosed) ? **mClosedResistance : **mOpenResistance;
 	**mIntfVoltage = initialVoltage(1) - initialVoltage(0);
 	**mIntfCurrent = **mIntfVoltage / impedance;
 
@@ -46,7 +46,7 @@ void DP::Ph3::SeriesSwitch::mnaInitialize(Real omega, Real timeStep, Attribute<M
 }
 
 void DP::Ph3::SeriesSwitch::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	Complex conductance = (**mIsClosed)
+	Complex conductance = (**mSwitchClosed)
 		? Complex( 1. / **mClosedResistance, 0 )
 		: Complex( 1. / **mOpenResistance, 0 );
 
@@ -120,7 +120,7 @@ void DP::Ph3::SeriesSwitch::mnaUpdateVoltage(const Matrix& leftVector) {
 }
 
 void DP::Ph3::SeriesSwitch::mnaUpdateCurrent(const Matrix& leftVector) {
-	Real impedance = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
+	Real impedance = (**mSwitchClosed) ? **mClosedResistance : **mOpenResistance;
 	**mIntfCurrent = **mIntfVoltage / impedance;
 
 	SPDLOG_LOGGER_DEBUG(mSLog, "Current A: {} < {}", std::abs((**mIntfCurrent)(0,0)), std::arg((**mIntfCurrent)(0,0)));

--- a/dpsim-models/src/EMT/EMT_Ph3_SeriesSwitch.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SeriesSwitch.cpp
@@ -20,7 +20,7 @@ EMT::Ph3::SeriesSwitch::SeriesSwitch(String uid, String name, Logger::Level logL
 
 	mOpenResistance = Attribute<Real>::create("R_open", mAttributes);
 	mClosedResistance = Attribute<Real>::create("R_closed", mAttributes);
-	mIsClosed = Attribute<Bool>::create("is_closed", mAttributes);
+	mSwitchClosed = Attribute<Bool>::create("is_closed", mAttributes);
 }
 
 SimPowerComp<Real>::Ptr EMT::Ph3::SeriesSwitch::clone(String name) {
@@ -31,7 +31,7 @@ SimPowerComp<Real>::Ptr EMT::Ph3::SeriesSwitch::clone(String name) {
 
 void EMT::Ph3::SeriesSwitch::initializeFromNodesAndTerminals(Real frequency) {
 
-	Real impedance = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
+	Real impedance = (**mSwitchClosed) ? **mClosedResistance : **mOpenResistance;
 
 	Complex phasorA = initialSingleVoltage(1) - initialSingleVoltage(0);
 	(**mIntfVoltage)(0,0) = phasorA.real();
@@ -61,7 +61,7 @@ void EMT::Ph3::SeriesSwitch::mnaInitialize(Real omega, Real timeStep, Attribute<
 }
 
 void EMT::Ph3::SeriesSwitch::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	Real conductance = (**mIsClosed)
+	Real conductance = (**mSwitchClosed)
 		? 1. / **mClosedResistance
 		: 1. / **mOpenResistance;
 
@@ -135,7 +135,7 @@ void EMT::Ph3::SeriesSwitch::mnaUpdateVoltage(const Matrix& leftVector) {
 }
 
 void EMT::Ph3::SeriesSwitch::mnaUpdateCurrent(const Matrix& leftVector) {
-	Real impedance = (**mIsClosed)? **mClosedResistance : **mOpenResistance;
+	Real impedance = (**mSwitchClosed)? **mClosedResistance : **mOpenResistance;
 	**mIntfCurrent = **mIntfVoltage / impedance;
 
 	SPDLOG_LOGGER_DEBUG(mSLog, "Current A: {}", (**mIntfCurrent)(0,0));

--- a/dpsim-models/src/SP/SP_Ph1_Switch.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Switch.cpp
@@ -18,18 +18,18 @@ SP::Ph1::Switch::Switch(String uid, String name, Logger::Level logLevel)
 
 	mOpenResistance = Attribute<Real>::create("R_open", mAttributes);
 	mClosedResistance = Attribute<Real>::create("R_closed", mAttributes);
-	mIsClosed = Attribute<Bool>::create("is_closed", mAttributes);
+	mSwitchClosed = Attribute<Bool>::create("is_closed", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr SP::Ph1::Switch::clone(String name) {
 	auto copy = Switch::make(name, mLogLevel);
-	copy->setParameters(**mOpenResistance, **mClosedResistance, **mIsClosed);
+	copy->setParameters(**mOpenResistance, **mClosedResistance, **mSwitchClosed);
 	return copy;
 }
 
 void SP::Ph1::Switch::initializeFromNodesAndTerminals(Real frequency) {
 
-	Real impedance = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
+	Real impedance = (**mSwitchClosed) ? **mClosedResistance : **mOpenResistance;
 	(**mIntfVoltage)(0,0) = initialSingleVoltage(1) - initialSingleVoltage(0);
 	(**mIntfCurrent)(0,0) = (**mIntfVoltage)(0,0) / impedance;
 
@@ -54,7 +54,7 @@ void SP::Ph1::Switch::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>
 }
 
 void SP::Ph1::Switch::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	Complex conductance = (**mIsClosed) ?
+	Complex conductance = (**mSwitchClosed) ?
 		Complex( 1. / **mClosedResistance, 0 ) : Complex( 1. / **mOpenResistance, 0 );
 
 	// Set diagonal entries
@@ -117,7 +117,7 @@ void SP::Ph1::Switch::mnaUpdateVoltage(const Matrix& leftVector) {
 }
 
 void SP::Ph1::Switch::mnaUpdateCurrent(const Matrix& leftVector) {
-	(**mIntfCurrent)(0,0) = (**mIsClosed) ?
+	(**mIntfCurrent)(0,0) = (**mSwitchClosed) ?
 		(**mIntfVoltage)(0,0) / **mClosedResistance :
 		(**mIntfVoltage)(0,0) / **mOpenResistance;
 }

--- a/dpsim-models/src/SP/SP_Ph1_varResSwitch.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_varResSwitch.cpp
@@ -18,12 +18,12 @@ SP::Ph1::varResSwitch::varResSwitch(String uid, String name, Logger::Level logLe
 
 	mOpenResistance = Attribute<Real>::create("R_open", mAttributes);
 	mClosedResistance = Attribute<Real>::create("R_closed", mAttributes);
-	mIsClosed = Attribute<Bool>::create("is_closed", mAttributes);
+	mSwitchClosed = Attribute<Bool>::create("is_closed", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr SP::Ph1::varResSwitch::clone(String name) {
 	auto copy = varResSwitch::make(name, mLogLevel);
-	copy->setParameters(**mOpenResistance, **mClosedResistance, **mIsClosed);
+	copy->setParameters(**mOpenResistance, **mClosedResistance, **mSwitchClosed);
 	return copy;
 }
 
@@ -32,7 +32,7 @@ void SP::Ph1::varResSwitch::initializeFromNodesAndTerminals(Real frequency) {
 	// // This function is not used!!!!!!
 
 	//Switch Resistance
-	Real impedance = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
+	Real impedance = (**mSwitchClosed) ? **mClosedResistance : **mOpenResistance;
 
 	(**mIntfVoltage)(0,0) = initialSingleVoltage(1) - initialSingleVoltage(0);
 	(**mIntfCurrent)(0,0)  = (**mIntfVoltage)(0,0) / impedance;
@@ -48,7 +48,7 @@ void SP::Ph1::varResSwitch::mnaInitialize(Real omega, Real timeStep, Attribute<M
 }
 
 void SP::Ph1::varResSwitch::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	Complex conductance = (**mIsClosed) ?
+	Complex conductance = (**mSwitchClosed) ?
 		Complex( 1. / **mClosedResistance, 0 ) : Complex( 1. / **mOpenResistance, 0 );
 
 	// Set diagonal entries
@@ -115,7 +115,7 @@ void SP::Ph1::varResSwitch::mnaUpdateVoltage(const Matrix& leftVector) {
 }
 
 void SP::Ph1::varResSwitch::mnaUpdateCurrent(const Matrix& leftVector) {
-	(**mIntfCurrent)(0,0) = (**mIsClosed) ?
+	(**mIntfCurrent)(0,0) = (**mSwitchClosed) ?
 		(**mIntfVoltage)(0,0) / **mClosedResistance :
 		(**mIntfVoltage)(0,0) / **mOpenResistance;
 }
@@ -161,8 +161,8 @@ void SP::Ph1::varResSwitch::setInitParameters(Real timestep) {
 	mDeltaResClosed= 0;
 	// mDeltaResOpen = 1.5; // assumption for 1ms step size
 	mDeltaResOpen= 0.5*timestep/0.001 + 1;
-	mPrevState= **mIsClosed;
-	mPrevRes= (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
+	mPrevState= **mSwitchClosed;
+	mPrevRes= (**mSwitchClosed) ? **mClosedResistance : **mOpenResistance;
 	mInitClosedRes= **mClosedResistance;
 	mInitOpenRes= **mOpenResistance;
 }

--- a/dpsim/examples/cxx/CIM/DP_WSCC9bus_SGReducedOrderVBR.cpp
+++ b/dpsim/examples/cxx/CIM/DP_WSCC9bus_SGReducedOrderVBR.cpp
@@ -125,7 +125,7 @@ int main(int argc, char *argv[]) {
 	if (withFault) {
 		faultDP->setParameters(1e12,0.02*529);
 		faultDP->connect({ SimNode::GND, sys.node<SimNode>(faultBusName) });
-		faultDP->open();
+		faultDP->openSwitch();
 		sys.addComponent(faultDP);
 	}
 

--- a/dpsim/examples/cxx/CIM/SP_WSCC-9bus_CIM_Dyn_Switch.cpp
+++ b/dpsim/examples/cxx/CIM/SP_WSCC-9bus_CIM_Dyn_Switch.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
 	auto sw = Ph1::Switch::make("Fault", Logger::Level::info);
 	sw->setParameters(1e12, 0.1*529);
 	sw->connect({ SimNode::GND, sys.node<SimNode>("BUS7") });
-	sw->open();
+	sw->openSwitch();
 	sys.addComponent(sw);
 
 	// Use omegNom for torque conversion in SG models for validation with PSAT

--- a/dpsim/examples/cxx/CIM/SP_WSCC9bus_SGReducedOrderVBR.cpp
+++ b/dpsim/examples/cxx/CIM/SP_WSCC9bus_SGReducedOrderVBR.cpp
@@ -125,7 +125,7 @@ int main(int argc, char *argv[]) {
 	if (withFault) {
 		faultSP->setParameters(1e12,0.02*529);
 		faultSP->connect({ SimNode::GND, sys.node<SimNode>(faultBusName) });
-		faultSP->open();
+		faultSP->openSwitch();
 		sys.addComponent(faultSP);
 	}
 

--- a/dpsim/examples/cxx/CIM/WSCC-9bus_CIM_Dyn_Switch.cpp
+++ b/dpsim/examples/cxx/CIM/WSCC-9bus_CIM_Dyn_Switch.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
 	auto sw = Ph1::Switch::make("StepLoad", Logger::Level::info);
 	sw->setParameters(1e9, 0.1);
 	sw->connect({ SimNode::GND, sys.node<SimNode>("BUS6") });
-	sw->open();
+	sw->openSwitch();
 	sys.addComponent(sw);
 
 	// Logging

--- a/dpsim/examples/cxx/Circuits/DP_ReducedOrderSG_SMIB_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_ReducedOrderSG_SMIB_Fault.cpp
@@ -113,7 +113,7 @@ void DP_1ph_SynGen_Fault(String simName, Real timeStep, Real finalTime, Real H,
 	//Breaker
 	auto fault = CPS::DP::Ph1::Switch::make("Br_fault", logLevel);
 	fault->setParameters(switchOpen, switchClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Topology
 	genDP->connect({ n1DP });

--- a/dpsim/examples/cxx/Circuits/DP_ReducedOrderSG_VBR_Load_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_ReducedOrderSG_VBR_Load_Fault.cpp
@@ -55,7 +55,7 @@ void DP_1ph_SynGen_Fault(String simName, Real timeStep, Real finalTime, Real H,
 	//Breaker
 	auto fault = CPS::DP::Ph1::Switch::make("Br_fault", logLevel);
 	fault->setParameters(switchOpen, switchClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Topology
 	genDP->connect({ n1DP });

--- a/dpsim/examples/cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
@@ -63,7 +63,7 @@ void DP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	//Switch
 	auto faultPF = CPS::SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	faultPF->setParameters(SwitchOpen, SwitchClosed);
-	faultPF->open();
+	faultPF->openSwitch();
 
 	// Topology
 	gen1PF->connect({ n1PF });
@@ -149,7 +149,7 @@ void DP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	auto faultDP = DP::Ph1::varResSwitch::make("Br_fault", Logger::Level::debug);
 	faultDP->setParameters(SwitchOpen, SwitchClosed);
 	faultDP->setInitParameters(timeStep);
-	faultDP->open();
+	faultDP->openSwitch();
 
 	// Topology
 	gen1DP->connect({ n1DP });

--- a/dpsim/examples/cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
@@ -51,7 +51,7 @@ void DP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bo
 	//Switch
 	auto faultPF = CPS::SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	faultPF->setParameters(SwitchOpen, SwitchClosed);
-	faultPF->open();
+	faultPF->openSwitch();
 
 	// Topology
 	genPF->connect({ n1PF });
@@ -111,7 +111,7 @@ void DP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bo
 	auto faultDP = DP::Ph1::varResSwitch::make("Br_fault", Logger::Level::debug);
 	faultDP->setParameters(SwitchOpen, SwitchClosed);
 	faultDP->setInitParameters(timeStep);
-	faultDP->open();
+	faultDP->openSwitch();
 
 	// Topology
 	genDP->connect({ n1DP });

--- a/dpsim/examples/cxx/Circuits/EMT_SynGenDQ7odTrapez_DP_SynGenTrStab_SMIB_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_SynGenDQ7odTrapez_DP_SynGenTrStab_SMIB_Fault.cpp
@@ -283,7 +283,7 @@ void DP_1ph_SynGenTrStab_Fault(Real timeStep, Real finalTime, bool startFaultEve
 	auto fault = CPS::DP::Ph1::varResSwitch::make("Br_fault", Logger::Level::debug);
 	fault->setParameters(BreakerOpen, BreakerClosed);
 	fault->setInitParameters(timeStep);
-	fault->open();
+	fault->openSwitch();
 
 	// Topology
 	gen->connect({ n1 });
@@ -425,7 +425,7 @@ void SP_1ph_SynGenTrStab_Fault(Real timeStep, Real finalTime, bool startFaultEve
 	auto fault = CPS::SP::Ph1::varResSwitch::make("Br_fault", Logger::Level::debug);
 	fault->setParameters(BreakerOpen, BreakerClosed);
 	fault->setInitParameters(timeStep);
-	fault->open();
+	fault->openSwitch();
 
 	// Topology
 	gen->connect({ n1 });

--- a/dpsim/examples/cxx/Circuits/SP_ReducedOrderSG_SMIB_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_ReducedOrderSG_SMIB_Fault.cpp
@@ -114,7 +114,7 @@ void SP_1ph_SynGen_Fault(String simName, Real timeStep, Real finalTime, Real H,
 	//Breaker
 	auto fault = CPS::SP::Ph1::Switch::make("Br_fault", logLevel);
 	fault->setParameters(switchOpen, switchClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Topology
 	genSP->connect({ n1SP });

--- a/dpsim/examples/cxx/Circuits/SP_ReducedOrderSG_VBR_Load_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_ReducedOrderSG_VBR_Load_Fault.cpp
@@ -52,7 +52,7 @@ void SP_1ph_SynGen_Load(String simName, Real timeStep, Real finalTime, Real H,
 	//Breaker
 	auto fault = CPS::SP::Ph1::Switch::make("Br_fault", logLevel);
 	fault->setParameters(switchOpen, switchClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Topology
 	genSP->connect({ n1SP });

--- a/dpsim/examples/cxx/Circuits/SP_SynGen4OrderDCIM_SMIB_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_SynGen4OrderDCIM_SMIB_Fault.cpp
@@ -105,7 +105,7 @@ void SP_1ph_SynGen_Fault(String simName, Real timeStep, Real finalTime, Real H,
 	//Breaker
 	auto fault = CPS::SP::Ph1::Switch::make("Br_fault", logLevel);
 	fault->setParameters(switchOpen, switchClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Topology
 	genSP->connect({ n1SP });

--- a/dpsim/examples/cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
@@ -63,7 +63,7 @@ void SP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	//Switch
 	auto faultPF = CPS::SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	faultPF->setParameters(SwitchOpen, SwitchClosed);
-	faultPF->open();
+	faultPF->openSwitch();
 
 	// Topology
 	gen1PF->connect({ n1PF });
@@ -149,7 +149,7 @@ void SP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	auto faultSP = SP::Ph1::varResSwitch::make("Br_fault", Logger::Level::debug);
 	faultSP->setParameters(SwitchOpen, SwitchClosed);
 	faultSP->setInitParameters(timeStep);
-	faultSP->open();
+	faultSP->openSwitch();
 
 	// Topology
 	gen1SP->connect({ n1SP });

--- a/dpsim/examples/cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_SynGenTrStab_SMIB_Fault.cpp
@@ -51,7 +51,7 @@ void SP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bo
 	//Switch
 	auto faultPF = CPS::SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	faultPF->setParameters(SwitchOpen, SwitchClosed);
-	faultPF->open();
+	faultPF->openSwitch();
 
 	// Topology
 	genPF->connect({ n1PF });
@@ -111,7 +111,7 @@ void SP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, bo
 	auto faultSP = SP::Ph1::varResSwitch::make("Br_fault", Logger::Level::debug);
 	faultSP->setParameters(SwitchOpen, SwitchClosed);
 	faultSP->setInitParameters(timeStep);
-	faultSP->open();
+	faultSP->openSwitch();
 
 	// Topology
 	genSP->connect({ n1SP });

--- a/dpsim/examples/cxx/Circuits/SP_SynGenTrStab_SMIB_Fault_KundurExample1.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_SynGenTrStab_SMIB_Fault_KundurExample1.cpp
@@ -97,7 +97,7 @@ void SP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, Re
 	// Switch
 	auto faultPF = CPS::SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	faultPF->setParameters(SwitchOpen, SwitchClosed);
-	faultPF->open();
+	faultPF->openSwitch();
 
 	// Topology
 	genPF->connect({ n1PF });
@@ -163,7 +163,7 @@ void SP_1ph_SynGenTrStab_Fault(String simName, Real timeStep, Real finalTime, Re
 	//Switch
 	auto faultSP = SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	faultSP->setParameters(SwitchOpen, SwitchClosed);
-	faultSP->open();
+	faultSP->openSwitch();
 
 	// Topology
 	genSP->connect({ n1SP });

--- a/dpsim/examples/cxx/Components/DP_EMT_SynGenDq7odTrapez_LoadStep.cpp
+++ b/dpsim/examples/cxx/Components/DP_EMT_SynGenDq7odTrapez_LoadStep.cpp
@@ -72,7 +72,7 @@ void DP_SynGenDq7odTrapez_LoadStep(Real timeStep, Real finalTime, Real breakerCl
 
 	auto fault = CPS::DP::Ph3::SeriesSwitch::make("Br_fault");
 	fault->setParameters(BreakerOpen, breakerClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Connections
 	gen->connect({n1});
@@ -124,7 +124,7 @@ void EMT_SynGenDq7odTrapez_LoadStep(Real timeStep, Real finalTime, Real breakerC
 
 	auto fault = CPS::EMT::Ph3::SeriesSwitch::make("Br_fault");
 	fault->setParameters(BreakerOpen, breakerClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Connections
 	gen->connect({n1});

--- a/dpsim/examples/cxx/Components/DP_EMT_SynGenDq7odTrapez_ThreePhFault.cpp
+++ b/dpsim/examples/cxx/Components/DP_EMT_SynGenDq7odTrapez_ThreePhFault.cpp
@@ -71,7 +71,7 @@ void DP_SynGenDq7odTrapez_ThreePhFault(Real timeStep, Real finalTime) {
 
 	auto fault = CPS::DP::Ph3::SeriesSwitch::make("Br_fault");
 	fault->setParameters(BreakerOpen, BreakerClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Connections
 	gen->connect({n1});
@@ -121,7 +121,7 @@ void EMT_SynGenDq7odTrapez_ThreePhFault(Real timeStep, Real finalTime) {
 
 	auto fault = CPS::EMT::Ph3::SeriesSwitch::make("Br_fault");
 	fault->setParameters(BreakerOpen, BreakerClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Connections
 	gen->connect({n1});

--- a/dpsim/examples/cxx/Components/DP_SP_SynGenTrStab_testModels.cpp
+++ b/dpsim/examples/cxx/Components/DP_SP_SynGenTrStab_testModels.cpp
@@ -152,7 +152,7 @@ void SP_1ph_SynGenTrStab_Fault(Real timeStep, Real finalTime, bool startFaultEve
 	//Breaker
 	auto fault = CPS::SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	fault->setParameters(BreakerOpen, BreakerClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Topology
 	gen->connect({ n1 });
@@ -281,7 +281,7 @@ void DP_1ph_SynGenTrStab_Fault(Real timeStep, Real finalTime, bool startFaultEve
 	//Breaker
 	auto fault = CPS::DP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	fault->setParameters(BreakerOpen, BreakerClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Topology
 	gen->connect({ n1 });

--- a/dpsim/examples/cxx/Components/DP_SP_SynGenTrStab_testModels_doubleLine.cpp
+++ b/dpsim/examples/cxx/Components/DP_SP_SynGenTrStab_testModels_doubleLine.cpp
@@ -175,7 +175,7 @@ void SP_1ph_SynGenTrStab_Fault(Real timeStep, Real finalTime, bool startFaultEve
 	//Breaker
 	auto fault = CPS::SP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	fault->setParameters(BreakerOpen, BreakerClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Topology
 	gen->connect({ n1 });
@@ -334,7 +334,7 @@ void DP_1ph_SynGenTrStab_Fault(Real timeStep, Real finalTime, bool startFaultEve
 	//Breaker
 	auto fault = CPS::DP::Ph1::Switch::make("Br_fault", Logger::Level::debug);
 	fault->setParameters(BreakerOpen, BreakerClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Topology
 	gen->connect({ n1 });

--- a/dpsim/examples/cxx/Components/DP_SynGenDq7odTrapez_ThreePhFault.cpp
+++ b/dpsim/examples/cxx/Components/DP_SynGenDq7odTrapez_ThreePhFault.cpp
@@ -67,7 +67,7 @@ int main(int argc, char* argv[]) {
 
 	auto fault = Ph3::SeriesSwitch::make("Br_fault");
 	fault->setParameters(BreakerOpen, BreakerClosed);
-	fault->open();
+	fault->openSwitch();
 
 	// Connections
 	gen->connect({n1});

--- a/dpsim/examples/cxx/Components/DP_SynGenTrStab_LoadStep.cpp
+++ b/dpsim/examples/cxx/Components/DP_SynGenTrStab_LoadStep.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
 	auto load = Ph1::Switch::make("StepLoad", Logger::Level::debug);
 	load->setParameters(Rload, RloadStep);
 	load->connect({SimNode::GND, n1});
-	load->open();
+	load->openSwitch();
 
 	// System
 	auto sys = SystemTopology(60, SystemNodeList{n1}, SystemComponentList{gen, load});

--- a/dpsim/examples/cxx/Examples.h
+++ b/dpsim/examples/cxx/Examples.h
@@ -602,7 +602,7 @@ namespace Events {
             auto connectionNode = system.node<CPS::SimNode<Complex>>(nodeName);
             Real resistance = std::abs(connectionNode->initialSingleVoltage())*std::abs(connectionNode->initialSingleVoltage())/additionalActivePower;
             loadSwitch->setParameters(1e9, resistance);
-            loadSwitch->open();
+            loadSwitch->openSwitch();
             system.addComponent(loadSwitch);
             system.connectComponentToNodes<Complex>(loadSwitch, { CPS::SimNode<Complex>::GND, connectionNode});
             logger->logAttribute("switchedload_i", loadSwitch->attribute("i_intf"));
@@ -612,7 +612,7 @@ namespace Events {
             auto connectionNode = system.node<CPS::SimNode<Complex>>(nodeName);
             Real resistance = std::abs(connectionNode->initialSingleVoltage())*std::abs(connectionNode->initialSingleVoltage())/additionalActivePower;
             loadSwitch->setParameters(1e9, resistance);
-            loadSwitch->open();
+            loadSwitch->openSwitch();
             system.addComponent(loadSwitch);
             system.connectComponentToNodes<Complex>(loadSwitch, { CPS::SimNode<Complex>::GND, connectionNode});
             logger->logAttribute("switchedload_i", loadSwitch->attribute("i_intf"));

--- a/dpsim/include/dpsim/Event.h
+++ b/dpsim/include/dpsim/Event.h
@@ -86,9 +86,9 @@ namespace DPsim {
 
 		void execute() {
 			if (mNewState)
-				mSwitch->close();
+				mSwitch->closeSwitch();
 			else
-				mSwitch->open();
+				mSwitch->openSwitch();
 		}
 	};
 


### PR DESCRIPTION
- added EMT_Ph1_Switch.cpp and EMT_Ph1_Switch.h
- implementation is based on DP_Ph1_Switch and was tested

- there are naming inconsistency between **Base_Ph1_Switch.h** and **Base_Ph3_Switch.h**: 
1. Attribute<Bool>::Ptr mIsClosed;  <--> Attribute<Bool>::Ptr mSwitchClosed; 
2. void close()    <-->     void closeSwitch()
- Proposal: change to  mSwitchClosed and closeSwitch() for all switches--> these changes are included here

Signed-off-by: cwirtz <Christoph.Wirtz@fgh-ma.de>