### PR TITLE
Add Github actions workflow for publishing to PyPi

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -84,3 +84,23 @@ jobs:
          push: true
          tags: sogno/dpsim:dev-minimal
 
+  create-docker-manylinux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_SECRET }}
+
+      - name: Build and push
+        id: docker_build_dev
+        uses: docker/build-push-action@v2
+        with:
+         file: packaging/Docker/Dockerfile.manylinux
+         push: true
+         tags: sogno/dpsim:manylinux
+

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -1,0 +1,38 @@
+name: Publish dpsim package to PyPi
+
+on:
+  push:
+    branches:
+      - master
+      - pypi-actions
+
+jobs:
+  build-and-publish:
+    name: Build dpsim and publish to PyPi
+    runs-on: ubuntu-latest
+    container: sogno/dpsim:dev
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Build dpsim source dist and wheel
+      shell: bash
+      run: python -m build --sdist --wheel --outdir dist/
+
+    - name: Remove built wheel # Necessary as long as the wheel is not built on manylinux and therefore has the wrong target for PyPi
+      shell: bash
+      run: rm dist/*.whl
+
+    - name: Publish distribution to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    # - name: Publish distribution to PyPI
+    #   if: startsWith(github.ref, 'refs/tags')
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -7,8 +7,8 @@ on:
       - pypi-actions
 
 jobs:
-  build-and-publish:
-    name: Build dpsim and publish to PyPi
+  build-and-publish-sdist:
+    name: Build dpsim sdist and publish to PyPi
     runs-on: ubuntu-latest
     container: sogno/dpsim:dev
     steps:
@@ -17,13 +17,40 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Build dpsim source dist and wheel
+    - name: Build dpsim source dist
       shell: bash
-      run: python -m build --sdist --wheel --outdir dist/
+      run: python -m build --sdist --outdir dist/
 
-    - name: Remove built wheel # Necessary as long as the wheel is not built on manylinux and therefore has the wrong target for PyPi
+    - name: Publish distribution to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    # - name: Publish distribution to PyPI
+    #   if: startsWith(github.ref, 'refs/tags')
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     password: ${{ secrets.PYPI_API_TOKEN }}#
+
+
+  build-and-publish-wheels:
+    name: Build dpsim wheels and publish to PyPi
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Build manylinux docker image # Remove this step as soon as the image is published on docker hub
       shell: bash
-      run: rm dist/*.whl
+      run: docker build . --file packaging/Docker/Dockerfile.manylinux -t sogno/dpsim:manylinux
+
+    - name: Build dpsim wheels for all supported python versions
+      uses: pypa/cibuildwheel@v2.11.2
+      with:
+        output-dir: dist
 
     - name: Publish distribution to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - pypi-actions
 
 jobs:
   build-and-publish-sdist:
@@ -28,11 +27,11 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
         skip_existing: true
 
-    # - name: Publish distribution to PyPI
-    #   if: startsWith(github.ref, 'refs/tags')
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     password: ${{ secrets.PYPI_API_TOKEN }}#
+    - name: Publish distribution to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
 
 
   build-and-publish-wheels:
@@ -60,8 +59,8 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
         skip_existing: true
 
-    # - name: Publish distribution to PyPI
-    #   if: startsWith(github.ref, 'refs/tags')
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Publish distribution to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -26,6 +26,7 @@ jobs:
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
+        skip_existing: true
 
     # - name: Publish distribution to PyPI
     #   if: startsWith(github.ref, 'refs/tags')
@@ -57,6 +58,7 @@ jobs:
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
+        skip_existing: true
 
     # - name: Publish distribution to PyPI
     #   if: startsWith(github.ref, 'refs/tags')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,7 @@ else()
 	endif()
 endif()
 
-
 include(CheckSymbolExists)
-check_symbol_exists(pipe unistd.h HAVE_PIPE)
 check_symbol_exists(timerfd_create sys/timerfd.h HAVE_TIMERFD)
 check_symbol_exists(getopt_long getopt.h HAVE_GETOPT)
 

--- a/dpsim/include/dpsim/Config.h.in
+++ b/dpsim/include/dpsim/Config.h.in
@@ -29,6 +29,5 @@
 #cmakedefine WITH_MAGMA
 #cmakedefine CGMES_BUILD
 
-#cmakedefine HAVE_TIMERFD
-#cmakedefine HAVE_PIPE
 #cmakedefine HAVE_GETOPT
+#cmakedefine HAVE_TIMERFD

--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -3,56 +3,98 @@
 #
 # See: https://github.com/pypa/manylinux
 
-FROM quay.io/pypa/manylinux2010_x86_64
+FROM quay.io/pypa/manylinux_2_28_x86_64
 
-ENV VILLAS_VERSION=0.8.0
-ENV PLAT=manylinux2010_x86_64
+ENV PLAT=manylinux_2_28_x86_64
 
 LABEL \
-	org.label-schema.schema-version = "1.0" \
+	org.label-schema.schema-version = "1.0.0" \
 	org.label-schema.name = "DPsim" \
 	org.label-schema.license = "MPL 2.0" \
-	org.label-schema.vendor = "Institute for Automation of Complex Power Systems, RWTH Aachen University" \
-	org.label-schema.author.name = "Steffen Vogel" \
-	org.label-schema.author.email = "stvogel@eonerc.rwth-aachen.de" \
-	org.label-schema.url = "http://fein-aachen.org/projects/dpsim/" \
-	org.label-schema.vcs-url = "https://git.rwth-aachen.de/acs/core/simulation/DPsim"
+	org.label-schema.url = "http://dpsim.fein-aachen.org/" \
+	org.label-schema.vcs-url = "https://github.com/sogno-platform/dpsim"
 
-# Set up DPsim dependencies
-ADD https://packages.fein-aachen.org/redhat/fein.repo /etc/yum.repos.d/
-
-# Enable Extra Packages for Enterprise Linux (EPEL) repo
-RUN yum -y install epel-release
-
-# Uninstall old CMake v2.8
-RUN yum -y remove cmake
+RUN dnf -y update
+RUN yum install -y epel-release
 
 # Toolchain
-RUN yum -y install \
-	devtoolset-7-toolchain \
-	pkgconfig make cmake3 flex \
-	git tar \
-	expat-devel \
-	gsl-devel \
-    libxml2-devel \
-	libpng-devel \
-	freetype-devel
-	# libvillas-devel-${VILLAS_VERSION} \
-	# villas-node-${VILLAS_VERSION}
+RUN yum install -y \
+	gcc gcc-c++ clang \
+	git \
+	rpmdevtools rpm-build \
+	make cmake pkgconfig \
+	python3-pip \
+	cppcheck
 
-RUN update-alternatives --install /usr/bin/cmake cmake /usr/bin/cmake3 1
+# Tools needed for developement
+RUN dnf -y install \
+	doxygen graphviz \
+	gdb \
+	procps-ng
 
-RUN git clone https://gitlab.com/graphviz/graphviz.git && \
-	mkdir -p graphviz/build && cd graphviz/build && \
-	cmake .. && make install -j$(nproc)
+# Dependencies
+RUN dnf --refresh -y install \
+	python3-devel \
+	eigen3-devel \
+	libxml2-devel \
+	graphviz-devel
 
-RUN git clone --branch v3.1.1 https://github.com/LLNL/sundials.git && \
-    mkdir -p sundials/build && \
-    cd  sundials/build && \
-    cmake .. \
-        -DBUILD_SHARED_LIBS=OFF \
-        -DBUILD_STATIC_LIBS=ON \
-        -DEXAMPLES_ENABLE_C=OFF \
-        -DCMAKE_C_FLAGS=-fPIC \
-        -DCMAKE_CXX_FLAGS=-fPIC && \
+RUN yum install -y fmt-devel
+
+# Install some debuginfos
+RUN dnf -y debuginfo-install \
+	python3
+
+# Build & Install sundials
+RUN cd /tmp && \
+	git clone --recursive https://github.com/LLNL/sundials.git && \
+	mkdir -p sundials/build && cd sundials/build && \
+	git checkout v3.2.1 && \
+	cmake -DCMAKE_BUILD_TYPE=Release ..  && \
 	make -j$(nproc) install
+
+# CIMpp and VILLAS are installed here
+ENV LD_LIBRARY_PATH="/usr/local/lib64:${LD_LIBRARY_PATH}"
+
+# Python dependencies
+ADD requirements-manylinux.txt .
+RUN pip3 install --upgrade wheel build
+RUN pip3 install -r requirements-manylinux.txt
+
+# Install CIMpp from source
+RUN cd /tmp && \
+	git clone --recursive https://github.com/cim-iec/libcimpp.git && \
+	mkdir -p libcimpp/build && cd libcimpp/build && \
+	cmake -DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 -DUSE_CIM_VERSION=CGMES_2.4.15_16FEB2016 -DBUILD_SHARED_LIBS=ON -DBUILD_ARABICA_EXAMPLES=OFF .. && make -j$(nproc) install && \
+	rm -rf /tmp/libcimpp
+
+# villas dependencies
+RUN yum install -y \
+    openssl-devel \
+    libuuid-devel \
+    libcurl-devel \
+    jansson-devel \
+    libwebsockets-devel \
+	mosquitto-devel \
+	libconfig-devel \
+  	libnl3-devel
+
+# Install spdlog from source
+RUN cd /tmp && \
+	git clone --recursive https://github.com/gabime/spdlog.git && \
+	cd spdlog && \
+	git checkout tags/v1.6.1 && \
+	mkdir -p build && cd build && \
+	cmake -DCMAKE_POSITION_INDEPENDENT_CODE=True -DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 .. && make -j$(nproc) install && \
+	rm -rf /tmp/spdlog
+
+# Install VILLAS from source
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
+RUN cd /tmp && \
+	git -c submodule.fpga.update=none clone --recursive https://git.rwth-aachen.de/acs/public/villas/node.git villasnode && \	
+	mkdir -p villasnode/build && cd villasnode/build && \
+	git -c submodule.fpga.update=none checkout b94746effb015aa98791c0e319ef11223d18e8b0 && git -c submodule.fpga.update=none submodule update --recursive && \
+	cmake -DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 .. && make -j$(nproc) install && \
+	rm -rf /tmp/villasnode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
 requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+build="[cp]p3{6,7,8,9,10,11}-manylinux_x86_64"
+manylinux-x86_64-image = "sogno/dpsim:manylinux"
+manylinux-pypy_x86_64-image = "sogno/dpsim:manylinux"

--- a/requirements-manylinux.txt
+++ b/requirements-manylinux.txt
@@ -1,0 +1,7 @@
+sphinx
+sphinx_rtd_theme
+
+pytest-runner
+pytest
+pyyaml
+pybind11[global]


### PR DESCRIPTION
Adds a new workflow for packaging the dpsim source distribution as well as building multiple binary wheels for Python versions 3.6 to 3.11 using [cibuildwheel](https://github.com/pypa/cibuildwheel). Every commit to the master branch will be pushed to TestPyPi while only tagged commits will also be uploaded to production PyPi.

Closes #127 