### PR TITLE
Unify subcomponent handling and call MNA methods through the parent

### DIFF
--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PQLoadCS.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PQLoadCS.h
@@ -62,14 +62,15 @@ namespace Ph1 {
 		/// Stamps right side (source) vector
 		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
 
+		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
+
 		class MnaPreStep : public Task {
 		public:
 			MnaPreStep(PQLoadCS& load) :
 				Task(**load.mName + ".MnaPreStep"), mLoad(load) {
-				mAttributeDependencies.push_back(load.attribute("P"));
-				mAttributeDependencies.push_back(load.attribute("Q"));
-				mAttributeDependencies.push_back(load.attribute("V_nom"));
-				mModifiedAttributes.push_back(load.mSubCurrentSource->attribute("I_ref"));
+				mLoad.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
 			}
 
 			void execute(Real time, Int timeStepCount);
@@ -80,18 +81,16 @@ namespace Ph1 {
 
 		class MnaPostStep : public Task {
 		public:
-			MnaPostStep(PQLoadCS& load) :
-				Task(**load.mName + ".MnaPostStep"), mLoad(load) {
-				mAttributeDependencies.push_back(load.mSubCurrentSource->attribute("i_intf"));
-				mAttributeDependencies.push_back(load.mSubCurrentSource->attribute("v_intf"));
-				mModifiedAttributes.push_back(load.attribute("i_intf"));
-				mModifiedAttributes.push_back(load.attribute("v_intf"));
+			MnaPostStep(PQLoadCS& load, Attribute<Matrix>::Ptr leftVector) :
+				Task(**load.mName + ".MnaPostStep"), mLoad(load), mLeftVector(leftVector) {
+				mLoad.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 			}
 
 			void execute(Real time, Int timeStepCount);
 
 		private:
 			PQLoadCS& mLoad;
+			Attribute<Matrix>::Ptr mLeftVector;
 		};
 	};
 }

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
@@ -61,14 +61,14 @@ namespace Ph1 {
 		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
 		void mnaUpdateVoltage(const Matrix& leftVector);
 		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		class MnaPreStep : public Task {
 		public:
 			MnaPreStep(RxLine& line) :
 				Task(**line.mName + ".MnaPreStep"), mLine(line) {
-				mAttributeDependencies.push_back(line.mSubResistor->attribute("right_vector"));
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("right_vector"));
-				mModifiedAttributes.push_back(line.attribute("right_vector"));
+				mLine.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
 			}
 
 			void execute(Real time, Int timeStepCount);
@@ -81,10 +81,7 @@ namespace Ph1 {
 		public:
 			MnaPostStep(RxLine& line, Attribute<Matrix>::Ptr leftVector) :
 				Task(**line.mName + ".MnaPostStep"), mLine(line), mLeftVector(leftVector) {
-				mAttributeDependencies.push_back(leftVector);
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("v_intf"));
+				mLine.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceRamp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceRamp.h
@@ -20,7 +20,7 @@ namespace Ph1 {
 		public MNAInterface,
 		public SharedFactory<VoltageSourceRamp> {
 	protected:
-		
+
 		///
 		Complex mAddVoltage;
 		///
@@ -62,14 +62,10 @@ namespace Ph1 {
 		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
 		/// Stamps right side (source) vector
 		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
-
-
 		class MnaPreStep : public Task {
 		public:
 			MnaPreStep(VoltageSourceRamp& voltageSource) :
 				Task(**voltageSource.mName + ".MnaPreStep"), mVoltageSource(voltageSource) {
-				// rampTime etc. aren't attributes (yet), so doesn't really depend on anything
-				mModifiedAttributes.push_back(voltageSource.mSubVoltageSource->attribute("V_ref"));
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceRamp.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceRamp.h
@@ -66,8 +66,6 @@ namespace Ph1 {
 		public:
 			MnaPreStep(VoltageSourceRamp& voltageSource) :
 				Task(**voltageSource.mName + ".MnaPreStep"), mVoltageSource(voltageSource) {
-				// rampTime etc. aren't attributes (yet), so doesn't really depend on anything
-				mModifiedAttributes.push_back(voltageSource.mSubVoltageSource->attribute("V_ref"));
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
@@ -90,17 +90,14 @@ namespace CPS {
 				void mnaUpdateCurrent(const Matrix& leftVector);
 				void mnaUpdateVoltage(const Matrix& leftVector);
 
+				void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+				void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
 				class MnaPreStep : public Task {
 				public:
 					MnaPreStep(RXLoad& load) :
 						Task(**load.mName + ".MnaPreStep"), mLoad(load) {
-						if (load.mSubResistor)
-							mAttributeDependencies.push_back(load.mSubResistor->attribute("right_vector"));
-						if (load.mSubInductor)
-							mAttributeDependencies.push_back(load.mSubInductor->attribute("right_vector"));
-						if (load.mSubCapacitor)
-							mAttributeDependencies.push_back(load.mSubCapacitor->attribute("right_vector"));
-						mModifiedAttributes.push_back(load.attribute("right_vector"));
+						mLoad.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
 					}
 
 					void execute(Real time, Int timeStepCount);
@@ -114,15 +111,7 @@ namespace CPS {
 				public:
 					MnaPostStep(RXLoad& load, Attribute<Matrix>::Ptr leftVector) :
 						Task(**load.mName + ".MnaPostStep"), mLoad(load), mLeftVector(leftVector) {
-						mAttributeDependencies.push_back(leftVector);
-						if (load.mSubResistor)
-							mAttributeDependencies.push_back(load.mSubResistor->attribute("i_intf"));
-						if (load.mSubInductor)
-							mAttributeDependencies.push_back(load.mSubInductor->attribute("i_intf"));
-						if (load.mSubCapacitor)
-							mAttributeDependencies.push_back(load.mSubCapacitor->attribute("i_intf"));
-						mModifiedAttributes.push_back(load.attribute("i_intf"));
-						mModifiedAttributes.push_back(load.attribute("v_intf"));
+						mLoad.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 					}
 
 					void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
@@ -62,13 +62,14 @@ namespace Ph3 {
 		void mnaUpdateVoltage(const Matrix& leftVector);
 		void mnaUpdateCurrent(const Matrix& leftVector);
 
+		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
 		class MnaPreStep : public Task {
 		public:
 			MnaPreStep(RxLine& line) :
 				Task(**line.mName + ".MnaPreStep"), mLine(line) {
-				mAttributeDependencies.push_back(line.mSubResistor->attribute("right_vector"));
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("right_vector"));
-				mModifiedAttributes.push_back(line.attribute("right_vector"));
+				mLine.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
 			}
 
 			void execute(Real time, Int timeStepCount);
@@ -81,10 +82,7 @@ namespace Ph3 {
 		public:
 			MnaPostStep(RxLine& line, Attribute<Matrix>::Ptr leftVector) :
 				Task(**line.mName + ".MnaPostStep"), mLine(line), mLeftVector(leftVector) {
-				mAttributeDependencies.push_back(leftVector);
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("v_intf"));
+				mLine.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
@@ -110,19 +110,13 @@ namespace Ph1 {
 		/// Updates internal voltage variable of the component
 		void mnaUpdateVoltage(const Matrix& leftVector) override;
 
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
 		class MnaPostStep : public Task {
 		public:
 			MnaPostStep(Load& load, Attribute<Matrix>::Ptr leftVector) :
 				Task(**load.mName + ".MnaPostStep"), mLoad(load), mLeftVector(leftVector) {
-				mAttributeDependencies.push_back(leftVector);
-				if (load.mSubResistor)
-					mAttributeDependencies.push_back(load.mSubResistor->attribute("i_intf"));
-				if (load.mSubInductor)
-					mAttributeDependencies.push_back(load.mSubInductor->attribute("i_intf"));
-				if (load.mSubCapacitor)
-					mAttributeDependencies.push_back(load.mSubCapacitor->attribute("i_intf"));
-				mModifiedAttributes.push_back(load.attribute("i_intf"));
-				mModifiedAttributes.push_back(load.attribute("v_intf"));
+				mLoad.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
@@ -138,13 +138,14 @@ namespace Ph1 {
 		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 
+		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
 		class MnaPreStep : public Task {
 		public:
 			MnaPreStep(RXLine& line) :
 				Task(**line.mName + ".MnaPreStep"), mLine(line) {
-				mAttributeDependencies.push_back(line.mSubResistor->attribute("right_vector"));
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("right_vector"));
-				mModifiedAttributes.push_back(line.attribute("right_vector"));
+				mLine.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
 			}
 
 			void execute(Real time, Int timeStepCount);
@@ -157,10 +158,7 @@ namespace Ph1 {
 		public:
 			MnaPostStep(RXLine& line, Attribute<Matrix>::Ptr leftVector) :
 				Task(**line.mName + ".MnaPostStep"), mLine(line), mLeftVector(leftVector) {
-				mAttributeDependencies.push_back(leftVector);
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("v_intf"));
+				mLine.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
@@ -73,6 +73,7 @@ void DP::Ph1::PQLoadCS::initializeFromNodesAndTerminals(Real frequency) {
 	// A positive power should result in a positive current to ground.
 	mSubCurrentSource->connect({ mTerminals[0]->node(), SimNode::GND });
 	mSubCurrentSource->initializeFromNodesAndTerminals(frequency);
+	mSubComponents.push_back(mSubCurrentSource);
 	updateIntfValues();
 
 	mSLog->info(
@@ -91,21 +92,29 @@ void DP::Ph1::PQLoadCS::initializeFromNodesAndTerminals(Real frequency) {
 void DP::Ph1::PQLoadCS::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-	mSubCurrentSource->mnaInitialize(omega, timeStep, leftVector);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
+	}
+
 	///CHECK: Can we avoid setting the right_vector attribute to dynamic? Maybe just copy the current source's right_vector somewhere? Or make a new attribute?
 	mRightVector->setReference(mSubCurrentSource->mRightVector);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this));
-	for (auto task : mSubCurrentSource->mnaTasks())
-		mMnaTasks.push_back(task);
+	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
 void DP::Ph1::PQLoadCS::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	mSubCurrentSource->mnaApplyRightSideVectorStamp(rightVector);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
+	}
 }
 
 void DP::Ph1::PQLoadCS::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	mSubCurrentSource->mnaApplySystemMatrixStamp(systemMatrix);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
+	}
 }
 
 void DP::Ph1::PQLoadCS::updateSetPoint() {
@@ -123,8 +132,31 @@ void DP::Ph1::PQLoadCS::updateSetPoint() {
 		Logger::phasorToString(std::conj(current)));
 }
 
+void DP::Ph1::PQLoadCS::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+	attributeDependencies.push_back(mActivePower);
+	attributeDependencies.push_back(mReactivePower);
+	attributeDependencies.push_back(mNomVoltage);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
+	}
+}
+
+void DP::Ph1::PQLoadCS::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
+	modifiedAttributes.push_back(mIntfCurrent);
+	modifiedAttributes.push_back(mIntfVoltage);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
+	}
+}
+
 void DP::Ph1::PQLoadCS::MnaPreStep::execute(Real time, Int timeStepCount) {
 	mLoad.updateSetPoint();
+	for (auto subComp : mLoad.mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaPreStep(time, timeStepCount);
+	}
 }
 
 void DP::Ph1::PQLoadCS::updateIntfValues() {
@@ -133,6 +165,10 @@ void DP::Ph1::PQLoadCS::updateIntfValues() {
 }
 
 void DP::Ph1::PQLoadCS::MnaPostStep::execute(Real time, Int timeStepCount) {
+	for (auto subComp : mLoad.mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaPostStep(time, timeStepCount, mLeftVector);
+	}
 	mLoad.updateIntfValues();
 }
 

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
@@ -51,6 +51,7 @@ void DP::Ph1::VoltageSourceRamp::initialize(Matrix frequencies) {
 	mSubVoltageSource->connect({ node(0), node(1) });
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[0], 0);
 	mSubVoltageSource->initialize(frequencies);
+	mSubComponents.push_back(mSubVoltageSource);
 }
 
 void DP::Ph1::VoltageSourceRamp::initializeFromNodesAndTerminals(Real frequency) {
@@ -60,23 +61,31 @@ void DP::Ph1::VoltageSourceRamp::initializeFromNodesAndTerminals(Real frequency)
 void DP::Ph1::VoltageSourceRamp::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-	mSubVoltageSource->mnaInitialize(omega, timeStep, leftVector);
+
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
+	}
+
 	// only need a new MnaPreStep that updates the reference voltage of mSubVoltageSource;
 	// its own tasks then do the rest
 	/// FIXME: Can we avoid setting right_vector to dynamic?
 	mRightVector->setReference(mSubVoltageSource->mRightVector);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	for (auto task : mSubVoltageSource->mnaTasks()) {
-		mMnaTasks.push_back(task);
-	}
 }
 
 void DP::Ph1::VoltageSourceRamp::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	mSubVoltageSource->mnaApplySystemMatrixStamp(systemMatrix);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
+	}
 }
 
 void DP::Ph1::VoltageSourceRamp::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	mSubVoltageSource->mnaApplyRightSideVectorStamp(rightVector);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
+	}
 }
 
 void DP::Ph1::VoltageSourceRamp::updateState(Real time) {
@@ -98,4 +107,8 @@ void DP::Ph1::VoltageSourceRamp::updateState(Real time) {
 void DP::Ph1::VoltageSourceRamp::MnaPreStep::execute(Real time, Int timeStepCount) {
 	mVoltageSource.updateState(time);
 	**mVoltageSource.mSubVoltageSource->mVoltageRef = (**mVoltageSource.mIntfVoltage)(0, 0);
+	for (auto subComp : mVoltageSource.mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaPreStep(time, timeStepCount);
+	}
 }

--- a/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
@@ -53,6 +53,9 @@ void SP::Ph1::SolidStateTransformer::initializeFromNodesAndTerminals(Real freque
     mSubLoadSide1->connect({mTerminals[0]->node()});
     mSubLoadSide2->connect({mTerminals[1]->node()});
 
+	mSubComponents.push_back(mSubLoadSide1);
+	mSubComponents.push_back(mSubLoadSide2);
+
     mSLog->info(
 		"\n--- Initialization from powerflow ---"
 		"\nTerminal 0 power flow: {:s} VA"


### PR DESCRIPTION
For all components that declare some kind of subcomponents, this PR unifies the handling of these subcomponents such that:
- Subcomponents are always added to `mSubComponents`
- Subcomponent MNA methods (`mnaPreStep`, `mnaPostStep`...) are called directly in the same-named parent method and not through custom tasks
- The parent calls the subcomponent's methods by iterating through `mSubComponents`

Based on #140 
Related to #131 