### PR TITLE
fix rxload initialization

### DIFF
--- a/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
@@ -119,7 +119,7 @@ void DP::Ph1::RXLoad::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>
 	}
 	if (mSubCapacitor) {
 		mSubCapacitor->mnaInitialize(omega, timeStep, leftVector);
-		mRightVectorStamps.push_back(&**mSubInductor->mRightVector);
+		mRightVectorStamps.push_back(&**mSubCapacitor->mRightVector);
 	}
 
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));


### PR DESCRIPTION
Fix the copy paste error in rxload mentioned in #118 
Probably, this has not been noticed so far because we usually use a combination of resistor and inductor rather than the capacitor.