### PR TITLE
Introduce a common subclass for composite components

### DIFF
--- a/dpsim-models/include/dpsim-models/AttributeList.h
+++ b/dpsim-models/include/dpsim-models/AttributeList.h
@@ -28,7 +28,7 @@ namespace CPS {
 
 		AttributeList() { };
 
-		virtual ~AttributeList() {};
+		virtual ~AttributeList() = default;
 
 		const AttributeBase::Map & attributes() { return mAttributes; };
 

--- a/dpsim-models/include/dpsim-models/AttributeList.h
+++ b/dpsim-models/include/dpsim-models/AttributeList.h
@@ -31,7 +31,7 @@ namespace CPS {
 		// 	} else {
 		// 		newAttr = AttributeStatic<T>::make(std::forward<Args>(args)...);
 		// 	}
-			 
+
 		// 	mAttributes[name] = newAttr;
 		// 	return newAttr;
 		// }
@@ -54,7 +54,7 @@ namespace CPS {
 
 		/// Return pointer to an attribute.
 		template<typename T>
-		typename Attribute<T>::Ptr attribute(const String &name) {
+		typename Attribute<T>::Ptr attributeTyped(const String &name) {
 			auto attr = attribute(name);
 			auto attrPtr = std::dynamic_pointer_cast<Attribute<T>>(attr.getPtr());
 

--- a/dpsim-models/include/dpsim-models/AttributeList.h
+++ b/dpsim-models/include/dpsim-models/AttributeList.h
@@ -23,28 +23,17 @@ namespace CPS {
 		/// Map of all attributes
 		AttributeBase::Map mAttributes;
 
-		// template<typename T, typename... Args>
-		// typename Attribute<T>::Ptr addAttribute(const String &name, bool dynamic, Args&&... args) {
-		// 	typename Attribute<T>::Ptr newAttr;
-		// 	if (dynamic) {
-		// 		newAttr = AttributeDynamic<T>::make(std::forward<Args>(args)...);
-		// 	} else {
-		// 		newAttr = AttributeStatic<T>::make(std::forward<Args>(args)...);
-		// 	}
-
-		// 	mAttributes[name] = newAttr;
-		// 	return newAttr;
-		// }
-
 	public:
 		typedef std::shared_ptr<AttributeList> Ptr;
 
 		AttributeList() { };
 
+		virtual ~AttributeList() {};
+
 		const AttributeBase::Map & attributes() { return mAttributes; };
 
 		/// Return pointer to an attribute.
-		AttributeBase::Ptr attribute(const String &name) {
+		virtual AttributeBase::Ptr attribute(const String &name) {
 			auto it = mAttributes.find(name);
 			if (it == mAttributes.end())
 				throw InvalidAttributeException();
@@ -64,10 +53,5 @@ namespace CPS {
 			return typename Attribute<T>::Ptr(attrPtr);
 		}
 
-		// void reset() {
-		// 	for (auto a : mAttributes) {
-		// 		a.second->reset();
-		// 	}
-		// }
 	};
 }

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Capacitor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Capacitor.h
@@ -18,7 +18,7 @@ namespace Ph1 {
 		/// Capacitance [F]
 		const CPS::Attribute<Real>::Ptr mCapacitance;
 
-		Capacitor(CPS::AttributeBase::Map &attributeList) :
+		explicit Capacitor(CPS::AttributeBase::Map &attributeList) :
 			mCapacitance(CPS::Attribute<Real>::create("C", attributeList)) { };
 
 		/// Sets model specific parameters

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Capacitor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Capacitor.h
@@ -16,7 +16,10 @@ namespace Ph1 {
 	class Capacitor {
 	public:
 		/// Capacitance [F]
-		CPS::Attribute<Real>::Ptr mCapacitance;
+		const CPS::Attribute<Real>::Ptr mCapacitance;
+
+		Capacitor(CPS::AttributeBase::Map &attributeList) :
+			mCapacitance(CPS::Attribute<Real>::create("C", attributeList)) { };
 
 		/// Sets model specific parameters
 		void setParameters(Real capacitance) {

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Inductor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Inductor.h
@@ -16,7 +16,11 @@ namespace Ph1 {
 	class Inductor {
 	public:
 		/// Inductance [H]
-		CPS::Attribute<Real>::Ptr mInductance;
+		const CPS::Attribute<Real>::Ptr mInductance;
+
+		Inductor(CPS::AttributeBase::Map &attributeList) :
+			mInductance(CPS::Attribute<Real>::create("L", attributeList)) { };
+
 		/// Sets model specific parameters
 		void setParameters(Real inductance) {
 			**mInductance = inductance;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Inductor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Inductor.h
@@ -18,7 +18,7 @@ namespace Ph1 {
 		/// Inductance [H]
 		const CPS::Attribute<Real>::Ptr mInductance;
 
-		Inductor(CPS::AttributeBase::Map &attributeList) :
+		explicit Inductor(CPS::AttributeBase::Map &attributeList) :
 			mInductance(CPS::Attribute<Real>::create("L", attributeList)) { };
 
 		/// Sets model specific parameters

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_PiLine.h
@@ -18,13 +18,19 @@ namespace Ph1 {
 
 	public:
 		/// Resistance along the line [ohms]
-		Attribute<Real>::Ptr mSeriesRes;
+		const Attribute<Real>::Ptr mSeriesRes;
 		/// Inductance along the line [H]
-		Attribute<Real>::Ptr mSeriesInd;
-		/// Conductance in parallel to the line [S]
-		Attribute<Real>::Ptr mParallelCond;
+		const Attribute<Real>::Ptr mSeriesInd;
 		/// Capacitance in parallel to the line [F]
-		Attribute<Real>::Ptr mParallelCap;
+		const Attribute<Real>::Ptr mParallelCap;
+		/// Conductance in parallel to the line [S]
+		const Attribute<Real>::Ptr mParallelCond;
+
+		PiLine(CPS::AttributeBase::Map &attributeList) :
+			mSeriesRes(Attribute<Real>::create("R_series", attributeList)),
+			mSeriesInd(Attribute<Real>::create("L_series", attributeList)),
+			mParallelCap(Attribute<Real>::create("C_parallel", attributeList)),
+			mParallelCond(Attribute<Real>::create("G_parallel", attributeList)) { };
 
 		///
 		void setParameters(Real seriesResistance, Real seriesInductance,

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_PiLine.h
@@ -26,7 +26,7 @@ namespace Ph1 {
 		/// Conductance in parallel to the line [S]
 		const Attribute<Real>::Ptr mParallelCond;
 
-		PiLine(CPS::AttributeBase::Map &attributeList) :
+		explicit PiLine(CPS::AttributeBase::Map &attributeList) :
 			mSeriesRes(Attribute<Real>::create("R_series", attributeList)),
 			mSeriesInd(Attribute<Real>::create("L_series", attributeList)),
 			mParallelCap(Attribute<Real>::create("C_parallel", attributeList)),
@@ -34,7 +34,7 @@ namespace Ph1 {
 
 		///
 		void setParameters(Real seriesResistance, Real seriesInductance,
-			Real parallelCapacitance = 0, Real parallelConductance = 0) {
+			Real parallelCapacitance = 0, Real parallelConductance = 0) const {
 			**mSeriesRes = seriesResistance;
 			**mSeriesInd = seriesInductance;
 			**mParallelCond = parallelConductance;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_PiLine.h
@@ -15,14 +15,7 @@ namespace CPS {
 namespace Base {
 namespace Ph1 {
 	class PiLine {
-	protected:
-		/// Conductance along the line [S]
-		/// FIXME: This is never used...
-		Real mSeriesCond;
-		/// Resistance in parallel to the line [ohms]
-		/// FIXME: This is never used...
-		Real mParallelRes;
-		
+
 	public:
 		/// Resistance along the line [ohms]
 		Attribute<Real>::Ptr mSeriesRes;
@@ -37,10 +30,8 @@ namespace Ph1 {
 		void setParameters(Real seriesResistance, Real seriesInductance,
 			Real parallelCapacitance = 0, Real parallelConductance = 0) {
 			**mSeriesRes = seriesResistance;
-			mSeriesCond = 1. / **mSeriesRes;
 			**mSeriesInd = seriesInductance;
 			**mParallelCond = parallelConductance;
-			mParallelRes = 1. / **mParallelCond;
 			**mParallelCap = parallelCapacitance;
 		}
 	};

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Resistor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Resistor.h
@@ -17,7 +17,12 @@ namespace Ph1 {
 	class Resistor {
 	public:
 		///Resistance [ohm]
-		CPS::Attribute<Real>::Ptr mResistance;
+		const CPS::Attribute<Real>::Ptr mResistance;
+
+		Resistor(CPS::AttributeBase::Map &attributeList) :
+			mResistance(CPS::Attribute<Real>::create("R", attributeList)) { };
+
+
 		///
 		void setParameters(Real resistance) {
 			**mResistance = resistance;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Resistor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Resistor.h
@@ -19,7 +19,7 @@ namespace Ph1 {
 		///Resistance [ohm]
 		const CPS::Attribute<Real>::Ptr mResistance;
 
-		Resistor(CPS::AttributeBase::Map &attributeList) :
+		explicit Resistor(CPS::AttributeBase::Map &attributeList) :
 			mResistance(CPS::Attribute<Real>::create("R", attributeList)) { };
 
 

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_SVC.h
@@ -18,7 +18,6 @@ namespace Ph1 {
 	class SVC {
 	protected:
 		/// Inductance [H]
-		/// FIXME: This is only ever written to but never read
 		Real mInductance;
 		/// Maximium susceptance [p.u.]
 		Real mBMax;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Switch.h
@@ -18,11 +18,17 @@ namespace Ph1 {
 	class Switch {
 	public:
 		/// Resistance if switch is open [ohm]
-		Attribute<Real>::Ptr mOpenResistance;
+		const Attribute<Real>::Ptr mOpenResistance;
 		/// Resistance if switch is closed [ohm]
-		Attribute<Real>::Ptr mClosedResistance;
+		const Attribute<Real>::Ptr mClosedResistance;
 		/// Defines if Switch is open or closed
-		Attribute<Bool>::Ptr mIsClosed;
+		const Attribute<Bool>::Ptr mIsClosed;
+
+		Switch(CPS::AttributeBase::Map &attributeList) :
+			mOpenResistance(Attribute<Real>::create("R_open", attributeList)),
+			mClosedResistance(Attribute<Real>::create("R_closed", attributeList)),
+			mIsClosed(Attribute<Bool>::create("is_closed", attributeList)) { };
+
 		///
 		void setParameters(Real openResistance, Real closedResistance, Bool closed = false) {
 			**mOpenResistance = openResistance;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Switch.h
@@ -24,7 +24,7 @@ namespace Ph1 {
 		/// Defines if Switch is open or closed
 		const Attribute<Bool>::Ptr mIsClosed;
 
-		Switch(CPS::AttributeBase::Map &attributeList) :
+		explicit Switch(CPS::AttributeBase::Map &attributeList) :
 			mOpenResistance(Attribute<Real>::create("R_open", attributeList)),
 			mClosedResistance(Attribute<Real>::create("R_closed", attributeList)),
 			mIsClosed(Attribute<Bool>::create("is_closed", attributeList)) { };

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Transformer.h
@@ -29,7 +29,7 @@ namespace Ph1 {
 		/// Inductance [H]
 		const Attribute<Real>::Ptr mInductance;
 
-		Transformer(CPS::AttributeBase::Map &attributeList) :
+		explicit Transformer(CPS::AttributeBase::Map &attributeList) :
 			mNominalVoltageEnd1(Attribute<Real>::create("nominal_voltage_end1", attributeList)),
 			mNominalVoltageEnd2(Attribute<Real>::create("nominal_voltage_end2", attributeList)),
 			mRatedPower(Attribute<Real>::create("S", attributeList)),

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Transformer.h
@@ -17,17 +17,27 @@ namespace Ph1 {
 	class Transformer {
 	public:
 		/// Nominal voltage of primary side
-		Attribute<Real>::Ptr mNominalVoltageEnd1;
+		const Attribute<Real>::Ptr mNominalVoltageEnd1;
 		/// Nominal voltage of secondary side
-		Attribute<Real>::Ptr mNominalVoltageEnd2;
+		const Attribute<Real>::Ptr mNominalVoltageEnd2;
 		/// Rated Apparent Power [VA]
-		Attribute<Real>::Ptr mRatedPower;
+		const Attribute<Real>::Ptr mRatedPower;
 		/// Complex transformer ratio
-		Attribute<Complex>::Ptr mRatio;
+		const Attribute<Complex>::Ptr mRatio;
 		/// Resistance [Ohm]
-		Attribute<Real>::Ptr mResistance;
+		const Attribute<Real>::Ptr mResistance;
 		/// Inductance [H]
-		Attribute<Real>::Ptr mInductance;
+		const Attribute<Real>::Ptr mInductance;
+
+		Transformer(CPS::AttributeBase::Map &attributeList) :
+			mNominalVoltageEnd1(Attribute<Real>::create("nominal_voltage_end1", attributeList)),
+			mNominalVoltageEnd2(Attribute<Real>::create("nominal_voltage_end2", attributeList)),
+			mRatedPower(Attribute<Real>::create("S", attributeList)),
+			mRatio(Attribute<Complex>::create("ratio", attributeList)),
+			mResistance(Attribute<Real>::create("R", attributeList)),
+			mInductance(Attribute<Real>::create("L", attributeList)) { };
+
+
 		///
 		void setParameters(Real nomVoltageEnd1, Real nomVoltageEnd2, Real ratioAbs, Real ratioPhase, Real resistance, Real inductance) {
 			**mNominalVoltageEnd1 = nomVoltageEnd1;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_VoltageSource.h
@@ -21,7 +21,7 @@ namespace Ph1 {
 		/// Source frequency [Hz]
 		const Attribute<Real>::Ptr mSrcFreq;
 
-		VoltageSource(CPS::AttributeBase::Map &attributeList) :
+		explicit VoltageSource(CPS::AttributeBase::Map &attributeList) :
 			mVoltageRef(Attribute<Complex>::create("V_ref", attributeList)),
 			mSrcFreq(Attribute<Real>::create("f_src", attributeList, -1)) { };
 

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_VoltageSource.h
@@ -17,9 +17,14 @@ namespace Ph1 {
 	class VoltageSource {
 	public:
 		/// Voltage set point [V]
-		Attribute<Complex>::Ptr mVoltageRef;
+		const Attribute<Complex>::Ptr mVoltageRef;
 		/// Source frequency [Hz]
-		Attribute<Real>::Ptr mSrcFreq;
+		const Attribute<Real>::Ptr mSrcFreq;
+
+		VoltageSource(CPS::AttributeBase::Map &attributeList) :
+			mVoltageRef(Attribute<Complex>::create("V_ref", attributeList)),
+			mSrcFreq(Attribute<Real>::create("f_src", attributeList, -1)) { };
+
 		/// Sets model specific parameters
 		void setParameters(Complex voltageRef, Real srcFreq = -1) {
 			**mVoltageRef = voltageRef;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Capacitor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Capacitor.h
@@ -19,7 +19,7 @@ namespace Ph3 {
 		/// Capacitance [F]
 		const CPS::Attribute<Matrix>::Ptr mCapacitance;
 
-		Capacitor(CPS::AttributeBase::Map &attributeList) :
+		explicit Capacitor(CPS::AttributeBase::Map &attributeList) :
 			mCapacitance(CPS::Attribute<Matrix>::create("C", attributeList)) { };
 
 		/// Sets model specific parameters

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Capacitor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Capacitor.h
@@ -17,7 +17,11 @@ namespace Ph3 {
 	class Capacitor {
 	public:
 		/// Capacitance [F]
-		CPS::Attribute<Matrix>::Ptr mCapacitance;
+		const CPS::Attribute<Matrix>::Ptr mCapacitance;
+
+		Capacitor(CPS::AttributeBase::Map &attributeList) :
+			mCapacitance(CPS::Attribute<Matrix>::create("C", attributeList)) { };
+
 		/// Sets model specific parameters
 		void setParameters(Matrix capacitance) {
 			**mCapacitance = capacitance;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Inductor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Inductor.h
@@ -19,7 +19,7 @@ namespace Ph3 {
 		/// Inductance [H]
 		const CPS::Attribute<Matrix>::Ptr mInductance;
 
-		Inductor(CPS::AttributeBase::Map &attributeList) :
+		explicit Inductor(CPS::AttributeBase::Map &attributeList) :
 			mInductance(CPS::Attribute<Matrix>::create("L", attributeList)) { };
 
 		/// Sets model specific parameters

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Inductor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Inductor.h
@@ -17,7 +17,11 @@ namespace Ph3 {
 	class Inductor {
 	public:
 		/// Inductance [H]
-		CPS::Attribute<Matrix>::Ptr mInductance;
+		const CPS::Attribute<Matrix>::Ptr mInductance;
+
+		Inductor(CPS::AttributeBase::Map &attributeList) :
+			mInductance(CPS::Attribute<Matrix>::create("L", attributeList)) { };
+
 		/// Sets model specific parameters
 		void setParameters(Matrix inductance) {
 			**mInductance = inductance;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_PiLine.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_PiLine.h
@@ -18,13 +18,20 @@ namespace Ph3 {
 
 	public:
 		/// Resistance along the line [ohms]
-		Attribute<Matrix>::Ptr mSeriesRes;
+		const Attribute<Matrix>::Ptr mSeriesRes;
 		/// Inductance along the line [H]
-		Attribute<Matrix>::Ptr mSeriesInd;
-		/// Conductance in parallel to the line [S]
-		Attribute<Matrix>::Ptr mParallelCond;
+		const Attribute<Matrix>::Ptr mSeriesInd;
 		/// Capacitance in parallel to the line [F]
-		Attribute<Matrix>::Ptr mParallelCap;
+		const Attribute<Matrix>::Ptr mParallelCap;
+		/// Conductance in parallel to the line [S]
+		const Attribute<Matrix>::Ptr mParallelCond;
+
+		PiLine(CPS::AttributeBase::Map &attributeList) :
+			mSeriesRes(Attribute<Matrix>::create("R_series", attributeList)),
+			mSeriesInd(Attribute<Matrix>::create("L_series", attributeList)),
+			mParallelCap(Attribute<Matrix>::create("C_parallel", attributeList)),
+			mParallelCond(Attribute<Matrix>::create("G_parallel", attributeList)) { };
+
 		///
 		void setParameters(Matrix seriesResistance, Matrix seriesInductance,
 			Matrix parallelCapacitance = Matrix::Zero(3,3), Matrix parallelConductance = Matrix::Zero(3,3)) {

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_PiLine.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_PiLine.h
@@ -15,13 +15,7 @@ namespace CPS {
 namespace Base {
 namespace Ph3 {
 	class PiLine {
-	protected:
-		/// Conductance along the line [S]
-		/// FIXME: This is never used...
-		Matrix mSeriesCond;
-		/// Resistance in parallel to the line [ohms]
-		/// FIXME: This is never used...
-		Matrix mParallelRes;
+
 	public:
 		/// Resistance along the line [ohms]
 		Attribute<Matrix>::Ptr mSeriesRes;
@@ -35,10 +29,8 @@ namespace Ph3 {
 		void setParameters(Matrix seriesResistance, Matrix seriesInductance,
 			Matrix parallelCapacitance = Matrix::Zero(3,3), Matrix parallelConductance = Matrix::Zero(3,3)) {
 			**mSeriesRes = seriesResistance;
-			mSeriesCond = (**mSeriesRes).inverse();
 			**mSeriesInd = seriesInductance;
 			**mParallelCond = parallelConductance;
-			mParallelRes = (**mParallelCond).inverse();
 			**mParallelCap = parallelCapacitance;
 		}
 	};

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_PiLine.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_PiLine.h
@@ -26,7 +26,7 @@ namespace Ph3 {
 		/// Conductance in parallel to the line [S]
 		const Attribute<Matrix>::Ptr mParallelCond;
 
-		PiLine(CPS::AttributeBase::Map &attributeList) :
+		explicit PiLine(CPS::AttributeBase::Map &attributeList) :
 			mSeriesRes(Attribute<Matrix>::create("R_series", attributeList)),
 			mSeriesInd(Attribute<Matrix>::create("L_series", attributeList)),
 			mParallelCap(Attribute<Matrix>::create("C_parallel", attributeList)),
@@ -34,7 +34,7 @@ namespace Ph3 {
 
 		///
 		void setParameters(Matrix seriesResistance, Matrix seriesInductance,
-			Matrix parallelCapacitance = Matrix::Zero(3,3), Matrix parallelConductance = Matrix::Zero(3,3)) {
+			Matrix parallelCapacitance = Matrix::Zero(3,3), Matrix parallelConductance = Matrix::Zero(3,3)) const {
 			**mSeriesRes = seriesResistance;
 			**mSeriesInd = seriesInductance;
 			**mParallelCond = parallelConductance;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Resistor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Resistor.h
@@ -16,7 +16,11 @@ namespace Ph3 {
 	class Resistor {
 	public:
 		///Resistance [ohm]
-		CPS::Attribute<Matrix>::Ptr mResistance;
+		const CPS::Attribute<Matrix>::Ptr mResistance;
+
+		Resistor(CPS::AttributeBase::Map &attributeList) :
+			mResistance(CPS::Attribute<Matrix>::create("R", attributeList)) { };
+
 		/// Sets model specific parameters
 		void setParameters(Matrix resistance) {
 			**mResistance = resistance;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Resistor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Resistor.h
@@ -18,7 +18,7 @@ namespace Ph3 {
 		///Resistance [ohm]
 		const CPS::Attribute<Matrix>::Ptr mResistance;
 
-		Resistor(CPS::AttributeBase::Map &attributeList) :
+		explicit Resistor(CPS::AttributeBase::Map &attributeList) :
 			mResistance(CPS::Attribute<Matrix>::create("R", attributeList)) { };
 
 		/// Sets model specific parameters

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Switch.h
@@ -17,11 +17,17 @@ namespace Ph3 {
 	class Switch {
 	public:
 		/// Resistance if switch is open [ohm]
-		CPS::Attribute<Matrix>::Ptr mOpenResistance;
+		const CPS::Attribute<Matrix>::Ptr mOpenResistance;
 		/// Resistance if switch is closed [ohm]
-		CPS::Attribute<Matrix>::Ptr mClosedResistance;
+		const CPS::Attribute<Matrix>::Ptr mClosedResistance;
 		/// Defines if Switch is open or closed
-		CPS::Attribute<Bool>::Ptr mSwitchClosed;
+		const CPS::Attribute<Bool>::Ptr mSwitchClosed;
+
+		Switch(CPS::AttributeBase::Map &attributeList) :
+			mOpenResistance(Attribute<Matrix>::create("R_open", attributeList)),
+			mClosedResistance(Attribute<Matrix>::create("R_closed", attributeList)),
+			mSwitchClosed(Attribute<Bool>::create("is_closed", attributeList)) { };
+
 		///
 		void setParameters(Matrix openResistance, Matrix closedResistance, Bool closed = false) {
 			**mOpenResistance = openResistance;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Switch.h
@@ -23,7 +23,7 @@ namespace Ph3 {
 		/// Defines if Switch is open or closed
 		const CPS::Attribute<Bool>::Ptr mSwitchClosed;
 
-		Switch(CPS::AttributeBase::Map &attributeList) :
+		explicit Switch(CPS::AttributeBase::Map &attributeList) :
 			mOpenResistance(Attribute<Matrix>::create("R_open", attributeList)),
 			mClosedResistance(Attribute<Matrix>::create("R_closed", attributeList)),
 			mSwitchClosed(Attribute<Bool>::create("is_closed", attributeList)) { };

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Transformer.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Transformer.h
@@ -29,7 +29,11 @@ namespace Ph3 {
 
 	public:
 		///Transformer ratio
-		Attribute<Complex>::Ptr mRatio;
+		const Attribute<Complex>::Ptr mRatio;
+
+		Transformer(CPS::AttributeBase::Map &attributeList) :
+			mRatio(Attribute<Complex>::create("ratio", attributeList)) { };
+
 		///
 		void setParameters(Real nomVoltageEnd1, Real nomVoltageEnd2, Real ratedPower, Real ratioAbs, Real ratioPhase, Matrix resistance, Matrix inductance) {
 			mNominalVoltageEnd1 = nomVoltageEnd1;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Transformer.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Transformer.h
@@ -31,7 +31,7 @@ namespace Ph3 {
 		///Transformer ratio
 		const Attribute<Complex>::Ptr mRatio;
 
-		Transformer(CPS::AttributeBase::Map &attributeList) :
+		explicit Transformer(CPS::AttributeBase::Map &attributeList) :
 			mRatio(Attribute<Complex>::create("ratio", attributeList)) { };
 
 		///

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_VoltageSource.h
@@ -15,7 +15,6 @@ namespace CPS {
 namespace Base {
 namespace Ph3 {
 	class VoltageSource {
-	protected:
 	public:
 		/// Sets model specific parameters
 		virtual void setParameters(Complex voltageRef, Real srcFreq = -1) {}=0;

--- a/dpsim-models/include/dpsim-models/Base/Base_SynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_SynchronGenerator.h
@@ -287,7 +287,7 @@ namespace Base {
 			mOmMech(Attribute<Real>::create("w_r", attributeList, 0)),
 			mElecActivePower(Attribute<Real>::create("P_elec", attributeList, 0)),
 			mElecReactivePower(Attribute<Real>::create("Q_elec", attributeList, 0)),
-			mMechPower(Attribute<Real>::create("P_m", attributeList, 0)),
+			mMechPower(Attribute<Real>::create("P_mech", attributeList, 0)),
 			mElecTorque(Attribute<Real>::create("T_e", attributeList, 0)) { };
 
 		///

--- a/dpsim-models/include/dpsim-models/Base/Base_SynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_SynchronGenerator.h
@@ -31,7 +31,7 @@ namespace Base {
 		enum class StateType { perUnit, statorReferred, rotorReferred };
 		/// \brief Machine parameters type.
 		enum class ParameterType { perUnit, statorReferred, operational };
-		
+
 		/// Add governor and turbine
 		void addGovernor(Real Ta, Real Tb, Real Tc, Real Fa,
 			Real Fb, Real Fc, Real K, Real Tsr, Real Tsm, Real Tm_init, Real PmRef);
@@ -68,8 +68,8 @@ namespace Base {
 		Int mNumDampingWindings = 0;
 		/// mNumber of poles
 		Int mPoleNumber = 0;
-		
-		
+
+
 		/// d-axis mutual inductance Lmd [H]
 		Real mLmd = 0;
 		/// q-axis mutual inductance Lmq [H]
@@ -103,31 +103,31 @@ namespace Base {
 
 	public:
 		/// stator resistance Rs [Ohm]
-		Attribute<Real>::Ptr mRs;
+		const Attribute<Real>::Ptr mRs;
 		/// leakage inductance Ll [H]
-		Attribute<Real>::Ptr mLl;
+		const Attribute<Real>::Ptr mLl;
 		/// d-axis inductance Ld [H]
-		Attribute<Real>::Ptr mLd;
+		const Attribute<Real>::Ptr mLd;
 		/// q-axis inductance Lq [H]
-		Attribute<Real>::Ptr mLq;
-		
+		const Attribute<Real>::Ptr mLq;
+
 		// Operational parameters
 		/// Transient d-axis inductance [H]
-		Attribute<Real>::Ptr mLd_t;
+		const Attribute<Real>::Ptr mLd_t;
 		/// Transient q-axis inductance [H]
-		Attribute<Real>::Ptr mLq_t;
+		const Attribute<Real>::Ptr mLq_t;
 		/// Subtransient d-axis inductance [H]
-		Attribute<Real>::Ptr mLd_s;
+		const Attribute<Real>::Ptr mLd_s;
 		/// Subtransient q-axis inductance [H]
-		Attribute<Real>::Ptr mLq_s;
+		const Attribute<Real>::Ptr mLq_s;
 		/// Transient time constant of d-axis [s]
-		Attribute<Real>::Ptr mTd0_t;
+		const Attribute<Real>::Ptr mTd0_t;
 		/// Transient time constant of q-axis [s]
-		Attribute<Real>::Ptr mTq0_t;
+		const Attribute<Real>::Ptr mTq0_t;
 		/// Subtransient time constant of d-axis [s]
-		Attribute<Real>::Ptr mTd0_s;
+		const Attribute<Real>::Ptr mTd0_s;
 		/// Subtransient time constant of q-axis [s]
-		Attribute<Real>::Ptr mTq0_s;
+		const Attribute<Real>::Ptr mTq0_s;
 
 	protected:
 		// #### Initial Values ####
@@ -179,21 +179,21 @@ namespace Base {
 		Real mThetaMech = 0;
 	public:
 		/// rotor angle delta
-		Attribute<Real>::Ptr mDelta;
+		const Attribute<Real>::Ptr mDelta;
 		/// mechanical torque
-		Attribute<Real>::Ptr mMechTorque;
+		const Attribute<Real>::Ptr mMechTorque;
 		/// inertia constant H [s] for per unit or moment of inertia J [kg*m^2]
-		Attribute<Real>::Ptr mInertia;
+		const Attribute<Real>::Ptr mInertia;
 		/// rotor speed omega_r
-		Attribute<Real>::Ptr mOmMech;
+		const Attribute<Real>::Ptr mOmMech;
 		/// Active part of the electrical power
-		Attribute<Real>::Ptr mElecActivePower;
+		const Attribute<Real>::Ptr mElecActivePower;
 		/// Reactive part of the electrical power
-		Attribute<Real>::Ptr mElecReactivePower;
+		const Attribute<Real>::Ptr mElecReactivePower;
 		/// mechanical Power Pm [W]
-		Attribute<Real>::Ptr mMechPower;
+		const Attribute<Real>::Ptr mMechPower;
 		/// electrical torque
-		Attribute<Real>::Ptr mElecTorque;
+		const Attribute<Real>::Ptr mElecTorque;
 	protected:
 		/// \brief Vector of stator and rotor voltages.
 		///
@@ -267,8 +267,29 @@ namespace Base {
 		Real mInitTerminalVoltage = 0;
 		Real mInitVoltAngle = 0;
 
-		/// Constructor - does nothing.
-		SynchronGenerator() = default;
+		/// Constructor
+		SynchronGenerator(CPS::AttributeBase::Map &attributeList) :
+			mRs(Attribute<Real>::create("Rs", attributeList, 0)),
+			mLl(Attribute<Real>::create("Ll", attributeList, 0)),
+			mLd(Attribute<Real>::create("Ld", attributeList, 0)),
+			mLq(Attribute<Real>::create("Lq", attributeList, 0)),
+			mLd_t(Attribute<Real>::create("Ld_t", attributeList, 0)),
+			mLq_t(Attribute<Real>::create("Lq_t", attributeList, 0)),
+			mLd_s(Attribute<Real>::create("Ld_s", attributeList, 0)),
+			mLq_s(Attribute<Real>::create("Lq_s", attributeList, 0)),
+			mTd0_t(Attribute<Real>::create("Td0_t", attributeList, 0)),
+			mTq0_t(Attribute<Real>::create("Tq0_t", attributeList, 0)),
+			mTd0_s(Attribute<Real>::create("Td0_s", attributeList, 0)),
+			mTq0_s(Attribute<Real>::create("Tq0_s", attributeList, 0)),
+			mDelta(Attribute<Real>::create("delta_r", attributeList, 0)),
+			mMechTorque(Attribute<Real>::create("T_m", attributeList, 0)),
+			mInertia(Attribute<Real>::create("inertia", attributeList, 0)),
+			mOmMech(Attribute<Real>::create("w_r", attributeList, 0)),
+			mElecActivePower(Attribute<Real>::create("P_elec", attributeList, 0)),
+			mElecReactivePower(Attribute<Real>::create("Q_elec", attributeList, 0)),
+			mMechPower(Attribute<Real>::create("P_m", attributeList, 0)),
+			mElecTorque(Attribute<Real>::create("T_e", attributeList, 0)) { };
+
 		///
 		void setBaseParameters(Real nomPower, Real nomVolt, Real nomFreq);
 		///

--- a/dpsim-models/include/dpsim-models/Base/Base_SynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_SynchronGenerator.h
@@ -268,7 +268,7 @@ namespace Base {
 		Real mInitVoltAngle = 0;
 
 		/// Constructor
-		SynchronGenerator(CPS::AttributeBase::Map &attributeList) :
+		explicit SynchronGenerator(CPS::AttributeBase::Map &attributeList) :
 			mRs(Attribute<Real>::create("Rs", attributeList, 0)),
 			mLl(Attribute<Real>::create("Ll", attributeList, 0)),
 			mLd(Attribute<Real>::create("Ld", attributeList, 0)),

--- a/dpsim-models/include/dpsim-models/CompositePowerComp.h
+++ b/dpsim-models/include/dpsim-models/CompositePowerComp.h
@@ -45,9 +45,6 @@ namespace CPS {
 		/// @param postStepOrder When to execute the subcomponent's post-step in relation to the parent
 		void addMNASubComponent(typename SimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder);
 
-		//void addMNASubComponent(typename MNASimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder);
-
-
 		// #### MNA Interface Functions ####
 		/// Initializes variables of components
 		virtual void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;

--- a/dpsim-models/include/dpsim-models/CompositePowerComp.h
+++ b/dpsim-models/include/dpsim-models/CompositePowerComp.h
@@ -28,16 +28,13 @@ namespace CPS {
 		Bool mHasPostStep;
 
 	public:
-		typedef VarType Type;
-		typedef std::shared_ptr<CompositePowerComp<VarType>> Ptr;
-		typedef std::vector<Ptr> List;
+		using Type = VarType;
+		using Ptr = std::shared_ptr<CompositePowerComp<VarType>>;
+		using List = std::vector<Ptr>;
 
 		/// Basic constructor that takes UID, name and log level
 		CompositePowerComp(String uid, String name, Bool hasPreStep, Bool hasPostStep, Logger::Level logLevel)
-			: MNASimPowerComp<VarType>(uid, name, logLevel) {
-				mHasPreStep = hasPreStep;
-				mHasPostStep = hasPostStep;
-			}
+			: MNASimPowerComp<VarType>(uid, name, logLevel), mHasPreStep(hasPreStep), mHasPostStep(hasPostStep) { }
 
 		/// Basic constructor that takes name and log level and sets the UID to name as well
 		CompositePowerComp(String name, Bool hasPreStep = true, Bool hasPostStep = true, Logger::Level logLevel = Logger::Level::off)
@@ -54,19 +51,19 @@ namespace CPS {
 
 		// #### MNA Interface Functions ####
 		/// Initializes variables of components
-		virtual void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
+		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps system matrix
-		virtual void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
+		void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
 		/// Stamps right side (source) vector
-		virtual void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
+		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// MNA pre step operations
-		virtual void mnaPreStep(Real time, Int timeStepCount) override;
+		void mnaPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		virtual void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
+		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		virtual void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		virtual void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		// #### MNA Parent Functions ####
 		virtual void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {

--- a/dpsim-models/include/dpsim-models/CompositePowerComp.h
+++ b/dpsim-models/include/dpsim-models/CompositePowerComp.h
@@ -22,6 +22,8 @@ namespace CPS {
 		MNAInterface::List mSubcomponentsBeforePostStep;
 		MNAInterface::List mSubcomponentsAfterPostStep;
 
+		std::vector<CPS::Attribute<Matrix>::Ptr> mRightVectorStamps;
+
 		Bool mHasPreStep;
 		Bool mHasPostStep;
 
@@ -48,7 +50,7 @@ namespace CPS {
 		/// @param subc The new subcomponent
 		/// @param preStepOrder When to execute the subcomponent's pre-step in relation to the parent
 		/// @param postStepOrder When to execute the subcomponent's post-step in relation to the parent
-		void addMNASubComponent(typename SimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder);
+		void addMNASubComponent(typename SimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder, Bool contributeToRightVector);
 
 		// #### MNA Interface Functions ####
 		/// Initializes variables of components

--- a/dpsim-models/include/dpsim-models/CompositePowerComp.h
+++ b/dpsim-models/include/dpsim-models/CompositePowerComp.h
@@ -69,12 +69,26 @@ namespace CPS {
 		virtual void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		// #### MNA Parent Functions ####
-		virtual void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) { };
-		virtual void mnaParentApplySystemMatrixStamp(Matrix& systemMatrix) { };
-		virtual void mnaParentApplyRightSideVectorStamp(Matrix& rightVector) { };
-		virtual void mnaParentPreStep(Real time, Int timeStepCount) { };
-		virtual void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) { };
-		virtual void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) { };
-		virtual void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) { };
+		virtual void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+			// By default, the parent has no custom initialization beyond what is done in CompositePowerComp::mnaInitialize
+		};
+		virtual void mnaParentApplySystemMatrixStamp(Matrix& systemMatrix) {
+			// By default, the parent has no custom stamp on the system matrix, only the subcomponents are stamped
+		};
+		virtual void mnaParentApplyRightSideVectorStamp(Matrix& rightVector) {
+			// By default, the parent has no custom stamp on the right vector, only the subcomponents are stamped
+		};
+		virtual void mnaParentPreStep(Real time, Int timeStepCount) {
+			// By default, the parent has no custom pre-step, only the subcomponents' pre-steps are executed
+		};
+		virtual void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+			// By default, the parent has no custom post-step, only the subcomponents' post-steps are executed
+		};
+		virtual void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+			// By default, the parent has no custom pre-step-dependencies, only the subcomponents' dependencies are added
+		};
+		virtual void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
+			// By default, the parent has no custom post-step-dependencies, only the subcomponents' dependencies are added
+		};
 	};
 }

--- a/dpsim-models/include/dpsim-models/CompositePowerComp.h
+++ b/dpsim-models/include/dpsim-models/CompositePowerComp.h
@@ -5,23 +5,25 @@
 #include <dpsim-models/MNASimPowerComp.h>
 
 namespace CPS {
-
 	enum class MNA_SUBCOMP_TASK_ORDER {
-			NO_TASK,
-			TASK_BEFORE_PARENT,
-			TASK_AFTER_PARENT
+		NO_TASK,
+		TASK_BEFORE_PARENT,
+		TASK_AFTER_PARENT
 	};
 
 	/// Base class for composite power components
 	template <typename VarType>
 	class CompositePowerComp : public MNASimPowerComp<VarType> {
 
-	protected:
+	private:
 		MNAInterface::List mSubcomponentsMNA;
 		MNAInterface::List mSubcomponentsBeforePreStep;
 		MNAInterface::List mSubcomponentsAfterPreStep;
 		MNAInterface::List mSubcomponentsBeforePostStep;
 		MNAInterface::List mSubcomponentsAfterPostStep;
+
+		Bool mHasPreStep;
+		Bool mHasPostStep;
 
 	public:
 		typedef VarType Type;
@@ -29,12 +31,15 @@ namespace CPS {
 		typedef std::vector<Ptr> List;
 
 		/// Basic constructor that takes UID, name and log level
-		CompositePowerComp(String uid, String name, Logger::Level logLevel)
-			: MNASimPowerComp<VarType>(uid, name, logLevel) { }
+		CompositePowerComp(String uid, String name, Bool hasPreStep, Bool hasPostStep, Logger::Level logLevel)
+			: MNASimPowerComp<VarType>(uid, name, logLevel) {
+				mHasPreStep = hasPreStep;
+				mHasPostStep = hasPostStep;
+			}
 
 		/// Basic constructor that takes name and log level and sets the UID to name as well
-		CompositePowerComp(String name, Logger::Level logLevel = Logger::Level::off)
-			: MNASimPowerComp<VarType>(name, name, logLevel) { }
+		CompositePowerComp(String name, Bool hasPreStep = true, Bool hasPostStep = true, Logger::Level logLevel = Logger::Level::off)
+			: CompositePowerComp<VarType>(name, name, hasPreStep, hasPostStep, logLevel) { }
 
 		/// Destructor - does not do anything
 		virtual ~CompositePowerComp() = default;

--- a/dpsim-models/include/dpsim-models/CompositePowerComp.h
+++ b/dpsim-models/include/dpsim-models/CompositePowerComp.h
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <dpsim-models/MNASimPowerComp.h>
+
+namespace CPS {
+
+	enum class MNA_SUBCOMP_TASK_ORDER {
+			NO_TASK,
+			TASK_BEFORE_PARENT,
+			TASK_AFTER_PARENT
+	};
+
+	/// Base class for composite power components
+	template <typename VarType>
+	class CompositePowerComp : public MNASimPowerComp<VarType> {
+
+	protected:
+		MNAInterface::List mSubcomponentsMNA;
+		MNAInterface::List mSubcomponentsBeforePreStep;
+		MNAInterface::List mSubcomponentsAfterPreStep;
+		MNAInterface::List mSubcomponentsBeforePostStep;
+		MNAInterface::List mSubcomponentsAfterPostStep;
+
+	public:
+		typedef VarType Type;
+		typedef std::shared_ptr<CompositePowerComp<VarType>> Ptr;
+		typedef std::vector<Ptr> List;
+
+		/// Basic constructor that takes UID, name and log level
+		CompositePowerComp(String uid, String name, Logger::Level logLevel)
+			: MNASimPowerComp<VarType>(uid, name, logLevel) { }
+
+		/// Basic constructor that takes name and log level and sets the UID to name as well
+		CompositePowerComp(String name, Logger::Level logLevel = Logger::Level::off)
+			: MNASimPowerComp<VarType>(name, name, logLevel) { }
+
+		/// Destructor - does not do anything
+		virtual ~CompositePowerComp() = default;
+
+		/// @brief Add a new subcomponent implementing MNA methods
+		/// @param subc The new subcomponent
+		/// @param preStepOrder When to execute the subcomponent's pre-step in relation to the parent
+		/// @param postStepOrder When to execute the subcomponent's post-step in relation to the parent
+		void addMNASubComponent(typename SimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder);
+
+		//void addMNASubComponent(typename MNASimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder);
+
+
+		// #### MNA Interface Functions ####
+		/// Initializes variables of components
+		virtual void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
+		/// Stamps system matrix
+		virtual void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
+		/// Stamps right side (source) vector
+		virtual void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
+		/// MNA pre step operations
+		virtual void mnaPreStep(Real time, Int timeStepCount) override;
+		/// MNA post step operations
+		virtual void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
+		/// Add MNA pre step dependencies
+		virtual void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		/// Add MNA post step dependencies
+		virtual void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
+		// #### MNA Parent Functions ####
+		virtual void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) { };
+		virtual void mnaParentApplySystemMatrixStamp(Matrix& systemMatrix) { };
+		virtual void mnaParentApplyRightSideVectorStamp(Matrix& rightVector) { };
+		virtual void mnaParentPreStep(Real time, Int timeStepCount) { };
+		virtual void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) { };
+		virtual void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) { };
+		virtual void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) { };
+	};
+}

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_AvVoltageSourceInverterDQ.h
@@ -65,10 +65,6 @@ namespace Ph1 {
 		/// Flag for controller usage
 		Bool mWithControl=true;
 
-		// #### solver ####
-		///
-		std::vector<const Matrix*> mRightVectorStamps;
-
 	public:
 		// ### General Parameters ###
 
@@ -130,8 +126,6 @@ namespace Ph1 {
 		// #### MNA section ####
 		/// Initializes internal variables of the component
 		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Updates current through the component
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates voltage across component

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_AvVoltageSourceInverterDQ.h
@@ -129,21 +129,21 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Updates current through the component
-		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates voltage across component
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		/// MNA pre step operations
-		void mnaPreStep(Real time, Int timeStepCount);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		// #### Control section ####
 		/// Control pre step operations

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_AvVoltageSourceInverterDQ.h
@@ -8,7 +8,7 @@
 #pragma once
 
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/MNASimPowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/DP/DP_Ph1_Resistor.h>
@@ -25,8 +25,7 @@ namespace DP {
 namespace Ph1 {
 	class AvVoltageSourceInverterDQ :
 		public Base::AvVoltageSourceInverterDQ,
-		public SimPowerComp<Complex>,
-		public MNAInterface,
+		public MNASimPowerComp<Complex>,
 		public SharedFactory<AvVoltageSourceInverterDQ> {
 	protected:
 
@@ -130,9 +129,7 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
 		/// Stamps right side (source) vector
 		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
 		/// Updates current through the component
@@ -142,11 +139,11 @@ namespace Ph1 {
 		/// MNA pre step operations
 		void mnaPreStep(Real time, Int timeStepCount);
 		/// MNA post step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
 		/// Add MNA pre step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
 		/// Add MNA post step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
 
 		// #### Control section ####
 		/// Control pre step operations
@@ -180,31 +177,6 @@ namespace Ph1 {
 
 		private:
 			AvVoltageSourceInverterDQ& mAvVoltageSourceInverterDQ;
-		};
-
-		class MnaPreStep : public CPS::Task {
-		public:
-			MnaPreStep(AvVoltageSourceInverterDQ& AvVoltageSourceInverterDQ) :
-				Task(**AvVoltageSourceInverterDQ.mName + ".MnaPreStep"), mAvVoltageSourceInverterDQ(AvVoltageSourceInverterDQ) {
-					mAvVoltageSourceInverterDQ.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-			void execute(Real time, Int timeStepCount) { mAvVoltageSourceInverterDQ.mnaPreStep(time, timeStepCount); };
-
-		private:
-			AvVoltageSourceInverterDQ& mAvVoltageSourceInverterDQ;
-		};
-
-		class MnaPostStep : public CPS::Task {
-		public:
-			MnaPostStep(AvVoltageSourceInverterDQ& AvVoltageSourceInverterDQ, Attribute<Matrix>::Ptr leftVector) :
-				Task(**AvVoltageSourceInverterDQ.mName + ".MnaPostStep"), mAvVoltageSourceInverterDQ(AvVoltageSourceInverterDQ), mLeftVector(leftVector) {
-				mAvVoltageSourceInverterDQ.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mAvVoltageSourceInverterDQ.mnaPostStep(time, timeStepCount, mLeftVector); };
-
-		private:
-			AvVoltageSourceInverterDQ& mAvVoltageSourceInverterDQ;
-			Attribute<Matrix>::Ptr mLeftVector;
 		};
 
 	};

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_AvVoltageSourceInverterDQ.h
@@ -8,7 +8,7 @@
 #pragma once
 
 
-#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/DP/DP_Ph1_Resistor.h>
@@ -25,7 +25,7 @@ namespace DP {
 namespace Ph1 {
 	class AvVoltageSourceInverterDQ :
 		public Base::AvVoltageSourceInverterDQ,
-		public MNASimPowerComp<Complex>,
+		public CompositePowerComp<Complex>,
 		public SharedFactory<AvVoltageSourceInverterDQ> {
 	protected:
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inductor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inductor.h
@@ -25,6 +25,7 @@ namespace Ph1 {
 	class Inductor :
 		public Base::Ph1::Inductor,
 		public MNATearInterface,
+		public MNAInterface,
 		public SimPowerComp<Complex>,
 		public SharedFactory<Inductor> {
 	protected:

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_NetworkInjection.h
@@ -68,14 +68,12 @@ namespace Ph1 {
 		//void setVoltageSource(std::shared_ptr<DP::Ph1::VoltageSource> subVoltageSource);
 
 		// #### MNA Section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+		void mnaParentApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Returns current through the component
-		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates voltage across component
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		/// MNA pre step operations
 		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_NetworkInjection.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Solver/DAEInterface.h>
 #include <dpsim-models/DP/DP_Ph1_VoltageSource.h>
@@ -24,7 +24,7 @@ namespace Ph1 {
 	/// the frequency, magnitude and phase of the sine wave can be modified through the mVoltageRef and mSrcFreq attributes.
 	/// See DP_Ph1_VoltageSource.h for more details.
 	class NetworkInjection :
-		public MNASimPowerComp<Complex>,
+		public CompositePowerComp<Complex>,
 		public DAEInterface,
 		public SharedFactory<NetworkInjection> {
 	private:

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PQLoadCS.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PQLoadCS.h
@@ -62,14 +62,15 @@ namespace Ph1 {
 		/// Stamps right side (source) vector
 		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
 
+		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
+
 		class MnaPreStep : public Task {
 		public:
 			MnaPreStep(PQLoadCS& load) :
 				Task(**load.mName + ".MnaPreStep"), mLoad(load) {
-				mAttributeDependencies.push_back(load.attribute("P"));
-				mAttributeDependencies.push_back(load.attribute("Q"));
-				mAttributeDependencies.push_back(load.attribute("V_nom"));
-				mModifiedAttributes.push_back(load.mSubCurrentSource->attribute("I_ref"));
+				mLoad.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
 			}
 
 			void execute(Real time, Int timeStepCount);
@@ -80,18 +81,16 @@ namespace Ph1 {
 
 		class MnaPostStep : public Task {
 		public:
-			MnaPostStep(PQLoadCS& load) :
-				Task(**load.mName + ".MnaPostStep"), mLoad(load) {
-				mAttributeDependencies.push_back(load.mSubCurrentSource->attribute("i_intf"));
-				mAttributeDependencies.push_back(load.mSubCurrentSource->attribute("v_intf"));
-				mModifiedAttributes.push_back(load.attribute("i_intf"));
-				mModifiedAttributes.push_back(load.attribute("v_intf"));
+			MnaPostStep(PQLoadCS& load, Attribute<Matrix>::Ptr leftVector) :
+				Task(**load.mName + ".MnaPostStep"), mLoad(load), mLeftVector(leftVector) {
+				mLoad.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 			}
 
 			void execute(Real time, Int timeStepCount);
 
 		private:
 			PQLoadCS& mLoad;
+			Attribute<Matrix>::Ptr mLeftVector;
 		};
 	};
 }

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PQLoadCS.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PQLoadCS.h
@@ -54,9 +54,6 @@ namespace Ph1 {
 		void initializeFromNodesAndTerminals(Real frequency);
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-
 		/// MNA pre and post step operations
 		void mnaParentPreStep(Real time, Int timeStepCount)  override;
 		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PQLoadCS.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PQLoadCS.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/DP/DP_Ph1_CurrentSource.h>
 #include <dpsim-models/PowerProfile.h>
@@ -19,7 +19,7 @@ namespace Ph1 {
 	/// TODO: read from CSV files
 	/// \brief PQ-load represented by a current source
 	class PQLoadCS :
-		public MNASimPowerComp<Complex>,
+		public CompositePowerComp<Complex>,
 		public SharedFactory<PQLoadCS> {
 	protected:
 		/// Internal current source

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
@@ -23,9 +23,9 @@ namespace Ph1 {
 	/// This model consists sub components to represent the
 	/// RLC elements of a PI-line.
 	class PiLine :
+		public Base::Ph1::PiLine,
 		public SimPowerComp<Complex>,
 		public MNATearInterface,
-		public Base::Ph1::PiLine,
 		public SharedFactory<PiLine> {
 	protected:
 		/// Series Inductance submodel

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/MNASimPowerComp.h>
 #include <dpsim-models/Solver/MNATearInterface.h>
 #include <dpsim-models/Base/Base_Ph1_PiLine.h>
 #include <dpsim-models/DP/DP_Ph1_Resistor.h>
@@ -23,10 +23,8 @@ namespace Ph1 {
 	/// This model consists sub components to represent the
 	/// RLC elements of a PI-line.
 	class PiLine :
-		public Base::Ph1::PiLine,
-		public SimPowerComp<Complex>,
+		public MNASimPowerComp<Complex>,
 		public MNATearInterface,
-		public MNAInterface,
 		public Base::Ph1::PiLine,
 		public SharedFactory<PiLine> {
 	protected:
@@ -59,9 +57,7 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps right side (source) vector
 		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
 		/// Updates internal current variable of the component
@@ -69,34 +65,11 @@ namespace Ph1 {
 		/// Updates internal voltage variable of the component
 		void mnaUpdateVoltage(const Matrix& leftVector);
 		/// MNA pre and post step operations
-		void mnaPreStep(Real time, Int timeStepCount);
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPreStep(Real time, Int timeStepCount)  override;
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// add MNA pre and post step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
-
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(PiLine& line) :
-				Task(**line.mName + ".MnaPreStep"), mLine(line) {
-					mLine.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-			void execute(Real time, Int timeStepCount) { mLine.mnaPreStep(time, timeStepCount); };
-		private:
-			PiLine& mLine;
-		};
-
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(PiLine& line, Attribute<Matrix>::Ptr leftVector) :
-				Task(**line.mName + ".MnaPostStep"), mLine(line), mLeftVector(leftVector) {
-					mLine.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mLine.mnaPostStep(time, timeStepCount, mLeftVector); };
-		private:
-			PiLine& mLine;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		MNAInterface::List mnaTearGroundComponents();
 		void mnaTearInitialize(Real omega, Real timeStep);

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNATearInterface.h>
 #include <dpsim-models/Base/Base_Ph1_PiLine.h>
 #include <dpsim-models/DP/DP_Ph1_Resistor.h>
@@ -23,7 +23,7 @@ namespace Ph1 {
 	/// This model consists sub components to represent the
 	/// RLC elements of a PI-line.
 	class PiLine :
-		public MNASimPowerComp<Complex>,
+		public CompositePowerComp<Complex>,
 		public MNATearInterface,
 		public Base::Ph1::PiLine,
 		public SharedFactory<PiLine> {

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
@@ -65,7 +65,7 @@ namespace Ph1 {
 		/// Updates internal voltage variable of the component
 		void mnaUpdateVoltage(const Matrix& leftVector);
 		/// MNA pre and post step operations
-		void mnaParentPreStep(Real time, Int timeStepCount)  override;
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// add MNA pre and post step dependencies
 		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
@@ -26,6 +26,8 @@ namespace Ph1 {
 		public Base::Ph1::PiLine,
 		public SimPowerComp<Complex>,
 		public MNATearInterface,
+		public MNAInterface,
+		public Base::Ph1::PiLine,
 		public SharedFactory<PiLine> {
 	protected:
 		/// Series Inductance submodel

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
@@ -56,10 +56,6 @@ namespace Ph1 {
 		void initializeFromNodesAndTerminals(Real frequency);
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
 		/// Updates internal current variable of the component
 		void mnaUpdateCurrent(const Matrix& leftVector);
 		/// Updates internal voltage variable of the component

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
@@ -23,15 +23,6 @@ namespace Ph1 {
 		public MNAInterface,
 		public SharedFactory<RXLoad> {
 	protected:
-		/// Power [Watt]
-		/// FIXME: This is never read, only written to
-		Complex mPower;
-		/// Actual voltage [V]
-		/// FIXME: This is never used
-		Complex mVoltage;
-		/// Actual voltage [V]
-		/// FIXME: This is never used
-		Complex mCurrent;
 		/// Resistance [Ohm]
 		/// CHECK: This is only used for logging output
 		Real mResistance;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
@@ -62,8 +62,6 @@ namespace Ph1 {
 		void setParameters(Real activePower, Real ReactivePower, Real volt);
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Update interface current from MNA system result
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Update interface voltage from MNA system result

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/DP/DP_Ph1_Capacitor.h>
 #include <dpsim-models/DP/DP_Ph1_Inductor.h>
@@ -19,8 +19,7 @@ namespace DP {
 namespace Ph1 {
 	/// Constant impedance load model consisting of RLC elements
 	class RXLoad :
-		public SimPowerComp<Complex>,
-		public MNAInterface,
+		public CompositePowerComp<Complex>,
 		public SharedFactory<RXLoad> {
 	protected:
 		/// Resistance [Ohm]
@@ -64,49 +63,22 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Update interface current from MNA system result
-		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Update interface voltage from MNA system result
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		/// MNA pre step operations
-		void mnaPreStep(Real time, Int timeStepCount);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies,
-			AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies,
+			AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
 			AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes,
-			Attribute<Matrix>::Ptr &leftVector);
-
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(RXLoad& load) :
-				Task(**load.mName + ".MnaPreStep"), mLoad(load) {
-				mLoad.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-			void execute(Real time, Int timeStepCount) { mLoad.mnaPreStep(time, timeStepCount); }
-		private:
-			RXLoad& mLoad;
-		};
-
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(RXLoad& load, Attribute<Matrix>::Ptr leftVector) :
-				Task(**load.mName + ".MnaPostStep"), mLoad(load), mLeftVector(leftVector) {
-					mLoad.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mLoad.mnaPostStep(time, timeStepCount, mLeftVector); }
-		private:
-			RXLoad& mLoad;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
+			Attribute<Matrix>::Ptr &leftVector) override;
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoadSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoadSwitch.h
@@ -48,54 +48,26 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
-		/// Update interface current from MNA system result
-		void mnaUpdateCurrent(const Matrix& leftVector) { }
-		/// Update interface voltage from MNA system result
-		void mnaUpdateVoltage(const Matrix& leftVector) { }
+		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// MNA pre step operations
-		void mnaPreStep(Real time, Int timeStepCount);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies,
-			AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies,
+			AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
 			AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes,
-			Attribute<Matrix>::Ptr &leftVector);
+			Attribute<Matrix>::Ptr &leftVector) override;
 
 		// #### MNA section for switch ####
 		/// Check if switch is closed
-		Bool mnaIsClosed();
+		Bool mnaIsClosed() override;
 		/// Stamps system matrix considering the defined switch position
-		void mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& systemMatrix, Int freqIdx);
-
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(RXLoadSwitch& load) : Task(**load.mName + ".MnaPreStep"), mLoad(load) {
-				mLoad.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-			void execute(Real time, Int timeStepCount) { mLoad.mnaPreStep(time, timeStepCount); }
-		private:
-			RXLoadSwitch& mLoad;
-		};
-
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(RXLoadSwitch& load, Attribute<Matrix>::Ptr leftVector) :
-				Task(**load.mName + ".MnaPostStep"), mLoad(load), mLeftVector(leftVector) {
-					mLoad.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mLoad.mnaPostStep(time, timeStepCount, mLeftVector); }
-		private:
-			RXLoadSwitch& mLoad;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
+		void mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& systemMatrix, Int freqIdx) override;
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoadSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoadSwitch.h
@@ -16,7 +16,7 @@ namespace DP {
 namespace Ph1 {
 	/// Constant impedance load model consisting of RLC elements
 	class RXLoadSwitch :
-		public SimPowerComp<Complex>,
+		public CompositePowerComp<Complex>,
 		public MNASwitchInterface,
 		public SharedFactory<RXLoadSwitch> {
 	protected:

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoadSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoadSwitch.h
@@ -47,10 +47,6 @@ namespace Ph1 {
 		void updateSwitchState(Real time);
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// MNA pre step operations
 		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_ResIndSeries.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_ResIndSeries.h
@@ -20,9 +20,6 @@ namespace Ph1 {
 		public SimPowerComp<Complex>,
 		public SharedFactory<ResIndSeries> {
 	protected:
-		///FIXME: This is never used...
-		///Conductance [S]
-		Real mConductance;
 		/// DC equivalent current source for harmonics [A]
 		MatrixComp mEquivCurrent;
 		/// Equivalent conductance for harmonics [S]

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_ResIndSeries.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_ResIndSeries.h
@@ -17,6 +17,7 @@ namespace Ph1 {
 	/// \brief resistor inductor series element
 	class ResIndSeries :
 		public MNATearInterface,
+		public MNAInterface,
 		public SimPowerComp<Complex>,
 		public SharedFactory<ResIndSeries> {
 	protected:

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Resistor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Resistor.h
@@ -20,6 +20,7 @@ namespace Ph1 {
 	class Resistor :
 		public Base::Ph1::Resistor,
 		public MNATearInterface,
+		public MNAInterface,
 		public DAEInterface,
 		public SimPowerComp<Complex>,
 		public SharedFactory<Resistor> {

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
@@ -44,10 +44,6 @@ namespace Ph1 {
 		void initializeFromNodesAndTerminals(Real frequency);
 
 		// #### MNA section ####
-		/// Stamps system matrix
-		void mnaApplyInitialSystemMatrixStamp(Matrix& systemMatrix);
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
@@ -44,8 +44,6 @@ namespace Ph1 {
 		void initializeFromNodesAndTerminals(Real frequency);
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps system matrix
 		void mnaApplyInitialSystemMatrixStamp(Matrix& systemMatrix);
 		/// Stamps right side (source) vector

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
@@ -61,14 +61,14 @@ namespace Ph1 {
 		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
 		void mnaUpdateVoltage(const Matrix& leftVector);
 		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		class MnaPreStep : public Task {
 		public:
 			MnaPreStep(RxLine& line) :
 				Task(**line.mName + ".MnaPreStep"), mLine(line) {
-				mAttributeDependencies.push_back(line.mSubResistor->attribute("right_vector"));
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("right_vector"));
-				mModifiedAttributes.push_back(line.attribute("right_vector"));
+				mLine.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
 			}
 
 			void execute(Real time, Int timeStepCount);
@@ -81,10 +81,7 @@ namespace Ph1 {
 		public:
 			MnaPostStep(RxLine& line, Attribute<Matrix>::Ptr leftVector) :
 				Task(**line.mName + ".MnaPostStep"), mLine(line), mLeftVector(leftVector) {
-				mAttributeDependencies.push_back(leftVector);
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("v_intf"));
+				mLine.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Base/Base_Ph1_PiLine.h>
 #include <dpsim-models/DP/DP_Ph1_Inductor.h>
@@ -19,9 +19,8 @@ namespace DP {
 namespace Ph1 {
 
 	class RxLine :
+		public CompositePowerComp<Complex>,
 		public Base::Ph1::PiLine,
-		public SimPowerComp<Complex>,
-		public MNAInterface,
 		public SharedFactory<RxLine> {
 	protected:
 		/// Inductance submodel
@@ -46,44 +45,20 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps system matrix
 		void mnaApplyInitialSystemMatrixStamp(Matrix& systemMatrix);
 		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
-		void mnaUpdateVoltage(const Matrix& leftVector);
-		void mnaUpdateCurrent(const Matrix& leftVector);
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(RxLine& line) :
-				Task(**line.mName + ".MnaPreStep"), mLine(line) {
-				mLine.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
+		/// MNA pre and post step operations
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 
-			void execute(Real time, Int timeStepCount);
-
-		private:
-			RxLine& mLine;
-		};
-
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(RxLine& line, Attribute<Matrix>::Ptr leftVector) :
-				Task(**line.mName + ".MnaPostStep"), mLine(line), mLeftVector(leftVector) {
-				mLine.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
-			}
-
-			void execute(Real time, Int timeStepCount);
-
-		private:
-			RxLine& mLine;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
@@ -19,9 +19,9 @@ namespace DP {
 namespace Ph1 {
 
 	class RxLine :
+		public Base::Ph1::PiLine,
 		public SimPowerComp<Complex>,
 		public MNAInterface,
-		public Base::Ph1::PiLine,
 		public SharedFactory<RxLine> {
 	protected:
 		/// Inductance submodel

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
@@ -24,12 +24,6 @@ namespace Ph1 {
 		public Base::Ph1::PiLine,
 		public SharedFactory<RxLine> {
 	protected:
-		/// Voltage across the component [V]
-		/// FIXME: This is only read once, but never written to, so its always zero
-		Complex mVoltage;
-		/// Current through the component [A]
-		/// FIXME: This is never used...
-		Complex mCurrent;
 		/// Inductance submodel
 		std::shared_ptr<Inductor> mSubInductor;
 		/// Resistor submodel

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SVC.h
@@ -66,7 +66,6 @@ namespace Ph1 {
 		Bool mDisconnect = false;
 
 	public:
-		/// FIXME: This is only written once and never read
 		const Attribute<Real>::Ptr mVpcc;
 		const Attribute<Real>::Ptr mVmeasPrev;
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Switch.h
@@ -10,6 +10,7 @@
 
 #include <dpsim-models/SimPowerComp.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Logger.h>
 #include <dpsim-models/Base/Base_Ph1_Switch.h>
@@ -25,7 +26,8 @@ namespace Ph1 {
 		public Base::Ph1::Switch,
 		public SimPowerComp<Complex>,
 		public SharedFactory<Switch>,
-		public MNASwitchInterface {
+		public MNASwitchInterface,
+		public MNAInterface {
 	protected:
 	public:
 		/// Defines UID, name, component parameters and logging level

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGeneratorIdeal.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGeneratorIdeal.h
@@ -40,7 +40,6 @@ namespace Ph1 {
 		void initializeFromNodesAndTerminals(Real frequency);
 
 		// #### MNA section ####
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// MNA pre step operations
 		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGeneratorIdeal.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGeneratorIdeal.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/DP/DP_Ph1_VoltageSource.h>
 
@@ -17,8 +17,7 @@ namespace DP {
 namespace Ph1 {
 	/// Ideal voltage source representing a synchronous generator
 	class SynchronGeneratorIdeal :
-		public SimPowerComp<Complex>,
-		public MNAInterface,
+		public CompositePowerComp<Complex>,
 		public SharedFactory<SynchronGeneratorIdeal> {
 	private:
 		/// Inner voltage source that represents the generator
@@ -41,48 +40,19 @@ namespace Ph1 {
 		void initializeFromNodesAndTerminals(Real frequency);
 
 		// #### MNA section ####
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// MNA pre step operations
-		void mnaPreStep(Real time, Int timeStepCount);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Updates current through the component
-		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates voltage across component
-		void mnaUpdateVoltage(const Matrix& leftVector);
-
-		class MnaPreStep : public CPS::Task {
-		public:
-			MnaPreStep(SynchronGeneratorIdeal& SynchronGeneratorIdeal) :
-				Task(**SynchronGeneratorIdeal.mName + ".MnaPreStep"), mSynchronGeneratorIdeal(SynchronGeneratorIdeal) {
-					mSynchronGeneratorIdeal.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-			void execute(Real time, Int timeStepCount) { mSynchronGeneratorIdeal.mnaPreStep(time, timeStepCount); };
-
-		private:
-			SynchronGeneratorIdeal& mSynchronGeneratorIdeal;
-		};
-
-		class MnaPostStep : public CPS::Task {
-		public:
-			MnaPostStep(SynchronGeneratorIdeal& SynchronGeneratorIdeal, Attribute<Matrix>::Ptr leftVector) :
-				Task(**SynchronGeneratorIdeal.mName + ".MnaPostStep"), mSynchronGeneratorIdeal(SynchronGeneratorIdeal), mLeftVector(leftVector) {
-				mSynchronGeneratorIdeal.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mSynchronGeneratorIdeal.mnaPostStep(time, timeStepCount, mLeftVector); };
-
-		private:
-			SynchronGeneratorIdeal& mSynchronGeneratorIdeal;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Transformer.h
@@ -20,10 +20,10 @@ namespace DP {
 namespace Ph1 {
 	/// Transformer that includes an inductance and resistance
 	class Transformer :
+		public Base::Ph1::Transformer,
 		public SimPowerComp<Complex>,
 		public MNAInterface,
-		public SharedFactory<Transformer>,
-		public Base::Ph1::Transformer {
+		public SharedFactory<Transformer> {
 	private:
 		/// Internal resistor to model losses
 		std::shared_ptr<DP::Ph1::Resistor> mSubResistor;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Transformer.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/DP/DP_Ph1_Resistor.h>
 #include <dpsim-models/DP/DP_Ph1_Capacitor.h>
@@ -20,10 +20,9 @@ namespace DP {
 namespace Ph1 {
 	/// Transformer that includes an inductance and resistance
 	class Transformer :
-		public Base::Ph1::Transformer,
-		public SimPowerComp<Complex>,
-		public MNAInterface,
-		public SharedFactory<Transformer> {
+		public CompositePowerComp<Complex>,
+		public SharedFactory<Transformer>,
+		public Base::Ph1::Transformer {
 	private:
 		/// Internal resistor to model losses
 		std::shared_ptr<DP::Ph1::Resistor> mSubResistor;
@@ -70,48 +69,22 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+		void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
 		/// Updates internal current variable of the component
-		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates internal voltage variable of the component
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		/// MNA pre step operations
-		void mnaPreStep(Real time, Int timeStepCount);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(Transformer& transformer) :
-				Task(**transformer.mName + ".MnaPreStep"), mTransformer(transformer) {
-					mTransformer.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-			void execute(Real time, Int timeStepCount) { mTransformer.mnaPreStep(time, timeStepCount); };
-		private:
-			Transformer& mTransformer;
-		};
-
-
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(Transformer& transformer, Attribute<Matrix>::Ptr leftVector) :
-				Task(**transformer.mName + ".MnaPostStep"), mTransformer(transformer), mLeftVector(leftVector) {
-					mTransformer.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mTransformer.mnaPostStep(time, timeStepCount, mLeftVector); };
-
-		private:
-			Transformer& mTransformer;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceNorton.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceNorton.h
@@ -21,8 +21,8 @@ namespace Ph1 {
 	/// which is transformed to a current source with
 	/// a parallel resistance using the Norton equivalent.
 	class VoltageSourceNorton :
-		public SimPowerComp<Complex>,
 		public Base::Ph1::VoltageSource,
+		public SimPowerComp<Complex>,
 		public MNAInterface,
 		public SharedFactory<VoltageSourceNorton> {
 	protected:

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceRamp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceRamp.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/DP/DP_Ph1_VoltageSource.h>
 
@@ -16,8 +16,7 @@ namespace CPS {
 namespace DP {
 namespace Ph1 {
 	class VoltageSourceRamp :
-		public SimPowerComp<Complex>,
-		public MNAInterface,
+		public CompositePowerComp<Complex>,
 		public SharedFactory<VoltageSourceRamp> {
 	protected:
 
@@ -57,22 +56,8 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(VoltageSourceRamp& voltageSource) :
-				Task(**voltageSource.mName + ".MnaPreStep"), mVoltageSource(voltageSource) {
-			}
-
-			void execute(Real time, Int timeStepCount);
-
-		private:
-			VoltageSourceRamp& mVoltageSource;
-		};
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceRamp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceRamp.h
@@ -55,8 +55,6 @@ namespace Ph1 {
 		void initialize(Matrix frequencies);
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		void mnaParentPreStep(Real time, Int timeStepCount) override;
 	};
 }

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceRamp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceRamp.h
@@ -20,7 +20,7 @@ namespace Ph1 {
 		public MNAInterface,
 		public SharedFactory<VoltageSourceRamp> {
 	protected:
-		
+
 		///
 		Complex mAddVoltage;
 		///
@@ -62,14 +62,10 @@ namespace Ph1 {
 		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
 		/// Stamps right side (source) vector
 		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
-
-
 		class MnaPreStep : public Task {
 		public:
 			MnaPreStep(VoltageSourceRamp& voltageSource) :
 				Task(**voltageSource.mName + ".MnaPreStep"), mVoltageSource(voltageSource) {
-				// rampTime etc. aren't attributes (yet), so doesn't really depend on anything
-				mModifiedAttributes.push_back(voltageSource.mSubVoltageSource->attribute("V_ref"));
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_varResSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_varResSwitch.h
@@ -11,7 +11,7 @@
 #include <dpsim-models/SimPowerComp.h>
 #include <dpsim-models/Solver/MNAVariableCompInterface.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
-// #include <dpsim-models/Solver/MNAInterface.h>
+#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Base/Base_Ph1_Switch.h>
 
 namespace CPS {
@@ -28,6 +28,7 @@ namespace Ph1 {
 		public Base::Ph1::Switch,
 		public MNAVariableCompInterface,
 		public MNASwitchInterface,
+		public MNAInterface,
 		public SimPowerComp<Complex>,
 		public SharedFactory<varResSwitch> {
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_Inductor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_Inductor.h
@@ -25,6 +25,7 @@ namespace Ph3 {
 	class Inductor :
 		public Base::Ph3::Inductor,
 		public MNATearInterface,
+		public MNAInterface,
 		public SimPowerComp<Complex>,
 		public SharedFactory<Inductor> {
 	protected:

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesSwitch.h
@@ -10,6 +10,7 @@
 
 #include <dpsim-models/SimPowerComp.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Logger.h>
 #include <dpsim-models/Base/Base_Ph1_Switch.h>
@@ -27,7 +28,8 @@ namespace Ph3 {
 		public Base::Ph1::Switch,
 		public SimPowerComp<Complex>,
 		public SharedFactory<SeriesSwitch>,
-		public MNASwitchInterface {
+		public MNASwitchInterface,
+		public MNAInterface {
 	protected:
 	public:
 		/// Defines UID, name and logging level

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceNorton.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceNorton.h
@@ -17,9 +17,9 @@ namespace EMT {
 namespace Ph1 {
 	/// Voltage source as Norton equivalent
 	class VoltageSourceNorton :
+		public Base::Ph1::VoltageSource,
 		public SimPowerComp<Real>,
 		public MNAInterface,
-		public Base::Ph1::VoltageSource,
 		public SharedFactory<VoltageSourceNorton> {
 	protected:
 		void updateState(Real time);

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceRamp.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceRamp.h
@@ -66,8 +66,6 @@ namespace Ph1 {
 		public:
 			MnaPreStep(VoltageSourceRamp& voltageSource) :
 				Task(**voltageSource.mName + ".MnaPreStep"), mVoltageSource(voltageSource) {
-				// rampTime etc. aren't attributes (yet), so doesn't really depend on anything
-				mModifiedAttributes.push_back(voltageSource.mSubVoltageSource->attribute("V_ref"));
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceRamp.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceRamp.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/EMT/EMT_Ph1_VoltageSource.h>
 
@@ -16,8 +16,7 @@ namespace CPS {
 namespace EMT {
 namespace Ph1 {
 	class VoltageSourceRamp :
-		public SimPowerComp<Real>,
-		public MNAInterface,
+		public CompositePowerComp<Real>,
 		public SharedFactory<VoltageSourceRamp> {
 	protected:
 		///
@@ -54,25 +53,9 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
-
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		void updateState(Real time);
-
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(VoltageSourceRamp& voltageSource) :
-				Task(**voltageSource.mName + ".MnaPreStep"), mVoltageSource(voltageSource) {
-			}
-
-			void execute(Real time, Int timeStepCount);
-
-		private:
-			VoltageSourceRamp& mVoltageSource;
-		};
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceRamp.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceRamp.h
@@ -52,8 +52,6 @@ namespace Ph1 {
 		void initialize(Matrix frequencies);
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		void updateState(Real time);
 	};

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_AvVoltSourceInverterStateSpace.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_AvVoltSourceInverterStateSpace.h
@@ -19,8 +19,8 @@ namespace Ph3 {
 	/// average inverter model with LC filter
 	class AvVoltSourceInverterStateSpace :
 		public MNAInterface,
-		public SimPowerComp<Real>,
 		public Base::Ph1::VoltageSource,
+		public SimPowerComp<Real>,
 		public SharedFactory<AvVoltSourceInverterStateSpace> {
 	protected:
 		Real mTimeStep;
@@ -76,7 +76,7 @@ namespace Ph3 {
 		/*Real mIfa;
 		Real mIfb;
 		Real mIfc;*/
-		
+
 		/*Real mVca;
 		Real mVcb;
 		Real mVcc;*/

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.h
@@ -7,7 +7,7 @@
  *********************************************************************************/
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/EMT/EMT_Ph3_Resistor.h>
@@ -24,8 +24,7 @@ namespace EMT {
 namespace Ph3 {
 	class AvVoltageSourceInverterDQ :
 		public Base::AvVoltageSourceInverterDQ,
-		public SimPowerComp<Real>,
-		public MNAInterface,
+		public CompositePowerComp<Real>,
 		public SharedFactory<AvVoltageSourceInverterDQ> {
 	protected:
 
@@ -137,23 +136,21 @@ namespace Ph3 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Updates current through the component
-		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates voltage across component
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		/// MNA pre step operations
-		void mnaPreStep(Real time, Int timeStepCount);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		// #### Control section ####
 		/// Control pre step operations
@@ -188,32 +185,6 @@ namespace Ph3 {
 		private:
 			AvVoltageSourceInverterDQ& mAvVoltageSourceInverterDQ;
 		};
-
-		class MnaPreStep : public CPS::Task {
-		public:
-			MnaPreStep(AvVoltageSourceInverterDQ& AvVoltageSourceInverterDQ) :
-				Task(**AvVoltageSourceInverterDQ.mName + ".MnaPreStep"), mAvVoltageSourceInverterDQ(AvVoltageSourceInverterDQ) {
-					mAvVoltageSourceInverterDQ.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-			void execute(Real time, Int timeStepCount) { mAvVoltageSourceInverterDQ.mnaPreStep(time, timeStepCount); };
-
-		private:
-			AvVoltageSourceInverterDQ& mAvVoltageSourceInverterDQ;
-		};
-
-		class MnaPostStep : public CPS::Task {
-		public:
-			MnaPostStep(AvVoltageSourceInverterDQ& AvVoltageSourceInverterDQ, Attribute<Matrix>::Ptr leftVector) :
-				Task(**AvVoltageSourceInverterDQ.mName + ".MnaPostStep"), mAvVoltageSourceInverterDQ(AvVoltageSourceInverterDQ), mLeftVector(leftVector) {
-				mAvVoltageSourceInverterDQ.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mAvVoltageSourceInverterDQ.mnaPostStep(time, timeStepCount, mLeftVector); };
-
-		private:
-			AvVoltageSourceInverterDQ& mAvVoltageSourceInverterDQ;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
-
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.h
@@ -137,8 +137,6 @@ namespace Ph3 {
 		// #### MNA section ####
 		/// Initializes internal variables of the component
 		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Updates current through the component
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates voltage across component

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_NetworkInjection.h
@@ -55,10 +55,8 @@ namespace CPS {
 				void setParameters(MatrixComp voltageRef, Real modulationFrequency, Real modulationAmplitude, Real baseFrequency = 50.0, bool zigzag = false);
 
 				// #### MNA Section ####
-				/// Initializes internal variables of the component
-				void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 				/// Stamps right side (source) vector
-				void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
+				void mnaParentApplyRightSideVectorStamp(Matrix& rightVector) override;
 				/// Returns current through the component
 				void mnaUpdateCurrent(const Matrix& leftVector) override;
 				/// Updates voltage across component

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_NetworkInjection.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/EMT/EMT_Ph3_VoltageSource.h>
 
@@ -19,8 +19,7 @@ namespace CPS {
 			///
 			/// This model represents network injections by an ideal voltage source.
 			class NetworkInjection :
-				public SimPowerComp<Real>,
-				public MNAInterface,
+				public CompositePowerComp<Real>,
 				public SharedFactory<NetworkInjection> {
 			private:
 				// ### Electrical Subcomponents ###
@@ -57,48 +56,22 @@ namespace CPS {
 
 				// #### MNA Section ####
 				/// Initializes internal variables of the component
-				void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-				/// Stamps system matrix
-				void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
+				void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 				/// Stamps right side (source) vector
-				void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+				void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 				/// Returns current through the component
-				void mnaUpdateCurrent(const Matrix& leftVector);
+				void mnaUpdateCurrent(const Matrix& leftVector) override;
 				/// Updates voltage across component
-				void mnaUpdateVoltage(const Matrix& leftVector);
+				void mnaUpdateVoltage(const Matrix& leftVector) override;
 				/// MNA pre step operations
-				void mnaPreStep(Real time, Int timeStepCount);
+				void mnaParentPreStep(Real time, Int timeStepCount) override;
 				/// MNA post step operations
-				void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+				void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 				/// Add MNA pre step dependencies
-				void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+				void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 				/// Add MNA post step dependencies
-				void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
+				void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
-				class MnaPreStep : public CPS::Task {
-				public:
-					MnaPreStep(NetworkInjection& networkInjection) :
-						Task(**networkInjection.mName + ".MnaPreStep"), mNetworkInjection(networkInjection) {
-							mNetworkInjection.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-					}
-					void execute(Real time, Int timeStepCount) { mNetworkInjection.mnaPreStep(time, timeStepCount); };
-
-				private:
-					NetworkInjection& mNetworkInjection;
-				};
-
-				class MnaPostStep : public CPS::Task {
-				public:
-					MnaPostStep(NetworkInjection& networkInjection, Attribute<Matrix>::Ptr leftVector) :
-						Task(**networkInjection.mName + ".MnaPostStep"), mNetworkInjection(networkInjection), mLeftVector(leftVector) {
-						mNetworkInjection.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-					}
-					void execute(Real time, Int timeStepCount) { mNetworkInjection.mnaPostStep(time, timeStepCount, mLeftVector); };
-
-				private:
-					NetworkInjection& mNetworkInjection;
-					Attribute<Matrix>::Ptr mLeftVector;
-				};
 			};
 		}
 	}

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_PiLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_PiLine.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Base/Base_Ph3_PiLine.h>
 #include <dpsim-models/EMT/EMT_Ph3_Resistor.h>
@@ -23,9 +23,8 @@ namespace Ph3 {
 	/// This model consists sub components to represent the
 	/// RLC elements of a PI-line.
 	class PiLine :
+		public CompositePowerComp<Real>,
 		public Base::Ph3::PiLine,
-		public SimPowerComp<Real>,
-		public MNAInterface,
 		public SharedFactory<PiLine> {
 	protected:
 		/// Series Inductance submodel
@@ -57,46 +56,21 @@ namespace Ph3 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Updates internal current variable of the component
-		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates internal voltage variable of the component
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		/// MNA pre step operations
-		void mnaPreStep(Real time, Int timeStepCount);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
-
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(PiLine& line) :
-				Task(**line.mName + ".MnaPreStep"), mLine(line) {
-					mLine.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-				}
-			void execute(Real time, Int timeStepCount) {mLine.mnaPreStep(time, timeStepCount);};
-		private:
-			PiLine& mLine;
-		};
-
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(PiLine& line, Attribute<Matrix>::Ptr leftVector) :
-				Task(**line.mName + ".MnaPostStep"), mLine(line), mLeftVector(leftVector) {
-					mLine.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-				}
-			void execute(Real time, Int timeStepCount) { mLine.mnaPostStep(time, timeStepCount, mLeftVector); };
-		private:
-			PiLine& mLine;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		//MNAInterface::List mnaTearGroundComponents();
 		/*void mnaTearInitialize(Real omega, Real timeStep);

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_PiLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_PiLine.h
@@ -55,10 +55,6 @@ namespace Ph3 {
 		void initializeFromNodesAndTerminals(Real frequency);
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Updates internal current variable of the component
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates internal voltage variable of the component

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_PiLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_PiLine.h
@@ -23,9 +23,9 @@ namespace Ph3 {
 	/// This model consists sub components to represent the
 	/// RLC elements of a PI-line.
 	class PiLine :
+		public Base::Ph3::PiLine,
 		public SimPowerComp<Real>,
 		public MNAInterface,
-		public Base::Ph3::PiLine,
 		public SharedFactory<PiLine> {
 	protected:
 		/// Series Inductance submodel

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
@@ -90,17 +90,14 @@ namespace CPS {
 				void mnaUpdateCurrent(const Matrix& leftVector);
 				void mnaUpdateVoltage(const Matrix& leftVector);
 
+				void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+				void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
 				class MnaPreStep : public Task {
 				public:
 					MnaPreStep(RXLoad& load) :
 						Task(**load.mName + ".MnaPreStep"), mLoad(load) {
-						if (load.mSubResistor)
-							mAttributeDependencies.push_back(load.mSubResistor->attribute("right_vector"));
-						if (load.mSubInductor)
-							mAttributeDependencies.push_back(load.mSubInductor->attribute("right_vector"));
-						if (load.mSubCapacitor)
-							mAttributeDependencies.push_back(load.mSubCapacitor->attribute("right_vector"));
-						mModifiedAttributes.push_back(load.attribute("right_vector"));
+						mLoad.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
 					}
 
 					void execute(Real time, Int timeStepCount);
@@ -114,15 +111,7 @@ namespace CPS {
 				public:
 					MnaPostStep(RXLoad& load, Attribute<Matrix>::Ptr leftVector) :
 						Task(**load.mName + ".MnaPostStep"), mLoad(load), mLeftVector(leftVector) {
-						mAttributeDependencies.push_back(leftVector);
-						if (load.mSubResistor)
-							mAttributeDependencies.push_back(load.mSubResistor->attribute("i_intf"));
-						if (load.mSubInductor)
-							mAttributeDependencies.push_back(load.mSubInductor->attribute("i_intf"));
-						if (load.mSubCapacitor)
-							mAttributeDependencies.push_back(load.mSubCapacitor->attribute("i_intf"));
-						mModifiedAttributes.push_back(load.attribute("i_intf"));
-						mModifiedAttributes.push_back(load.attribute("v_intf"));
+						mLoad.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 					}
 
 					void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
@@ -25,18 +25,8 @@ namespace CPS {
 				public MNAInterface,
 				public SharedFactory<RXLoad> {
 			protected:
-				/// Conductance [S]
-				/// FIXME: This is never read, only written to
-				Matrix mConductance;
 				/// Power [Watt]
 				MatrixComp mPower;
-				/// Actual voltage [V]
-				/// FIXME: This is never used
-				Matrix mVoltage;
-				/// Actual voltage [V]
-				/// FIXME: This is never used
-				Matrix mCurrent;
-
 				/// Resistance [Ohm]
 				Matrix mResistance;
 				/// Reactance [Ohm]

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
@@ -69,9 +69,6 @@ namespace CPS {
 				void initializeFromNodesAndTerminals(Real frequency);
 
 				// #### MNA section ####
-				/// Initializes internal variables of the component
-				void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-
 				void mnaUpdateCurrent(const Matrix& leftVector) override;
 				void mnaUpdateVoltage(const Matrix& leftVector) override;
 

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
@@ -44,8 +44,6 @@ namespace Ph3 {
 		void initializeFromNodesAndTerminals(Real frequency);
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps right side (source) vector
 		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		void mnaUpdateVoltage(const Matrix& leftVector) override;

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
@@ -62,13 +62,14 @@ namespace Ph3 {
 		void mnaUpdateVoltage(const Matrix& leftVector);
 		void mnaUpdateCurrent(const Matrix& leftVector);
 
+		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
 		class MnaPreStep : public Task {
 		public:
 			MnaPreStep(RxLine& line) :
 				Task(**line.mName + ".MnaPreStep"), mLine(line) {
-				mAttributeDependencies.push_back(line.mSubResistor->attribute("right_vector"));
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("right_vector"));
-				mModifiedAttributes.push_back(line.attribute("right_vector"));
+				mLine.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
 			}
 
 			void execute(Real time, Int timeStepCount);
@@ -81,10 +82,7 @@ namespace Ph3 {
 		public:
 			MnaPostStep(RxLine& line, Attribute<Matrix>::Ptr leftVector) :
 				Task(**line.mName + ".MnaPostStep"), mLine(line), mLeftVector(leftVector) {
-				mAttributeDependencies.push_back(leftVector);
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("v_intf"));
+				mLine.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
@@ -44,8 +44,6 @@ namespace Ph3 {
 		void initializeFromNodesAndTerminals(Real frequency);
 
 		// #### MNA section ####
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
@@ -19,9 +19,9 @@ namespace EMT {
 namespace Ph3 {
 
 	class RxLine :
+		public Base::Ph3::PiLine,
 		public SimPowerComp<Real>,
 		public MNAInterface,
-		public Base::Ph3::PiLine,
 		public SharedFactory<RxLine> {
 	protected:
 		/// Inductance submodel

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
@@ -24,12 +24,6 @@ namespace Ph3 {
 		public Base::Ph3::PiLine,
 		public SharedFactory<RxLine> {
 	protected:
-		/// Voltage across the component [V]
-		/// FIXME: This is never used...
-		Matrix mVoltage;
-		/// Current through the component [A]
-		/// FIXME: This is never used...
-		Matrix mCurrent;
 		/// Inductance submodel
 		std::shared_ptr<Inductor> mSubInductor;
 		/// Resistor submodel

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SeriesSwitch.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SeriesSwitch.h
@@ -10,6 +10,7 @@
 
 #include <dpsim-models/SimPowerComp.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Base/Base_Ph1_Switch.h>
 
 namespace CPS {
@@ -25,7 +26,8 @@ namespace Ph3 {
 		public Base::Ph1::Switch,
 		public SimPowerComp<Real>,
 		public SharedFactory<SeriesSwitch>,
-		public MNASwitchInterface {
+		public MNASwitchInterface,
+		public MNAInterface {
 	protected:
 	public:
 		/// Defines UID, name and log level

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Switch.h
@@ -10,6 +10,7 @@
 
 #include <dpsim-models/SimPowerComp.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Logger.h>
 #include <dpsim-models/Base/Base_Ph3_Switch.h>
@@ -25,7 +26,8 @@ namespace Ph3 {
 		public Base::Ph3::Switch,
 		public SimPowerComp<Real>,
 		public SharedFactory<Switch>,
-		public MNASwitchInterface {
+		public MNASwitchInterface,
+		public MNAInterface {
 	protected:
 	public:
 		/// Defines UID, name, component parameters and logging level

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SynchronGeneratorIdeal.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SynchronGeneratorIdeal.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/EMT/EMT_Ph3_VoltageSource.h>
 #include <dpsim-models/EMT/EMT_Ph3_CurrentSource.h>
@@ -18,8 +18,7 @@ namespace EMT {
 namespace Ph3 {
 	/// Ideal voltage source representing a synchronous generator
 	class SynchronGeneratorIdeal :
-		public SimPowerComp<Real>,
-		public MNAInterface,
+		public CompositePowerComp<Real>,
 		public SharedFactory<SynchronGeneratorIdeal> {
 	private:
 		/// Specifies type of ideal source
@@ -46,48 +45,20 @@ namespace Ph3 {
 		void initializeFromNodesAndTerminals(Real frequency);
 
 		// #### MNA section ####
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// MNA pre step operations
-		void mnaPreStep(Real time, Int timeStepCount);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Updates current through the component
-		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates voltage across component
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
 
-		class MnaPreStep : public CPS::Task {
-		public:
-			MnaPreStep(SynchronGeneratorIdeal& SynchronGeneratorIdeal) :
-				Task(**SynchronGeneratorIdeal.mName + ".MnaPreStep"), mSynchronGeneratorIdeal(SynchronGeneratorIdeal) {
-					mSynchronGeneratorIdeal.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-			void execute(Real time, Int timeStepCount) { mSynchronGeneratorIdeal.mnaPreStep(time, timeStepCount); };
-
-		private:
-			SynchronGeneratorIdeal& mSynchronGeneratorIdeal;
-		};
-
-		class MnaPostStep : public CPS::Task {
-		public:
-			MnaPostStep(SynchronGeneratorIdeal& SynchronGeneratorIdeal, Attribute<Matrix>::Ptr leftVector) :
-				Task(**SynchronGeneratorIdeal.mName + ".MnaPostStep"), mSynchronGeneratorIdeal(SynchronGeneratorIdeal), mLeftVector(leftVector) {
-				mSynchronGeneratorIdeal.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mSynchronGeneratorIdeal.mnaPostStep(time, timeStepCount, mLeftVector); };
-
-		private:
-			SynchronGeneratorIdeal& mSynchronGeneratorIdeal;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SynchronGeneratorIdeal.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SynchronGeneratorIdeal.h
@@ -45,7 +45,6 @@ namespace Ph3 {
 		void initializeFromNodesAndTerminals(Real frequency);
 
 		// #### MNA section ####
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// MNA pre step operations
 		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SynchronGeneratorTrStab.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SynchronGeneratorTrStab.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Base/Base_SynchronGenerator.h>
 #include <dpsim-models/EMT/EMT_Ph3_VoltageSource.h>
@@ -22,8 +22,7 @@ namespace Ph3 {
 	/// This model is based on Eremia section 2.1.6.
 	class SynchronGeneratorTrStab :
 		public Base::SynchronGenerator,
-		public MNAInterface,
-		public SimPowerComp<Real>,
+		public CompositePowerComp<Real>,
 		public SharedFactory<SynchronGeneratorTrStab> {
 	protected:
 		// #### Model specific variables ####
@@ -92,67 +91,33 @@ namespace Ph3 {
 
 		// #### MNA Functions ####
 		/// Initializes variables of component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Performs with the model of a synchronous generator
 		/// to calculate the flux and current from the voltage vector.
-		void mnaStep(Matrix& systemMatrix, Matrix& rightVector, Matrix& leftVector, Real time);
-		///
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
-		///
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// Retrieves calculated voltage from simulation for next step
-		void mnaPostStep(Matrix& rightVector, Matrix& leftVector, Real time);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		///
-		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		///
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
 
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
-
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(SynchronGeneratorTrStab& generator) :
-				Task(**generator.mName + ".MnaPreStep"), mGenerator(generator) {
-				// other attributes generally also influence the pre step,
-				// but aren't marked as writable anyway
-				/// CHECK: Is the upper comment still relevant. Any attribute is writable now...
-				mGenerator.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-
-			void execute(Real time, Int timeStepCount);
-
-		private:
-			SynchronGeneratorTrStab& mGenerator;
-		};
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		class AddBStep : public Task {
 		public:
 			AddBStep(SynchronGeneratorTrStab& generator) :
 				Task(**generator.mName + ".AddBStep"), mGenerator(generator) {
+				mAttributeDependencies.push_back(generator.mSubVoltageSource->mRightVector);
+				mAttributeDependencies.push_back(generator.mSubInductor->mRightVector);
+				mModifiedAttributes.push_back(generator.mRightVector);
 			}
 
 			void execute(Real time, Int timeStepCount);
 
 		private:
 			SynchronGeneratorTrStab& mGenerator;
-		};
-
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(SynchronGeneratorTrStab& generator, Attribute<Matrix>::Ptr leftVector) :
-				Task(**generator.mName + ".MnaPostStep"), mGenerator(generator), mLeftVector(leftVector) {
-				mGenerator.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
-				mAttributeDependencies.push_back(leftVector);
-				mAttributeDependencies.push_back(generator.mSubInductor->attribute("i_intf"));
-				mModifiedAttributes.push_back(generator.attribute("v_intf"));
-			}
-
-			void execute(Real time, Int timeStepCount);
-
-		private:
-			SynchronGeneratorTrStab& mGenerator;
-			Attribute<Matrix>::Ptr mLeftVector;
 		};
 	};
 }

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SynchronGeneratorVBR.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SynchronGeneratorVBR.h
@@ -27,10 +27,10 @@ namespace Ph3 {
 	/// parameter names include underscores and typical variables names found in literature instead of
 	/// descriptive names in order to shorten formulas and increase the readability
 	class SynchronGeneratorVBR :
+		public Base::SynchronGenerator,
 		public SimPowerComp<Real>,
 		public MNAInterface,
 		public MNAVariableCompInterface,
-		public Base::SynchronGenerator,
 		public SharedFactory<SynchronGeneratorVBR> {
 	protected:
 		/// d dynamic inductance

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Transformer.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Transformer.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/EMT/EMT_Ph3_Inductor.h>
 #include <dpsim-models/EMT/EMT_Ph3_Resistor.h>
@@ -20,10 +20,9 @@ namespace CPS {
 		namespace Ph3 {
 			/// Transformer that includes an inductance and resistance
 			class Transformer :
-				public Base::Ph3::Transformer,
-				public SimPowerComp<Real>,
-				public MNAInterface,
-				public SharedFactory<Transformer> {
+				public CompositePowerComp<Real>,
+				public SharedFactory<Transformer>,
+				public Base::Ph3::Transformer {
 			private:
 				/// Internal resistor to model losses
 				std::shared_ptr<EMT::Ph3::Resistor> mSubResistor;
@@ -68,48 +67,21 @@ namespace CPS {
 
 				// #### MNA section ####
 				/// Initializes internal variables of the component
-				void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
+				void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 				/// Stamps system matrix
-				void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
-				/// Stamps right side (source) vector
-				void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+				void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
 				/// Updates internal current variable of the component
-				void mnaUpdateCurrent(const Matrix& leftVector);
+				void mnaUpdateCurrent(const Matrix& leftVector) override;
 				/// Updates internal voltage variable of the component
-				void mnaUpdateVoltage(const Matrix& leftVector);
+				void mnaUpdateVoltage(const Matrix& leftVector) override;
 				/// MNA pre step operations
-				void mnaPreStep(Real time, Int timeStepCount);
+				void mnaParentPreStep(Real time, Int timeStepCount) override;
 				/// MNA post step operations
-				void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+				void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 				/// Add MNA pre step dependencies
-				void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+				void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 				/// Add MNA post step dependencies
-				void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
-
-				class MnaPreStep : public Task {
-				public:
-					MnaPreStep(Transformer& transformer) :
-						Task(**transformer.mName + ".MnaPreStep"), mTransformer(transformer) {
-							mTransformer.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-					}
-					void execute(Real time, Int timeStepCount) { mTransformer.mnaPreStep(time, timeStepCount); };
-				private:
-					Transformer& mTransformer;
-				};
-
-
-				class MnaPostStep : public Task {
-				public:
-					MnaPostStep(Transformer& transformer, Attribute<Matrix>::Ptr leftVector) :
-						Task(**transformer.mName + ".MnaPostStep"), mTransformer(transformer), mLeftVector(leftVector) {
-							mTransformer.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-					}
-					void execute(Real time, Int timeStepCount) { mTransformer.mnaPostStep(time, timeStepCount, mLeftVector); };
-
-				private:
-					Transformer& mTransformer;
-					Attribute<Matrix>::Ptr mLeftVector;
-				};
+				void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 			};
 		}
 	}

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Transformer.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Transformer.h
@@ -20,10 +20,10 @@ namespace CPS {
 		namespace Ph3 {
 			/// Transformer that includes an inductance and resistance
 			class Transformer :
+				public Base::Ph3::Transformer,
 				public SimPowerComp<Real>,
 				public MNAInterface,
-				public SharedFactory<Transformer>,
-				public Base::Ph3::Transformer {
+				public SharedFactory<Transformer> {
 			private:
 				/// Internal resistor to model losses
 				std::shared_ptr<EMT::Ph3::Resistor> mSubResistor;

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_VoltageSourceNorton.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_VoltageSourceNorton.h
@@ -17,8 +17,8 @@ namespace CPS {
 			/// \brief Voltage source with Norton equivalent model
 			class VoltageSourceNorton :
 				public MNAInterface,
-				public SimPowerComp<Real>,
 				public Base::Ph1::VoltageSource,
+				public SimPowerComp<Real>,
 				public SharedFactory<VoltageSourceNorton> {
 			protected:
 				void updateState(Real time);

--- a/dpsim-models/include/dpsim-models/IdentifiedObject.h
+++ b/dpsim-models/include/dpsim-models/IdentifiedObject.h
@@ -36,12 +36,11 @@ namespace CPS {
 		IdentifiedObject(String name) :
 			IdentifiedObject(name, name) { }
 
-		virtual ~IdentifiedObject() { }
-
-		/// FIXME: Workaround for pybind. The methods that return attributes with and without the full (template) type should not have the same name!
-		AttributeBase::Ptr attributeBase(const String &name) {
-			return attribute(name);
+		AttributeBase::Ptr attribute(const String &name) {
+			return AttributeList::attribute(name);
 		}
+
+		virtual ~IdentifiedObject() { }
 
 		/// Returns component name
 		String name() { return **mName; }

--- a/dpsim-models/include/dpsim-models/IdentifiedObject.h
+++ b/dpsim-models/include/dpsim-models/IdentifiedObject.h
@@ -36,7 +36,7 @@ namespace CPS {
 		IdentifiedObject(String name) :
 			IdentifiedObject(name, name) { }
 
-		AttributeBase::Ptr attribute(const String &name) {
+		AttributeBase::Ptr attribute(const String &name) override {
 			return AttributeList::attribute(name);
 		}
 

--- a/dpsim-models/include/dpsim-models/MNASimPowerComp.h
+++ b/dpsim-models/include/dpsim-models/MNASimPowerComp.h
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/Solver/MNAInterface.h>
+
+namespace CPS {
+	/// Base class for all components that are transmitting power.
+	template <typename VarType>
+	class MNASimPowerComp : public SimPowerComp<VarType>, public MNAInterface {
+
+	protected:
+		MNAInterface::List mSubcomponentsBeforePreStep;
+		MNAInterface::List mSubcomponentsAfterPreStep;
+		MNAInterface::List mSubcomponentsBeforePostStep;
+		MNAInterface::List mSubcomponentsAfterPostStep;
+
+	public:
+		typedef VarType Type;
+		typedef std::shared_ptr<MNASimPowerComp<VarType>> Ptr;
+		typedef std::vector<Ptr> List;
+
+		enum class MNA_SUBCOMP_TASK_ORDER {
+			NO_TASK,
+			TASK_BEFORE_PARENT,
+			TASK_AFTER_PARENT
+		};
+
+		/// Basic constructor that takes UID, name and log level
+		MNASimPowerComp<VarType>::MNASimPowerComp(String uid, String name, Logger::Level logLevel)
+			: SimPowerComp<VarType>(uid, name, logLevel) { }
+
+		/// Basic constructor that takes name and log level and sets the UID to name as well
+		MNASimPowerComp(String name, Logger::Level logLevel = Logger::Level::off)
+			: SimPowerComp<VarType>(name, name, logLevel) { }
+
+		/// Destructor - does not do anything
+		virtual ~MNASimPowerComp() { }
+
+		/// @brief Add a new subcomponent implementing MNA methods
+		/// @param subc The new subcomponent
+		/// @param preStepOrder When to execute the subcomponent's pre-step in relation to the parent
+		/// @param postStepOrder When to execute the subcomponent's post-step in relation to the parent
+		void addMNASubComponent(typename MNASimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder);
+
+		// #### MNA Interface Functions ####
+		/// Initializes variables of components
+		virtual void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
+		/// Stamps system matrix
+		virtual void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
+		/// Stamps right side (source) vector
+		virtual void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
+		/// MNA pre step operations
+		virtual void mnaPreStep(Real time, Int timeStepCount) override;
+		/// MNA post step operations
+		virtual void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
+		/// Add MNA pre step dependencies
+		virtual void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		/// Add MNA post step dependencies
+		virtual void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
+		// #### MNA Parent Functions ####
+		virtual void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) { };
+		virtual void mnaParentApplySystemMatrixStamp(Matrix& systemMatrix) { };
+		virtual void mnaParentApplyRightSideVectorStamp(Matrix& rightVector) { };
+		virtual void mnaParentPreStep(Real time, Int timeStepCount) { };
+		virtual void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) { };
+		virtual void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) { };
+		virtual void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) { };
+	};
+}

--- a/dpsim-models/include/dpsim-models/MNASimPowerComp.h
+++ b/dpsim-models/include/dpsim-models/MNASimPowerComp.h
@@ -7,22 +7,9 @@
 
 namespace CPS {
 
-	enum class MNA_SUBCOMP_TASK_ORDER {
-			NO_TASK,
-			TASK_BEFORE_PARENT,
-			TASK_AFTER_PARENT
-	};
-
-	/// Base class for all components that are transmitting power.
+	/// Base class for all MNA components that are transmitting power.
 	template <typename VarType>
 	class MNASimPowerComp : public SimPowerComp<VarType>, public MNAInterface {
-
-	protected:
-		MNAInterface::List mSubcomponentsMNA;
-		MNAInterface::List mSubcomponentsBeforePreStep;
-		MNAInterface::List mSubcomponentsAfterPreStep;
-		MNAInterface::List mSubcomponentsBeforePostStep;
-		MNAInterface::List mSubcomponentsAfterPostStep;
 
 	public:
 		typedef VarType Type;
@@ -38,42 +25,7 @@ namespace CPS {
 			: SimPowerComp<VarType>(name, name, logLevel) { }
 
 		/// Destructor - does not do anything
-		virtual ~MNASimPowerComp() { }
-
-		/// @brief Add a new subcomponent implementing MNA methods
-		/// @param subc The new subcomponent
-		/// @param preStepOrder When to execute the subcomponent's pre-step in relation to the parent
-		/// @param postStepOrder When to execute the subcomponent's post-step in relation to the parent
-		void addMNASubComponent(typename SimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder);
-
-		//void addMNASubComponent(typename MNASimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder);
-
-
-		// #### MNA Interface Functions ####
-		/// Initializes variables of components
-		virtual void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps system matrix
-		virtual void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
-		/// Stamps right side (source) vector
-		virtual void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
-		/// MNA pre step operations
-		virtual void mnaPreStep(Real time, Int timeStepCount) override;
-		/// MNA post step operations
-		virtual void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
-		/// Add MNA pre step dependencies
-		virtual void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
-		/// Add MNA post step dependencies
-		virtual void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
-
-		// #### MNA Parent Functions ####
-		virtual void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) { };
-		virtual void mnaParentApplySystemMatrixStamp(Matrix& systemMatrix) { };
-		virtual void mnaParentApplyRightSideVectorStamp(Matrix& rightVector) { };
-		virtual void mnaParentPreStep(Real time, Int timeStepCount) { };
-		virtual void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) { };
-		virtual void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) { };
-		virtual void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) { };
-
+		virtual ~MNASimPowerComp() = default;
 		class MnaPreStep : public CPS::Task {
 		public:
 			MnaPreStep(MNASimPowerComp<VarType>& comp) :

--- a/dpsim-models/include/dpsim-models/MNASimPowerComp.h
+++ b/dpsim-models/include/dpsim-models/MNASimPowerComp.h
@@ -12,27 +12,29 @@ namespace CPS {
 	class MNASimPowerComp : public SimPowerComp<VarType>, public MNAInterface {
 
 	public:
-		typedef VarType Type;
-		typedef std::shared_ptr<MNASimPowerComp<VarType>> Ptr;
-		typedef std::vector<Ptr> List;
+		using Type = VarType;
+		using Ptr = std::shared_ptr<MNASimPowerComp<VarType>>;
+		using List = std::vector<Ptr>;
 
 		/// Basic constructor that takes UID, name and log level
 		MNASimPowerComp(String uid, String name, Logger::Level logLevel)
 			: SimPowerComp<VarType>(uid, name, logLevel) { }
 
 		/// Basic constructor that takes name and log level and sets the UID to name as well
-		MNASimPowerComp(String name, Logger::Level logLevel = Logger::Level::off)
+		explicit MNASimPowerComp(String name, Logger::Level logLevel = Logger::Level::off)
 			: SimPowerComp<VarType>(name, name, logLevel) { }
 
 		/// Destructor - does not do anything
 		virtual ~MNASimPowerComp() = default;
 		class MnaPreStep : public CPS::Task {
 		public:
-			MnaPreStep(MNASimPowerComp<VarType>& comp) :
+			explicit MnaPreStep(MNASimPowerComp<VarType>& comp) :
 				Task(**comp.mName + ".MnaPreStep"), mComp(comp) {
 					mComp.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
 			}
-			void execute(Real time, Int timeStepCount) { mComp.mnaPreStep(time, timeStepCount); };
+			void execute(Real time, Int timeStepCount) override {
+				mComp.mnaPreStep(time, timeStepCount);
+			};
 
 		private:
 			MNASimPowerComp<VarType>& mComp;
@@ -44,7 +46,9 @@ namespace CPS {
 				Task(**comp.mName + ".MnaPostStep"), mComp(comp), mLeftVector(leftVector) {
 				mComp.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
 			}
-			void execute(Real time, Int timeStepCount) { mComp.mnaPostStep(time, timeStepCount, mLeftVector); };
+			void execute(Real time, Int timeStepCount) override {
+				mComp.mnaPostStep(time, timeStepCount, mLeftVector);
+			};
 
 		private:
 			MNASimPowerComp<VarType>& mComp;

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_AvVoltageSourceInverterDQ.h
@@ -100,7 +100,7 @@ namespace Ph1 {
 		const Attribute<Matrix>::Ptr mPowerctrlInputs;
 		const Attribute<Matrix>::Ptr mPowerctrlStates;
 		const Attribute<Matrix>::Ptr mPowerctrlOutputs;
-		
+
 		/// Defines name amd logging level
 		AvVoltageSourceInverterDQ(String name, Logger::Level logLevel = Logger::Level::off)
 			: AvVoltageSourceInverterDQ(name, name, logLevel) {}
@@ -150,9 +150,9 @@ namespace Ph1 {
 		/// Perform step of controller
 		void controlStep(Real time, Int timeStepCount);
 		/// Add control step dependencies
-		void addControlPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void addControlPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) const;
 		/// Add control step dependencies
-		void addControlStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void addControlStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) const;
 
 		class ControlPreStep : public CPS::Task {
 		public:

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_AvVoltageSourceInverterDQ.h
@@ -8,8 +8,7 @@
 #pragma once
 
 
-#include <dpsim-models/SimPowerComp.h>
-#include <dpsim-models/Solver/MNAInterface.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/SP/SP_Ph1_Resistor.h>
 #include <dpsim-models/SP/SP_Ph1_Inductor.h>
@@ -25,8 +24,7 @@ namespace SP {
 namespace Ph1 {
 	class AvVoltageSourceInverterDQ :
 		public Base::AvVoltageSourceInverterDQ,
-		public SimPowerComp<Complex>,
-		public MNAInterface,
+		public CompositePowerComp<Complex>,
 		public SharedFactory<AvVoltageSourceInverterDQ> {
 	protected:
 
@@ -126,23 +124,21 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Updates current through the component
-		void mnaUpdateCurrent(const Matrix& leftVector);
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates voltage across component
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		/// MNA pre step operations
-		void mnaPreStep(Real time, Int timeStepCount);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		// #### Control section ####
 		/// Control pre step operations
@@ -176,31 +172,6 @@ namespace Ph1 {
 
 		private:
 			AvVoltageSourceInverterDQ& mAvVoltageSourceInverterDQ;
-		};
-
-		class MnaPreStep : public CPS::Task {
-		public:
-			MnaPreStep(AvVoltageSourceInverterDQ& AvVoltageSourceInverterDQ) :
-				Task(**AvVoltageSourceInverterDQ.mName + ".MnaPreStep"), mAvVoltageSourceInverterDQ(AvVoltageSourceInverterDQ) {
-					mAvVoltageSourceInverterDQ.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-			void execute(Real time, Int timeStepCount) { mAvVoltageSourceInverterDQ.mnaPreStep(time, timeStepCount); };
-
-		private:
-			AvVoltageSourceInverterDQ& mAvVoltageSourceInverterDQ;
-		};
-
-		class MnaPostStep : public CPS::Task {
-		public:
-			MnaPostStep(AvVoltageSourceInverterDQ& AvVoltageSourceInverterDQ, Attribute<Matrix>::Ptr leftVector) :
-				Task(**AvVoltageSourceInverterDQ.mName + ".MnaPostStep"), mAvVoltageSourceInverterDQ(AvVoltageSourceInverterDQ), mLeftVector(leftVector) {
-				mAvVoltageSourceInverterDQ.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mAvVoltageSourceInverterDQ.mnaPostStep(time, timeStepCount, mLeftVector); };
-
-		private:
-			AvVoltageSourceInverterDQ& mAvVoltageSourceInverterDQ;
-			Attribute<Matrix>::Ptr mLeftVector;
 		};
 
 	};

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_AvVoltageSourceInverterDQ.h
@@ -125,8 +125,6 @@ namespace Ph1 {
 		// #### MNA section ####
 		/// Initializes internal variables of the component
 		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Updates current through the component
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates voltage across component

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Inductor.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Inductor.h
@@ -20,6 +20,7 @@ namespace Ph1 {
 	class Inductor :
 		public Base::Ph1::Inductor,
 		public MNATearInterface,
+		public MNAInterface,
 		public SimPowerComp<Complex>,
 		public SharedFactory<Inductor> {
 	protected:

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
@@ -8,12 +8,11 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/PFSolverInterfaceBus.h>
 #include <dpsim-models/SP/SP_Ph1_PVNode.h>
 #include <dpsim-models/SP/SP_Ph1_PQNode.h>
 #include <dpsim-models/SP/SP_Ph1_VDNode.h>
-#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/SP/SP_Ph1_Capacitor.h>
 #include <dpsim-models/SP/SP_Ph1_Inductor.h>
 #include <dpsim-models/SP/SP_Ph1_Resistor.h>
@@ -23,10 +22,9 @@ namespace CPS {
 namespace SP {
 namespace Ph1 {
 	class Load :
-		public SimPowerComp<Complex>,
+		public CompositePowerComp<Complex>,
 		public SharedFactory<Load>,
-		public PFSolverInterfaceBus,
-		public MNAInterface {
+		public PFSolverInterfaceBus {
 	public:
 		/// Nominal voltage [V]
 		const Attribute<Real>::Ptr mNomVoltage;
@@ -90,29 +88,16 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Updates internal current variable of the component
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates internal voltage variable of the component
 		void mnaUpdateVoltage(const Matrix& leftVector) override;
 
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+		/// MNA post step operations
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(Load& load, Attribute<Matrix>::Ptr leftVector) :
-				Task(**load.mName + ".MnaPostStep"), mLoad(load), mLeftVector(leftVector) {
-				mLoad.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
-			}
-
-			void execute(Real time, Int timeStepCount);
-
-		private:
-			Load& mLoad;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
@@ -27,10 +27,6 @@ namespace Ph1 {
 		public SharedFactory<Load>,
 		public PFSolverInterfaceBus,
 		public MNAInterface {
-	private:
-		/// Power [Watt]
-		/// FIXME: This is only written to, but never read
-		Complex mPower;
 	public:
 		/// Nominal voltage [V]
 		const Attribute<Real>::Ptr mNomVoltage;
@@ -48,14 +44,6 @@ namespace Ph1 {
 		Real mBaseApparentPower;
 		///base omega [1/s]
 		Real mBaseOmega;
-
-		/// Actual voltage [V]
-		/// FIXME: This is never used
-		Complex mVoltage;
-		/// Actual voltage [V]
-		/// FIXME: This is never used
-		Complex mCurrent;
-
 		/// Resistance [Ohm]
 		Real mResistance;
 		/// Conductance [S]

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
@@ -110,19 +110,13 @@ namespace Ph1 {
 		/// Updates internal voltage variable of the component
 		void mnaUpdateVoltage(const Matrix& leftVector) override;
 
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
 		class MnaPostStep : public Task {
 		public:
 			MnaPostStep(Load& load, Attribute<Matrix>::Ptr leftVector) :
 				Task(**load.mName + ".MnaPostStep"), mLoad(load), mLeftVector(leftVector) {
-				mAttributeDependencies.push_back(leftVector);
-				if (load.mSubResistor)
-					mAttributeDependencies.push_back(load.mSubResistor->attribute("i_intf"));
-				if (load.mSubInductor)
-					mAttributeDependencies.push_back(load.mSubInductor->attribute("i_intf"));
-				if (load.mSubCapacitor)
-					mAttributeDependencies.push_back(load.mSubCapacitor->attribute("i_intf"));
-				mModifiedAttributes.push_back(load.attribute("i_intf"));
-				mModifiedAttributes.push_back(load.attribute("v_intf"));
+				mLoad.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
@@ -87,8 +87,6 @@ namespace Ph1 {
 		void modifyPowerFlowBusType(PowerflowBusType powerflowBusType) override;
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Updates internal current variable of the component
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates internal voltage variable of the component

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_NetworkInjection.h
@@ -41,16 +41,12 @@ namespace Ph1 {
 		std::vector<const Matrix*> mRightVectorStamps;
 
 		// #### Powerflow section ####
-		/// Apparent Power Injection [VA]
-		/// FIXME: Never used
-		Complex mPowerInjection;
-
 		/// Base voltage [V]
 		Real mBaseVoltage;
 
     public:
 		const Attribute<Complex>::Ptr mVoltageRef;
-		const Attribute<Real>::Ptr mSrcFreq; 
+		const Attribute<Real>::Ptr mSrcFreq;
 
 		// #### Powerflow section ####
 		/// Voltage set point [V]

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_NetworkInjection.h
@@ -92,10 +92,8 @@ namespace Ph1 {
 		/// This will create a CosineFMGenerator which will not react to external changes to mVoltageRef or mSrcFreq!
 		void setParameters(Complex initialPhasor, Real modulationFrequency, Real modulationAmplitude, Real baseFrequency = 0.0, bool zigzag = false);
 
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
+		void mnaParentApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Returns current through the component
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates voltage across component

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_NetworkInjection.h
@@ -8,9 +8,8 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/PFSolverInterfaceBus.h>
-#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Solver/DAEInterface.h>
 #include <dpsim-models/SP/SP_Ph1_VoltageSource.h>
 
@@ -25,10 +24,9 @@ namespace Ph1 {
 	/// the frequency, magnitude and phase of the sine wave can be modified through the mVoltageRef and mSrcFreq attributes.
 	/// See SP_Ph1_VoltageSource.h for more details.
     class NetworkInjection:
-		public SimPowerComp<Complex>,
+		public CompositePowerComp<Complex>,
 		public SharedFactory<NetworkInjection>,
 		public PFSolverInterfaceBus,
-		public MNAInterface,
 		public DAEInterface {
 
     private:
@@ -93,49 +91,23 @@ namespace Ph1 {
 		/// Setter for reference signal of type cosine frequency modulation
 		/// This will create a CosineFMGenerator which will not react to external changes to mVoltageRef or mSrcFreq!
 		void setParameters(Complex initialPhasor, Real modulationFrequency, Real modulationAmplitude, Real baseFrequency = 0.0, bool zigzag = false);
+
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps right side (source) vector
 		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Returns current through the component
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates voltage across component
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		/// MNA pre step operations
-		void mnaPreStep(Real time, Int timeStepCount);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
-
-		class MnaPreStep : public CPS::Task {
-		public:
-			MnaPreStep(NetworkInjection& networkInjection) :
-				Task(**networkInjection.mName + ".MnaPreStep"), mNetworkInjection(networkInjection) {
-					mNetworkInjection.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-			void execute(Real time, Int timeStepCount) { mNetworkInjection.mnaPreStep(time, timeStepCount); };
-
-		private:
-			NetworkInjection& mNetworkInjection;
-		};
-
-		class MnaPostStep : public CPS::Task {
-		public:
-			MnaPostStep(NetworkInjection& networkInjection, Attribute<Matrix>::Ptr leftVector) :
-				Task(**networkInjection.mName + ".MnaPostStep"), mNetworkInjection(networkInjection), mLeftVector(leftVector) {
-				mNetworkInjection.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mNetworkInjection.mnaPostStep(time, timeStepCount, mLeftVector); };
-
-		private:
-			NetworkInjection& mNetworkInjection;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		// #### DAE Section ####
 		/// Residual function for DAE Solver

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_PQNode.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_PQNode.h
@@ -22,7 +22,6 @@ namespace Ph1 {
 		const Attribute<Real>::Ptr mPower;
 		const Attribute<Real>::Ptr mReactivePower;
 
-	public:
 		PQNode(String uid, String name,
 			Logger::Level logLevel = Logger::Level::off);
 

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_PQNode.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_PQNode.h
@@ -22,12 +22,6 @@ namespace Ph1 {
 		const Attribute<Real>::Ptr mPower;
 		const Attribute<Real>::Ptr mReactivePower;
 
-	private:
-		/// FIXME: Never used
-		Real mVoltageAbsPerUnit;
-		/// FIXME: Never used
-		Complex mVoltagePerUnit;
-
 	public:
 		PQNode(String uid, String name,
 			Logger::Level logLevel = Logger::Level::off);

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_PVNode.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_PVNode.h
@@ -14,11 +14,6 @@ namespace SP {
 namespace Ph1 {
 
     class PVNode: public SimPowerComp<Complex>, public SharedFactory<PVNode> {
-	private:
-		/// FIXME: Only used once as local variable
-		Real mRatedU;
-		/// FIXME: Only written to, never read
-		Real mQLimit;
     public:
 		const Attribute<Real>::Ptr mVoltageSetPoint;
 		const Attribute<Real>::Ptr mPowerSetPoint;

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNATearInterface.h>
 #include <dpsim-models/Solver/PFSolverInterfaceBranch.h>
 #include <dpsim-models/Base/Base_Ph1_PiLine.h>
@@ -25,9 +25,8 @@ namespace Ph1 {
 	/// RLC elements of a PI-line.
 	class PiLine :
 	 public Base::Ph1::PiLine,
-	 public SimPowerComp<Complex>,
+	 public CompositePowerComp<Complex>,
 	 public MNATearInterface,
-	public MNAInterface,
 	 public SharedFactory<PiLine>,
 	 public PFSolverInterfaceBranch {
 	public:
@@ -123,31 +122,17 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
+		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Updates internal current variable of the component
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates internal voltage variable of the component
 		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		/// MNA post-step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// add MNA post-step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
-
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(PiLine& line, Attribute<Matrix>::Ptr leftVector) :
-				Task(**line.mName + ".MnaPostStep"), mLine(line), mLeftVector(leftVector) {
-					mLine.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mLine.mnaPostStep(time, timeStepCount, mLeftVector); };
-		private:
-			PiLine& mLine;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		MNAInterface::List mnaTearGroundComponents() override;
 		void mnaTearInitialize(Real omega, Real timeStep) override;

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
@@ -27,6 +27,7 @@ namespace Ph1 {
 	 public Base::Ph1::PiLine,
 	 public SimPowerComp<Complex>,
 	 public MNATearInterface,
+	public MNAInterface,
 	 public SharedFactory<PiLine>,
 	 public PFSolverInterfaceBranch {
 	public:

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
@@ -24,10 +24,10 @@ namespace Ph1 {
 	/// For MNA this model consists sub components to represent the
 	/// RLC elements of a PI-line.
 	class PiLine :
+	 public Base::Ph1::PiLine,
 	 public SimPowerComp<Complex>,
 	 public MNATearInterface,
 	 public SharedFactory<PiLine>,
-	 public Base::Ph1::PiLine,
 	 public PFSolverInterfaceBranch {
 	public:
 		///base voltage [V]

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
@@ -90,9 +90,6 @@ namespace Ph1 {
 		const Attribute<Real>::Ptr mActivePowerInjection;
 		/// nodal reactive power injection
 		const Attribute<Real>::Ptr mReactivePowerInjection;
-		/// whether the total power injection of its from node is stored in this line
-		/// FIXME: This is only written to, but never read
-		const Attribute<Bool>::Ptr mStoreNodalPowerInjection;
 
 		// #### General ####
 		/// Defines UID, name and logging level

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
@@ -121,10 +121,6 @@ namespace Ph1 {
 		MatrixComp Y_element();
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Updates internal current variable of the component
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates internal voltage variable of the component

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
@@ -138,13 +138,14 @@ namespace Ph1 {
 		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 
+		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+
 		class MnaPreStep : public Task {
 		public:
 			MnaPreStep(RXLine& line) :
 				Task(**line.mName + ".MnaPreStep"), mLine(line) {
-				mAttributeDependencies.push_back(line.mSubResistor->attribute("right_vector"));
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("right_vector"));
-				mModifiedAttributes.push_back(line.attribute("right_vector"));
+				mLine.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
 			}
 
 			void execute(Real time, Int timeStepCount);
@@ -157,10 +158,7 @@ namespace Ph1 {
 		public:
 			MnaPostStep(RXLine& line, Attribute<Matrix>::Ptr leftVector) :
 				Task(**line.mName + ".MnaPostStep"), mLine(line), mLeftVector(leftVector) {
-				mAttributeDependencies.push_back(leftVector);
-				mAttributeDependencies.push_back(line.mSubInductor->attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("i_intf"));
-				mModifiedAttributes.push_back(line.attribute("v_intf"));
+				mLine.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
 			}
 
 			void execute(Real time, Int timeStepCount);

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
@@ -125,8 +125,6 @@ namespace Ph1 {
 		void initializeFromNodesAndTerminals(Real frequency) override;
 
 		// #### MNA section ####
-		/// Initializes internal variables of the component
-		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
@@ -71,9 +71,6 @@ namespace Ph1 {
 		const Attribute<Real>::Ptr mActivePowerInjection;
 		/// nodal reactive power injection
 		const Attribute<Real>::Ptr mReactivePowerInjection;
-		/// whether the total power injection of its from node is stored in this line
-		/// FIXME: This is only written to, but never read
-		const Attribute<Bool>::Ptr mStoreNodalPowerInjection;
 
 		// #### Power flow results ####
 		/// branch Current flow [A], coef(0) has data from node 0, coef(1) from node 1.

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include "dpsim-models/Solver/PFSolverInterfaceBranch.h"
 #include <dpsim-models/Base/Base_Ph1_PiLine.h>
 #include <dpsim-models/SP/SP_Ph1_Inductor.h>
@@ -19,11 +19,10 @@ namespace SP {
 namespace Ph1 {
 
 	class RXLine :
-		public SimPowerComp<Complex>,
+		public CompositePowerComp<Complex>,
 		public SharedFactory<RXLine>,
 		public PFSolverInterfaceBranch,
-		public Base::Ph1::PiLine,
-		public MNAInterface{
+		public Base::Ph1::PiLine {
 	protected:
 		/// CHECK: Which of these really need to be member variables?
 		///Capacitance of the line in [F]
@@ -127,43 +126,16 @@ namespace Ph1 {
 
 		// #### MNA section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
-		/// Stamps system matrix
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
-		/// Stamps system matrix
-		void mnaApplyInitialSystemMatrixStamp(Matrix& systemMatrix);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(RXLine& line) :
-				Task(**line.mName + ".MnaPreStep"), mLine(line) {
-				mLine.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
-			void execute(Real time, Int timeStepCount);
-
-		private:
-			RXLine& mLine;
-		};
-
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(RXLine& line, Attribute<Matrix>::Ptr leftVector) :
-				Task(**line.mName + ".MnaPostStep"), mLine(line), mLeftVector(leftVector) {
-				mLine.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
-			}
-
-			void execute(Real time, Int timeStepCount);
-
-		private:
-			RXLine& mLine;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
 	};
 }
 }

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Resistor.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Resistor.h
@@ -22,6 +22,7 @@ namespace Ph1 {
 	class Resistor :
 		public Base::Ph1::Resistor,
 		public MNATearInterface,
+		public MNAInterface,
 		public SimPowerComp<Complex>,
 		public SharedFactory<Resistor>,
 		public PFSolverInterfaceBranch {

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Shunt.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Shunt.h
@@ -21,25 +21,6 @@ namespace SP {namespace Ph1 {
 		/// Susceptance [S]
 		const Attribute<Real>::Ptr mSusceptance;
 	private:
-		/// Impedance [Ohm]
-		/// FIXME: Never used
-		Complex mImpedance;
-		/// Addmitance [S]
-		/// FIXME: Never used
-		Complex mAdmittance;
-
-        /// Base apparent power [VA]
-		/// FIXME: Only used as local variable
-        Real mBaseApparentPower;
-        /// Base impedance [Ohm]
-		/// FIXME: Only used as local variable
-        Real mBaseImpedance;
-        /// Base admittance [S]
-		/// FIXME: Only used as local variable
-        Real mBaseAdmittance;
-        /// Base omega [1/s]
-		/// FIXME: Only written to once, never read
-        Real mBaseOmega;
         /// Base voltage [V]
         Real mBaseVoltage;
 
@@ -47,12 +28,6 @@ namespace SP {namespace Ph1 {
         Real mConductancePerUnit;
 		/// Susceptance [pu]
         Real mSusceptancePerUnit;
-		/// Impedance [pu]
-		/// FIXME: Never used
-        Complex mImpedancePerUnit;
-		/// Addmitance [pu]
-		/// FIXME: Never used
-        Complex mAdmittancePerUnit;
 
 	public:
 		/// Defines UID, name, component parameters and logging level

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SolidStateTransformer.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SolidStateTransformer.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/SP/SP_Ph1_Load.h>
 
@@ -21,9 +21,8 @@ namespace SP { namespace Ph1 {
     * Depends on the actual condition, values can be negative
     */
 	class SolidStateTransformer :
-		public SimPowerComp<Complex>,
-		public SharedFactory<SolidStateTransformer>,
-		public MNAInterface{
+		public CompositePowerComp<Complex>,
+		public SharedFactory<SolidStateTransformer> {
 	private:
     ///
     std::shared_ptr<SP::Ph1::Load> mSubLoadSide1;

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SolidStateTransformer.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SolidStateTransformer.h
@@ -30,9 +30,6 @@ namespace SP { namespace Ph1 {
     ///
     std::shared_ptr<SP::Ph1::Load> mSubLoadSide2;
 
-    /// Rated Apparent Power [VA]
-    /// FIXME: Never used
-    Real mRatedPower = 0;
     /// Active power at secondary side [watt]
     Real mP2 = std::numeric_limits<double>::infinity();
     /// Nominal voltage of primary side [V]

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Switch.h
@@ -10,6 +10,7 @@
 
 #include <dpsim-models/SimPowerComp.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Logger.h>
 #include <dpsim-models/Base/Base_Ph1_Switch.h>
@@ -25,7 +26,8 @@ namespace Ph1 {
 		public Base::Ph1::Switch,
 		public SimPowerComp<Complex>,
 		public SharedFactory<Switch>,
-		public MNASwitchInterface {
+		public MNASwitchInterface,
+		public MNAInterface {
 	protected:
 	public:
 		/// Defines UID, name, component parameters and logging level
@@ -56,7 +58,7 @@ namespace Ph1 {
 		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
 			AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes,
 			Attribute<Matrix>::Ptr &leftVector);
-		
+
 		// #### MNA section for switch ####
 		/// Check if switch is closed
 		Bool mnaIsClosed() override;

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
@@ -22,21 +22,8 @@ namespace Ph1 {
 			public SharedFactory<SynchronGenerator>,
 			public PFSolverInterfaceBus {
 	    private:
-			/// Rate apparent power [VA]
-			/// FIXME: Only used as local variable
-		    Real mRatedApparentPower;
-			/// Rated voltage [V]
-			/// FIXME: Only used as local variable
-		    Real mRatedVoltage;
-			/// Maximum reactive power [VAr]
-			/// FIXME: Never used
-			Real mMaximumReactivePower;
-
 			/// Base apparent power[VA]
 			Real mBaseApparentPower;
-			/// Base omega [1/s]
-			/// FIXME: Only used as local variable
-			Real mBaseOmega;
 
         public:
 			/// Active power set point of the machine [W]

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGeneratorTrStab.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGeneratorTrStab.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Base/Base_SynchronGenerator.h>
 #include <dpsim-models/SP/SP_Ph1_VoltageSource.h>
@@ -22,8 +22,7 @@ namespace Ph1 {
 	/// This model is based on Eremia section 2.1.6.
 	class SynchronGeneratorTrStab :
 		public Base::SynchronGenerator,
-		public MNAInterface,
-		public SimPowerComp<Complex>,
+		public CompositePowerComp<Complex>,
 		public SharedFactory<SynchronGeneratorTrStab> {
 	protected:
 		// #### Model specific variables ####
@@ -90,42 +89,20 @@ namespace Ph1 {
 
 		// #### MNA Functions ####
 		/// Initializes variables of component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector);
-		/// Performs with the model of a synchronous generator
-		/// to calculate the flux and current from the voltage vector.
-		void mnaStep(Matrix& systemMatrix, Matrix& rightVector, Matrix& leftVector, Real time);
-		///
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector);
-		///
-		void mnaApplySystemMatrixStamp(Matrix& systemMatrix);
-		/// Retrieves calculated voltage from simulation for next step
-		void mnaPostStep(Matrix& rightVector, Matrix& leftVector, Real time);
-		///
-		void mnaUpdateCurrent(const Matrix& leftVector);
-		///
-		void mnaUpdateVoltage(const Matrix& leftVector);
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
+		/// MNA pre and post step operations
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
+		///
+		void mnaUpdateCurrent(const Matrix& leftVector) override;
+		///
+		void mnaUpdateVoltage(const Matrix& leftVector) override;
+
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
 		void setReferenceOmega(Attribute<Real>::Ptr refOmegaPtr, Attribute<Real>::Ptr refDeltaPtr);
-
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(SynchronGeneratorTrStab& generator) :
-				Task(**generator.mName + ".MnaPreStep"), mGenerator(generator) {
-				mGenerator.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-				// other attributes generally also influence the pre step,
-				// but aren't marked as writable anyway
-				/// CHECK: Is the upper comment still relevant. Any attribute is writable now...
-			}
-
-			void execute(Real time, Int timeStepCount);
-
-		private:
-			SynchronGeneratorTrStab& mGenerator;
-		};
-
 		class AddBStep : public Task {
 		public:
 			AddBStep(SynchronGeneratorTrStab& generator) :
@@ -139,20 +116,6 @@ namespace Ph1 {
 
 		private:
 			SynchronGeneratorTrStab& mGenerator;
-		};
-
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(SynchronGeneratorTrStab& generator, Attribute<Matrix>::Ptr leftVector) :
-				Task(**generator.mName + ".MnaPostStep"), mGenerator(generator), mLeftVector(leftVector) {
-				mGenerator.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, leftVector);
-			}
-
-			void execute(Real time, Int timeStepCount);
-
-		private:
-			SynchronGeneratorTrStab& mGenerator;
-			Attribute<Matrix>::Ptr mLeftVector;
 		};
 	};
 }

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Transformer.h
@@ -57,13 +57,6 @@ namespace Ph1 {
 		Real mRatioPhase = 0;
 		/// Nominal omega
 		Real mNominalOmega;
-
-		/// Voltage [V]
-		/// FIXME: Not used
-		Real mSvVoltage;
-		/// Conductance [S]
-		/// FIXME: Only set, never read
-		Real mConductance;
 		/// Reactance [Ohm]
 		Real mReactance;
 
@@ -119,9 +112,6 @@ namespace Ph1 {
 		const Attribute<Real>::Ptr mActivePowerInjection;
 		/// nodal reactive power injection
 		const Attribute<Real>::Ptr mReactivePowerInjection;
-		/// whether the total power injection of its from node is stored in this line
-		/// FIXME: This is only written to, but never read
-		const Attribute<Bool>::Ptr mStoreNodalPowerInjection;
 
 		/// Defines UID, name and logging level
 		Transformer(String uid, String name,

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Transformer.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <dpsim-models/SimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Solver/PFSolverInterfaceBranch.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/SP/SP_Ph1_Resistor.h>
@@ -22,10 +22,9 @@ namespace Ph1 {
 	/// Transformer that includes an inductance and resistance
 	class Transformer :
 		public Base::Ph1::Transformer,
-		public SimPowerComp<Complex>,
+		public CompositePowerComp<Complex>,
 		public SharedFactory<Transformer>,
-		public PFSolverInterfaceBranch,
-		public MNAInterface {
+		public PFSolverInterfaceBranch {
 
 	private:
 		/// Internal resistor to model losses
@@ -148,48 +147,22 @@ namespace Ph1 {
 
 		// #### MNA Section ####
 		/// Initializes internal variables of the component
-		void mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
+		void mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
 		/// Stamps system matrix
 		void mnaApplySystemMatrixStamp(Matrix& systemMatrix) override;
-		/// Stamps right side (source) vector
-		void mnaApplyRightSideVectorStamp(Matrix& rightVector) override;
 		/// Updates internal current variable of the component
 		void mnaUpdateCurrent(const Matrix& leftVector) override;
 		/// Updates internal voltage variable of the component
 		void mnaUpdateVoltage(const Matrix& leftVector) override;
 		/// MNA pre step operations
-		void mnaPreStep(Real time, Int timeStepCount);
+		void mnaParentPreStep(Real time, Int timeStepCount) override;
 		/// MNA post step operations
-		void mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
 		/// Add MNA pre step dependencies
-		void mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes);
+		void mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
 		/// Add MNA post step dependencies
-		void mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector);
+		void mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) override;
 
-		class MnaPreStep : public Task {
-		public:
-			MnaPreStep(Transformer& transformer) :
-				Task(**transformer.mName + ".MnaPreStep"), mTransformer(transformer) {
-					mTransformer.mnaAddPreStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
-			}
-			void execute(Real time, Int timeStepCount) { mTransformer.mnaPreStep(time, timeStepCount); };
-		private:
-			Transformer& mTransformer;
-		};
-
-
-		class MnaPostStep : public Task {
-		public:
-			MnaPostStep(Transformer& transformer, Attribute<Matrix>::Ptr leftVector) :
-				Task(**transformer.mName + ".MnaPostStep"), mTransformer(transformer), mLeftVector(leftVector) {
-					mTransformer.mnaAddPostStepDependencies(mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes, mLeftVector);
-			}
-			void execute(Real time, Int timeStepCount) { mTransformer.mnaPostStep(time, timeStepCount, mLeftVector); };
-
-		private:
-			Transformer& mTransformer;
-			Attribute<Matrix>::Ptr mLeftVector;
-		};
     };
 }
 }

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Transformer.h
@@ -21,11 +21,11 @@ namespace SP {
 namespace Ph1 {
 	/// Transformer that includes an inductance and resistance
 	class Transformer :
+		public Base::Ph1::Transformer,
 		public SimPowerComp<Complex>,
 		public SharedFactory<Transformer>,
 		public PFSolverInterfaceBranch,
-		public MNAInterface,
-		public Base::Ph1::Transformer {
+		public MNAInterface {
 
 	private:
 		/// Internal resistor to model losses

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_varResSwitch.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_varResSwitch.h
@@ -11,7 +11,7 @@
 #include <dpsim-models/SimPowerComp.h>
 #include <dpsim-models/Solver/MNAVariableCompInterface.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
-// #include <dpsim-models/Solver/MNAInterface.h>
+#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Base/Base_Ph1_Switch.h>
 
 namespace CPS {
@@ -28,6 +28,7 @@ namespace Ph1 {
 		public Base::Ph1::Switch,
 		public MNAVariableCompInterface,
 		public MNASwitchInterface,
+		public MNAInterface,
 		public SimPowerComp<Complex>,
 		public SharedFactory<varResSwitch> {
 

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph3_Inductor.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph3_Inductor.h
@@ -26,6 +26,7 @@ namespace CPS {
 			class Inductor :
 				public Base::Ph3::Inductor,
 				public MNATearInterface,
+				public MNAInterface,
 				public SimPowerComp<Complex>,
 				public SharedFactory<Inductor> {
 			protected:

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph3_Resistor.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph3_Resistor.h
@@ -21,6 +21,7 @@ namespace CPS {
 			class Resistor :
 				public Base::Ph3::Resistor,
 				public MNATearInterface,
+				public MNAInterface,
 				public SimPowerComp<Complex>,
 				public SharedFactory<Resistor> {
 

--- a/dpsim-models/include/dpsim-models/Signal/FIRFilter.h
+++ b/dpsim-models/include/dpsim-models/Signal/FIRFilter.h
@@ -22,16 +22,16 @@ namespace Signal {
 	protected:
 		std::vector<Real> mSignal;
 		std::vector<Real> mFilter;
-		
+
 		Attribute<Real>::Ptr mInput;
 		Int mCurrentIdx;
 		Int mFilterLength;
-		
+
 		void incrementIndex();
 		Int getIndex(Int index);
 	public:
 		const Attribute<Real>::Ptr mOutput;
-		///FIXME: This is never written to, so it is always zero
+		/// This is never explicitely set to reference anything, so the outside code is responsible for setting up the reference.
 		const Attribute<Real>::Ptr mInitSample;
 
 		FIRFilter(String uid, String name, Logger::Level logLevel = Logger::Level::off);

--- a/dpsim-models/include/dpsim-models/Signal/Integrator.h
+++ b/dpsim-models/include/dpsim-models/Signal/Integrator.h
@@ -26,7 +26,7 @@ namespace Signal {
 
 	public:
 
-		///FIXME: This is never explicitely set to reference anything, so the outside code is responsible for setting up the reference.
+		/// This is never explicitely set to reference anything, so the outside code is responsible for setting up the reference.
 		const Attribute<Real>::Ptr mInputRef;
 
 		/// Previous Input

--- a/dpsim-models/include/dpsim-models/Signal/PLL.h
+++ b/dpsim-models/include/dpsim-models/Signal/PLL.h
@@ -42,7 +42,7 @@ namespace Signal {
 
 	public:
 
-		///FIXME: This is never explicitely set to reference anything, so the outside code is responsible for setting up the reference.
+		/// This is never explicitely set to reference anything, so the outside code is responsible for setting up the reference.
 		const Attribute<Real>::Ptr mInputRef;
 
 		/// Previous Input

--- a/dpsim-models/include/dpsim-models/Signal/PowerControllerVSI.h
+++ b/dpsim-models/include/dpsim-models/Signal/PowerControllerVSI.h
@@ -62,7 +62,7 @@ namespace Signal {
 	public:
 
 		// attributes of input references
-		///FIXME: These are never explicitely set to reference anything, so the outside code is responsible for setting up the reference.
+		/// These are never explicitely set to reference anything, so the outside code is responsible for setting up the reference.
 		const Attribute<Real>::Ptr mVc_d;
 		const Attribute<Real>::Ptr mVc_q;
 		const Attribute<Real>::Ptr mIrc_d;

--- a/dpsim-models/include/dpsim-models/SimPowerComp.h
+++ b/dpsim-models/include/dpsim-models/SimPowerComp.h
@@ -28,7 +28,9 @@ namespace CPS {
 		UInt mNumFreqs = 0;
 		///
 		PhaseType mPhaseType = PhaseType::Single;
+
 		/// List of subcomponents
+		/// DEPRECATED: Delete or move into CompositePowerComp
 		typename std::vector<std::shared_ptr<SimPowerComp<VarType>>> mSubComponents;
 		/// "Cached" list of simulation nodes (to avoid shared_ptr accesses during simulation)
 		std::vector<UInt> mMatrixNodeIndices;

--- a/dpsim-models/include/dpsim-models/Solver/MNAInterface.h
+++ b/dpsim-models/include/dpsim-models/Solver/MNAInterface.h
@@ -35,7 +35,7 @@ namespace CPS {
 		/// Stamps system matrix
 		virtual void mnaApplySystemMatrixStamp(Matrix& systemMatrix) { }
 		/// Stamps (sparse) system matrix
-		virtual void mnaApplySystemMatrixStamp(SparseMatrixRow& systemMatrix) {
+		virtual void mnaApplySparseSystemMatrixStamp(SparseMatrixRow& systemMatrix) {
 			Matrix mat = Matrix(systemMatrix);
 			mnaApplySystemMatrixStamp(mat);
 			systemMatrix = mat.sparseView();

--- a/dpsim-models/include/dpsim-models/Solver/MNASwitchInterface.h
+++ b/dpsim-models/include/dpsim-models/Solver/MNASwitchInterface.h
@@ -24,7 +24,7 @@ namespace CPS {
 		/// Stamps system matrix considering the defined switch position
 		virtual void mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& systemMatrix, Int freqIdx) { }
 		/// Stamps (sparse) system matrix considering the defined switch position
-		virtual void mnaApplySwitchSystemMatrixStamp(Bool closed, SparseMatrixRow& systemMatrix, Int freqIdx) {
+		virtual void mnaApplySwitchSparseSystemMatrixStamp(Bool closed, SparseMatrixRow& systemMatrix, Int freqIdx) {
 			Matrix mat = Matrix(systemMatrix);
 			mnaApplySwitchSystemMatrixStamp(closed, mat, freqIdx);
 			systemMatrix = mat.sparseView();

--- a/dpsim-models/include/dpsim-models/Solver/MNASwitchInterface.h
+++ b/dpsim-models/include/dpsim-models/Solver/MNASwitchInterface.h
@@ -18,6 +18,8 @@ namespace CPS {
 		typedef std::shared_ptr<MNASwitchInterface> Ptr;
 		typedef std::vector<Ptr> List;
 
+		virtual ~MNASwitchInterface() = default;
+
 		// #### MNA section ####
 		/// Check if switch is closed
 		virtual Bool mnaIsClosed() = 0;

--- a/dpsim-models/include/dpsim-models/Solver/MNASwitchInterface.h
+++ b/dpsim-models/include/dpsim-models/Solver/MNASwitchInterface.h
@@ -10,11 +10,10 @@
 
 #include <dpsim-models/Config.h>
 #include <dpsim-models/Definitions.h>
-#include <dpsim-models/Solver/MNAInterface.h>
 
 namespace CPS {
 	/// \brief MNA interface to be used by switching devices.
-	class MNASwitchInterface : public MNAInterface {
+	class MNASwitchInterface {
 	public:
 		typedef std::shared_ptr<MNASwitchInterface> Ptr;
 		typedef std::vector<Ptr> List;

--- a/dpsim-models/include/dpsim-models/Solver/MNATearInterface.h
+++ b/dpsim-models/include/dpsim-models/Solver/MNATearInterface.h
@@ -12,7 +12,7 @@
 #include <dpsim-models/Solver/MNAInterface.h>
 
 namespace CPS {
-	class MNATearInterface : public MNAInterface {
+	class MNATearInterface {
 	public:
 		// Returns a list of additional components connected to ground that
 		// need to be considered for the original systems.

--- a/dpsim-models/src/Base/Base_ReducedOrderSynchronGenerator.cpp
+++ b/dpsim-models/src/Base/Base_ReducedOrderSynchronGenerator.cpp
@@ -21,9 +21,9 @@ Base::ReducedOrderSynchronGenerator<Real>::ReducedOrderSynchronGenerator(
 	mOmMech(Attribute<Real>::create("w_r", mAttributes)),
 	mVdq0(Attribute<Matrix>::create("Vdq0", mAttributes)),
 	mIdq0(Attribute<Matrix>::create("Idq0", mAttributes)) {
-	
+
 	mSimTime = 0.0;
-	
+
 	// declare state variables
 	**mVdq0 = Matrix::Zero(3,1);
 	**mIdq0 = Matrix::Zero(3,1);
@@ -38,12 +38,11 @@ Base::ReducedOrderSynchronGenerator<Complex>::ReducedOrderSynchronGenerator(
 	mDelta(Attribute<Real>::create("delta", mAttributes)),
 	mThetaMech(Attribute<Real>::create("Theta", mAttributes)),
 	mOmMech(Attribute<Real>::create("w_r", mAttributes)),
-	///FIXME: The mVdq0 and mVdq member variables are mutually exclusive and carry the same attribute name. Maybe they can be unified?
 	mVdq(Attribute<Matrix>::create("Vdq0", mAttributes)),
 	mIdq(Attribute<Matrix>::create("Idq0", mAttributes))  {
-	
+
 	mSimTime = 0.0;
-	
+
 	// declare state variables
 	**mVdq = Matrix::Zero(2,1);
 	**mIdq = Matrix::Zero(2,1);
@@ -54,7 +53,7 @@ void Base::ReducedOrderSynchronGenerator<VarType>::setBaseParameters(
 	Real nomPower, Real nomVolt, Real nomFreq) {
 
 	/// used p.u. system: Lad-Base reciprocal per unit system (Kundur, p. 84-88)
-	
+
 	// set base nominal values
 	mNomPower = nomPower;
 	mNomVolt = nomVolt;
@@ -73,7 +72,7 @@ void Base::ReducedOrderSynchronGenerator<VarType>::setBaseParameters(
 }
 
 template <typename VarType>
-void Base::ReducedOrderSynchronGenerator<VarType>::setOperationalParametersPerUnit(Real nomPower, 
+void Base::ReducedOrderSynchronGenerator<VarType>::setOperationalParametersPerUnit(Real nomPower,
 	Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
 	Real Ld_t, Real Td0_t) {
 
@@ -88,7 +87,7 @@ void Base::ReducedOrderSynchronGenerator<VarType>::setOperationalParametersPerUn
 }
 
 template <typename VarType>
-void Base::ReducedOrderSynchronGenerator<VarType>::setOperationalParametersPerUnit(Real nomPower, 
+void Base::ReducedOrderSynchronGenerator<VarType>::setOperationalParametersPerUnit(Real nomPower,
 	Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
 	Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t) {
 
@@ -105,7 +104,7 @@ void Base::ReducedOrderSynchronGenerator<VarType>::setOperationalParametersPerUn
 }
 
 template <typename VarType>
-void Base::ReducedOrderSynchronGenerator<VarType>::setOperationalParametersPerUnit(Real nomPower, 
+void Base::ReducedOrderSynchronGenerator<VarType>::setOperationalParametersPerUnit(Real nomPower,
 	Real nomVolt, Real nomFreq, Real H, Real Ld, Real Lq, Real L0,
 	Real Ld_t, Real Lq_t, Real Td0_t, Real Tq0_t,
 	Real Ld_s, Real Lq_s, Real Td0_s, Real Tq0_s,
@@ -131,22 +130,22 @@ void Base::ReducedOrderSynchronGenerator<VarType>::setOperationalParametersPerUn
 template <>
 void Base::ReducedOrderSynchronGenerator<Real>::scaleInertiaConstant(Real scalingFactor) {
 	mH = mH * scalingFactor;
-	mSLog->info("Scaling inertia with factor {:e}:\n resulting inertia: {:e}\n", scalingFactor, mH); 
+	mSLog->info("Scaling inertia with factor {:e}:\n resulting inertia: {:e}\n", scalingFactor, mH);
 }
 
 template <>
 void Base::ReducedOrderSynchronGenerator<Complex>::scaleInertiaConstant(Real scalingFactor) {
 	mH = mH * scalingFactor;
-	mSLog->info("Scaling inertia with factor {:e}:\n resulting inertia: {:e}\n", scalingFactor, mH); 
+	mSLog->info("Scaling inertia with factor {:e}:\n resulting inertia: {:e}\n", scalingFactor, mH);
 }
 
 template <typename VarType>
 void Base::ReducedOrderSynchronGenerator<VarType>::setInitialValues(
 	Complex initComplexElectricalPower, Real initMechanicalPower, Complex initTerminalVoltage) {
-	
+
 	mInitElecPower = initComplexElectricalPower;
 	mInitMechPower = initMechanicalPower;
-	
+
 	mInitVoltage = initTerminalVoltage;
 	mInitVoltageAngle = Math::phase(mInitVoltage);
 
@@ -169,13 +168,13 @@ void Base::ReducedOrderSynchronGenerator<Real>::initializeFromNodesAndTerminals(
 
 	// Initialize mechanical torque
 	**mMechTorque = mInitMechPower / mNomPower;
-		
+
 	// calculate steady state machine emf (i.e. voltage behind synchronous reactance)
 	Complex Eq0 = mInitVoltage + Complex(0, mLq) * mInitCurrent;
 
 	// Load angle
 	**mDelta = Math::phase(Eq0);
-	
+
 	// convert currrents to dq reference frame
 	(**mIdq0)(0,0) = Math::abs(mInitCurrent) * sin(**mDelta - mInitCurrentAngle);
 	(**mIdq0)(1,0) = Math::abs(mInitCurrent) * cos(**mDelta - mInitCurrentAngle);
@@ -189,10 +188,10 @@ void Base::ReducedOrderSynchronGenerator<Real>::initializeFromNodesAndTerminals(
 
 	// initial electrical torque
 	**mElecTorque = (**mVdq0)(0,0) * (**mIdq0)(0,0) + (**mVdq0)(1,0) * (**mIdq0)(1,0);
-	
+
 	// Initialize omega mech with nominal system frequency
 	**mOmMech = mNomOmega / mBase_OmMech;
-	
+
 	// initialize theta and calculate transform matrix
 	**mThetaMech = **mDelta - PI / 2.;
 
@@ -232,13 +231,13 @@ void Base::ReducedOrderSynchronGenerator<Complex>::initializeFromNodesAndTermina
 
 	// Initialize mechanical torque
 	**mMechTorque = mInitMechPower / mNomPower;
-		
+
 	// calculate steady state machine emf (i.e. voltage behind synchronous reactance)
 	Complex Eq0 = mInitVoltage + Complex(0, mLq) * mInitCurrent;
-	
+
 	// Load angle
 	**mDelta = Math::phase(Eq0);
-	
+
 	// convert currrents to dq reference frame
 	(**mIdq)(0,0) = Math::abs(mInitCurrent) * sin(**mDelta - mInitCurrentAngle);
 	(**mIdq)(1,0) = Math::abs(mInitCurrent) * cos(**mDelta - mInitCurrentAngle);
@@ -252,10 +251,10 @@ void Base::ReducedOrderSynchronGenerator<Complex>::initializeFromNodesAndTermina
 
 	// initial electrical torque
 	**mElecTorque = (**mVdq)(0,0) * (**mIdq)(0,0) + (**mVdq)(1,0) * (**mIdq)(1,0);
-	
+
 	// Initialize omega mech with nominal system frequency
 	**mOmMech = mNomOmega / mBase_OmMech;
-	
+
 	// initialize theta and calculate transform matrix
 	**mThetaMech = **mDelta - PI / 2.;
 
@@ -286,7 +285,7 @@ void Base::ReducedOrderSynchronGenerator<Complex>::initializeFromNodesAndTermina
 }
 
 template <typename VarType>
-void Base::ReducedOrderSynchronGenerator<VarType>::mnaInitialize(Real omega, 
+void Base::ReducedOrderSynchronGenerator<VarType>::mnaInitialize(Real omega,
 		Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 
 	MNAInterface::mnaInitialize(omega, timeStep);

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(dpsim-models STATIC
 	TopologicalTerminal.cpp
 	SimNode.cpp
 	SimPowerComp.cpp
-	MNASimPowerComp.cpp
+	CompositePowerComp.cpp
 	SystemTopology.cpp
 	CSVReader.cpp
 )

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(dpsim-models STATIC
 	TopologicalTerminal.cpp
 	SimNode.cpp
 	SimPowerComp.cpp
+	MNASimPowerComp.cpp
 	SystemTopology.cpp
 	CSVReader.cpp
 )

--- a/dpsim-models/src/CompositePowerComp.cpp
+++ b/dpsim-models/src/CompositePowerComp.cpp
@@ -43,6 +43,13 @@ void CompositePowerComp<VarType>::mnaInitialize(Real omega, Real timeStep, Attri
 		subComp->mnaInitialize(omega, timeStep, leftVector);
 	}
 	mnaParentInitialize(omega, timeStep, leftVector);
+
+	if (mHasPreStep) {
+		this->mMnaTasks.push_back(std::make_shared<typename MNASimPowerComp<VarType>::MnaPreStep>(*this));
+	}
+	if (mHasPostStep) {
+		this->mMnaTasks.push_back(std::make_shared<typename MNASimPowerComp<VarType>::MnaPostStep>(*this, leftVector));
+	}
 }
 
 template <typename VarType>

--- a/dpsim-models/src/CompositePowerComp.cpp
+++ b/dpsim-models/src/CompositePowerComp.cpp
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/CompositePowerComp.h>
 
 using namespace CPS;
 
 template <typename VarType>
-void MNASimPowerComp<VarType>::addMNASubComponent(typename SimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder) {
+void CompositePowerComp<VarType>::addMNASubComponent(typename SimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder) {
 	this->mSubComponents.push_back(subc);
 	if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subc)) {
 		this->mSubcomponentsMNA.push_back(mnasubcomp);
@@ -35,7 +35,7 @@ void MNASimPowerComp<VarType>::addMNASubComponent(typename SimPowerComp<VarType>
 }
 
 // template <typename VarType>
-// void MNASimPowerComp<VarType>::addMNASubComponent(typename MNASimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder) {
+// void CompositePowerComp<VarType>::addMNASubComponent(typename CompositePowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder) {
 // 	this->mSubComponents.push_back(subc);
 // 	this->mSubcomponentsMNA.push_back(subc);
 // 	switch (preStepOrder) {
@@ -63,7 +63,7 @@ void MNASimPowerComp<VarType>::addMNASubComponent(typename SimPowerComp<VarType>
 // }
 
 template <typename VarType>
-void MNASimPowerComp<VarType>::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void CompositePowerComp<VarType>::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	if (this->hasSubComponents()) {
 		for (auto subComp : mSubcomponentsMNA) {
 			subComp->mnaInitialize(omega, timeStep, leftVector);
@@ -73,7 +73,7 @@ void MNASimPowerComp<VarType>::mnaInitialize(Real omega, Real timeStep, Attribut
 }
 
 template <typename VarType>
-void MNASimPowerComp<VarType>::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
+void CompositePowerComp<VarType>::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
 	if (this->hasSubComponents()) {
 		for (auto subComp : mSubcomponentsMNA) {
 			subComp->mnaApplySystemMatrixStamp(systemMatrix);
@@ -83,7 +83,7 @@ void MNASimPowerComp<VarType>::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
 }
 
 template <typename VarType>
-void MNASimPowerComp<VarType>::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
+void CompositePowerComp<VarType>::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
 	if (this->hasSubComponents()) {
 		for (auto subComp : mSubcomponentsMNA) {
 			subComp->mnaApplyRightSideVectorStamp(rightVector);
@@ -93,7 +93,7 @@ void MNASimPowerComp<VarType>::mnaApplyRightSideVectorStamp(Matrix& rightVector)
 }
 
 template <typename VarType>
-void MNASimPowerComp<VarType>::mnaPreStep(Real time, Int timeStepCount) {
+void CompositePowerComp<VarType>::mnaPreStep(Real time, Int timeStepCount) {
 	if (this->hasSubComponents()) {
 		for (auto subComp : mSubcomponentsBeforePreStep) {
 			subComp->mnaPreStep(time, timeStepCount);
@@ -106,7 +106,7 @@ void MNASimPowerComp<VarType>::mnaPreStep(Real time, Int timeStepCount) {
 }
 
 template <typename VarType>
-void MNASimPowerComp<VarType>::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+void CompositePowerComp<VarType>::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	if (this->hasSubComponents()) {
 		for (auto subComp : mSubcomponentsBeforePostStep) {
 			subComp->mnaPostStep(time, timeStepCount, leftVector);
@@ -119,7 +119,7 @@ void MNASimPowerComp<VarType>::mnaPostStep(Real time, Int timeStepCount, Attribu
 }
 
 template <typename VarType>
-void MNASimPowerComp<VarType>::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+void CompositePowerComp<VarType>::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	if (this->hasSubComponents()) {
 		for (auto subComp : mSubcomponentsMNA) {
 			subComp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
@@ -129,7 +129,7 @@ void MNASimPowerComp<VarType>::mnaAddPreStepDependencies(AttributeBase::List &pr
 }
 
 template <typename VarType>
-void MNASimPowerComp<VarType>::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
+void CompositePowerComp<VarType>::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	if (this->hasSubComponents()) {
 		for (auto subComp : mSubcomponentsMNA) {
 			subComp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
@@ -139,5 +139,5 @@ void MNASimPowerComp<VarType>::mnaAddPostStepDependencies(AttributeBase::List &p
 }
 
 // Declare specializations to move definitions to .cpp
-template class CPS::MNASimPowerComp<Real>;
-template class CPS::MNASimPowerComp<Complex>;
+template class CPS::CompositePowerComp<Real>;
+template class CPS::CompositePowerComp<Complex>;

--- a/dpsim-models/src/CompositePowerComp.cpp
+++ b/dpsim-models/src/CompositePowerComp.cpp
@@ -34,111 +34,69 @@ void CompositePowerComp<VarType>::addMNASubComponent(typename SimPowerComp<VarTy
 	}
 }
 
-// template <typename VarType>
-// void CompositePowerComp<VarType>::addMNASubComponent(typename CompositePowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder) {
-// 	this->mSubComponents.push_back(subc);
-// 	this->mSubcomponentsMNA.push_back(subc);
-// 	switch (preStepOrder) {
-// 		case MNA_SUBCOMP_TASK_ORDER::NO_TASK: break;
-// 		case MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT: {
-// 			this->mSubcomponentsBeforePreStep.push_back(subc);
-// 			break;
-// 		}
-// 		case MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT: {
-// 			this->mSubcomponentsAfterPreStep.push_back(subc);
-// 			break;
-// 		}
-// 	}
-// 	switch (postStepOrder) {
-// 		case MNA_SUBCOMP_TASK_ORDER::NO_TASK: break;
-// 		case MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT: {
-// 			this->mSubcomponentsBeforePostStep.push_back(subc);
-// 			break;
-// 		}
-// 		case MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT: {
-// 			this->mSubcomponentsAfterPostStep.push_back(subc);
-// 			break;
-// 		}
-// 	}
-// }
-
 template <typename VarType>
 void CompositePowerComp<VarType>::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	SimPowerComp<VarType>::updateMatrixNodeIndices();
 
-	if (this->hasSubComponents()) {
-		for (auto subComp : mSubcomponentsMNA) {
-			subComp->mnaInitialize(omega, timeStep, leftVector);
-		}
-		mnaParentInitialize(omega, timeStep, leftVector);
+	for (auto subComp : mSubcomponentsMNA) {
+		subComp->mnaInitialize(omega, timeStep, leftVector);
 	}
+	mnaParentInitialize(omega, timeStep, leftVector);
 }
 
 template <typename VarType>
 void CompositePowerComp<VarType>::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	if (this->hasSubComponents()) {
-		for (auto subComp : mSubcomponentsMNA) {
-			subComp->mnaApplySystemMatrixStamp(systemMatrix);
-		}
-		mnaParentApplySystemMatrixStamp(systemMatrix);
+	for (auto subComp : mSubcomponentsMNA) {
+		subComp->mnaApplySystemMatrixStamp(systemMatrix);
 	}
+	mnaParentApplySystemMatrixStamp(systemMatrix);
 }
 
 template <typename VarType>
 void CompositePowerComp<VarType>::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	if (this->hasSubComponents()) {
-		for (auto subComp : mSubcomponentsMNA) {
-			subComp->mnaApplyRightSideVectorStamp(rightVector);
-		}
-		mnaParentApplyRightSideVectorStamp(rightVector);
+	for (auto subComp : mSubcomponentsMNA) {
+		subComp->mnaApplyRightSideVectorStamp(rightVector);
 	}
+	mnaParentApplyRightSideVectorStamp(rightVector);
 }
 
 template <typename VarType>
 void CompositePowerComp<VarType>::mnaPreStep(Real time, Int timeStepCount) {
-	if (this->hasSubComponents()) {
-		for (auto subComp : mSubcomponentsBeforePreStep) {
-			subComp->mnaPreStep(time, timeStepCount);
-		}
-		mnaParentPreStep(time, timeStepCount);
-		for (auto subComp : mSubcomponentsAfterPreStep) {
-			subComp->mnaPreStep(time, timeStepCount);
-		}
+	for (auto subComp : mSubcomponentsBeforePreStep) {
+		subComp->mnaPreStep(time, timeStepCount);
+	}
+	mnaParentPreStep(time, timeStepCount);
+	for (auto subComp : mSubcomponentsAfterPreStep) {
+		subComp->mnaPreStep(time, timeStepCount);
 	}
 }
 
 template <typename VarType>
 void CompositePowerComp<VarType>::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	if (this->hasSubComponents()) {
-		for (auto subComp : mSubcomponentsBeforePostStep) {
-			subComp->mnaPostStep(time, timeStepCount, leftVector);
-		}
-		mnaParentPostStep(time, timeStepCount, leftVector);
-		for (auto subComp : mSubcomponentsAfterPostStep) {
-			subComp->mnaPostStep(time, timeStepCount, leftVector);
-		}
+	for (auto subComp : mSubcomponentsBeforePostStep) {
+		subComp->mnaPostStep(time, timeStepCount, leftVector);
+	}
+	mnaParentPostStep(time, timeStepCount, leftVector);
+	for (auto subComp : mSubcomponentsAfterPostStep) {
+		subComp->mnaPostStep(time, timeStepCount, leftVector);
 	}
 }
 
 template <typename VarType>
 void CompositePowerComp<VarType>::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	if (this->hasSubComponents()) {
-		for (auto subComp : mSubcomponentsMNA) {
-			subComp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-		}
-		mnaParentAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
+	for (auto subComp : mSubcomponentsMNA) {
+		subComp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
 	}
+	mnaParentAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
 }
 
 template <typename VarType>
 void CompositePowerComp<VarType>::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	if (this->hasSubComponents()) {
-		for (auto subComp : mSubcomponentsMNA) {
-			subComp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-		}
-		mnaParentAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
+	for (auto subComp : mSubcomponentsMNA) {
+		subComp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
 	}
+	mnaParentAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
 }
 
 // Declare specializations to move definitions to .cpp

--- a/dpsim-models/src/CompositePowerComp.cpp
+++ b/dpsim-models/src/CompositePowerComp.cpp
@@ -64,6 +64,9 @@ void CompositePowerComp<VarType>::addMNASubComponent(typename SimPowerComp<VarTy
 
 template <typename VarType>
 void CompositePowerComp<VarType>::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+	MNAInterface::mnaInitialize(omega, timeStep);
+	SimPowerComp<VarType>::updateMatrixNodeIndices();
+
 	if (this->hasSubComponents()) {
 		for (auto subComp : mSubcomponentsMNA) {
 			subComp->mnaInitialize(omega, timeStep, leftVector);

--- a/dpsim-models/src/CompositePowerComp.cpp
+++ b/dpsim-models/src/CompositePowerComp.cpp
@@ -42,6 +42,9 @@ void CompositePowerComp<VarType>::mnaInitialize(Real omega, Real timeStep, Attri
 	for (auto subComp : mSubcomponentsMNA) {
 		subComp->mnaInitialize(omega, timeStep, leftVector);
 	}
+
+	**this->mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
+
 	mnaParentInitialize(omega, timeStep, leftVector);
 
 	if (mHasPreStep) {

--- a/dpsim-models/src/DP/DP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 
 DP::Ph1::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, String name, Logger::Level logLevel, Bool withTrafo) :
-	MNASimPowerComp<Complex>(uid, name, logLevel),
+	CompositePowerComp<Complex>(uid, name, logLevel),
 	mOmegaN(Attribute<Real>::create("Omega_nom", mAttributes)),
 	mPref(Attribute<Real>::create("P_ref", mAttributes)),
 	mQref(Attribute<Real>::create("Q_ref", mAttributes)),

--- a/dpsim-models/src/DP/DP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -308,8 +308,8 @@ void DP::Ph1::AvVoltageSourceInverterDQ::addControlStepDependencies(AttributeBas
 void DP::Ph1::AvVoltageSourceInverterDQ::controlStep(Real time, Int timeStepCount) {
 	// Transformation interface forward
 	Complex vcdq, ircdq;
-	vcdq = Math::rotatingFrame2to1(mVirtualNodes[3]->singleVoltage(), mPLL->attribute<Matrix>("output_prev")->get()(0, 0), mThetaN);
-	ircdq = Math::rotatingFrame2to1(-1. * (**mSubResistorC->mIntfCurrent)(0, 0), mPLL->attribute<Matrix>("output_prev")->get()(0, 0), mThetaN);
+	vcdq = Math::rotatingFrame2to1(mVirtualNodes[3]->singleVoltage(), mPLL->attributeTyped<Matrix>("output_prev")->get()(0, 0), mThetaN);
+	ircdq = Math::rotatingFrame2to1(-1. * (**mSubResistorC->mIntfCurrent)(0, 0), mPLL->attributeTyped<Matrix>("output_prev")->get()(0, 0), mThetaN);
 	**mVcd = vcdq.real();
 	**mVcq = vcdq.imag();
 	**mIrcd = ircdq.real();
@@ -320,7 +320,7 @@ void DP::Ph1::AvVoltageSourceInverterDQ::controlStep(Real time, Int timeStepCoun
 	mPowerControllerVSI->signalStep(time, timeStepCount);
 
 	// Transformation interface backward
-	(**mVsref)(0,0) = Math::rotatingFrame2to1(Complex(mPowerControllerVSI->attribute<Matrix>("output_curr")->get()(0, 0), mPowerControllerVSI->attribute<Matrix>("output_curr")->get()(1, 0)), mThetaN, mPLL->attribute<Matrix>("output_prev")->get()(0, 0));
+	(**mVsref)(0,0) = Math::rotatingFrame2to1(Complex(mPowerControllerVSI->attributeTyped<Matrix>("output_curr")->get()(0, 0), mPowerControllerVSI->attributeTyped<Matrix>("output_curr")->get()(1, 0)), mThetaN, mPLL->attributeTyped<Matrix>("output_prev")->get()(0, 0));
 
 	// Update nominal system angle
 	mThetaN = mThetaN + mTimeStep * **mOmegaN;
@@ -335,8 +335,8 @@ void DP::Ph1::AvVoltageSourceInverterDQ::mnaAddPreStepDependencies(AttributeBase
 	prevStepDependencies.push_back(mVsref);
 	prevStepDependencies.push_back(mIntfCurrent);
 	prevStepDependencies.push_back(mIntfVoltage);
-	attributeDependencies.push_back(mPowerControllerVSI->attribute<Matrix>("output_prev"));
-	attributeDependencies.push_back(mPLL->attribute<Matrix>("output_prev"));
+	attributeDependencies.push_back(mPowerControllerVSI->attributeTyped<Matrix>("output_prev"));
+	attributeDependencies.push_back(mPLL->attributeTyped<Matrix>("output_prev"));
 	modifiedAttributes.push_back(mRightVector);
 }
 

--- a/dpsim-models/src/DP/DP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -257,8 +257,6 @@ void DP::Ph1::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real ti
 	// TODO: these are actually no MNA tasks
 	mMnaTasks.push_back(std::make_shared<ControlPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<ControlStep>(*this));
-
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 

--- a/dpsim-models/src/DP/DP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 
 DP::Ph1::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, String name, Logger::Level logLevel, Bool withTrafo) :
-	CompositePowerComp<Complex>(uid, name, logLevel),
+	CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 	mOmegaN(Attribute<Real>::create("Omega_nom", mAttributes)),
 	mPref(Attribute<Real>::create("P_ref", mAttributes)),
 	mQref(Attribute<Real>::create("Q_ref", mAttributes)),
@@ -253,10 +253,6 @@ void DP::Ph1::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real ti
 	mRightVectorStamps.push_back(&**mSubCtrledVoltageSource->mRightVector);
 	if (mWithConnectionTransformer)
 		mRightVectorStamps.push_back(&**mConnectionTransformer->mRightVector);
-
-	// collect tasks
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 
 	// TODO: these are actually no MNA tasks
 	mMnaTasks.push_back(std::make_shared<ControlPreStep>(*this));

--- a/dpsim-models/src/DP/DP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -241,8 +241,6 @@ void DP::Ph1::AvVoltageSourceInverterDQ::initializeFromNodesAndTerminals(Real fr
 }
 
 void DP::Ph1::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
 	mTimeStep = timeStep;
 
 	// initialize state space controller

--- a/dpsim-models/src/DP/DP_Ph1_Capacitor.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Capacitor.cpp
@@ -12,13 +12,11 @@ using namespace CPS;
 using namespace CPS::DP::Ph1;
 
 DP::Ph1::Capacitor::Capacitor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Capacitor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	mEquivCurrent = { 0, 0 };
 	**mIntfVoltage = MatrixComp::Zero(1,1);
 	**mIntfCurrent = MatrixComp::Zero(1,1);
 	setTerminalNumber(2);
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mCapacitance = CPS::Attribute<Real>::create("C", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph1::Capacitor::clone(String name) {

--- a/dpsim-models/src/DP/DP_Ph1_Inductor.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Inductor.cpp
@@ -11,14 +11,11 @@
 using namespace CPS;
 
 DP::Ph1::Inductor::Inductor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Inductor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	mEquivCurrent = { 0, 0 };
 	**mIntfVoltage = MatrixComp::Zero(1,1);
 	**mIntfCurrent = MatrixComp::Zero(1,1);
 	setTerminalNumber(2);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mInductance = CPS::Attribute<Real>::create("L", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph1::Inductor::clone(String name) {

--- a/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::NetworkInjection::NetworkInjection(String uid, String name, Logger::Level logLevel)
-	: CompositePowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 	mVoltageRef(Attribute<Complex>::createDynamic("V_ref", mAttributes)),
 	mSrcFreq(Attribute<Real>::createDynamic("f_src", mAttributes)) {
 	setVirtualNodeNumber(0);
@@ -89,10 +89,6 @@ void DP::Ph1::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, A
 	// collect right side vectors of subcomponents
 	/// CHECK: This might be incorrect, depending on if the ** actually returns the reference or copies the object
 	mRightVectorStamps.push_back(&**(mSubVoltageSource->mRightVector));
-
-	// collect tasks
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }

--- a/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
@@ -89,8 +89,6 @@ void DP::Ph1::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, A
 	// collect right side vectors of subcomponents
 	/// CHECK: This might be incorrect, depending on if the ** actually returns the reference or copies the object
 	mRightVectorStamps.push_back(&**(mSubVoltageSource->mRightVector));
-
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 

--- a/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
@@ -86,9 +86,6 @@ void DP::Ph1::NetworkInjection::initializeFromNodesAndTerminals(Real frequency) 
 // #### MNA functions ####
 
 void DP::Ph1::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	// collect right side vectors of subcomponents
 	/// CHECK: This might be incorrect, depending on if the ** actually returns the reference or copies the object
 	mRightVectorStamps.push_back(&**(mSubVoltageSource->mRightVector));

--- a/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::NetworkInjection::NetworkInjection(String uid, String name, Logger::Level logLevel)
-	: MNASimPowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, logLevel),
 	mVoltageRef(Attribute<Complex>::createDynamic("V_ref", mAttributes)),
 	mSrcFreq(Attribute<Real>::createDynamic("f_src", mAttributes)) {
 	setVirtualNodeNumber(0);

--- a/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::NetworkInjection::NetworkInjection(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: MNASimPowerComp<Complex>(uid, name, logLevel),
 	mVoltageRef(Attribute<Complex>::createDynamic("V_ref", mAttributes)),
 	mSrcFreq(Attribute<Real>::createDynamic("f_src", mAttributes)) {
 	setVirtualNodeNumber(0);
@@ -23,7 +23,8 @@ DP::Ph1::NetworkInjection::NetworkInjection(String uid, String name, Logger::Lev
 
 	// Create electrical sub components
 	mSubVoltageSource = std::make_shared<DP::Ph1::VoltageSource>(**mName + "_vs", mLogLevel);
-	mSubComponents.push_back(mSubVoltageSource);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+
 	mSLog->info("Electrical subcomponents: ");
 	for (auto subcomp: mSubComponents)
 		mSLog->info("- {}", subcomp->name());
@@ -84,14 +85,9 @@ void DP::Ph1::NetworkInjection::initializeFromNodesAndTerminals(Real frequency) 
 
 // #### MNA functions ####
 
-void DP::Ph1::NetworkInjection::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void DP::Ph1::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-
-	// initialize electrical subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
 
 	// collect right side vectors of subcomponents
 	/// CHECK: This might be incorrect, depending on if the ** actually returns the reference or copies the object
@@ -104,11 +100,6 @@ void DP::Ph1::NetworkInjection::mnaInitialize(Real omega, Real timeStep, Attribu
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
-void DP::Ph1::NetworkInjection::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-}
 
 void DP::Ph1::NetworkInjection::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
 	rightVector.setZero();
@@ -119,42 +110,26 @@ void DP::Ph1::NetworkInjection::mnaApplyRightSideVectorStamp(Matrix& rightVector
 				Logger::matrixToString(rightVector));
 }
 
-void DP::Ph1::NetworkInjection::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	// add pre-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
+void DP::Ph1::NetworkInjection::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	// add pre-step dependencies of component itself
 	prevStepDependencies.push_back(mIntfCurrent);
 	prevStepDependencies.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mRightVector);
 }
 
-void DP::Ph1::NetworkInjection::mnaPreStep(Real time, Int timeStepCount) {
-	// pre-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
+void DP::Ph1::NetworkInjection::mnaParentPreStep(Real time, Int timeStepCount) {
 	// pre-step of component itself
 	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void DP::Ph1::NetworkInjection::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	// add post-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
+void DP::Ph1::NetworkInjection::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	// add post-step dependencies of component itself
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mIntfCurrent);
 }
 
-void DP::Ph1::NetworkInjection::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	// post-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
+void DP::Ph1::NetworkInjection::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	// post-step of component itself
 	mnaUpdateCurrent(**leftVector);
 	mnaUpdateVoltage(**leftVector);

--- a/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp
@@ -23,7 +23,7 @@ DP::Ph1::NetworkInjection::NetworkInjection(String uid, String name, Logger::Lev
 
 	// Create electrical sub components
 	mSubVoltageSource = std::make_shared<DP::Ph1::VoltageSource>(**mName + "_vs", mLogLevel);
-	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	mSLog->info("Electrical subcomponents: ");
 	for (auto subcomp: mSubComponents)
@@ -85,18 +85,7 @@ void DP::Ph1::NetworkInjection::initializeFromNodesAndTerminals(Real frequency) 
 
 // #### MNA functions ####
 
-void DP::Ph1::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	// collect right side vectors of subcomponents
-	/// CHECK: This might be incorrect, depending on if the ** actually returns the reference or copies the object
-	mRightVectorStamps.push_back(&**(mSubVoltageSource->mRightVector));
-}
-
-
-void DP::Ph1::NetworkInjection::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	rightVector.setZero();
-	for (auto stamp : mRightVectorStamps)
-		rightVector += *stamp;
-
+void DP::Ph1::NetworkInjection::mnaParentApplyRightSideVectorStamp(Matrix& rightVector) {
 	mSLog->debug("Right Side Vector: {:s}",
 				Logger::matrixToString(rightVector));
 }

--- a/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
@@ -49,7 +49,7 @@ void DP::Ph1::PQLoadCS::setParameters(Real activePower, Real reactivePower, Real
 ///DEPRECATED: Delete method
 SimPowerComp<Complex>::Ptr DP::Ph1::PQLoadCS::clone(String name) {
 	auto copy = PQLoadCS::make(name, mLogLevel);
-	copy->setParameters(attribute<Real>("P")->get(), attribute<Real>("Q")->get(), attribute<Real>("V_nom")->get());
+	copy->setParameters(**mActivePower, **mReactivePower, **mNomVoltage);
 	return copy;
 }
 

--- a/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
@@ -73,6 +73,7 @@ void DP::Ph1::PQLoadCS::initializeFromNodesAndTerminals(Real frequency) {
 	// A positive power should result in a positive current to ground.
 	mSubCurrentSource->connect({ mTerminals[0]->node(), SimNode::GND });
 	mSubCurrentSource->initializeFromNodesAndTerminals(frequency);
+	mSubComponents.push_back(mSubCurrentSource);
 	updateIntfValues();
 
 	mSLog->info(
@@ -91,21 +92,29 @@ void DP::Ph1::PQLoadCS::initializeFromNodesAndTerminals(Real frequency) {
 void DP::Ph1::PQLoadCS::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-	mSubCurrentSource->mnaInitialize(omega, timeStep, leftVector);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
+	}
+
 	///CHECK: Can we avoid setting the right_vector attribute to dynamic? Maybe just copy the current source's right_vector somewhere? Or make a new attribute?
 	mRightVector->setReference(mSubCurrentSource->mRightVector);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this));
-	for (auto task : mSubCurrentSource->mnaTasks())
-		mMnaTasks.push_back(task);
+	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
 void DP::Ph1::PQLoadCS::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	mSubCurrentSource->mnaApplyRightSideVectorStamp(rightVector);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
+	}
 }
 
 void DP::Ph1::PQLoadCS::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	mSubCurrentSource->mnaApplySystemMatrixStamp(systemMatrix);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
+	}
 }
 
 void DP::Ph1::PQLoadCS::updateSetPoint() {
@@ -123,8 +132,31 @@ void DP::Ph1::PQLoadCS::updateSetPoint() {
 		Logger::phasorToString(std::conj(current)));
 }
 
+void DP::Ph1::PQLoadCS::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+	attributeDependencies.push_back(mActivePower);
+	attributeDependencies.push_back(mReactivePower);
+	attributeDependencies.push_back(mNomVoltage);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
+	}
+}
+
+void DP::Ph1::PQLoadCS::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
+	modifiedAttributes.push_back(mIntfCurrent);
+	modifiedAttributes.push_back(mIntfVoltage);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
+	}
+}
+
 void DP::Ph1::PQLoadCS::MnaPreStep::execute(Real time, Int timeStepCount) {
 	mLoad.updateSetPoint();
+	for (auto subComp : mLoad.mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaPreStep(time, timeStepCount);
+	}
 }
 
 void DP::Ph1::PQLoadCS::updateIntfValues() {
@@ -133,6 +165,10 @@ void DP::Ph1::PQLoadCS::updateIntfValues() {
 }
 
 void DP::Ph1::PQLoadCS::MnaPostStep::execute(Real time, Int timeStepCount) {
+	for (auto subComp : mLoad.mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaPostStep(time, timeStepCount, mLeftVector);
+	}
 	mLoad.updateIntfValues();
 }
 

--- a/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
@@ -90,9 +90,6 @@ void DP::Ph1::PQLoadCS::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void DP::Ph1::PQLoadCS::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	///CHECK: Can we avoid setting the right_vector attribute to dynamic? Maybe just copy the current source's right_vector somewhere? Or make a new attribute?
 	mRightVector->setReference(mSubCurrentSource->mRightVector);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));

--- a/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
@@ -73,7 +73,7 @@ void DP::Ph1::PQLoadCS::initializeFromNodesAndTerminals(Real frequency) {
 	// A positive power should result in a positive current to ground.
 	mSubCurrentSource->connect({ mTerminals[0]->node(), SimNode::GND });
 	mSubCurrentSource->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubCurrentSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubCurrentSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	updateIntfValues();
 
 	mSLog->info(
@@ -87,11 +87,6 @@ void DP::Ph1::PQLoadCS::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString((**mIntfCurrent)(0,0)),
 		Logger::phasorToString(initialSingleVoltage(0)),
 		Logger::phasorToString(current));
-}
-
-void DP::Ph1::PQLoadCS::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	///CHECK: Can we avoid setting the right_vector attribute to dynamic? Maybe just copy the current source's right_vector somewhere? Or make a new attribute?
-	mRightVector->setReference(mSubCurrentSource->mRightVector);
 }
 
 void DP::Ph1::PQLoadCS::updateSetPoint() {
@@ -122,6 +117,7 @@ void DP::Ph1::PQLoadCS::mnaParentAddPostStepDependencies(AttributeBase::List &pr
 
 void DP::Ph1::PQLoadCS::mnaParentPreStep(Real time, Int timeStepCount) {
 	updateSetPoint();
+	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
 void DP::Ph1::PQLoadCS::updateIntfValues() {

--- a/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 DP::Ph1::PQLoadCS::PQLoadCS(String uid, String name,
 	Logger::Level logLevel)
-	: MNASimPowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, logLevel),
 	mActivePower(Attribute<Real>::create("P", mAttributes, 0)),
 	mReactivePower(Attribute<Real>::create("Q", mAttributes, 0)),
 	mNomVoltage(Attribute<Real>::create("V_nom", mAttributes)) {

--- a/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 DP::Ph1::PQLoadCS::PQLoadCS(String uid, String name,
 	Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: MNASimPowerComp<Complex>(uid, name, logLevel),
 	mActivePower(Attribute<Real>::create("P", mAttributes, 0)),
 	mReactivePower(Attribute<Real>::create("Q", mAttributes, 0)),
 	mNomVoltage(Attribute<Real>::create("V_nom", mAttributes)) {
@@ -73,7 +73,7 @@ void DP::Ph1::PQLoadCS::initializeFromNodesAndTerminals(Real frequency) {
 	// A positive power should result in a positive current to ground.
 	mSubCurrentSource->connect({ mTerminals[0]->node(), SimNode::GND });
 	mSubCurrentSource->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubCurrentSource);
+	addMNASubComponent(mSubCurrentSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	updateIntfValues();
 
 	mSLog->info(
@@ -89,32 +89,14 @@ void DP::Ph1::PQLoadCS::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(current));
 }
 
-void DP::Ph1::PQLoadCS::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void DP::Ph1::PQLoadCS::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 
 	///CHECK: Can we avoid setting the right_vector attribute to dynamic? Maybe just copy the current source's right_vector somewhere? Or make a new attribute?
 	mRightVector->setReference(mSubCurrentSource->mRightVector);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
-}
-
-void DP::Ph1::PQLoadCS::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
-	}
-}
-
-void DP::Ph1::PQLoadCS::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
 }
 
 void DP::Ph1::PQLoadCS::updateSetPoint() {
@@ -132,31 +114,19 @@ void DP::Ph1::PQLoadCS::updateSetPoint() {
 		Logger::phasorToString(std::conj(current)));
 }
 
-void DP::Ph1::PQLoadCS::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+void DP::Ph1::PQLoadCS::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	attributeDependencies.push_back(mActivePower);
 	attributeDependencies.push_back(mReactivePower);
 	attributeDependencies.push_back(mNomVoltage);
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	}
 }
 
-void DP::Ph1::PQLoadCS::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
+void DP::Ph1::PQLoadCS::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	modifiedAttributes.push_back(mIntfCurrent);
 	modifiedAttributes.push_back(mIntfVoltage);
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	}
 }
 
-void DP::Ph1::PQLoadCS::MnaPreStep::execute(Real time, Int timeStepCount) {
-	mLoad.updateSetPoint();
-	for (auto subComp : mLoad.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	}
+void DP::Ph1::PQLoadCS::mnaParentPreStep(Real time, Int timeStepCount) {
+	updateSetPoint();
 }
 
 void DP::Ph1::PQLoadCS::updateIntfValues() {
@@ -164,11 +134,7 @@ void DP::Ph1::PQLoadCS::updateIntfValues() {
 	**mIntfVoltage = mSubCurrentSource->intfVoltage();
 }
 
-void DP::Ph1::PQLoadCS::MnaPostStep::execute(Real time, Int timeStepCount) {
-	for (auto subComp : mLoad.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, mLeftVector);
-	}
-	mLoad.updateIntfValues();
+void DP::Ph1::PQLoadCS::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+	updateIntfValues();
 }
 

--- a/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PQLoadCS.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 DP::Ph1::PQLoadCS::PQLoadCS(String uid, String name,
 	Logger::Level logLevel)
-	: CompositePowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 	mActivePower(Attribute<Real>::create("P", mAttributes, 0)),
 	mReactivePower(Attribute<Real>::create("Q", mAttributes, 0)),
 	mNomVoltage(Attribute<Real>::create("V_nom", mAttributes)) {
@@ -92,8 +92,6 @@ void DP::Ph1::PQLoadCS::initializeFromNodesAndTerminals(Real frequency) {
 void DP::Ph1::PQLoadCS::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	///CHECK: Can we avoid setting the right_vector attribute to dynamic? Maybe just copy the current source's right_vector somewhere? Or make a new attribute?
 	mRightVector->setReference(mSubCurrentSource->mRightVector);
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
 void DP::Ph1::PQLoadCS::updateSetPoint() {

--- a/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::PiLine::PiLine(String uid, String name, Logger::Level logLevel)
-	: Base::Ph1::PiLine(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::PiLine(mAttributes), CompositePowerComp<Complex>(uid, name, true, true, logLevel) {
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);
 
@@ -112,8 +112,6 @@ void DP::Ph1::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<M
 		mRightVectorStamps.push_back(&**mSubParallelCapacitor0->mRightVector);
 		mRightVectorStamps.push_back(&**mSubParallelCapacitor1->mRightVector);
 	}
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 

--- a/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::PiLine::PiLine(String uid, String name, Logger::Level logLevel)
-	: Base::Ph1::PiLine(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::PiLine(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel) {
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);
 

--- a/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
@@ -44,14 +44,14 @@ void DP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSeriesResistor->connect({ mTerminals[0]->node(), mVirtualNodes[0] });
 	mSubSeriesResistor->initialize(mFrequencies);
 	mSubSeriesResistor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubSeriesResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSeriesResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 	mSubSeriesInductor = std::make_shared<DP::Ph1::Inductor>(**mName + "_ind", mLogLevel);
 	mSubSeriesInductor->setParameters(**mSeriesInd);
 	mSubSeriesInductor->connect({ mVirtualNodes[0], mTerminals[1]->node() });
 	mSubSeriesInductor->initialize(mFrequencies);
 	mSubSeriesInductor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubSeriesInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSeriesInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	// By default there is always a small conductance to ground to
 	// avoid problems with floating nodes.
@@ -64,14 +64,14 @@ void DP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubParallelResistor0->connect(SimNode::List{ SimNode::GND, mTerminals[0]->node() });
 	mSubParallelResistor0->initialize(mFrequencies);
 	mSubParallelResistor0->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubParallelResistor0, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubParallelResistor0, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 	mSubParallelResistor1 = std::make_shared<DP::Ph1::Resistor>(**mName + "_con1", mLogLevel);
 	mSubParallelResistor1->setParameters(2. / **mParallelCond);
 	mSubParallelResistor1->connect(SimNode::List{ SimNode::GND, mTerminals[1]->node() });
 	mSubParallelResistor1->initialize(mFrequencies);
 	mSubParallelResistor1->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubParallelResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubParallelResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 
 	if (**mParallelCap >= 0) {
@@ -80,14 +80,14 @@ void DP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 		mSubParallelCapacitor0->connect(SimNode::List{ SimNode::GND, mTerminals[0]->node() });
 		mSubParallelCapacitor0->initialize(mFrequencies);
 		mSubParallelCapacitor0->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubParallelCapacitor0, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubParallelCapacitor0, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 		mSubParallelCapacitor1 = std::make_shared<DP::Ph1::Capacitor>(**mName + "_cap1", mLogLevel);
 		mSubParallelCapacitor1->setParameters(**mParallelCap / 2.);
 		mSubParallelCapacitor1->connect(SimNode::List{ SimNode::GND, mTerminals[1]->node() });
 		mSubParallelCapacitor1->initialize(mFrequencies);
 		mSubParallelCapacitor1->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubParallelCapacitor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubParallelCapacitor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	}
 
 	mSLog->info(
@@ -103,21 +103,6 @@ void DP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(initialSingleVoltage(0)),
 		Logger::phasorToString(initialSingleVoltage(1)),
 		Logger::phasorToString(mVirtualNodes[0]->initialSingleVoltage()));
-}
-
-void DP::Ph1::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	mRightVectorStamps.push_back(&**mSubSeriesInductor->mRightVector);
-
-	if (**mParallelCap >= 0) {
-		mRightVectorStamps.push_back(&**mSubParallelCapacitor0->mRightVector);
-		mRightVectorStamps.push_back(&**mSubParallelCapacitor1->mRightVector);
-	}
-}
-
-void DP::Ph1::PiLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	rightVector.setZero();
-	for (auto stamp : mRightVectorStamps)
-		rightVector += *stamp;
 }
 
 void DP::Ph1::PiLine::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {

--- a/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
@@ -11,15 +11,9 @@
 using namespace CPS;
 
 DP::Ph1::PiLine::PiLine(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::PiLine(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);
-
-	///FIXME: Move initialization into base class
-	mSeriesRes = Attribute<Real>::create("R_series", mAttributes);
-	mSeriesInd = Attribute<Real>::create("L_series", mAttributes);
-	mParallelCap = Attribute<Real>::create("C_parallel", mAttributes);
-	mParallelCond = Attribute<Real>::create("G_parallel", mAttributes); 
 
 	mSLog->info("Create {} {}", this->type(), name);
 	**mIntfVoltage = MatrixComp::Zero(1,1);

--- a/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
@@ -112,7 +112,6 @@ void DP::Ph1::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<M
 		mRightVectorStamps.push_back(&**mSubParallelCapacitor0->mRightVector);
 		mRightVectorStamps.push_back(&**mSubParallelCapacitor1->mRightVector);
 	}
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 void DP::Ph1::PiLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {

--- a/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
@@ -106,9 +106,6 @@ void DP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void DP::Ph1::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	mRightVectorStamps.push_back(&**mSubSeriesInductor->mRightVector);
 
 	if (**mParallelCap >= 0) {

--- a/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
@@ -44,14 +44,14 @@ void DP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSeriesResistor->connect({ mTerminals[0]->node(), mVirtualNodes[0] });
 	mSubSeriesResistor->initialize(mFrequencies);
 	mSubSeriesResistor->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubSeriesResistor);
+	addMNASubComponent(mSubSeriesResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	mSubSeriesInductor = std::make_shared<DP::Ph1::Inductor>(**mName + "_ind", mLogLevel);
 	mSubSeriesInductor->setParameters(**mSeriesInd);
 	mSubSeriesInductor->connect({ mVirtualNodes[0], mTerminals[1]->node() });
 	mSubSeriesInductor->initialize(mFrequencies);
 	mSubSeriesInductor->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubSeriesInductor);
+	addMNASubComponent(mSubSeriesInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	// By default there is always a small conductance to ground to
 	// avoid problems with floating nodes.
@@ -64,14 +64,14 @@ void DP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubParallelResistor0->connect(SimNode::List{ SimNode::GND, mTerminals[0]->node() });
 	mSubParallelResistor0->initialize(mFrequencies);
 	mSubParallelResistor0->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubParallelResistor0);
+	addMNASubComponent(mSubParallelResistor0, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	mSubParallelResistor1 = std::make_shared<DP::Ph1::Resistor>(**mName + "_con1", mLogLevel);
 	mSubParallelResistor1->setParameters(2. / **mParallelCond);
 	mSubParallelResistor1->connect(SimNode::List{ SimNode::GND, mTerminals[1]->node() });
 	mSubParallelResistor1->initialize(mFrequencies);
 	mSubParallelResistor1->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubParallelResistor1);
+	addMNASubComponent(mSubParallelResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 
 	if (**mParallelCap >= 0) {
@@ -80,14 +80,14 @@ void DP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 		mSubParallelCapacitor0->connect(SimNode::List{ SimNode::GND, mTerminals[0]->node() });
 		mSubParallelCapacitor0->initialize(mFrequencies);
 		mSubParallelCapacitor0->initializeFromNodesAndTerminals(frequency);
-		mSubComponents.push_back(mSubParallelCapacitor0);
+		addMNASubComponent(mSubParallelCapacitor0, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 		mSubParallelCapacitor1 = std::make_shared<DP::Ph1::Capacitor>(**mName + "_cap1", mLogLevel);
 		mSubParallelCapacitor1->setParameters(**mParallelCap / 2.);
 		mSubParallelCapacitor1->connect(SimNode::List{ SimNode::GND, mTerminals[1]->node() });
 		mSubParallelCapacitor1->initialize(mFrequencies);
 		mSubParallelCapacitor1->initializeFromNodesAndTerminals(frequency);
-		mSubComponents.push_back(mSubParallelCapacitor1);
+		addMNASubComponent(mSubParallelCapacitor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	}
 
 	mSLog->info(
@@ -105,14 +105,10 @@ void DP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(mVirtualNodes[0]->initialSingleVoltage()));
 }
 
-void DP::Ph1::PiLine::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void DP::Ph1::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
 
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 	mRightVectorStamps.push_back(&**mSubSeriesInductor->mRightVector);
 
 	if (**mParallelCap >= 0) {
@@ -124,62 +120,32 @@ void DP::Ph1::PiLine::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
-void DP::Ph1::PiLine::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
-}
-
 void DP::Ph1::PiLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
 	rightVector.setZero();
 	for (auto stamp : mRightVectorStamps)
 		rightVector += *stamp;
 }
 
-void DP::Ph1::PiLine::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	// add pre-step dependencies of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	}
-
+void DP::Ph1::PiLine::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	// add pre-step dependencies of component itself
 	prevStepDependencies.push_back(mIntfCurrent);
 	prevStepDependencies.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mRightVector);
 }
 
-void DP::Ph1::PiLine::mnaPreStep(Real time, Int timeStepCount) {
-	// pre-step of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	}
+void DP::Ph1::PiLine::mnaParentPreStep(Real time, Int timeStepCount) {
 	// pre-step of component itself
 	this->mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void DP::Ph1::PiLine::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	// add post-step dependencies of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	}
-
+void DP::Ph1::PiLine::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	// add post-step dependencies of component itself
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mIntfCurrent);
 }
 
-void DP::Ph1::PiLine::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	// post-step of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
-	}
-
+void DP::Ph1::PiLine::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	// post-step of component itself
 	this->mnaUpdateVoltage(**leftVector);
 	this->mnaUpdateCurrent(**leftVector);

--- a/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
@@ -115,8 +115,6 @@ void DP::Ph1::RXLoad::mnaParentInitialize(Real omega, Real timeStep, Attribute<M
 	if (mSubCapacitor) {
 		mRightVectorStamps.push_back(&**mSubCapacitor->mRightVector);
 	}
-
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 void DP::Ph1::RXLoad::mnaUpdateVoltage(const Matrix& leftVector) {

--- a/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::RXLoad::RXLoad(String uid, String name, Logger::Level logLevel)
-	: CompositePowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 	mActivePower(Attribute<Real>::create("P", mAttributes)),
 	mReactivePower(Attribute<Real>::create("Q", mAttributes)),
 	mNomVoltage(Attribute<Real>::create("V_nom", mAttributes)) {
@@ -116,8 +116,6 @@ void DP::Ph1::RXLoad::mnaParentInitialize(Real omega, Real timeStep, Attribute<M
 		mRightVectorStamps.push_back(&**mSubCapacitor->mRightVector);
 	}
 
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 

--- a/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
@@ -50,7 +50,7 @@ void DP::Ph1::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubResistor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubResistor->initialize(mFrequencies);
 		mSubResistor->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 	}
 	else {
 		mResistance = 0;
@@ -68,7 +68,7 @@ void DP::Ph1::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubInductor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubInductor->initialize(mFrequencies);
 		mSubInductor->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	}
 	else if (mReactance < 0) {
 		mCapacitance = -1. / (2.*PI*frequency) / mReactance;
@@ -77,7 +77,7 @@ void DP::Ph1::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubCapacitor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubCapacitor->initialize(mFrequencies);
 		mSubCapacitor->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	}
 
 	(**mIntfVoltage)(0, 0) = mTerminals[0]->initialSingleVoltage();
@@ -106,15 +106,6 @@ void DP::Ph1::RXLoad::setParameters(Real activePower, Real reactivePower, Real v
 
 	mSLog->info("Active Power={} [W] Reactive Power={} [VAr]", **mActivePower, **mReactivePower);
 	mSLog->info("Nominal Voltage={} [V]", **mNomVoltage);
-}
-
-void DP::Ph1::RXLoad::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	if (mSubInductor) {
-		mRightVectorStamps.push_back(&**mSubInductor->mRightVector);
-	}
-	if (mSubCapacitor) {
-		mRightVectorStamps.push_back(&**mSubCapacitor->mRightVector);
-	}
 }
 
 void DP::Ph1::RXLoad::mnaUpdateVoltage(const Matrix& leftVector) {

--- a/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
@@ -102,7 +102,6 @@ void DP::Ph1::RXLoad::setParameters(Real activePower, Real reactivePower, Real v
 	mParametersSet = true;
 	**mActivePower = activePower;
 	**mReactivePower = reactivePower;
-	mPower = { **mActivePower, **mReactivePower};
 	**mNomVoltage = volt;
 
 	mSLog->info("Active Power={} [W] Reactive Power={} [VAr]", **mActivePower, **mReactivePower);

--- a/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
@@ -109,9 +109,6 @@ void DP::Ph1::RXLoad::setParameters(Real activePower, Real reactivePower, Real v
 }
 
 void DP::Ph1::RXLoad::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	if (mSubInductor) {
 		mRightVectorStamps.push_back(&**mSubInductor->mRightVector);
 	}

--- a/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::RXLoad::RXLoad(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, logLevel),
 	mActivePower(Attribute<Real>::create("P", mAttributes)),
 	mReactivePower(Attribute<Real>::create("Q", mAttributes)),
 	mNomVoltage(Attribute<Real>::create("V_nom", mAttributes)) {
@@ -50,7 +50,7 @@ void DP::Ph1::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubResistor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubResistor->initialize(mFrequencies);
 		mSubResistor->initializeFromNodesAndTerminals(frequency);
-		mSubComponents.push_back(mSubResistor);
+		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	}
 	else {
 		mResistance = 0;
@@ -68,7 +68,7 @@ void DP::Ph1::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubInductor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubInductor->initialize(mFrequencies);
 		mSubInductor->initializeFromNodesAndTerminals(frequency);
-		mSubComponents.push_back(mSubInductor);
+		addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	}
 	else if (mReactance < 0) {
 		mCapacitance = -1. / (2.*PI*frequency) / mReactance;
@@ -77,7 +77,7 @@ void DP::Ph1::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubCapacitor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubCapacitor->initialize(mFrequencies);
 		mSubCapacitor->initializeFromNodesAndTerminals(frequency);
-		mSubComponents.push_back(mSubCapacitor);
+		addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	}
 
 	(**mIntfVoltage)(0, 0) = mTerminals[0]->initialSingleVoltage();
@@ -108,14 +108,9 @@ void DP::Ph1::RXLoad::setParameters(Real activePower, Real reactivePower, Real v
 	mSLog->info("Nominal Voltage={} [V]", **mNomVoltage);
 }
 
-void DP::Ph1::RXLoad::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void DP::Ph1::RXLoad::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 
 	if (mSubInductor) {
 		mRightVectorStamps.push_back(&**mSubInductor->mRightVector);
@@ -127,20 +122,6 @@ void DP::Ph1::RXLoad::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-}
-
-void DP::Ph1::RXLoad::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
-	}
-}
-
-void DP::Ph1::RXLoad::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
 }
 
 void DP::Ph1::RXLoad::mnaUpdateVoltage(const Matrix& leftVector) {
@@ -155,49 +136,21 @@ void DP::Ph1::RXLoad::mnaUpdateCurrent(const Matrix& leftVector) {
 	}
 }
 
-void DP::Ph1::RXLoad::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	// add pre-step dependencies of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	}
-
-	// add pre-step dependencies of component itself
+void DP::Ph1::RXLoad::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	modifiedAttributes.push_back(mRightVector);
 }
 
-void DP::Ph1::RXLoad::mnaPreStep(Real time, Int timeStepCount) {
-	// pre-step of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	}
-
-	// pre-step of component itself
+void DP::Ph1::RXLoad::mnaParentPreStep(Real time, Int timeStepCount) {
 	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void DP::Ph1::RXLoad::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	// add post-step dependencies of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	}
-
-	// add post-step dependencies of component itself
+void DP::Ph1::RXLoad::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mIntfCurrent);
 }
 
-void DP::Ph1::RXLoad::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	// post-step of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
-	}
-
-	// post-step of component itself
+void DP::Ph1::RXLoad::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	mnaUpdateVoltage(**leftVector);
 	mnaUpdateCurrent(**leftVector);
 }

--- a/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::RXLoadSwitch::RXLoadSwitch(String uid, String name, Logger::Level logLevel)
-	: CompositePowerComp<Complex>(uid, name, logLevel) {
+	: CompositePowerComp<Complex>(uid, name, true, true, logLevel) {
 	setTerminalNumber(1);
 	setVirtualNodeNumber(1);
 	**mIntfVoltage = MatrixComp::Zero(1, 1);
@@ -79,8 +79,6 @@ void DP::Ph1::RXLoadSwitch::mnaParentInitialize(Real omega, Real timeStep, Attri
 	mRightVectorStamps.push_back(&**mSubRXLoad->mRightVector);
 
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
 void DP::Ph1::RXLoadSwitch::mnaApplyRightSideVectorStamp(Matrix& rightVector) {

--- a/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
@@ -20,8 +20,8 @@ DP::Ph1::RXLoadSwitch::RXLoadSwitch(String uid, String name, Logger::Level logLe
 	// Create sub components
 	mSubRXLoad = std::make_shared<DP::Ph1::RXLoad>(**mName + "_rxload", mLogLevel);
 	mSubSwitch = std::make_shared<DP::Ph1::Switch>(**mName + "_switch", mLogLevel);
-	addMNASubComponent(mSubRXLoad, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
-	addMNASubComponent(mSubSwitch, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubRXLoad, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
+	addMNASubComponent(mSubSwitch, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 	// Set switch default values
 	mSubSwitch->setParameters(1e9, 1e-9, true);
 }
@@ -72,17 +72,6 @@ void DP::Ph1::RXLoadSwitch::setParameters(Real activePower, Real reactivePower, 
 
 void DP::Ph1::RXLoadSwitch::setSwitchParameters(Real openResistance, Real closedResistance, Bool closed) {
 	mSubSwitch->setParameters(openResistance, closedResistance, closed);
-}
-
-void DP::Ph1::RXLoadSwitch::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	// get sub component right vector
-	mRightVectorStamps.push_back(&**mSubRXLoad->mRightVector);
-}
-
-void DP::Ph1::RXLoadSwitch::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	rightVector.setZero();
-	for (auto stamp : mRightVectorStamps)
-		rightVector += *stamp;
 }
 
 void DP::Ph1::RXLoadSwitch::mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& systemMatrix, Int freqIdx) {

--- a/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
@@ -75,9 +75,6 @@ void DP::Ph1::RXLoadSwitch::setSwitchParameters(Real openResistance, Real closed
 }
 
 void DP::Ph1::RXLoadSwitch::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	// get sub component right vector
 	mRightVectorStamps.push_back(&**mSubRXLoad->mRightVector);
 

--- a/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::RXLoadSwitch::RXLoadSwitch(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: CompositePowerComp<Complex>(uid, name, logLevel) {
 	setTerminalNumber(1);
 	setVirtualNodeNumber(1);
 	**mIntfVoltage = MatrixComp::Zero(1, 1);
@@ -20,8 +20,8 @@ DP::Ph1::RXLoadSwitch::RXLoadSwitch(String uid, String name, Logger::Level logLe
 	// Create sub components
 	mSubRXLoad = std::make_shared<DP::Ph1::RXLoad>(**mName + "_rxload", mLogLevel);
 	mSubSwitch = std::make_shared<DP::Ph1::Switch>(**mName + "_switch", mLogLevel);
-	mSubComponents.push_back(mSubRXLoad);
-	mSubComponents.push_back(mSubSwitch);
+	addMNASubComponent(mSubRXLoad, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSwitch, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	// Set switch default values
 	mSubSwitch->setParameters(1e9, 1e-9, true);
 }
@@ -74,14 +74,9 @@ void DP::Ph1::RXLoadSwitch::setSwitchParameters(Real openResistance, Real closed
 	mSubSwitch->setParameters(openResistance, closedResistance, closed);
 }
 
-void DP::Ph1::RXLoadSwitch::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void DP::Ph1::RXLoadSwitch::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 
 	// get sub component right vector
 	mRightVectorStamps.push_back(&**mSubRXLoad->mRightVector);
@@ -97,63 +92,31 @@ void DP::Ph1::RXLoadSwitch::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
 		rightVector += *stamp;
 }
 
-void DP::Ph1::RXLoadSwitch::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
-}
-
 void DP::Ph1::RXLoadSwitch::mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& systemMatrix, Int freqIdx) {
 	mSubRXLoad->mnaApplySystemMatrixStamp(systemMatrix);
 	mSubSwitch->mnaApplySwitchSystemMatrixStamp(closed, systemMatrix, freqIdx);
 }
 
-void DP::Ph1::RXLoadSwitch::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies,
+void DP::Ph1::RXLoadSwitch::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies,
 	AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	// add pre-step dependencies of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	}
-	// add pre-step dependencies of component
 	prevStepDependencies.push_back(mIntfCurrent);
 	prevStepDependencies.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mRightVector);
 }
 
-void DP::Ph1::RXLoadSwitch::mnaPreStep(Real time, Int timeStepCount) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	}
-
-	// pre-step of component itself
+void DP::Ph1::RXLoadSwitch::mnaParentPreStep(Real time, Int timeStepCount) {
 	updateSwitchState(time);
 	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void DP::Ph1::RXLoadSwitch::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
+void DP::Ph1::RXLoadSwitch::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
 	AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	// add post-step dependencies of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	}
-
-	// add post-step dependencies of component itself
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mIntfCurrent);
 }
 
-void DP::Ph1::RXLoadSwitch::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	// post-step of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
-	}
-
+void DP::Ph1::RXLoadSwitch::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	**mIntfVoltage = **mSubRXLoad->mIntfVoltage;
 	**mIntfCurrent = **mSubRXLoad->mIntfCurrent;
 }

--- a/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
@@ -77,8 +77,6 @@ void DP::Ph1::RXLoadSwitch::setSwitchParameters(Real openResistance, Real closed
 void DP::Ph1::RXLoadSwitch::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	// get sub component right vector
 	mRightVectorStamps.push_back(&**mSubRXLoad->mRightVector);
-
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 void DP::Ph1::RXLoadSwitch::mnaApplyRightSideVectorStamp(Matrix& rightVector) {

--- a/dpsim-models/src/DP/DP_Ph1_Resistor.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Resistor.cpp
@@ -11,13 +11,10 @@
 using namespace CPS;
 
 DP::Ph1::Resistor::Resistor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Resistor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	**mIntfVoltage = MatrixComp::Zero(1,1);
 	**mIntfCurrent = MatrixComp::Zero(1,1);
 	setTerminalNumber(2);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mResistance = CPS::Attribute<Real>::create("R", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph1::Resistor::clone(String name) {

--- a/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
@@ -71,9 +71,6 @@ void DP::Ph1::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void DP::Ph1::RxLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);

--- a/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
@@ -70,10 +70,6 @@ void DP::Ph1::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(initialSingleVoltage(1)));
 }
 
-void DP::Ph1::RxLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-}
-
 void DP::Ph1::RxLine::mnaApplyInitialSystemMatrixStamp(Matrix& systemMatrix) {
 	mInitialResistor->mnaApplySystemMatrixStamp(systemMatrix);
 }

--- a/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::RxLine::RxLine(String uid, String name, Logger::Level logLevel)
-	: Base::Ph1::PiLine(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::PiLine(mAttributes), CompositePowerComp<Complex>(uid, name, true, true, logLevel) {
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);
 
@@ -71,8 +71,6 @@ void DP::Ph1::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void DP::Ph1::RxLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 

--- a/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::RxLine::RxLine(String uid, String name, Logger::Level logLevel)
-	: Base::Ph1::PiLine(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::PiLine(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel) {
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);
 
@@ -40,21 +40,22 @@ void DP::Ph1::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubResistor->connect({ mTerminals[0]->node(), mVirtualNodes[0] });
 	mSubResistor->initialize(mFrequencies);
 	mSubResistor->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubResistor);
+	addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+
 
 	mSubInductor = std::make_shared<DP::Ph1::Inductor>(**mName + "_ind", mLogLevel);
 	mSubInductor->setParameters(**mSeriesInd);
 	mSubInductor->connect({ mVirtualNodes[0], mTerminals[1]->node() });
 	mSubInductor->initialize(mFrequencies);
 	mSubInductor->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubInductor);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	mInitialResistor = std::make_shared<DP::Ph1::Resistor>(**mName + "_snubber_res", mLogLevel);
 	mInitialResistor->setParameters(1e6);
 	mInitialResistor->connect({ SimNode::GND, mTerminals[1]->node() });
 	mInitialResistor->initialize(mFrequencies);
 	mInitialResistor->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mInitialResistor);
+	addMNASubComponent(mInitialResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	mSLog->info(
 		"\n--- Initialization from powerflow ---"
@@ -69,14 +70,9 @@ void DP::Ph1::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(initialSingleVoltage(1)));
 }
 
-void DP::Ph1::RxLine::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void DP::Ph1::RxLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
@@ -87,53 +83,28 @@ void DP::Ph1::RxLine::mnaApplyInitialSystemMatrixStamp(Matrix& systemMatrix) {
 	mInitialResistor->mnaApplySystemMatrixStamp(systemMatrix);
 }
 
-void DP::Ph1::RxLine::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
-
-}
-
 void DP::Ph1::RxLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
 	mSubResistor->mnaApplyRightSideVectorStamp(rightVector);
 	mSubInductor->mnaApplyRightSideVectorStamp(rightVector);
 }
 
-void DP::Ph1::RxLine::MnaPreStep::execute(Real time, Int timeStepCount) {
-	for (auto subComp : mLine.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	}
-	mLine.mnaApplyRightSideVectorStamp(**mLine.mRightVector);
+void DP::Ph1::RxLine::mnaParentPreStep(Real time, Int timeStepCount) {
+	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void DP::Ph1::RxLine::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	}
+void DP::Ph1::RxLine::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	modifiedAttributes.push_back(mRightVector);
 }
 
-void DP::Ph1::RxLine::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	}
-
+void DP::Ph1::RxLine::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfCurrent);
 	modifiedAttributes.push_back(mIntfVoltage);
 }
 
-void DP::Ph1::RxLine::MnaPostStep::execute(Real time, Int timeStepCount) {
-	for (auto subComp : mLine.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, mLeftVector);
-	}
-	mLine.mnaUpdateVoltage(**mLeftVector);
-	mLine.mnaUpdateCurrent(**mLeftVector);
+void DP::Ph1::RxLine::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+	mnaUpdateVoltage(**leftVector);
+	mnaUpdateCurrent(**leftVector);
 }
 
 void DP::Ph1::RxLine::mnaUpdateVoltage(const Matrix& leftVector) {

--- a/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
@@ -35,8 +35,7 @@ void DP::Ph1::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 
 	(**mIntfVoltage)(0,0) = initialSingleVoltage(1) - initialSingleVoltage(0);
 	Complex impedance = { **mSeriesRes, **mSeriesInd * 2.*PI * frequency };
-	/// FIXME: This is always zero, as mVoltage is uninitialized
-	(**mIntfCurrent)(0, 0) = mVoltage / impedance;
+	(**mIntfCurrent)(0, 0) = 0;
 	mVirtualNodes[0]->setInitialVoltage( initialSingleVoltage(0) + (**mIntfCurrent)(0, 0) * **mSeriesRes );
 
 	// Default model with virtual node in between

--- a/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
@@ -11,17 +11,13 @@
 using namespace CPS;
 
 DP::Ph1::RxLine::RxLine(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::PiLine(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);
 
 	mSLog->info("Create {} {}", this->type(), name);
 	**mIntfVoltage = MatrixComp::Zero(1, 1);
 	**mIntfCurrent = MatrixComp::Zero(1, 1);
-
-	mSeriesRes = Attribute<Real>::create("R", mAttributes);
-	mSeriesInd = Attribute<Real>::create("L", mAttributes);
-
 }
 
 ///DEPRECATED: Delete method

--- a/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
@@ -40,7 +40,7 @@ void DP::Ph1::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubResistor->connect({ mTerminals[0]->node(), mVirtualNodes[0] });
 	mSubResistor->initialize(mFrequencies);
 	mSubResistor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 
 	mSubInductor = std::make_shared<DP::Ph1::Inductor>(**mName + "_ind", mLogLevel);
@@ -48,14 +48,14 @@ void DP::Ph1::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubInductor->connect({ mVirtualNodes[0], mTerminals[1]->node() });
 	mSubInductor->initialize(mFrequencies);
 	mSubInductor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	mInitialResistor = std::make_shared<DP::Ph1::Resistor>(**mName + "_snubber_res", mLogLevel);
 	mInitialResistor->setParameters(1e6);
 	mInitialResistor->connect({ SimNode::GND, mTerminals[1]->node() });
 	mInitialResistor->initialize(mFrequencies);
 	mInitialResistor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mInitialResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mInitialResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 	mSLog->info(
 		"\n--- Initialization from powerflow ---"
@@ -68,15 +68,6 @@ void DP::Ph1::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString((**mIntfCurrent)(0,0)),
 		Logger::phasorToString(initialSingleVoltage(0)),
 		Logger::phasorToString(initialSingleVoltage(1)));
-}
-
-void DP::Ph1::RxLine::mnaApplyInitialSystemMatrixStamp(Matrix& systemMatrix) {
-	mInitialResistor->mnaApplySystemMatrixStamp(systemMatrix);
-}
-
-void DP::Ph1::RxLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	mSubResistor->mnaApplyRightSideVectorStamp(rightVector);
-	mSubInductor->mnaApplyRightSideVectorStamp(rightVector);
 }
 
 void DP::Ph1::RxLine::mnaParentPreStep(Real time, Int timeStepCount) {

--- a/dpsim-models/src/DP/DP_Ph1_SVC.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SVC.cpp
@@ -120,16 +120,16 @@ void DP::Ph1::SVC::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::P
 		mTerminals[0]->node()->name(), mTerminals[0]->node()->matrixNodeIndex());
 
     mSubInductor->mnaInitialize(omega, timeStep, leftVector);
-    mRightVectorStamps.push_back(&mSubInductor->attribute<Matrix>("right_vector")->get());
+    mRightVectorStamps.push_back(&mSubInductor->attributeTyped<Matrix>("right_vector")->get());
 
     mSubInductorSwitch->mnaInitialize(omega, timeStep, leftVector);
-    mRighteVctorStamps.push_back(&mSubInductorSwitch->attribute<Matrix>("right_vector")->get());
+    mRighteVctorStamps.push_back(&mSubInductorSwitch->attributeTyped<Matrix>("right_vector")->get());
 
     mSubCapacitor->mnaInitialize(omega, timeStep, leftVector);
-    mRightVectorStamps.push_back(&mSubCapacitor->attribute<Matrix>("right_vector")->get());
+    mRightVectorStamps.push_back(&mSubCapacitor->attributeTyped<Matrix>("right_vector")->get());
 
     mSubCapacitorSwitch->mnaInitialize(omega, timeStep, leftVector);
-    mRightVectorStamps.push_back(&mSubCapacitorSwitch->attribute<Matrix>("right_vector")->get());
+    mRightVectorStamps.push_back(&mSubCapacitorSwitch->attributeTyped<Matrix>("right_vector")->get());
 
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));

--- a/dpsim-models/src/DP/DP_Ph1_Switch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Switch.cpp
@@ -11,14 +11,10 @@
 using namespace CPS;
 
 DP::Ph1::Switch::Switch(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Switch(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	setTerminalNumber(2);
 	**mIntfVoltage = MatrixComp::Zero(1,1);
 	**mIntfCurrent = MatrixComp::Zero(1,1);
-
-	mOpenResistance = Attribute<Real>::create("R_open", mAttributes);
-	mClosedResistance = Attribute<Real>::create("R_closed", mAttributes);
-	mIsClosed = Attribute<Bool>::create("is_closed", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph1::Switch::clone(String name) {

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
@@ -50,9 +50,6 @@ void DP::Ph1::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real frequ
 }
 
 void DP::Ph1::SynchronGeneratorIdeal::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	// collect tasks
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
@@ -13,7 +13,7 @@ using namespace CPS;
 
 DP::Ph1::SynchronGeneratorIdeal::SynchronGeneratorIdeal(String uid, String name,
 	Logger::Level logLevel)
-	: CompositePowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 	mVoltageRef(Attribute<Complex>::createDynamic("V_ref", mAttributes)) {
 	setVirtualNodeNumber(1);
 	setTerminalNumber(1);
@@ -50,10 +50,6 @@ void DP::Ph1::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real frequ
 }
 
 void DP::Ph1::SynchronGeneratorIdeal::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	// collect tasks
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
-
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
@@ -36,7 +36,7 @@ void DP::Ph1::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real frequ
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[0], 0);
 	mSubVoltageSource->initialize(mFrequencies);
 	mSubVoltageSource->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	mSLog->info(
 		"\n--- Initialization from powerflow ---"

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
@@ -49,9 +49,6 @@ void DP::Ph1::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real frequ
 		Logger::phasorToString(initialSingleVoltage(0)));
 }
 
-void DP::Ph1::SynchronGeneratorIdeal::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-}
 
 void DP::Ph1::SynchronGeneratorIdeal::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	prevStepDependencies.push_back(mIntfCurrent);

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
@@ -10,7 +10,7 @@
 using namespace CPS;
 
 DP::Ph1::SynchronGeneratorTrStab::SynchronGeneratorTrStab(String uid, String name, Logger::Level logLevel)
-	: Base::SynchronGenerator(mAttributes), SimPowerComp<Complex>(uid, name, logLevel),
+	: Base::SynchronGenerator(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel),
 	mEp(Attribute<Complex>::create("Ep", mAttributes)),
 	mEp_abs(Attribute<Real>::create("Ep_mag", mAttributes)),
 	mEp_phase(Attribute<Real>::create("Ep_phase", mAttributes)),
@@ -176,7 +176,7 @@ void DP::Ph1::SynchronGeneratorTrStab::initializeFromNodesAndTerminals(Real freq
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[1], 0);
 	mSubVoltageSource->initialize(mFrequencies);
 	mSubVoltageSource->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubVoltageSource);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	// Create sub inductor as Xpd
 	mSubInductor = DP::Ph1::Inductor::make(**mName + "_ind", mLogLevel);
@@ -184,7 +184,7 @@ void DP::Ph1::SynchronGeneratorTrStab::initializeFromNodesAndTerminals(Real freq
 	mSubInductor->connect({mVirtualNodes[0], terminal(0)->node()});
 	mSubInductor->initialize(mFrequencies);
 	mSubInductor->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubInductor);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	mSLog->info("\n--- Initialize according to powerflow ---"
 				"\nTerminal 0 voltage: {:e}<{:e}"
@@ -234,15 +234,9 @@ void DP::Ph1::SynchronGeneratorTrStab::step(Real time) {
 	SPDLOG_LOGGER_DEBUG(mSLog, "\nStates, time {:f}: \n{:s}", time, Logger::matrixToString(mStates));
 }
 
-void DP::Ph1::SynchronGeneratorTrStab::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void DP::Ph1::SynchronGeneratorTrStab::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
-
 	mTimeStep = timeStep;
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
@@ -250,46 +244,22 @@ void DP::Ph1::SynchronGeneratorTrStab::mnaInitialize(Real omega, Real timeStep, 
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
-void DP::Ph1::SynchronGeneratorTrStab::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
-}
-
-void DP::Ph1::SynchronGeneratorTrStab::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
-	}
-}
-
-void DP::Ph1::SynchronGeneratorTrStab::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+void DP::Ph1::SynchronGeneratorTrStab::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+	// other attributes generally also influence the pre step,
+	// but aren't marked as writable anyway
+	/// CHECK: Is the upper comment still relevant. Any attribute is writable now...
 	prevStepDependencies.push_back(mIntfVoltage);
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	}
 }
 
-void DP::Ph1::SynchronGeneratorTrStab::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
+void DP::Ph1::SynchronGeneratorTrStab::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfVoltage);
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	}
 }
 
-void DP::Ph1::SynchronGeneratorTrStab::MnaPreStep::execute(Real time, Int timeStepCount) {
-	for (auto subComp : mGenerator.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	}
-
-	mGenerator.step(time);
+void DP::Ph1::SynchronGeneratorTrStab::mnaParentPreStep(Real time, Int timeStepCount) {
+	step(time);
 	//change V_ref of subvoltage source
-	mGenerator.mSubVoltageSource->mVoltageRef->set(**mGenerator.mEp);
+	mSubVoltageSource->mVoltageRef->set(**mEp);
 }
 
 void DP::Ph1::SynchronGeneratorTrStab::AddBStep::execute(Real time, Int timeStepCount) {
@@ -298,14 +268,9 @@ void DP::Ph1::SynchronGeneratorTrStab::AddBStep::execute(Real time, Int timeStep
 		+ mGenerator.mSubVoltageSource->mRightVector->get();
 }
 
-void DP::Ph1::SynchronGeneratorTrStab::MnaPostStep::execute(Real time, Int timeStepCount) {
-	for (auto subComp : mGenerator.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, mLeftVector);
-	}
-
-	mGenerator.mnaUpdateVoltage(**mLeftVector);
-	mGenerator.mnaUpdateCurrent(**mLeftVector);
+void DP::Ph1::SynchronGeneratorTrStab::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+	mnaUpdateVoltage(**leftVector);
+	mnaUpdateCurrent(**leftVector);
 }
 
 void DP::Ph1::SynchronGeneratorTrStab::mnaUpdateVoltage(const Matrix& leftVector) {

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
@@ -10,7 +10,7 @@
 using namespace CPS;
 
 DP::Ph1::SynchronGeneratorTrStab::SynchronGeneratorTrStab(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: Base::SynchronGenerator(mAttributes), SimPowerComp<Complex>(uid, name, logLevel),
 	mEp(Attribute<Complex>::create("Ep", mAttributes)),
 	mEp_abs(Attribute<Real>::create("Ep_mag", mAttributes)),
 	mEp_phase(Attribute<Real>::create("Ep_phase", mAttributes)),
@@ -21,18 +21,6 @@ DP::Ph1::SynchronGeneratorTrStab::SynchronGeneratorTrStab(String uid, String nam
 	setTerminalNumber(1);
 	**mIntfVoltage = MatrixComp::Zero(1, 1);
 	**mIntfCurrent = MatrixComp::Zero(1, 1);
-
-	// Register attributes
-	///CHECK: Are all of these used in this class or in subclasses?
-	mRs = Attribute<Real>::create("Rs", mAttributes, 0);
-	mLl = Attribute<Real>::create("Ll", mAttributes, 0);
-	mLd = Attribute<Real>::create("Ld", mAttributes, 0);
-	mLq = Attribute<Real>::create("Lq", mAttributes, 0);
-
-	mElecActivePower = Attribute<Real>::create("P_elec", mAttributes, 0);
-	mMechPower = Attribute<Real>::create("P_mech", mAttributes, 0);
-	mInertia = Attribute<Real>::create("inertia", mAttributes, 0);
-	mOmMech = Attribute<Real>::create("w_r", mAttributes, 0);
 
 	mStates = Matrix::Zero(10,1);
 }

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
@@ -235,8 +235,6 @@ void DP::Ph1::SynchronGeneratorTrStab::step(Real time) {
 }
 
 void DP::Ph1::SynchronGeneratorTrStab::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
 	mTimeStep = timeStep;
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
@@ -176,7 +176,7 @@ void DP::Ph1::SynchronGeneratorTrStab::initializeFromNodesAndTerminals(Real freq
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[1], 0);
 	mSubVoltageSource->initialize(mFrequencies);
 	mSubVoltageSource->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	// Create sub inductor as Xpd
 	mSubInductor = DP::Ph1::Inductor::make(**mName + "_ind", mLogLevel);
@@ -184,7 +184,7 @@ void DP::Ph1::SynchronGeneratorTrStab::initializeFromNodesAndTerminals(Real freq
 	mSubInductor->connect({mVirtualNodes[0], terminal(0)->node()});
 	mSubInductor->initialize(mFrequencies);
 	mSubInductor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	mSLog->info("\n--- Initialize according to powerflow ---"
 				"\nTerminal 0 voltage: {:e}<{:e}"

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
@@ -10,7 +10,7 @@
 using namespace CPS;
 
 DP::Ph1::SynchronGeneratorTrStab::SynchronGeneratorTrStab(String uid, String name, Logger::Level logLevel)
-	: Base::SynchronGenerator(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel),
+	: Base::SynchronGenerator(mAttributes), CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 	mEp(Attribute<Complex>::create("Ep", mAttributes)),
 	mEp_abs(Attribute<Real>::create("Ep_mag", mAttributes)),
 	mEp_phase(Attribute<Real>::create("Ep_phase", mAttributes)),
@@ -237,9 +237,7 @@ void DP::Ph1::SynchronGeneratorTrStab::step(Real time) {
 void DP::Ph1::SynchronGeneratorTrStab::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	mTimeStep = timeStep;
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<AddBStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
 void DP::Ph1::SynchronGeneratorTrStab::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
@@ -236,7 +236,6 @@ void DP::Ph1::SynchronGeneratorTrStab::step(Real time) {
 
 void DP::Ph1::SynchronGeneratorTrStab::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	mTimeStep = timeStep;
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 	mMnaTasks.push_back(std::make_shared<AddBStep>(*this));
 }
 

--- a/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 DP::Ph1::Transformer::Transformer(String uid, String name,
 	Logger::Level logLevel, Bool withResistiveLosses)
-	: Base::Ph1::Transformer(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Transformer(mAttributes), CompositePowerComp<Complex>(uid, name, true, true, logLevel) {
 	if (withResistiveLosses)
 		setVirtualNodeNumber(3);
 	else
@@ -160,9 +160,6 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 
 void DP::Ph1::Transformer::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 
 	mSLog->info(
 		"\nTerminal 0 connected to {:s} = sim node {:d}"

--- a/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
@@ -85,7 +85,7 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	// Create series sub components
 	mSubInductor = std::make_shared<DP::Ph1::Inductor>(**mName + "_ind", mLogLevel);
 	mSubInductor->setParameters(**mInductance);
-	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	if (mNumVirtualNodes == 3) {
 		mVirtualNodes[2]->setInitialVoltage(initialSingleVoltage(0));
@@ -93,7 +93,7 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 		mSubResistor->setParameters(**mResistance);
 		mSubResistor->connect({node(0), mVirtualNodes[2]});
 		mSubInductor->connect({mVirtualNodes[2], mVirtualNodes[0]});
-		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	} else {
 		mSubInductor->connect({node(0), mVirtualNodes[0]});
 	}
@@ -108,7 +108,7 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSnubResistor1->setParameters(mSnubberResistance1);
 	mSubSnubResistor1->connect({ node(0), DP::SimNode::GND });
 	mSLog->info("Snubber Resistance 1 (connected to higher voltage side {}) = {} [Ohm]", node(0)->name(), Logger::realToString(mSnubberResistance1));
-	addMNASubComponent(mSubSnubResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSnubResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 
 	// A snubber conductance is added on the lower voltage side
@@ -117,7 +117,7 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSnubResistor2->setParameters(mSnubberResistance2);
 	mSubSnubResistor2->connect({ node(1), DP::SimNode::GND });
 	mSLog->info("Snubber Resistance 2 (connected to lower voltage side {}) = {} [Ohm]", node(1)->name(), Logger::realToString(mSnubberResistance2));
-	addMNASubComponent(mSubSnubResistor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSnubResistor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	// // A snubber capacitance is added to higher voltage side (not used as capacitor at high voltage side made it worse)
 	// mSnubberCapacitance1 = qSnub / std::pow(std::abs(mNominalVoltageEnd1),2) / omega;
@@ -133,7 +133,7 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSnubCapacitor2->setParameters(mSnubberCapacitance2);
 	mSubSnubCapacitor2->connect({ node(1), DP::SimNode::GND });
 	mSLog->info("Snubber Capacitance 2 (connected to lower voltage side {}) = {} [F]", node(1)->name(), Logger::realToString(mSnubberCapacitance2));
-	addMNASubComponent(mSubSnubCapacitor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSnubCapacitor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	// Initialize electrical subcomponents
 	mSLog->info("Electrical subcomponents: ");

--- a/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
@@ -159,8 +159,6 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void DP::Ph1::Transformer::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-
 	mSLog->info(
 		"\nTerminal 0 connected to {:s} = sim node {:d}"
 		"\nTerminal 1 connected to {:s} = sim node {:d}",

--- a/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
@@ -159,9 +159,6 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void DP::Ph1::Transformer::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSourceNorton.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSourceNorton.cpp
@@ -11,14 +11,12 @@
 using namespace CPS;
 
 DP::Ph1::VoltageSourceNorton::VoltageSourceNorton(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
-	mResistance(Attribute<Real>::create("R", mAttributes)) {
+	: 	Base::Ph1::VoltageSource(mAttributes),
+		SimPowerComp<Complex>(uid, name, logLevel),
+		mResistance(Attribute<Real>::create("R", mAttributes)) {
 	setTerminalNumber(2);
 	**mIntfVoltage = MatrixComp::Zero(1,1);
 	**mIntfCurrent = MatrixComp::Zero(1,1);
-
-	mVoltageRef = Attribute<Complex>::create("V_ref", mAttributes);
-	mSrcFreq = Attribute<Real>::create("f_src", mAttributes, -1);
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph1::VoltageSourceNorton::clone(String name) {

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 DP::Ph1::VoltageSourceRamp::VoltageSourceRamp(String uid, String name,
 	Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, logLevel),
 	mVoltageRef(Attribute<Complex>::create("V_ref", mAttributes)),
 	mSrcFreq(Attribute<Real>::create("f_src", mAttributes)) {
 	setVirtualNodeNumber(1);
@@ -51,41 +51,22 @@ void DP::Ph1::VoltageSourceRamp::initialize(Matrix frequencies) {
 	mSubVoltageSource->connect({ node(0), node(1) });
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[0], 0);
 	mSubVoltageSource->initialize(frequencies);
-	mSubComponents.push_back(mSubVoltageSource);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::NO_TASK);
 }
 
 void DP::Ph1::VoltageSourceRamp::initializeFromNodesAndTerminals(Real frequency) {
 	mSubVoltageSource->initializeFromNodesAndTerminals(frequency);
 }
 
-void DP::Ph1::VoltageSourceRamp::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void DP::Ph1::VoltageSourceRamp::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 
 	// only need a new MnaPreStep that updates the reference voltage of mSubVoltageSource;
 	// its own tasks then do the rest
 	/// FIXME: Can we avoid setting right_vector to dynamic?
 	mRightVector->setReference(mSubVoltageSource->mRightVector);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-}
-
-void DP::Ph1::VoltageSourceRamp::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
-}
-
-void DP::Ph1::VoltageSourceRamp::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
-	}
 }
 
 void DP::Ph1::VoltageSourceRamp::updateState(Real time) {
@@ -104,11 +85,7 @@ void DP::Ph1::VoltageSourceRamp::updateState(Real time) {
 	}
 }
 
-void DP::Ph1::VoltageSourceRamp::MnaPreStep::execute(Real time, Int timeStepCount) {
-	mVoltageSource.updateState(time);
-	**mVoltageSource.mSubVoltageSource->mVoltageRef = (**mVoltageSource.mIntfVoltage)(0, 0);
-	for (auto subComp : mVoltageSource.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	}
+void DP::Ph1::VoltageSourceRamp::mnaParentPreStep(Real time, Int timeStepCount) {
+	updateState(time);
+	**mSubVoltageSource->mVoltageRef = (**mIntfVoltage)(0, 0);
 }

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
@@ -59,9 +59,6 @@ void DP::Ph1::VoltageSourceRamp::initializeFromNodesAndTerminals(Real frequency)
 }
 
 void DP::Ph1::VoltageSourceRamp::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	// only need a new MnaPreStep that updates the reference voltage of mSubVoltageSource;
 	// its own tasks then do the rest
 	/// FIXME: Can we avoid setting right_vector to dynamic?

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 DP::Ph1::VoltageSourceRamp::VoltageSourceRamp(String uid, String name,
 	Logger::Level logLevel)
-	: CompositePowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, true, false, logLevel),
 	mVoltageRef(Attribute<Complex>::create("V_ref", mAttributes)),
 	mSrcFreq(Attribute<Real>::create("f_src", mAttributes)) {
 	setVirtualNodeNumber(1);
@@ -63,7 +63,6 @@ void DP::Ph1::VoltageSourceRamp::mnaParentInitialize(Real omega, Real timeStep, 
 	// its own tasks then do the rest
 	/// FIXME: Can we avoid setting right_vector to dynamic?
 	mRightVector->setReference(mSubVoltageSource->mRightVector);
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 }
 
 void DP::Ph1::VoltageSourceRamp::updateState(Real time) {

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
@@ -51,6 +51,7 @@ void DP::Ph1::VoltageSourceRamp::initialize(Matrix frequencies) {
 	mSubVoltageSource->connect({ node(0), node(1) });
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[0], 0);
 	mSubVoltageSource->initialize(frequencies);
+	mSubComponents.push_back(mSubVoltageSource);
 }
 
 void DP::Ph1::VoltageSourceRamp::initializeFromNodesAndTerminals(Real frequency) {
@@ -60,23 +61,31 @@ void DP::Ph1::VoltageSourceRamp::initializeFromNodesAndTerminals(Real frequency)
 void DP::Ph1::VoltageSourceRamp::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-	mSubVoltageSource->mnaInitialize(omega, timeStep, leftVector);
+
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
+	}
+
 	// only need a new MnaPreStep that updates the reference voltage of mSubVoltageSource;
 	// its own tasks then do the rest
 	/// FIXME: Can we avoid setting right_vector to dynamic?
 	mRightVector->setReference(mSubVoltageSource->mRightVector);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	for (auto task : mSubVoltageSource->mnaTasks()) {
-		mMnaTasks.push_back(task);
-	}
 }
 
 void DP::Ph1::VoltageSourceRamp::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	mSubVoltageSource->mnaApplySystemMatrixStamp(systemMatrix);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
+	}
 }
 
 void DP::Ph1::VoltageSourceRamp::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	mSubVoltageSource->mnaApplyRightSideVectorStamp(rightVector);
+	for (auto subComp : mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
+	}
 }
 
 void DP::Ph1::VoltageSourceRamp::updateState(Real time) {
@@ -98,4 +107,8 @@ void DP::Ph1::VoltageSourceRamp::updateState(Real time) {
 void DP::Ph1::VoltageSourceRamp::MnaPreStep::execute(Real time, Int timeStepCount) {
 	mVoltageSource.updateState(time);
 	**mVoltageSource.mSubVoltageSource->mVoltageRef = (**mVoltageSource.mIntfVoltage)(0, 0);
+	for (auto subComp : mVoltageSource.mSubComponents) {
+		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
+			mnasubcomp->mnaPreStep(time, timeStepCount);
+	}
 }

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSourceRamp.cpp
@@ -51,18 +51,11 @@ void DP::Ph1::VoltageSourceRamp::initialize(Matrix frequencies) {
 	mSubVoltageSource->connect({ node(0), node(1) });
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[0], 0);
 	mSubVoltageSource->initialize(frequencies);
-	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::NO_TASK);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::NO_TASK, true);
 }
 
 void DP::Ph1::VoltageSourceRamp::initializeFromNodesAndTerminals(Real frequency) {
 	mSubVoltageSource->initializeFromNodesAndTerminals(frequency);
-}
-
-void DP::Ph1::VoltageSourceRamp::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	// only need a new MnaPreStep that updates the reference voltage of mSubVoltageSource;
-	// its own tasks then do the rest
-	/// FIXME: Can we avoid setting right_vector to dynamic?
-	mRightVector->setReference(mSubVoltageSource->mRightVector);
 }
 
 void DP::Ph1::VoltageSourceRamp::updateState(Real time) {
@@ -84,4 +77,5 @@ void DP::Ph1::VoltageSourceRamp::updateState(Real time) {
 void DP::Ph1::VoltageSourceRamp::mnaParentPreStep(Real time, Int timeStepCount) {
 	updateState(time);
 	**mSubVoltageSource->mVoltageRef = (**mIntfVoltage)(0, 0);
+	mnaApplyRightSideVectorStamp(**mRightVector);
 }

--- a/dpsim-models/src/DP/DP_Ph1_varResSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_varResSwitch.cpp
@@ -11,15 +11,11 @@
 using namespace CPS;
 
 DP::Ph1::varResSwitch::varResSwitch(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Switch(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	setTerminalNumber(2);
     **mIntfVoltage = MatrixComp::Zero(1,1);
 	**mIntfCurrent = MatrixComp::Zero(1,1);
-
-	mOpenResistance = Attribute<Real>::create("R_open", mAttributes);
-	mClosedResistance = Attribute<Real>::create("R_closed", mAttributes);
-	mIsClosed = Attribute<Bool>::create("is_closed", mAttributes);
-	}
+}
 
 SimPowerComp<Complex>::Ptr DP::Ph1::varResSwitch::clone(String name) {
 	auto copy = varResSwitch::make(name, mLogLevel);

--- a/dpsim-models/src/DP/DP_Ph3_Capacitor.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_Capacitor.cpp
@@ -14,15 +14,12 @@ using namespace CPS;
 using namespace CPS::DP::Ph3;
 
 DP::Ph3::Capacitor::Capacitor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph3::Capacitor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
 	mEquivCurrent = MatrixComp::Zero(3,1);
 	**mIntfVoltage = MatrixComp::Zero(3,1);
 	**mIntfCurrent = MatrixComp::Zero(3,1);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mCapacitance = CPS::Attribute<Matrix>::create("C", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph3::Capacitor::clone(String name) {

--- a/dpsim-models/src/DP/DP_Ph3_Inductor.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_Inductor.cpp
@@ -12,15 +12,12 @@ using namespace CPS;
 
 
 DP::Ph3::Inductor::Inductor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph3::Inductor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
 	mEquivCurrent = MatrixComp::Zero(3,1);
 	**mIntfVoltage = MatrixComp::Zero(3,1);
 	**mIntfCurrent = MatrixComp::Zero(3,1);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mInductance = CPS::Attribute<Matrix>::create("L", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph3::Inductor::clone(String name) {

--- a/dpsim-models/src/DP/DP_Ph3_Resistor.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_Resistor.cpp
@@ -12,14 +12,11 @@ using namespace CPS;
 
 DP::Ph3::Resistor::Resistor(String uid, String name,
 	Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph3::Resistor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
 	**mIntfVoltage = MatrixComp::Zero(3,1);
 	**mIntfCurrent = MatrixComp::Zero(3,1);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mResistance = CPS::Attribute<Matrix>::create("R", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph3::Resistor::clone(String name) {

--- a/dpsim-models/src/DP/DP_Ph3_SeriesResistor.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_SeriesResistor.cpp
@@ -11,13 +11,11 @@ using namespace CPS;
 
 DP::Ph3::SeriesResistor::SeriesResistor(String uid, String name,
 	Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Resistor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
 	**mIntfVoltage = MatrixComp::Zero(3,1);
 	**mIntfCurrent = MatrixComp::Zero(3,1);
-
-	mResistance = Attribute<Real>::create("R", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph3::SeriesResistor::clone(String name) {

--- a/dpsim-models/src/DP/DP_Ph3_SeriesSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_SeriesSwitch.cpp
@@ -11,14 +11,10 @@
 using namespace CPS;
 
 DP::Ph3::SeriesSwitch::SeriesSwitch(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Switch(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	setTerminalNumber(2);
 	**mIntfVoltage = MatrixComp::Zero(3,1);
 	**mIntfCurrent = MatrixComp::Zero(3,1);
-
-	mOpenResistance = Attribute<Real>::create("R_open", mAttributes);
-	mClosedResistance = Attribute<Real>::create("R_closed", mAttributes);
-	mIsClosed = Attribute<Bool>::create("is_closed", mAttributes);
 }
 
 void DP::Ph3::SeriesSwitch::initializeFromNodesAndTerminals(Real frequency) {

--- a/dpsim-models/src/DP/DP_Ph3_SynchronGeneratorDQ.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_SynchronGeneratorDQ.cpp
@@ -16,31 +16,11 @@ using namespace CPS;
 using namespace std;
 
 DP::Ph3::SynchronGeneratorDQ::SynchronGeneratorDQ(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::SynchronGenerator(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(1);
 	**mIntfVoltage = MatrixComp::Zero(3,1);
 	**mIntfCurrent = MatrixComp::Zero(3,1);
-
-	/// CHECK: Which of these are actually required in this class or its base classes?
-	mRs = Attribute<Real>::create("Rs", mAttributes, 0);
-	mLl = Attribute<Real>::create("Ll", mAttributes, 0);
-	mLd = Attribute<Real>::create("Ld", mAttributes, 0);
-	mLq = Attribute<Real>::create("Lq", mAttributes, 0);
-	mTd0_t = Attribute<Real>::create("Td0_t", mAttributes, 0);
-	mTd0_s = Attribute<Real>::create("Td0_s", mAttributes, 0);
-	mTq0_t = Attribute<Real>::create("Tq0_t", mAttributes, 0);
-	mTq0_s = Attribute<Real>::create("Tq0_s", mAttributes, 0);
-	mInertia = Attribute<Real>::create("inertia", mAttributes, 0);
-	mElecTorque = Attribute<Real>::create("T_e", mAttributes, 0);
-	mMechTorque = Attribute<Real>::create("T_m", mAttributes, 0);
-	mMechPower = Attribute<Real>::create("P_m", mAttributes, 0);
-	mOmMech = Attribute<Real>::create("w_r", mAttributes);
-	mDelta = Attribute<Real>::create("delta_r", mAttributes, 0);
-	mLd_s = Attribute<Real>::create("Ld_s", mAttributes, 0);
-	mLd_t = Attribute<Real>::create("Ld_t", mAttributes, 0);
-	mLq_s = Attribute<Real>::create("Lq_s", mAttributes, 0);
-	mLq_t = Attribute<Real>::create("Lq_t", mAttributes, 0);
 }
 
 DP::Ph3::SynchronGeneratorDQ::SynchronGeneratorDQ(String name, Logger::Level logLevel)

--- a/dpsim-models/src/EMT/EMT_Ph1_Capacitor.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_Capacitor.cpp
@@ -11,14 +11,11 @@
 using namespace CPS;
 
 EMT::Ph1::Capacitor::Capacitor(String uid, String name,	Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph1::Capacitor(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	mEquivCurrent = 0;
 	**mIntfVoltage = Matrix::Zero(1,1);
 	**mIntfCurrent = Matrix::Zero(1,1);
 	setTerminalNumber(2);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mCapacitance = CPS::Attribute<Real>::create("C", mAttributes);
 }
 
 SimPowerComp<Real>::Ptr EMT::Ph1::Capacitor::clone(String name) {

--- a/dpsim-models/src/EMT/EMT_Ph1_Inductor.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_Inductor.cpp
@@ -11,14 +11,11 @@
 using namespace CPS;
 
 EMT::Ph1::Inductor::Inductor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph1::Inductor(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	mEquivCurrent = 0;
 	**mIntfVoltage = Matrix::Zero(1,1);
 	**mIntfCurrent = Matrix::Zero(1,1);
 	setTerminalNumber(2);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mInductance = CPS::Attribute<Real>::create("L", mAttributes);
 }
 
 SimPowerComp<Real>::Ptr EMT::Ph1::Inductor::clone(String name) {

--- a/dpsim-models/src/EMT/EMT_Ph1_Resistor.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_Resistor.cpp
@@ -11,13 +11,10 @@
 using namespace CPS;
 
 EMT::Ph1::Resistor::Resistor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph1::Resistor(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	setTerminalNumber(2);
 	**mIntfVoltage = Matrix::Zero(1,1);
 	**mIntfCurrent = Matrix::Zero(1,1);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mResistance = CPS::Attribute<Real>::create("R", mAttributes);
 }
 
 SimPowerComp<Real>::Ptr EMT::Ph1::Resistor::clone(String name) {

--- a/dpsim-models/src/EMT/EMT_Ph1_VoltageSourceNorton.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_VoltageSourceNorton.cpp
@@ -11,14 +11,11 @@
 using namespace CPS;
 
 EMT::Ph1::VoltageSourceNorton::VoltageSourceNorton(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel),
+	: Base::Ph1::VoltageSource(mAttributes), SimPowerComp<Real>(uid, name, logLevel),
 	mResistance(Attribute<Real>::create("R", mAttributes)) {
 	setTerminalNumber(2);
 	**mIntfVoltage = Matrix::Zero(1,1);
 	**mIntfCurrent = Matrix::Zero(1,1);
-
-	mVoltageRef = Attribute<Complex>::create("V_ref", mAttributes);
-	mSrcFreq = Attribute<Real>::create("f_src", mAttributes, -1);
 }
 
 SimPowerComp<Real>::Ptr EMT::Ph1::VoltageSourceNorton::clone(String name) {

--- a/dpsim-models/src/EMT/EMT_Ph1_VoltageSourceRamp.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_VoltageSourceRamp.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 EMT::Ph1::VoltageSourceRamp::VoltageSourceRamp(String uid, String name,
 	Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel),
+	: CompositePowerComp<Real>(uid, name, logLevel),
 	mVoltageRef(Attribute<Complex>::create("V_ref", mAttributes)),
 	mSrcFreq(Attribute<Real>::create("f_src", mAttributes))  {
 	setVirtualNodeNumber(1);
@@ -51,36 +51,18 @@ void EMT::Ph1::VoltageSourceRamp::initialize(Matrix frequencies) {
 	mSubVoltageSource->connect({ node(0), node(1) });
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[0], 0);
 	mSubVoltageSource->initialize(frequencies);
-	mSubComponents.push_back(mSubVoltageSource);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::NO_TASK);
 }
 
-void EMT::Ph1::VoltageSourceRamp::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void EMT::Ph1::VoltageSourceRamp::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
 
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 	// only need a new MnaPreStep that updates the reference voltage of mSubVoltageSource;
 	// its own tasks then do the rest
 	/// FIXME: Can we avoid setting right_vector to dynamic?
 	mRightVector->setReference(mSubVoltageSource->mRightVector);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-}
-
-void EMT::Ph1::VoltageSourceRamp::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
-}
-
-void EMT::Ph1::VoltageSourceRamp::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
-	}
 }
 
 void EMT::Ph1::VoltageSourceRamp::updateState(Real time) {
@@ -101,11 +83,7 @@ void EMT::Ph1::VoltageSourceRamp::updateState(Real time) {
 	}
 }
 
-void EMT::Ph1::VoltageSourceRamp::MnaPreStep::execute(Real time, Int timeStepCount) {
-	mVoltageSource.updateState(time);
-	**mVoltageSource.mSubVoltageSource->mVoltageRef = (**mVoltageSource.mIntfVoltage)(0, 0);
-	for (auto subComp : mVoltageSource.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	}
+void EMT::Ph1::VoltageSourceRamp::mnaParentPreStep(Real time, Int timeStepCount) {
+	updateState(time);
+	**mSubVoltageSource->mVoltageRef = (**mIntfVoltage)(0, 0);
 }

--- a/dpsim-models/src/EMT/EMT_Ph1_VoltageSourceRamp.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_VoltageSourceRamp.cpp
@@ -51,14 +51,7 @@ void EMT::Ph1::VoltageSourceRamp::initialize(Matrix frequencies) {
 	mSubVoltageSource->connect({ node(0), node(1) });
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[0], 0);
 	mSubVoltageSource->initialize(frequencies);
-	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::NO_TASK);
-}
-
-void EMT::Ph1::VoltageSourceRamp::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	// only need a new MnaPreStep that updates the reference voltage of mSubVoltageSource;
-	// its own tasks then do the rest
-	/// FIXME: Can we avoid setting right_vector to dynamic?
-	mRightVector->setReference(mSubVoltageSource->mRightVector);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::NO_TASK, true);
 }
 
 void EMT::Ph1::VoltageSourceRamp::updateState(Real time) {
@@ -82,4 +75,5 @@ void EMT::Ph1::VoltageSourceRamp::updateState(Real time) {
 void EMT::Ph1::VoltageSourceRamp::mnaParentPreStep(Real time, Int timeStepCount) {
 	updateState(time);
 	**mSubVoltageSource->mVoltageRef = (**mIntfVoltage)(0, 0);
+	mnaApplyRightSideVectorStamp(**mRightVector);
 }

--- a/dpsim-models/src/EMT/EMT_Ph1_VoltageSourceRamp.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_VoltageSourceRamp.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 EMT::Ph1::VoltageSourceRamp::VoltageSourceRamp(String uid, String name,
 	Logger::Level logLevel)
-	: CompositePowerComp<Real>(uid, name, logLevel),
+	: CompositePowerComp<Real>(uid, name, true, false, logLevel),
 	mVoltageRef(Attribute<Complex>::create("V_ref", mAttributes)),
 	mSrcFreq(Attribute<Real>::create("f_src", mAttributes))  {
 	setVirtualNodeNumber(1);
@@ -59,7 +59,6 @@ void EMT::Ph1::VoltageSourceRamp::mnaParentInitialize(Real omega, Real timeStep,
 	// its own tasks then do the rest
 	/// FIXME: Can we avoid setting right_vector to dynamic?
 	mRightVector->setReference(mSubVoltageSource->mRightVector);
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 }
 
 void EMT::Ph1::VoltageSourceRamp::updateState(Real time) {

--- a/dpsim-models/src/EMT/EMT_Ph1_VoltageSourceRamp.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_VoltageSourceRamp.cpp
@@ -55,9 +55,6 @@ void EMT::Ph1::VoltageSourceRamp::initialize(Matrix frequencies) {
 }
 
 void EMT::Ph1::VoltageSourceRamp::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	// only need a new MnaPreStep that updates the reference voltage of mSubVoltageSource;
 	// its own tasks then do the rest
 	/// FIXME: Can we avoid setting right_vector to dynamic?

--- a/dpsim-models/src/EMT/EMT_Ph3_AvVoltSourceInverterStateSpace.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_AvVoltSourceInverterStateSpace.cpp
@@ -15,17 +15,17 @@ using namespace CPS;
 
 EMT::Ph3::AvVoltSourceInverterStateSpace::AvVoltSourceInverterStateSpace(String uid, String name, Logger::Level logLevel)
 : Base::Ph1::VoltageSource(mAttributes), SimPowerComp<Real>(uid, name, logLevel),
-	mVcabc(Attribute<Matrix>::create("V_cabc", mAttributes, Matrix::Zero(3, 1))),
-	mP(Attribute<Real>::create("p", mAttributes)),
-	mQ(Attribute<Real>::create("q", mAttributes)),
 	mPref(Attribute<Real>::create("P_ref", mAttributes)),
 	mQref(Attribute<Real>::create("Q_ref", mAttributes)),
 	mThetaPLL(Attribute<Real>::create("theta", mAttributes)),
 	mPhiPLL(Attribute<Real>::create("phipll", mAttributes)),
+	mP(Attribute<Real>::create("p", mAttributes)),
+	mQ(Attribute<Real>::create("q", mAttributes)),
 	mPhi_d(Attribute<Real>::create("phid", mAttributes)),
 	mPhi_q(Attribute<Real>::create("phiq", mAttributes)),
 	mGamma_d(Attribute<Real>::create("gammad", mAttributes)),
-	mGamma_q(Attribute<Real>::create("gammaq", mAttributes)) {
+	mGamma_q(Attribute<Real>::create("gammaq", mAttributes)),
+	mVcabc(Attribute<Matrix>::create("V_cabc", mAttributes, Matrix::Zero(3, 1))) {
 	setTerminalNumber(2);
 	**mIntfVoltage = Matrix::Zero(3, 1);
 	**mIntfCurrent = Matrix::Zero(3, 1);

--- a/dpsim-models/src/EMT/EMT_Ph3_AvVoltSourceInverterStateSpace.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_AvVoltSourceInverterStateSpace.cpp
@@ -14,7 +14,7 @@ using namespace CPS;
 // !!! 			with initialization from phase-to-phase RMS variables
 
 EMT::Ph3::AvVoltSourceInverterStateSpace::AvVoltSourceInverterStateSpace(String uid, String name, Logger::Level logLevel)
-: SimPowerComp<Real>(uid, name, logLevel),
+: Base::Ph1::VoltageSource(mAttributes), SimPowerComp<Real>(uid, name, logLevel),
 	mVcabc(Attribute<Matrix>::create("V_cabc", mAttributes, Matrix::Zero(3, 1))),
 	mP(Attribute<Real>::create("p", mAttributes)),
 	mQ(Attribute<Real>::create("q", mAttributes)),
@@ -29,8 +29,6 @@ EMT::Ph3::AvVoltSourceInverterStateSpace::AvVoltSourceInverterStateSpace(String 
 	setTerminalNumber(2);
 	**mIntfVoltage = Matrix::Zero(3, 1);
 	**mIntfCurrent = Matrix::Zero(3, 1);
-
-	mVoltageRef = Attribute<Complex>::create("V_ref", mAttributes);
 }
 
 

--- a/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
@@ -256,8 +256,6 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::initializeFromNodesAndTerminals(Real f
 }
 
 void EMT::Ph3::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
 	mTimeStep = timeStep;
 
 	// initialize state space controller

--- a/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
@@ -272,8 +272,6 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real t
 	// TODO: these are actually no MNA tasks
 	mMnaTasks.push_back(std::make_shared<ControlPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<ControlStep>(*this));
-
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 void EMT::Ph3::AvVoltageSourceInverterDQ::mnaApplyRightSideVectorStamp(Matrix& rightVector) {

--- a/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
@@ -95,9 +95,9 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::setParameters(Real sysOmega, Real sysV
 	**mQref = Qref;
 }
 
-void EMT::Ph3::AvVoltageSourceInverterDQ::setTransformerParameters(Real nomVoltageEnd1, Real nomVoltageEnd2, Real ratedPower, 
+void EMT::Ph3::AvVoltageSourceInverterDQ::setTransformerParameters(Real nomVoltageEnd1, Real nomVoltageEnd2, Real ratedPower,
 	Real ratioAbs,	Real ratioPhase, Real resistance, Real inductance, Real omega) {
-	
+
 	Base::AvVoltageSourceInverterDQ::setTransformerParameters(nomVoltageEnd1, nomVoltageEnd2, ratedPower,
 	ratioAbs, ratioPhase, resistance, inductance);
 
@@ -268,11 +268,11 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::mnaInitialize(Real omega, Real timeSte
 	mPLL->setSimulationParameters(timeStep);
 
 	// collect right side vectors of subcomponents
-	mRightVectorStamps.push_back(&mSubCapacitorF->attribute<Matrix>("right_vector")->get());
-	mRightVectorStamps.push_back(&mSubInductorF->attribute<Matrix>("right_vector")->get());
-	mRightVectorStamps.push_back(&mSubCtrledVoltageSource->attribute<Matrix>("right_vector")->get());
+	mRightVectorStamps.push_back(&mSubCapacitorF->attributeTyped<Matrix>("right_vector")->get());
+	mRightVectorStamps.push_back(&mSubInductorF->attributeTyped<Matrix>("right_vector")->get());
+	mRightVectorStamps.push_back(&mSubCtrledVoltageSource->attributeTyped<Matrix>("right_vector")->get());
 	if (mWithConnectionTransformer)
-		mRightVectorStamps.push_back(&mConnectionTransformer->attribute<Matrix>("right_vector")->get());
+		mRightVectorStamps.push_back(&mConnectionTransformer->attributeTyped<Matrix>("right_vector")->get());
 
 	// collect tasks
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
@@ -363,7 +363,7 @@ Matrix EMT::Ph3::AvVoltageSourceInverterDQ::getInverseParkTransformMatrixPowerIn
 void EMT::Ph3::AvVoltageSourceInverterDQ::controlStep(Real time, Int timeStepCount) {
 	// Transformation interface forward
 	Matrix vcdq, ircdq;
-	Real theta = mPLL->attribute<Matrix>("output_prev")->get()(0, 0);
+	Real theta = mPLL->attributeTyped<Matrix>("output_prev")->get()(0, 0);
 	vcdq = parkTransformPowerInvariant(theta, **mVirtualNodes[3]->mVoltage);
 	ircdq = parkTransformPowerInvariant(theta, - **mSubResistorC->mIntfCurrent);
 
@@ -377,7 +377,7 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::controlStep(Real time, Int timeStepCou
 	mPowerControllerVSI->signalStep(time, timeStepCount);
 
 	// Transformation interface backward
-	**mVsref = inverseParkTransformPowerInvariant(mPLL->attribute<Matrix>("output_prev")->get()(0, 0), mPowerControllerVSI->attribute<Matrix>("output_curr")->get());
+	**mVsref = inverseParkTransformPowerInvariant(mPLL->attributeTyped<Matrix>("output_prev")->get()(0, 0), mPowerControllerVSI->attributeTyped<Matrix>("output_curr")->get());
 
 	// Update nominal system angle
 	mThetaN = mThetaN + mTimeStep * **mOmegaN;
@@ -392,15 +392,15 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::mnaAddPreStepDependencies(AttributeBas
 	prevStepDependencies.push_back(attribute("Vsref"));
 	prevStepDependencies.push_back(attribute("i_intf"));
 	prevStepDependencies.push_back(attribute("v_intf"));
-	attributeDependencies.push_back(mPowerControllerVSI->attribute<Matrix>("output_prev"));
-	attributeDependencies.push_back(mPLL->attribute<Matrix>("output_prev"));
+	attributeDependencies.push_back(mPowerControllerVSI->attributeTyped<Matrix>("output_prev"));
+	attributeDependencies.push_back(mPLL->attributeTyped<Matrix>("output_prev"));
 	modifiedAttributes.push_back(attribute("right_vector"));
 }
 
 void EMT::Ph3::AvVoltageSourceInverterDQ::mnaPreStep(Real time, Int timeStepCount) {
 	// pre-step of subcomponents - controlled source
 	if (mWithControl)
-		mSubCtrledVoltageSource->attribute<MatrixComp>("V_ref")->set(PEAK1PH_TO_RMS3PH * **mVsref);
+		mSubCtrledVoltageSource->attributeTyped<MatrixComp>("V_ref")->set(PEAK1PH_TO_RMS3PH * **mVsref);
 	// pre-step of subcomponents - others
 	for (auto subcomp: mSubComponents)
 		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
@@ -432,9 +432,9 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::mnaPostStep(Real time, Int timeStepCou
 
 void EMT::Ph3::AvVoltageSourceInverterDQ::mnaUpdateCurrent(const Matrix& leftvector) {
 	if (mWithConnectionTransformer)
-		**mIntfCurrent = mConnectionTransformer->attribute<Matrix>("i_intf")->get();
+		**mIntfCurrent = mConnectionTransformer->attributeTyped<Matrix>("i_intf")->get();
 	else
-		**mIntfCurrent = mSubResistorC->attribute<Matrix>("i_intf")->get();
+		**mIntfCurrent = mSubResistorC->attributeTyped<Matrix>("i_intf")->get();
 }
 
 void EMT::Ph3::AvVoltageSourceInverterDQ::mnaUpdateVoltage(const Matrix& leftVector) {

--- a/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 
 EMT::Ph3::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, String name, Logger::Level logLevel, Bool withTrafo) :
-	SimPowerComp<Real>(uid, name, logLevel),
+	CompositePowerComp<Real>(uid, name, logLevel),
 	mOmegaN(Attribute<Real>::create("Omega_nom", mAttributes)),
 	mPref(Attribute<Real>::create("P_ref", mAttributes)),
 	mQref(Attribute<Real>::create("Q_ref", mAttributes)),
@@ -30,7 +30,7 @@ EMT::Ph3::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, Strin
 	if (withTrafo) {
 		setVirtualNodeNumber(4);
 		mConnectionTransformer = EMT::Ph3::Transformer::make(**mName + "_trans", **mName + "_trans", mLogLevel, false);
-		mSubComponents.push_back(mConnectionTransformer);
+		addMNASubComponent(mConnectionTransformer, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	} else {
 		setVirtualNodeNumber(3);
 	}
@@ -47,11 +47,13 @@ EMT::Ph3::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, Strin
 	mSubCapacitorF = EMT::Ph3::Capacitor::make(**mName + "_capF", mLogLevel);
 	mSubInductorF = EMT::Ph3::Inductor::make(**mName + "_indF", mLogLevel);
 	mSubCtrledVoltageSource = EMT::Ph3::VoltageSource::make(**mName + "_src", mLogLevel);
-	mSubComponents.push_back(mSubResistorF);
-	mSubComponents.push_back(mSubResistorC);
-	mSubComponents.push_back(mSubCapacitorF);
-	mSubComponents.push_back(mSubInductorF);
-	mSubComponents.push_back(mSubCtrledVoltageSource);
+	addMNASubComponent(mSubResistorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubResistorC, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubCapacitorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubInductorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+
+	// Pre-step of the subcontrolled voltage source is handled explicitly in mnaParentPreStep
+	addMNASubComponent(mSubCtrledVoltageSource, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	mSLog->info("Electrical subcomponents: ");
 	for (auto subcomp: mSubComponents)
@@ -253,26 +255,21 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::initializeFromNodesAndTerminals(Real f
 	mSLog->info("\n--- Initialization from powerflow finished ---");
 }
 
-void EMT::Ph3::AvVoltageSourceInverterDQ::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void EMT::Ph3::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
 	mTimeStep = timeStep;
-
-	// initialize electrical subcomponents with MNA interface
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
 
 	// initialize state space controller
 	mPowerControllerVSI->initializeStateSpaceModel(omega, timeStep, leftVector);
 	mPLL->setSimulationParameters(timeStep);
 
 	// collect right side vectors of subcomponents
-	mRightVectorStamps.push_back(&mSubCapacitorF->attributeTyped<Matrix>("right_vector")->get());
-	mRightVectorStamps.push_back(&mSubInductorF->attributeTyped<Matrix>("right_vector")->get());
-	mRightVectorStamps.push_back(&mSubCtrledVoltageSource->attributeTyped<Matrix>("right_vector")->get());
+	mRightVectorStamps.push_back(&mSubCapacitorF->mRightVector->get());
+	mRightVectorStamps.push_back(&mSubInductorF->mRightVector->get());
+	mRightVectorStamps.push_back(&mSubCtrledVoltageSource->mRightVector->get());
 	if (mWithConnectionTransformer)
-		mRightVectorStamps.push_back(&mConnectionTransformer->attributeTyped<Matrix>("right_vector")->get());
+		mRightVectorStamps.push_back(&mConnectionTransformer->mRightVector->get());
 
 	// collect tasks
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
@@ -283,13 +280,6 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::mnaInitialize(Real omega, Real timeSte
 	mMnaTasks.push_back(std::make_shared<ControlStep>(*this));
 
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-}
-
-
-void EMT::Ph3::AvVoltageSourceInverterDQ::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
 }
 
 void EMT::Ph3::AvVoltageSourceInverterDQ::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
@@ -315,9 +305,9 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::addControlStepDependencies(AttributeBa
 	mPLL->signalAddStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
 	mPowerControllerVSI->signalAddStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
 	// add step dependencies of component itself
-	attributeDependencies.push_back(attribute("i_intf"));
-	attributeDependencies.push_back(attribute("v_intf"));
-	modifiedAttributes.push_back(attribute("Vsref"));
+	attributeDependencies.push_back(mIntfCurrent);
+	attributeDependencies.push_back(mIntfVoltage);
+	modifiedAttributes.push_back(mVsref);
 }
 
 Matrix EMT::Ph3::AvVoltageSourceInverterDQ::parkTransformPowerInvariant(Real theta, const Matrix &fabc) {
@@ -363,7 +353,7 @@ Matrix EMT::Ph3::AvVoltageSourceInverterDQ::getInverseParkTransformMatrixPowerIn
 void EMT::Ph3::AvVoltageSourceInverterDQ::controlStep(Real time, Int timeStepCount) {
 	// Transformation interface forward
 	Matrix vcdq, ircdq;
-	Real theta = mPLL->attributeTyped<Matrix>("output_prev")->get()(0, 0);
+	Real theta = mPLL->mOutputPrev->get()(0, 0);
 	vcdq = parkTransformPowerInvariant(theta, **mVirtualNodes[3]->mVoltage);
 	ircdq = parkTransformPowerInvariant(theta, - **mSubResistorC->mIntfCurrent);
 
@@ -377,64 +367,45 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::controlStep(Real time, Int timeStepCou
 	mPowerControllerVSI->signalStep(time, timeStepCount);
 
 	// Transformation interface backward
-	**mVsref = inverseParkTransformPowerInvariant(mPLL->attributeTyped<Matrix>("output_prev")->get()(0, 0), mPowerControllerVSI->attributeTyped<Matrix>("output_curr")->get());
-
-	// Update nominal system angle
+	**mVsref = inverseParkTransformPowerInvariant(mPLL->mOutputPrev->get()(0, 0), mPowerControllerVSI->mOutputCurr->get());
 	mThetaN = mThetaN + mTimeStep * **mOmegaN;
 }
 
-void EMT::Ph3::AvVoltageSourceInverterDQ::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	// add pre-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	// add pre-step dependencies of component itself
-	prevStepDependencies.push_back(attribute("Vsref"));
-	prevStepDependencies.push_back(attribute("i_intf"));
-	prevStepDependencies.push_back(attribute("v_intf"));
-	attributeDependencies.push_back(mPowerControllerVSI->attributeTyped<Matrix>("output_prev"));
-	attributeDependencies.push_back(mPLL->attributeTyped<Matrix>("output_prev"));
-	modifiedAttributes.push_back(attribute("right_vector"));
+void EMT::Ph3::AvVoltageSourceInverterDQ::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+	prevStepDependencies.push_back(mVsref);
+	prevStepDependencies.push_back(mIntfCurrent);
+	prevStepDependencies.push_back(mIntfVoltage);
+	attributeDependencies.push_back(mPowerControllerVSI->mOutputPrev);
+	attributeDependencies.push_back(mPLL->mOutputPrev);
+	modifiedAttributes.push_back(mRightVector);
 }
 
-void EMT::Ph3::AvVoltageSourceInverterDQ::mnaPreStep(Real time, Int timeStepCount) {
+void EMT::Ph3::AvVoltageSourceInverterDQ::mnaParentPreStep(Real time, Int timeStepCount) {
 	// pre-step of subcomponents - controlled source
 	if (mWithControl)
-		mSubCtrledVoltageSource->attributeTyped<MatrixComp>("V_ref")->set(PEAK1PH_TO_RMS3PH * **mVsref);
-	// pre-step of subcomponents - others
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
+		mSubCtrledVoltageSource->mVoltageRef->set(PEAK1PH_TO_RMS3PH * **mVsref);
+
+	std::dynamic_pointer_cast<MNAInterface>(mSubCtrledVoltageSource)->mnaPreStep(time, timeStepCount);
 	// pre-step of component itself
 	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void EMT::Ph3::AvVoltageSourceInverterDQ::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	// add post-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	// add post-step dependencies of component itself
+void EMT::Ph3::AvVoltageSourceInverterDQ::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
-	modifiedAttributes.push_back(attribute("v_intf"));
-	modifiedAttributes.push_back(attribute("i_intf"));
+	modifiedAttributes.push_back(mIntfVoltage);
+	modifiedAttributes.push_back(mIntfCurrent);
 }
 
-void EMT::Ph3::AvVoltageSourceInverterDQ::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	// post-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
-	// post-step of component itself
+void EMT::Ph3::AvVoltageSourceInverterDQ::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	mnaUpdateCurrent(**leftVector);
 	mnaUpdateVoltage(**leftVector);
 }
 
 void EMT::Ph3::AvVoltageSourceInverterDQ::mnaUpdateCurrent(const Matrix& leftvector) {
 	if (mWithConnectionTransformer)
-		**mIntfCurrent = mConnectionTransformer->attributeTyped<Matrix>("i_intf")->get();
+		**mIntfCurrent = mConnectionTransformer->mIntfCurrent->get();
 	else
-		**mIntfCurrent = mSubResistorC->attributeTyped<Matrix>("i_intf")->get();
+		**mIntfCurrent = mSubResistorC->mIntfCurrent->get();
 }
 
 void EMT::Ph3::AvVoltageSourceInverterDQ::mnaUpdateVoltage(const Matrix& leftVector) {

--- a/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 
 EMT::Ph3::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, String name, Logger::Level logLevel, Bool withTrafo) :
-	CompositePowerComp<Real>(uid, name, logLevel),
+	CompositePowerComp<Real>(uid, name, true, true, logLevel),
 	mOmegaN(Attribute<Real>::create("Omega_nom", mAttributes)),
 	mPref(Attribute<Real>::create("P_ref", mAttributes)),
 	mQref(Attribute<Real>::create("Q_ref", mAttributes)),
@@ -268,10 +268,6 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real t
 	mRightVectorStamps.push_back(&mSubCtrledVoltageSource->mRightVector->get());
 	if (mWithConnectionTransformer)
 		mRightVectorStamps.push_back(&mConnectionTransformer->mRightVector->get());
-
-	// collect tasks
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 
 	// TODO: these are actually no MNA tasks
 	mMnaTasks.push_back(std::make_shared<ControlPreStep>(*this));

--- a/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
@@ -30,7 +30,7 @@ EMT::Ph3::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, Strin
 	if (withTrafo) {
 		setVirtualNodeNumber(4);
 		mConnectionTransformer = EMT::Ph3::Transformer::make(**mName + "_trans", **mName + "_trans", mLogLevel, false);
-		addMNASubComponent(mConnectionTransformer, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mConnectionTransformer, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	} else {
 		setVirtualNodeNumber(3);
 	}
@@ -47,13 +47,13 @@ EMT::Ph3::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, Strin
 	mSubCapacitorF = EMT::Ph3::Capacitor::make(**mName + "_capF", mLogLevel);
 	mSubInductorF = EMT::Ph3::Inductor::make(**mName + "_indF", mLogLevel);
 	mSubCtrledVoltageSource = EMT::Ph3::VoltageSource::make(**mName + "_src", mLogLevel);
-	addMNASubComponent(mSubResistorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
-	addMNASubComponent(mSubResistorC, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
-	addMNASubComponent(mSubCapacitorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
-	addMNASubComponent(mSubInductorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubResistorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
+	addMNASubComponent(mSubResistorC, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
+	addMNASubComponent(mSubCapacitorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
+	addMNASubComponent(mSubInductorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	// Pre-step of the subcontrolled voltage source is handled explicitly in mnaParentPreStep
-	addMNASubComponent(mSubCtrledVoltageSource, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubCtrledVoltageSource, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	mSLog->info("Electrical subcomponents: ");
 	for (auto subcomp: mSubComponents)
@@ -262,22 +262,9 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real t
 	mPowerControllerVSI->initializeStateSpaceModel(omega, timeStep, leftVector);
 	mPLL->setSimulationParameters(timeStep);
 
-	// collect right side vectors of subcomponents
-	mRightVectorStamps.push_back(&mSubCapacitorF->mRightVector->get());
-	mRightVectorStamps.push_back(&mSubInductorF->mRightVector->get());
-	mRightVectorStamps.push_back(&mSubCtrledVoltageSource->mRightVector->get());
-	if (mWithConnectionTransformer)
-		mRightVectorStamps.push_back(&mConnectionTransformer->mRightVector->get());
-
 	// TODO: these are actually no MNA tasks
 	mMnaTasks.push_back(std::make_shared<ControlPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<ControlStep>(*this));
-}
-
-void EMT::Ph3::AvVoltageSourceInverterDQ::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	rightVector.setZero();
-	for (auto stamp : mRightVectorStamps)
-		rightVector += *stamp;
 }
 
 void EMT::Ph3::AvVoltageSourceInverterDQ::addControlPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {

--- a/dpsim-models/src/EMT/EMT_Ph3_Capacitor.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Capacitor.cpp
@@ -11,15 +11,12 @@
 using namespace CPS;
 
 EMT::Ph3::Capacitor::Capacitor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::Capacitor(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
 	mEquivCurrent = Matrix::Zero(3, 1);
 	**mIntfVoltage = Matrix::Zero(3, 1);
 	**mIntfCurrent = Matrix::Zero(3, 1);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mCapacitance = CPS::Attribute<Matrix>::create("C", mAttributes);
 }
 
 

--- a/dpsim-models/src/EMT/EMT_Ph3_CurrentSource.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_CurrentSource.cpp
@@ -25,12 +25,12 @@ EMT::Ph3::CurrentSource::CurrentSource(String uid, String name, Logger::Level lo
 
 
 void EMT::Ph3::CurrentSource::initializeFromNodesAndTerminals(Real frequency) {
-	mSLog->info("\n--- Initialization from node voltages and terminal ---");	
+	mSLog->info("\n--- Initialization from node voltages and terminal ---");
 	if (!mParametersSet) {
 		auto srcSigSine = Signal::SineWaveGenerator::make(**mName + "_sw", Logger::Level::off);
 		// Complex(1,0) is used as initialPhasor for signal generator as only phase is used
 		srcSigSine->setParameters(Complex(1,0), frequency);
-		mSrcSig = srcSigSine; 
+		mSrcSig = srcSigSine;
 
 		Complex v_ref = initialSingleVoltage(1) - initialSingleVoltage(0);
 		Complex s_ref = terminal(1)->singlePower() - terminal(0)->singlePower();
@@ -39,7 +39,7 @@ void EMT::Ph3::CurrentSource::initializeFromNodesAndTerminals(Real frequency) {
 		Complex i_ref = std::conj(s_ref/v_ref/sqrt(3.));
 
 		**mCurrentRef = CPS::Math::singlePhaseVariableToThreePhase(i_ref);
-		mSrcFreq->setReference(mSrcSig->attribute<Real>("freq"));
+		mSrcFreq->setReference(mSrcSig->attributeTyped<Real>("freq"));
 
 		mSLog->info("\nReference current: {:s}"
 					"\nReference voltage: {:s}"
@@ -58,7 +58,7 @@ void EMT::Ph3::CurrentSource::initializeFromNodesAndTerminals(Real frequency) {
 	} else {
 		mSLog->info("\nInitialization from node voltages and terminal omitted (parameter already set)."
 					"\nReference voltage: {:s}",
-					Logger::matrixCompToString(attribute<MatrixComp>("I_ref")->get()));
+					Logger::matrixCompToString(attributeTyped<MatrixComp>("I_ref")->get()));
 	}
 	mSLog->info("\n--- Initialization from node voltages and terminal ---");
 	mSLog->flush();
@@ -67,7 +67,7 @@ void EMT::Ph3::CurrentSource::initializeFromNodesAndTerminals(Real frequency) {
 SimPowerComp<Real>::Ptr EMT::Ph3::CurrentSource::clone(String name) {
 	auto copy = CurrentSource::make(name, mLogLevel);
 	// TODO: implement setParameters
-	// copy->setParameters(attribute<MatrixComp>("I_ref")->get(), attribute<Real>("f_src")->get());
+	// copy->setParameters(attributeTyped<MatrixComp>("I_ref")->get(), attributeTyped<Real>("f_src")->get());
 	return copy;
 }
 
@@ -101,7 +101,7 @@ void EMT::Ph3::CurrentSource::updateCurrent(Real time) {
 	if(mSrcSig != nullptr) {
 		mSrcSig->step(time);
 		for(int i = 0; i < 3; i++) {
-			(**mIntfCurrent)(i, 0) = RMS_TO_PEAK * Math::abs((**mCurrentRef)(i, 0)) 
+			(**mIntfCurrent)(i, 0) = RMS_TO_PEAK * Math::abs((**mCurrentRef)(i, 0))
 				* cos(Math::phase(mSrcSig->getSignal()) + Math::phase((**mCurrentRef)(i, 0)));
 		}
 	} else {

--- a/dpsim-models/src/EMT/EMT_Ph3_Inductor.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Inductor.cpp
@@ -11,15 +11,12 @@
 using namespace CPS;
 
 EMT::Ph3::Inductor::Inductor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::Inductor(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
 	mEquivCurrent = Matrix::Zero(3, 1);
 	**mIntfVoltage = Matrix::Zero(3, 1);
 	**mIntfCurrent = Matrix::Zero(3, 1);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mInductance = CPS::Attribute<Matrix>::create("L", mAttributes);
 }
 
 SimPowerComp<Real>::Ptr EMT::Ph3::Inductor::clone(String name) {

--- a/dpsim-models/src/EMT/EMT_Ph3_NetworkInjection.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_NetworkInjection.cpp
@@ -24,7 +24,7 @@ EMT::Ph3::NetworkInjection::NetworkInjection(String uid, String name, Logger::Le
 
 	// Create electrical sub components
 	mSubVoltageSource = std::make_shared<EMT::Ph3::VoltageSource>(**mName + "_vs", mLogLevel);
-	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	mSLog->info("Electrical subcomponents: ");
 	for (auto subcomp: mSubComponents)
 		mSLog->info("- {}", subcomp->name());
@@ -84,17 +84,7 @@ void EMT::Ph3::NetworkInjection::initializeFromNodesAndTerminals(Real frequency)
 }
 
 // #### MNA functions ####
-
-void EMT::Ph3::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	// collect right side vectors of subcomponents
-	mRightVectorStamps.push_back(&**mSubVoltageSource->mRightVector);
-}
-
-void EMT::Ph3::NetworkInjection::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	rightVector.setZero();
-	for (auto stamp : mRightVectorStamps)
-		rightVector += *stamp;
-
+void EMT::Ph3::NetworkInjection::mnaParentApplyRightSideVectorStamp(Matrix& rightVector) {
 	mSLog->debug("Right Side Vector: {:s}",
 				Logger::matrixToString(rightVector));
 }

--- a/dpsim-models/src/EMT/EMT_Ph3_NetworkInjection.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_NetworkInjection.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 EMT::Ph3::NetworkInjection::NetworkInjection(String uid, String name, Logger::Level logLevel)
-	: CompositePowerComp<Real>(uid, name, logLevel),
+	: CompositePowerComp<Real>(uid, name, true, true, logLevel),
 	mVoltageRef(Attribute<MatrixComp>::createDynamic("V_ref", mAttributes)),
 	mSrcFreq(Attribute<Real>::createDynamic("f_src", mAttributes)) {
 	mPhaseType = PhaseType::ABC;
@@ -88,10 +88,6 @@ void EMT::Ph3::NetworkInjection::initializeFromNodesAndTerminals(Real frequency)
 void EMT::Ph3::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	// collect right side vectors of subcomponents
 	mRightVectorStamps.push_back(&**mSubVoltageSource->mRightVector);
-
-	// collect tasks
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }

--- a/dpsim-models/src/EMT/EMT_Ph3_NetworkInjection.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_NetworkInjection.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 EMT::Ph3::NetworkInjection::NetworkInjection(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel),
+	: CompositePowerComp<Real>(uid, name, logLevel),
 	mVoltageRef(Attribute<MatrixComp>::createDynamic("V_ref", mAttributes)),
 	mSrcFreq(Attribute<Real>::createDynamic("f_src", mAttributes)) {
 	mPhaseType = PhaseType::ABC;
@@ -24,7 +24,7 @@ EMT::Ph3::NetworkInjection::NetworkInjection(String uid, String name, Logger::Le
 
 	// Create electrical sub components
 	mSubVoltageSource = std::make_shared<EMT::Ph3::VoltageSource>(**mName + "_vs", mLogLevel);
-	mSubComponents.push_back(mSubVoltageSource);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	mSLog->info("Electrical subcomponents: ");
 	for (auto subcomp: mSubComponents)
 		mSLog->info("- {}", subcomp->name());
@@ -85,14 +85,9 @@ void EMT::Ph3::NetworkInjection::initializeFromNodesAndTerminals(Real frequency)
 
 // #### MNA functions ####
 
-void EMT::Ph3::NetworkInjection::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void EMT::Ph3::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-
-	// initialize electrical subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
 
 	// collect right side vectors of subcomponents
 	mRightVectorStamps.push_back(&**mSubVoltageSource->mRightVector);
@@ -104,12 +99,6 @@ void EMT::Ph3::NetworkInjection::mnaInitialize(Real omega, Real timeStep, Attrib
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
-void EMT::Ph3::NetworkInjection::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-}
-
 void EMT::Ph3::NetworkInjection::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
 	rightVector.setZero();
 	for (auto stamp : mRightVectorStamps)
@@ -119,44 +108,23 @@ void EMT::Ph3::NetworkInjection::mnaApplyRightSideVectorStamp(Matrix& rightVecto
 				Logger::matrixToString(rightVector));
 }
 
-
-void EMT::Ph3::NetworkInjection::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	// add pre-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	// add pre-step dependencies of component itself
+void EMT::Ph3::NetworkInjection::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	prevStepDependencies.push_back(mIntfCurrent);
 	prevStepDependencies.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mRightVector);
 }
 
-void EMT::Ph3::NetworkInjection::mnaPreStep(Real time, Int timeStepCount) {
-	// pre-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	// pre-step of component itself
+void EMT::Ph3::NetworkInjection::mnaParentPreStep(Real time, Int timeStepCount) {
 	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void EMT::Ph3::NetworkInjection::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	// add post-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	// add post-step dependencies of component itself
+void EMT::Ph3::NetworkInjection::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mIntfCurrent);
 }
 
-void EMT::Ph3::NetworkInjection::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	// post-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
-	// post-step of component itself
+void EMT::Ph3::NetworkInjection::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	mnaUpdateCurrent(**leftVector);
 	mnaUpdateVoltage(**leftVector);
 }

--- a/dpsim-models/src/EMT/EMT_Ph3_NetworkInjection.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_NetworkInjection.cpp
@@ -88,8 +88,6 @@ void EMT::Ph3::NetworkInjection::initializeFromNodesAndTerminals(Real frequency)
 void EMT::Ph3::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	// collect right side vectors of subcomponents
 	mRightVectorStamps.push_back(&**mSubVoltageSource->mRightVector);
-
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 void EMT::Ph3::NetworkInjection::mnaApplyRightSideVectorStamp(Matrix& rightVector) {

--- a/dpsim-models/src/EMT/EMT_Ph3_NetworkInjection.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_NetworkInjection.cpp
@@ -86,9 +86,6 @@ void EMT::Ph3::NetworkInjection::initializeFromNodesAndTerminals(Real frequency)
 // #### MNA functions ####
 
 void EMT::Ph3::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	// collect right side vectors of subcomponents
 	mRightVectorStamps.push_back(&**mSubVoltageSource->mRightVector);
 

--- a/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
@@ -142,9 +142,6 @@ void EMT::Ph3::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void EMT::Ph3::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	mRightVectorStamps.push_back(&mSubSeriesInductor->mRightVector->get());
 	if ((**mParallelCap)(0,0) > 0) {
 		mRightVectorStamps.push_back(&mSubParallelCapacitor0->mRightVector->get());

--- a/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 EMT::Ph3::PiLine::PiLine(String uid, String name, Logger::Level logLevel)
-	: Base::Ph3::PiLine(mAttributes), CompositePowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::PiLine(mAttributes), CompositePowerComp<Real>(uid, name, true, true, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);
@@ -147,8 +147,6 @@ void EMT::Ph3::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<
 		mRightVectorStamps.push_back(&mSubParallelCapacitor0->mRightVector->get());
 		mRightVectorStamps.push_back(&mSubParallelCapacitor1->mRightVector->get());
 	}
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 

--- a/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
@@ -147,7 +147,6 @@ void EMT::Ph3::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<
 		mRightVectorStamps.push_back(&mSubParallelCapacitor0->mRightVector->get());
 		mRightVectorStamps.push_back(&mSubParallelCapacitor1->mRightVector->get());
 	}
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 void EMT::Ph3::PiLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {

--- a/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
@@ -72,14 +72,14 @@ void EMT::Ph3::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSeriesResistor->connect({ mTerminals[0]->node(), mVirtualNodes[0] });
 	mSubSeriesResistor->initialize(mFrequencies);
 	mSubSeriesResistor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubSeriesResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSeriesResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 	mSubSeriesInductor = std::make_shared<EMT::Ph3::Inductor>(**mName + "_ind", mLogLevel);
 	mSubSeriesInductor->setParameters(**mSeriesInd);
 	mSubSeriesInductor->connect({ mVirtualNodes[0], mTerminals[1]->node() });
 	mSubSeriesInductor->initialize(mFrequencies);
 	mSubSeriesInductor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubSeriesInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSeriesInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	// Create parallel sub components
 	mSubParallelResistor0 = std::make_shared<EMT::Ph3::Resistor>(**mName + "_con0", mLogLevel);
@@ -87,14 +87,14 @@ void EMT::Ph3::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubParallelResistor0->connect(SimNode::List{ SimNode::GND, mTerminals[0]->node() });
 	mSubParallelResistor0->initialize(mFrequencies);
 	mSubParallelResistor0->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubParallelResistor0, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubParallelResistor0, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 	mSubParallelResistor1 = std::make_shared<EMT::Ph3::Resistor>(**mName + "_con1", mLogLevel);
 	mSubParallelResistor1->setParameters(2. * (**mParallelCond).inverse());
 	mSubParallelResistor1->connect(SimNode::List{ SimNode::GND, mTerminals[1]->node() });
 	mSubParallelResistor1->initialize(mFrequencies);
 	mSubParallelResistor1->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubParallelResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubParallelResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 	if ((**mParallelCap)(0,0) > 0) {
 		mSubParallelCapacitor0 = std::make_shared<EMT::Ph3::Capacitor>(**mName + "_cap0", mLogLevel);
@@ -102,14 +102,14 @@ void EMT::Ph3::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 		mSubParallelCapacitor0->connect(SimNode::List{ SimNode::GND, mTerminals[0]->node() });
 		mSubParallelCapacitor0->initialize(mFrequencies);
 		mSubParallelCapacitor0->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubParallelCapacitor0, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubParallelCapacitor0, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 		mSubParallelCapacitor1 = std::make_shared<EMT::Ph3::Capacitor>(**mName + "_cap1", mLogLevel);
 		mSubParallelCapacitor1->setParameters(**mParallelCap / 2.);
 		mSubParallelCapacitor1->connect(SimNode::List{ SimNode::GND, mTerminals[1]->node() });
 		mSubParallelCapacitor1->initialize(mFrequencies);
 		mSubParallelCapacitor1->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubParallelCapacitor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubParallelCapacitor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	}
 
 	mSLog->debug(
@@ -139,20 +139,6 @@ void EMT::Ph3::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(RMS3PH_TO_PEAK1PH * initialSingleVoltage(1)),
 		Logger::phasorToString(mVirtualNodes[0]->initialSingleVoltage()));
 	mSLog->flush();
-}
-
-void EMT::Ph3::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	mRightVectorStamps.push_back(&mSubSeriesInductor->mRightVector->get());
-	if ((**mParallelCap)(0,0) > 0) {
-		mRightVectorStamps.push_back(&mSubParallelCapacitor0->mRightVector->get());
-		mRightVectorStamps.push_back(&mSubParallelCapacitor1->mRightVector->get());
-	}
-}
-
-void EMT::Ph3::PiLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	rightVector.setZero();
-	for (auto stamp : mRightVectorStamps)
-		rightVector += *stamp;
 }
 
 void EMT::Ph3::PiLine::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes){

--- a/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 EMT::Ph3::PiLine::PiLine(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::PiLine(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);
@@ -20,11 +20,6 @@ EMT::Ph3::PiLine::PiLine(String uid, String name, Logger::Level logLevel)
 	**mIntfVoltage = Matrix::Zero(3, 1);
 	**mIntfCurrent = Matrix::Zero(3, 1);
 
-	///FIXME: Move initialization into base class
-	mSeriesRes = Attribute<Matrix>::create("R_series", mAttributes);
-	mSeriesInd = Attribute<Matrix>::create("L_series", mAttributes);
-	mParallelCap = Attribute<Matrix>::create("C_parallel", mAttributes);
-	mParallelCond = Attribute<Matrix>::create("G_parallel", mAttributes);
 	mSLog->flush();
 }
 

--- a/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
@@ -173,8 +173,6 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void EMT::Ph3::RXLoad::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));

--- a/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 EMT::Ph3::RXLoad::RXLoad(String uid, String name, Logger::Level logLevel)
-	: CompositePowerComp<Real>(uid, name, logLevel),
+	: CompositePowerComp<Real>(uid, name, true, true, logLevel),
 	mActivePower(Attribute<Matrix>::create("P", mAttributes)),
 	mReactivePower(Attribute<Matrix>::create("Q", mAttributes)),
 	mNomVoltage(Attribute<Real>::create("V_nom", mAttributes)) {
@@ -174,9 +174,6 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 
 void EMT::Ph3::RXLoad::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
 void EMT::Ph3::RXLoad::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {

--- a/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
@@ -106,7 +106,7 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubResistor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubResistor->initialize(mFrequencies);
 		mSubResistor->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	}
 
 	if ((**mReactivePower)(0, 0) != 0)
@@ -122,7 +122,7 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubInductor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubInductor->initialize(mFrequencies);
 		mSubInductor->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	}
 	else if (mReactance(0,0) < 0) {
 		mCapacitance = -1 / (2 * PI * frequency) * mReactance.inverse();
@@ -132,7 +132,7 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubCapacitor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubCapacitor->initialize(mFrequencies);
 		mSubCapacitor->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	}
 
 	MatrixComp vInitABC = MatrixComp::Zero(3, 1);
@@ -170,10 +170,6 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::matrixToString(mReactance));
 	mSLog->flush();
 
-}
-
-void EMT::Ph3::RXLoad::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 void EMT::Ph3::RXLoad::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {

--- a/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
@@ -101,7 +101,6 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 
 	if ((**mActivePower)(0,0) != 0) {
 		mResistance = std::pow(**mNomVoltage / sqrt(3), 2) * (**mActivePower).inverse();
-		mConductance = mResistance.inverse();
 		mSubResistor = std::make_shared<EMT::Ph3::Resistor>(**mName + "_res", mLogLevel);
 		mSubResistor->setParameters(mResistance);
 		mSubResistor->connect({ SimNode::GND, mTerminals[0]->node() });

--- a/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 EMT::Ph3::RXLoad::RXLoad(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel),
+	: CompositePowerComp<Real>(uid, name, logLevel),
 	mActivePower(Attribute<Matrix>::create("P", mAttributes)),
 	mReactivePower(Attribute<Matrix>::create("Q", mAttributes)),
 	mNomVoltage(Attribute<Real>::create("V_nom", mAttributes)) {
@@ -106,7 +106,7 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubResistor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubResistor->initialize(mFrequencies);
 		mSubResistor->initializeFromNodesAndTerminals(frequency);
-		mSubComponents.push_back(mSubResistor);
+		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	}
 
 	if ((**mReactivePower)(0, 0) != 0)
@@ -122,7 +122,7 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubInductor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubInductor->initialize(mFrequencies);
 		mSubInductor->initializeFromNodesAndTerminals(frequency);
-		mSubComponents.push_back(mSubInductor);
+		addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	}
 	else if (mReactance(0,0) < 0) {
 		mCapacitance = -1 / (2 * PI * frequency) * mReactance.inverse();
@@ -132,7 +132,7 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubCapacitor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubCapacitor->initialize(mFrequencies);
 		mSubCapacitor->initializeFromNodesAndTerminals(frequency);
-		mSubComponents.push_back(mSubCapacitor);
+		addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	}
 
 	MatrixComp vInitABC = MatrixComp::Zero(3, 1);
@@ -172,67 +172,32 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 
 }
 
-void EMT::Ph3::RXLoad::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void EMT::Ph3::RXLoad::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
-void EMT::Ph3::RXLoad::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
-	}
-}
-
-void EMT::Ph3::RXLoad::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
-}
-
-void EMT::Ph3::RXLoad::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	}
+void EMT::Ph3::RXLoad::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	modifiedAttributes.push_back(mRightVector);
 };
 
-void EMT::Ph3::RXLoad::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	}
+void EMT::Ph3::RXLoad::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfCurrent);
 	modifiedAttributes.push_back(mIntfVoltage);
 };
 
-void EMT::Ph3::RXLoad::MnaPreStep::execute(Real time, Int timeStepCount) {
-	for (auto subComp : mLoad.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	}
-	mLoad.mnaApplyRightSideVectorStamp(**mLoad.mRightVector);
+void EMT::Ph3::RXLoad::mnaParentPreStep(Real time, Int timeStepCount) {
+	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void EMT::Ph3::RXLoad::MnaPostStep::execute(Real time, Int timeStepCount) {
-	for (auto subComp : mLoad.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, mLeftVector);
-	}
-	mLoad.mnaUpdateVoltage(**mLeftVector);
-	mLoad.mnaUpdateCurrent(**mLeftVector);
+void EMT::Ph3::RXLoad::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+	mnaUpdateVoltage(**leftVector);
+	mnaUpdateCurrent(**leftVector);
 }
 
 void EMT::Ph3::RXLoad::mnaUpdateVoltage(const Matrix& leftVector) {

--- a/dpsim-models/src/EMT/EMT_Ph3_Resistor.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Resistor.cpp
@@ -11,14 +11,11 @@
 using namespace CPS;
 
 EMT::Ph3::Resistor::Resistor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::Resistor(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
 	**mIntfVoltage = Matrix::Zero(3, 1);
 	**mIntfCurrent = Matrix::Zero(3, 1);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mResistance = CPS::Attribute<Matrix>::create("R", mAttributes);
 }
 
 SimPowerComp<Real>::Ptr EMT::Ph3::Resistor::clone(String name) {

--- a/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
@@ -14,7 +14,7 @@ using namespace CPS;
 // !!! 			with initialization from phase-to-phase RMS variables
 
 EMT::Ph3::RxLine::RxLine(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::PiLine(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);
@@ -23,8 +23,6 @@ EMT::Ph3::RxLine::RxLine(String uid, String name, Logger::Level logLevel)
 	**mIntfVoltage = Matrix::Zero(3, 1);
 	**mIntfCurrent = Matrix::Zero(3, 1);
 
-	mSeriesRes = Attribute<Matrix>::create("R", mAttributes);
-	mSeriesInd = Attribute<Matrix>::create("L", mAttributes);
 	mSLog->flush();
 }
 

--- a/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
@@ -96,10 +96,6 @@ void EMT::Ph3::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(initialSingleVoltage(1)));
 }
 
-void EMT::Ph3::RxLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-}
-
 void EMT::Ph3::RxLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
 	mSubResistor->mnaApplyRightSideVectorStamp(rightVector);
 	mSubInductor->mnaApplyRightSideVectorStamp(rightVector);

--- a/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
@@ -64,13 +64,13 @@ void EMT::Ph3::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubResistor->setParameters(**mSeriesRes);
 	mSubResistor->connect({ mTerminals[0]->node(), mVirtualNodes[0] });
 	mSubResistor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 	mSubInductor = std::make_shared<EMT::Ph3::Inductor>(**mName + "_ind", mLogLevel);
 	mSubInductor->setParameters(**mSeriesInd);
 	mSubInductor->connect({ mVirtualNodes[0], mTerminals[1]->node() });
 	mSubInductor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	mInitialResistor = std::make_shared<EMT::Ph3::Resistor>(**mName + "_snubber_res", mLogLevel);
 	Matrix defaultSnubRes = Matrix::Zero(3, 1);
@@ -81,7 +81,7 @@ void EMT::Ph3::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 	mInitialResistor->setParameters(defaultSnubRes);
 	mInitialResistor->connect({ SimNode::GND, mTerminals[1]->node() });
 	mInitialResistor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mInitialResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mInitialResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 	mSLog->info(
 		"\n--- Initialization from powerflow ---"
@@ -94,11 +94,6 @@ void EMT::Ph3::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::matrixToString(**mIntfCurrent),
 		Logger::phasorToString(initialSingleVoltage(0)),
 		Logger::phasorToString(initialSingleVoltage(1)));
-}
-
-void EMT::Ph3::RxLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	mSubResistor->mnaApplyRightSideVectorStamp(rightVector);
-	mSubInductor->mnaApplyRightSideVectorStamp(rightVector);
 }
 
 void EMT::Ph3::RxLine::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {

--- a/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
@@ -14,7 +14,7 @@ using namespace CPS;
 // !!! 			with initialization from phase-to-phase RMS variables
 
 EMT::Ph3::RxLine::RxLine(String uid, String name, Logger::Level logLevel)
-	: Base::Ph3::PiLine(mAttributes), CompositePowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::PiLine(mAttributes), CompositePowerComp<Real>(uid, name, true, true, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);
@@ -97,8 +97,6 @@ void EMT::Ph3::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void EMT::Ph3::RxLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 

--- a/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
@@ -14,7 +14,7 @@ using namespace CPS;
 // !!! 			with initialization from phase-to-phase RMS variables
 
 EMT::Ph3::RxLine::RxLine(String uid, String name, Logger::Level logLevel)
-	: Base::Ph3::PiLine(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::PiLine(mAttributes), CompositePowerComp<Real>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);
@@ -64,13 +64,13 @@ void EMT::Ph3::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubResistor->setParameters(**mSeriesRes);
 	mSubResistor->connect({ mTerminals[0]->node(), mVirtualNodes[0] });
 	mSubResistor->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubResistor);
+	addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	mSubInductor = std::make_shared<EMT::Ph3::Inductor>(**mName + "_ind", mLogLevel);
 	mSubInductor->setParameters(**mSeriesInd);
 	mSubInductor->connect({ mVirtualNodes[0], mTerminals[1]->node() });
 	mSubInductor->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubInductor);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	mInitialResistor = std::make_shared<EMT::Ph3::Resistor>(**mName + "_snubber_res", mLogLevel);
 	Matrix defaultSnubRes = Matrix::Zero(3, 1);
@@ -81,7 +81,7 @@ void EMT::Ph3::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 	mInitialResistor->setParameters(defaultSnubRes);
 	mInitialResistor->connect({ SimNode::GND, mTerminals[1]->node() });
 	mInitialResistor->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mInitialResistor);
+	addMNASubComponent(mInitialResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	mSLog->info(
 		"\n--- Initialization from powerflow ---"
@@ -96,27 +96,12 @@ void EMT::Ph3::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(initialSingleVoltage(1)));
 }
 
-void EMT::Ph3::RxLine::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void EMT::Ph3::RxLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-}
-
-void EMT::Ph3::RxLine::mnaApplyInitialSystemMatrixStamp(Matrix& systemMatrix) {
-	mInitialResistor->mnaApplySystemMatrixStamp(systemMatrix);
-}
-
-void EMT::Ph3::RxLine::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
 }
 
 void EMT::Ph3::RxLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
@@ -124,31 +109,23 @@ void EMT::Ph3::RxLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
 	mSubInductor->mnaApplyRightSideVectorStamp(rightVector);
 }
 
-void EMT::Ph3::RxLine::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	}
+void EMT::Ph3::RxLine::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	modifiedAttributes.push_back(mRightVector);
 };
 
-void EMT::Ph3::RxLine::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	}
+void EMT::Ph3::RxLine::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfCurrent);
 	modifiedAttributes.push_back(mIntfVoltage);
 };
 
-void EMT::Ph3::RxLine::MnaPreStep::execute(Real time, Int timeStepCount) {
-	mLine.mnaApplyRightSideVectorStamp(**mLine.mRightVector);
+void EMT::Ph3::RxLine::mnaParentPreStep(Real time, Int timeStepCount) {
+	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void EMT::Ph3::RxLine::MnaPostStep::execute(Real time, Int timeStepCount) {
-	mLine.mnaUpdateVoltage(**mLeftVector);
-	mLine.mnaUpdateCurrent(**mLeftVector);
+void EMT::Ph3::RxLine::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+	mnaUpdateVoltage(**leftVector);
+	mnaUpdateCurrent(**leftVector);
 }
 
 void EMT::Ph3::RxLine::mnaUpdateVoltage(const Matrix& leftVector) {

--- a/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
@@ -97,8 +97,6 @@ void EMT::Ph3::RxLine::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void EMT::Ph3::RxLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);

--- a/dpsim-models/src/EMT/EMT_Ph3_SeriesResistor.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SeriesResistor.cpp
@@ -15,12 +15,10 @@ using namespace CPS;
 
 EMT::Ph3::SeriesResistor::SeriesResistor(String uid, String name,
 	Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph1::Resistor(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
-
-	mResistance = Attribute<Real>::create("R", mAttributes);
 }
 
 SimPowerComp<Real>::Ptr EMT::Ph3::SeriesResistor::clone(String name) {

--- a/dpsim-models/src/EMT/EMT_Ph3_SeriesSwitch.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SeriesSwitch.cpp
@@ -14,13 +14,9 @@ using namespace CPS;
 // !!! 			with initialization from phase-to-phase RMS variables
 
 EMT::Ph3::SeriesSwitch::SeriesSwitch(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph1::Switch(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
-
-	mOpenResistance = Attribute<Real>::create("R_open", mAttributes);
-	mClosedResistance = Attribute<Real>::create("R_closed", mAttributes);
-	mIsClosed = Attribute<Bool>::create("is_closed", mAttributes);
 }
 
 SimPowerComp<Real>::Ptr EMT::Ph3::SeriesSwitch::clone(String name) {

--- a/dpsim-models/src/EMT/EMT_Ph3_Switch.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Switch.cpp
@@ -14,14 +14,10 @@ using namespace CPS;
 // !!! 			with initialization from phase-to-phase RMS variables
 
 EMT::Ph3::Switch::Switch(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::Switch(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	setTerminalNumber(2);
 	**mIntfVoltage = Matrix::Zero(1,1);
 	**mIntfCurrent = Matrix::Zero(1,1);
-
-	mOpenResistance = Attribute<Matrix>::create("R_open", mAttributes);
-	mClosedResistance = Attribute<Matrix>::create("R_closed", mAttributes);
-	mSwitchClosed = Attribute<Bool>::create("is_closed", mAttributes);
 }
 
 SimPowerComp<Real>::Ptr EMT::Ph3::Switch::clone(String name) {
@@ -114,7 +110,7 @@ void EMT::Ph3::Switch::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
 		Math::addToMatrixElement(systemMatrix, matrixNodeIndex(1, 2), matrixNodeIndex(0, 1), -conductance(2, 1));
 		Math::addToMatrixElement(systemMatrix, matrixNodeIndex(1, 2), matrixNodeIndex(0, 2), -conductance(2, 2));
 	}
-	SPDLOG_LOGGER_TRACE(mSLog, 
+	SPDLOG_LOGGER_TRACE(mSLog,
 		"\nConductance matrix: {:s}",
 		Logger::matrixToString(conductance));
 }
@@ -172,7 +168,7 @@ void EMT::Ph3::Switch::mnaApplySwitchSystemMatrixStamp(Bool closed, Matrix& syst
 		Math::addToMatrixElement(systemMatrix, matrixNodeIndex(1, 2), matrixNodeIndex(0, 2), -conductance(2, 2));
 	}
 
-	SPDLOG_LOGGER_TRACE(mSLog, 
+	SPDLOG_LOGGER_TRACE(mSLog,
 		"\nConductance matrix: {:s}",
 		Logger::matrixToString(conductance));
 }

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorDQ.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorDQ.cpp
@@ -14,31 +14,11 @@ using namespace CPS;
 // !!! 			with initialization from phase-to-phase RMS variables
 
 EMT::Ph3::SynchronGeneratorDQ::SynchronGeneratorDQ(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::SynchronGenerator(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(1);
 	**mIntfVoltage = Matrix::Zero(3,1);
 	**mIntfCurrent = Matrix::Zero(3,1);
-
-	///CHECK: Are all of these used in this class or in subclasses?
-	mInertia = Attribute<Real>::create("inertia", mAttributes, 0);
-	mRs = Attribute<Real>::create("Rs", mAttributes, 0);
-	mLl = Attribute<Real>::create("Ll", mAttributes, 0);
-	mLd = Attribute<Real>::create("Ld", mAttributes, 0);
-	mLq = Attribute<Real>::create("Lq", mAttributes, 0);
-	mTd0_t = Attribute<Real>::create("Td0_t", mAttributes, 0);
-	mTd0_s = Attribute<Real>::create("Td0_s", mAttributes, 0);
-	mTq0_t = Attribute<Real>::create("Tq0_t", mAttributes, 0);
-	mTq0_s = Attribute<Real>::create("Tq0_s", mAttributes, 0);
-	mOmMech = Attribute<Real>::create("w_r", mAttributes, 0);
-	mDelta = Attribute<Real>::create("delta_r", mAttributes, 0);
-	mElecTorque = Attribute<Real>::create("T_e", mAttributes, 0);
-	mMechTorque = Attribute<Real>::create("T_m", mAttributes, 0);
-	mMechPower = Attribute<Real>::create("P_m", mAttributes, 0);
-	mLd_s = Attribute<Real>::create("Ld_s", mAttributes, 0);
-	mLd_t = Attribute<Real>::create("Ld_t", mAttributes, 0);
-	mLq_s = Attribute<Real>::create("Lq_s", mAttributes, 0);
-	mLq_t = Attribute<Real>::create("Lq_t", mAttributes, 0);
 }
 
 EMT::Ph3::SynchronGeneratorDQ::SynchronGeneratorDQ(String name, Logger::Level logLevel)
@@ -152,7 +132,7 @@ void EMT::Ph3::SynchronGeneratorDQ::applyParametersOperationalPerUnit() {
 void EMT::Ph3::SynchronGeneratorDQ::initializeFromNodesAndTerminals(Real frequency) {
 	if(!mInitialValuesSet) {
 		mSLog->info("--- Initialization from powerflow ---");
-		
+
 		// terminal powers in consumer system -> convert to generator system
 		Real activePower = -terminal(0)->singlePower().real();
 		Real reactivePower = -terminal(0)->singlePower().imag();

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 
 EMT::Ph3::SynchronGeneratorIdeal::SynchronGeneratorIdeal(String uid, String name, Logger::Level logLevel, CPS::GeneratorType sourceType)
-	: SimPowerComp<Real>(uid, name, logLevel),
+	: CompositePowerComp<Real>(uid, name, logLevel),
 	mRefVoltage(Attribute<MatrixComp>::createDynamic("V_ref", mAttributes)) {
 	mPhaseType = PhaseType::ABC;
 	mSourceType = sourceType;
@@ -39,10 +39,10 @@ void EMT::Ph3::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real freq
 
 	if (mSourceType == CPS::GeneratorType::IdealVoltageSource) {
 		mSubVoltageSource = EMT::Ph3::VoltageSource::make(**mName + "_vs", mLogLevel);
-		mSubComponents.push_back(mSubVoltageSource);
+		addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	} else {
 		mSubCurrentSource = EMT::Ph3::CurrentSource::make(**mName + "_cs", mLogLevel);
-		mSubComponents.push_back(mSubCurrentSource);
+		addMNASubComponent(mSubCurrentSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	}
 
 	mSubComponents[0]->connect({ SimNode::GND, node(0) });
@@ -68,15 +68,9 @@ void EMT::Ph3::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real freq
 		Logger::complexToString(terminal(0)->singlePower()));
 }
 
-void EMT::Ph3::SynchronGeneratorIdeal::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void EMT::Ph3::SynchronGeneratorIdeal::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-
-	// initialize subcomponent
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 
 	// collect tasks
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
@@ -85,47 +79,23 @@ void EMT::Ph3::SynchronGeneratorIdeal::mnaInitialize(Real omega, Real timeStep, 
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
-void EMT::Ph3::SynchronGeneratorIdeal::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	// add pre-step dependencies of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	}
-	// add pre-step dependencies of component itself
+void EMT::Ph3::SynchronGeneratorIdeal::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	prevStepDependencies.push_back(mIntfCurrent);
 	prevStepDependencies.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mRightVector);
 }
 
-void EMT::Ph3::SynchronGeneratorIdeal::mnaPreStep(Real time, Int timeStepCount) {
-	// pre-step of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	}
-	// pre-step of component itself
+void EMT::Ph3::SynchronGeneratorIdeal::mnaParentPreStep(Real time, Int timeStepCount) {
 	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void EMT::Ph3::SynchronGeneratorIdeal::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	// add post-step dependencies of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	}
-	// add post-step dependencies of component itself
+void EMT::Ph3::SynchronGeneratorIdeal::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mIntfCurrent);
 }
 
-void EMT::Ph3::SynchronGeneratorIdeal::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	// post-step of subcomponents
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
-	}
-	// post-step of component itself
+void EMT::Ph3::SynchronGeneratorIdeal::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	mnaUpdateCurrent(**leftVector);
 	mnaUpdateVoltage(**leftVector);
 }
@@ -136,19 +106,5 @@ void EMT::Ph3::SynchronGeneratorIdeal::mnaUpdateCurrent(const Matrix& leftvector
 
 void EMT::Ph3::SynchronGeneratorIdeal::mnaUpdateVoltage(const Matrix& leftVector) {
 	**mIntfVoltage = **mSubComponents[0]->mIntfVoltage;
-}
-
-void EMT::Ph3::SynchronGeneratorIdeal::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
-}
-
-void EMT::Ph3::SynchronGeneratorIdeal::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
-	}
 }
 

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
@@ -39,10 +39,10 @@ void EMT::Ph3::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real freq
 
 	if (mSourceType == CPS::GeneratorType::IdealVoltageSource) {
 		mSubVoltageSource = EMT::Ph3::VoltageSource::make(**mName + "_vs", mLogLevel);
-		addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	} else {
 		mSubCurrentSource = EMT::Ph3::CurrentSource::make(**mName + "_cs", mLogLevel);
-		addMNASubComponent(mSubCurrentSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubCurrentSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	}
 
 	mSubComponents[0]->connect({ SimNode::GND, node(0) });

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 
 EMT::Ph3::SynchronGeneratorIdeal::SynchronGeneratorIdeal(String uid, String name, Logger::Level logLevel, CPS::GeneratorType sourceType)
-	: CompositePowerComp<Real>(uid, name, logLevel),
+	: CompositePowerComp<Real>(uid, name, true, true, logLevel),
 	mRefVoltage(Attribute<MatrixComp>::createDynamic("V_ref", mAttributes)) {
 	mPhaseType = PhaseType::ABC;
 	mSourceType = sourceType;
@@ -69,10 +69,6 @@ void EMT::Ph3::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real freq
 }
 
 void EMT::Ph3::SynchronGeneratorIdeal::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	// collect tasks
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
-
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
@@ -68,10 +68,6 @@ void EMT::Ph3::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real freq
 		Logger::complexToString(terminal(0)->singlePower()));
 }
 
-void EMT::Ph3::SynchronGeneratorIdeal::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-}
-
 void EMT::Ph3::SynchronGeneratorIdeal::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	prevStepDependencies.push_back(mIntfCurrent);
 	prevStepDependencies.push_back(mIntfVoltage);

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
@@ -57,7 +57,7 @@ void EMT::Ph3::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real freq
 	mSubComponents[0]->initializeFromNodesAndTerminals(frequency);
 
 	if (mSourceType == CPS::GeneratorType::IdealVoltageSource)
-		mRefVoltage->setReference(mSubComponents[0]->attribute<MatrixComp>("V_ref"));
+		mRefVoltage->setReference(mSubComponents[0]->attributeTyped<MatrixComp>("V_ref"));
 
 	mSLog->info(
 		"\n--- Initialization from powerflow ---"

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
@@ -69,9 +69,6 @@ void EMT::Ph3::SynchronGeneratorIdeal::initializeFromNodesAndTerminals(Real freq
 }
 
 void EMT::Ph3::SynchronGeneratorIdeal::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	// collect tasks
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
@@ -243,7 +243,6 @@ void EMT::Ph3::SynchronGeneratorTrStab::step(Real time) {
 
 void EMT::Ph3::SynchronGeneratorTrStab::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	mTimeStep = timeStep;
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 	mMnaTasks.push_back(std::make_shared<AddBStep>(*this));
 }
 

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
@@ -31,7 +31,7 @@ Matrix EMT::Ph3::SynchronGeneratorTrStab::getParkTransformMatrixPowerInvariant(R
 
 
 EMT::Ph3::SynchronGeneratorTrStab::SynchronGeneratorTrStab(String uid, String name, Logger::Level logLevel)
-	: Base::SynchronGenerator(mAttributes), CompositePowerComp<Real>(uid, name, logLevel),
+	: Base::SynchronGenerator(mAttributes), CompositePowerComp<Real>(uid, name, true, true, logLevel),
 	mEp(Attribute<Complex>::create("Ep", mAttributes)),
 	mEp_abs(Attribute<Real>::create("Ep_mag", mAttributes)),
 	mEp_phase(Attribute<Real>::create("Ep_phase", mAttributes)),
@@ -244,9 +244,7 @@ void EMT::Ph3::SynchronGeneratorTrStab::step(Real time) {
 void EMT::Ph3::SynchronGeneratorTrStab::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	mTimeStep = timeStep;
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<AddBStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
 void EMT::Ph3::SynchronGeneratorTrStab::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
@@ -185,7 +185,7 @@ void EMT::Ph3::SynchronGeneratorTrStab::initializeFromNodesAndTerminals(Real fre
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[1], 0);
 	mSubVoltageSource->initialize(mFrequencies);
 	mSubVoltageSource->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	// Create sub inductor as Xpd
 	mSubInductor = EMT::Ph3::Inductor::make(**mName + "_ind", mLogLevel);
@@ -193,7 +193,7 @@ void EMT::Ph3::SynchronGeneratorTrStab::initializeFromNodesAndTerminals(Real fre
 	mSubInductor->connect({mVirtualNodes[0],terminal(0)->node()});
 	mSubInductor->initialize(mFrequencies);
 	mSubInductor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	mSLog->info("\n--- Initialize according to powerflow ---"
 				"\nTerminal 0 voltage: {:e}<{:e}"

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
@@ -242,9 +242,6 @@ void EMT::Ph3::SynchronGeneratorTrStab::step(Real time) {
 }
 
 void EMT::Ph3::SynchronGeneratorTrStab::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	mTimeStep = timeStep;
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
@@ -31,7 +31,7 @@ Matrix EMT::Ph3::SynchronGeneratorTrStab::getParkTransformMatrixPowerInvariant(R
 
 
 EMT::Ph3::SynchronGeneratorTrStab::SynchronGeneratorTrStab(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel),
+	: Base::SynchronGenerator(mAttributes), SimPowerComp<Real>(uid, name, logLevel),
 	mEp(Attribute<Complex>::create("Ep", mAttributes)),
 	mEp_abs(Attribute<Real>::create("Ep_mag", mAttributes)),
 	mEp_phase(Attribute<Real>::create("Ep_phase", mAttributes)),
@@ -43,18 +43,6 @@ EMT::Ph3::SynchronGeneratorTrStab::SynchronGeneratorTrStab(String uid, String na
 	**mIntfVoltage = Matrix::Zero(3,1);
 	**mIntfCurrent = Matrix::Zero(3,1);
 
-
-
-	// Register attributes
-	///CHECK: Are all of these used in this class or in subclasses?
-	mRs = Attribute<Real>::create("Rs", mAttributes, 0);
-	mLl = Attribute<Real>::create("Ll", mAttributes, 0);
-	mLd = Attribute<Real>::create("Ld", mAttributes, 0);
-	mLq = Attribute<Real>::create("Lq", mAttributes, 0);
-	mElecActivePower = Attribute<Real>::create("P_elec", mAttributes, 0);
-	mMechPower = Attribute<Real>::create("P_mech", mAttributes, 0);
-	mOmMech = Attribute<Real>::create("w_r", mAttributes, 0);
-	mInertia = Attribute<Real>::create("inertia", mAttributes, 0);
 	mStates = Matrix::Zero(10,1);
 }
 

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
@@ -14,32 +14,11 @@ using namespace CPS;
 // !!! 			with initialization from phase-to-phase RMS variables
 
 EMT::Ph3::SynchronGeneratorVBR::SynchronGeneratorVBR(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::SynchronGenerator(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(1);
 	**mIntfVoltage = Matrix::Zero(3,1);
 	**mIntfCurrent = Matrix::Zero(3,1);
-
-	///CHECK: Are all of these used in this class or in subclasses?
-	mInertia = Attribute<Real>::create("inertia", mAttributes, 0);
-	mRs = Attribute<Real>::create("Rs", mAttributes, 0);
-	mLl = Attribute<Real>::create("Ll", mAttributes, 0);
-	mLd = Attribute<Real>::create("Ld", mAttributes, 0);
-	mLq = Attribute<Real>::create("Lq", mAttributes, 0);
-	mTd0_t = Attribute<Real>::create("Td0_t", mAttributes, 0);
-	mTd0_s = Attribute<Real>::create("Td0_s", mAttributes, 0);
-	mTq0_t = Attribute<Real>::create("Tq0_t", mAttributes, 0);
-	mTq0_s = Attribute<Real>::create("Tq0_s", mAttributes, 0);
-	mOmMech = Attribute<Real>::create("w_r", mAttributes, 0);
-	mDelta = Attribute<Real>::create("delta_r", mAttributes, 0);
-	mElecTorque = Attribute<Real>::create("T_e", mAttributes, 0);
-	mMechTorque = Attribute<Real>::create("T_m", mAttributes, 0);
-	mMechPower = Attribute<Real>::create("P_m", mAttributes, 0);
-	mLd_s = Attribute<Real>::create("Ld_s", mAttributes, 0);
-	mLd_t = Attribute<Real>::create("Ld_t", mAttributes, 0);
-	mLq_s = Attribute<Real>::create("Lq_s", mAttributes, 0);
-	mLq_t = Attribute<Real>::create("Lq_t", mAttributes, 0);
-	
 }
 
 EMT::Ph3::SynchronGeneratorVBR::SynchronGeneratorVBR(String name, Logger::Level logLevel)
@@ -81,7 +60,7 @@ void EMT::Ph3::SynchronGeneratorVBR::setBaseAndOperationalPerUnitParameters(
 			"Ld_t: {:e}\nLq_t: {:e}\nLd_s: {:e}\nLq_s: {:e}\n"
 			"Td0_t: {:e}\nTq0_t: {:e}\nTd0_s: {:e}\nTq0_s: {:e}\n",
 			poleNumber, inertia,
-			Rs, Ld, Lq, Ll, 
+			Rs, Ld, Lq, Ll,
 			Ld_t, Lq_t, Ld_s, Lq_s,
 			Td0_t, Tq0_t, Td0_s, Tq0_s);
 
@@ -117,21 +96,21 @@ void EMT::Ph3::SynchronGeneratorVBR::setInitialValues(Real initActivePower, Real
 	mSLog->info("Set initial values: \n"
 				"initActivePower: {:e}\ninitReactivePower: {:e}\ninitTerminalVolt: {:e}\n"
 				"initVoltAngle: {:e} \ninitMechPower: {:e}",
-				initActivePower, initReactivePower, initTerminalVolt, 
+				initActivePower, initReactivePower, initTerminalVolt,
 				initVoltAngle, initMechPower);
 }
 
 void EMT::Ph3::SynchronGeneratorVBR::initializeFromNodesAndTerminals(Real frequency) {
 	if(!mInitialValuesSet) {
 		mSLog->info("--- Initialization from powerflow ---");
-		
+
 		// terminal powers in consumer system -> convert to generator system
 		Real activePower = -terminal(0)->singlePower().real();
 		Real reactivePower = -terminal(0)->singlePower().imag();
 
-		// 	voltage magnitude in phase-to-phase RMS -> convert to phase-to-ground peak expected by setInitialValues 
+		// 	voltage magnitude in phase-to-phase RMS -> convert to phase-to-ground peak expected by setInitialValues
 		Real voltMagnitude = RMS3PH_TO_PEAK1PH*Math::abs(initialSingleVoltage(0));
-		
+
 		this->setInitialValues(activePower, reactivePower, voltMagnitude, Math::phase(initialSingleVoltage(0)), activePower);
 
 		mSLog->info("\nTerminal 0 voltage: {:s}"
@@ -153,11 +132,11 @@ void EMT::Ph3::SynchronGeneratorVBR::mnaInitialize(Real omega, Real timeStep, At
 	for (UInt phase1Idx = 0; phase1Idx < 3; ++phase1Idx)
 		for (UInt phase2Idx = 0; phase2Idx < 3; ++phase2Idx)
 			mVariableSystemMatrixEntries.push_back(std::make_pair<UInt,UInt>(matrixNodeIndex(0, phase1Idx),matrixNodeIndex(0, phase2Idx)));
-	
+
 	mSLog->info("List of index pairs of varying matrix entries: ");
 	for (auto indexPair : mVariableSystemMatrixEntries)
 		mSLog->info("({}, {})", indexPair.first, indexPair.second);
-	
+
 
 	mSystemOmega = omega;
 	mTimeStep = timeStep;
@@ -306,7 +285,7 @@ void EMT::Ph3::SynchronGeneratorVBR::mnaApplyRightSideVectorStamp(Matrix& rightV
 	}
 }
 
-void EMT::Ph3::SynchronGeneratorVBR::stepInPerUnit() {	
+void EMT::Ph3::SynchronGeneratorVBR::stepInPerUnit() {
 
 	// Update of mechanical torque from turbine governor
 	if (mHasTurbineGovernor)

--- a/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 EMT::Ph3::Transformer::Transformer(String uid, String name,
 	Logger::Level logLevel, Bool withResistiveLosses)
-	: Base::Ph3::Transformer(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::Transformer(mAttributes), CompositePowerComp<Real>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	if (withResistiveLosses)
 		setVirtualNodeNumber(3);
@@ -89,13 +89,13 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 
 	// Create series sub components
 	mSubInductor = std::make_shared<EMT::Ph3::Inductor>(**mName + "_ind", mLogLevel);
-	mSubComponents.push_back(mSubInductor);
 	mSubInductor->setParameters(mInductance);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	if (mNumVirtualNodes == 3) {
 		mVirtualNodes[2]->setInitialVoltage(initialSingleVoltage(0));
 		mSubResistor = std::make_shared<EMT::Ph3::Resistor>(**mName + "_res", mLogLevel);
-		mSubComponents.push_back(mSubResistor);
+		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 		mSubResistor->setParameters(mResistance);
 		mSubResistor->connect({ node(0), mVirtualNodes[2] });
 		mSubInductor->connect({ mVirtualNodes[2], mVirtualNodes[0] });
@@ -115,7 +115,7 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSnubResistor1->setParameters(mSnubberResistance1);
 	mSubSnubResistor1->connect({ node(0), EMT::SimNode::GND });
 	mSLog->info("Snubber Resistance 1 (connected to higher voltage side {}) = {} [Ohm]", node(0)->name(), Logger::matrixToString(mSnubberResistance1));
-	mSubComponents.push_back(mSubSnubResistor1);
+	addMNASubComponent(mSubSnubResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	// A snubber conductance is added on the lower voltage side
 	Real snubberResistance2 = std::pow(std::abs(mNominalVoltageEnd2),2) / pSnub;
@@ -124,7 +124,7 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSnubResistor2->setParameters(mSnubberResistance2);
 	mSubSnubResistor2->connect({ node(1), EMT::SimNode::GND });
 	mSLog->info("Snubber Resistance 2 (connected to lower voltage side {}) = {} [Ohm]", node(1)->name(), Logger::matrixToString(mSnubberResistance2));
-	mSubComponents.push_back(mSubSnubResistor2);
+	addMNASubComponent(mSubSnubResistor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	// // A snubber capacitance is added to higher voltage side (not used as capacitor at high voltage side made it worse)
 	// Real snubberCapacitance1 = qSnub / std::pow(std::abs(mNominalVoltageEnd1),2) / omega;
@@ -142,7 +142,7 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSnubCapacitor2->setParameters(mSnubberCapacitance2);
 	mSubSnubCapacitor2->connect({ node(1), EMT::SimNode::GND });
 	mSLog->info("Snubber Capacitance 2 (connected to lower voltage side {}) = {} [F]", node(1)->name(), Logger::matrixToString(mSnubberCapacitance2));
-	mSubComponents.push_back(mSubSnubCapacitor2);
+	addMNASubComponent(mSubSnubCapacitor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	// Initialize electrical subcomponents
 	mSLog->info("Electrical subcomponents: ");
@@ -167,15 +167,11 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(RMS3PH_TO_PEAK1PH * mVirtualNodes[0]->initialSingleVoltage()));
 }
 
-void EMT::Ph3::Transformer::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void EMT::Ph3::Transformer::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
 
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
 
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
@@ -245,50 +241,23 @@ void EMT::Ph3::Transformer::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
 	}
 }
 
-void EMT::Ph3::Transformer::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	// Add subcomps to right side vector
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
-}
-
-void EMT::Ph3::Transformer::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	// add pre-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	// add pre-step dependencies of component itself
+void EMT::Ph3::Transformer::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	prevStepDependencies.push_back(attribute("i_intf"));
 	prevStepDependencies.push_back(attribute("v_intf"));
 	modifiedAttributes.push_back(attribute("right_vector"));
 }
 
-void EMT::Ph3::Transformer::mnaPreStep(Real time, Int timeStepCount) {
-	// pre-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	// pre-step of component itself
+void EMT::Ph3::Transformer::mnaParentPreStep(Real time, Int timeStepCount) {
 	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void EMT::Ph3::Transformer::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	// add post-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	// add post-step dependencies of component itself
+void EMT::Ph3::Transformer::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(attribute("v_intf"));
 	modifiedAttributes.push_back(attribute("i_intf"));
 }
 
-void EMT::Ph3::Transformer::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	// post-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
-	// post-step of component itself
+void EMT::Ph3::Transformer::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	mnaUpdateVoltage(**leftVector);
 	mnaUpdateCurrent(**leftVector);
 }

--- a/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
@@ -168,9 +168,6 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void EMT::Ph3::Transformer::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));

--- a/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 EMT::Ph3::Transformer::Transformer(String uid, String name,
 	Logger::Level logLevel, Bool withResistiveLosses)
-	: SimPowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::Transformer(mAttributes), SimPowerComp<Real>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	if (withResistiveLosses)
 		setVirtualNodeNumber(3);
@@ -24,8 +24,6 @@ EMT::Ph3::Transformer::Transformer(String uid, String name,
 	mSLog->info("Create {} {}", this->type(), name);
 	**mIntfVoltage = Matrix::Zero(3, 1);
 	**mIntfCurrent = Matrix::Zero(1, 1);
-
-	mRatio = Attribute<Complex>::create("ratio", mAttributes);
 }
 
 /// DEPRECATED: Delete method

--- a/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
@@ -168,8 +168,6 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void EMT::Ph3::Transformer::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-
 	mSLog->info(
 		"\nTerminal 0 connected to {:s} = sim node {:d}"
 		"\nTerminal 1 connected to {:s} = sim node {:d}",

--- a/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
@@ -90,12 +90,12 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	// Create series sub components
 	mSubInductor = std::make_shared<EMT::Ph3::Inductor>(**mName + "_ind", mLogLevel);
 	mSubInductor->setParameters(mInductance);
-	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	if (mNumVirtualNodes == 3) {
 		mVirtualNodes[2]->setInitialVoltage(initialSingleVoltage(0));
 		mSubResistor = std::make_shared<EMT::Ph3::Resistor>(**mName + "_res", mLogLevel);
-		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 		mSubResistor->setParameters(mResistance);
 		mSubResistor->connect({ node(0), mVirtualNodes[2] });
 		mSubInductor->connect({ mVirtualNodes[2], mVirtualNodes[0] });
@@ -115,7 +115,7 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSnubResistor1->setParameters(mSnubberResistance1);
 	mSubSnubResistor1->connect({ node(0), EMT::SimNode::GND });
 	mSLog->info("Snubber Resistance 1 (connected to higher voltage side {}) = {} [Ohm]", node(0)->name(), Logger::matrixToString(mSnubberResistance1));
-	addMNASubComponent(mSubSnubResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSnubResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	// A snubber conductance is added on the lower voltage side
 	Real snubberResistance2 = std::pow(std::abs(mNominalVoltageEnd2),2) / pSnub;
@@ -124,7 +124,7 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSnubResistor2->setParameters(mSnubberResistance2);
 	mSubSnubResistor2->connect({ node(1), EMT::SimNode::GND });
 	mSLog->info("Snubber Resistance 2 (connected to lower voltage side {}) = {} [Ohm]", node(1)->name(), Logger::matrixToString(mSnubberResistance2));
-	addMNASubComponent(mSubSnubResistor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSnubResistor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	// // A snubber capacitance is added to higher voltage side (not used as capacitor at high voltage side made it worse)
 	// Real snubberCapacitance1 = qSnub / std::pow(std::abs(mNominalVoltageEnd1),2) / omega;
@@ -142,7 +142,7 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSnubCapacitor2->setParameters(mSnubberCapacitance2);
 	mSubSnubCapacitor2->connect({ node(1), EMT::SimNode::GND });
 	mSLog->info("Snubber Capacitance 2 (connected to lower voltage side {}) = {} [F]", node(1)->name(), Logger::matrixToString(mSnubberCapacitance2));
-	addMNASubComponent(mSubSnubCapacitor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSnubCapacitor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	// Initialize electrical subcomponents
 	mSLog->info("Electrical subcomponents: ");

--- a/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Transformer.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 EMT::Ph3::Transformer::Transformer(String uid, String name,
 	Logger::Level logLevel, Bool withResistiveLosses)
-	: Base::Ph3::Transformer(mAttributes), CompositePowerComp<Real>(uid, name, logLevel) {
+	: Base::Ph3::Transformer(mAttributes), CompositePowerComp<Real>(uid, name, true, true, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	if (withResistiveLosses)
 		setVirtualNodeNumber(3);
@@ -169,9 +169,6 @@ void EMT::Ph3::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 
 void EMT::Ph3::Transformer::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 
 	mSLog->info(
 		"\nTerminal 0 connected to {:s} = sim node {:d}"

--- a/dpsim-models/src/EMT/EMT_Ph3_VoltageSourceNorton.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_VoltageSourceNorton.cpp
@@ -14,14 +14,11 @@ using namespace CPS;
 // !!! 			with initialization from phase-to-phase RMS variables
 
 EMT::Ph3::VoltageSourceNorton::VoltageSourceNorton(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Real>(uid, name, logLevel),
+	: Base::Ph1::VoltageSource(mAttributes), SimPowerComp<Real>(uid, name, logLevel),
 	mResistance(Attribute<Real>::create("R", mAttributes)) {
 	setTerminalNumber(2);
 	**mIntfVoltage = Matrix::Zero(3, 1);
 	**mIntfCurrent = Matrix::Zero(3, 1);
-
-	mVoltageRef = Attribute<Complex>::create("V_ref", mAttributes);
-	mSrcFreq = Attribute<Real>::create("f_src", mAttributes, -1);
 }
 
 void EMT::Ph3::VoltageSourceNorton::setParameters(Complex voltageRef, Real srcFreq,  Real resistance) {

--- a/dpsim-models/src/MNASimPowerComp.cpp
+++ b/dpsim-models/src/MNASimPowerComp.cpp
@@ -5,29 +5,136 @@
 using namespace CPS;
 
 template <typename VarType>
-void MNASimPowerComp<VarType>::addMNASubComponent(typename MNASimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder) {
+void MNASimPowerComp<VarType>::addMNASubComponent(typename SimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder) {
 	this->mSubComponents.push_back(subc);
-	switch preStepOrder {
-		case MNA_SUBCOMP_TASK_ORDER::NO_TASK: break;
-		case MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT: {
-			this->mSubcomponentsBeforePreStep.push_back(subc);
-			break;
+	if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subc)) {
+		this->mSubcomponentsMNA.push_back(mnasubcomp);
+		switch (preStepOrder) {
+			case MNA_SUBCOMP_TASK_ORDER::NO_TASK: break;
+			case MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT: {
+				this->mSubcomponentsBeforePreStep.push_back(mnasubcomp);
+				break;
+			}
+			case MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT: {
+				this->mSubcomponentsAfterPreStep.push_back(mnasubcomp);
+				break;
+			}
 		}
-		case MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT: {
-			this->mSubcomponentsAfterPreStep.push_back(subc);
-			break;
+		switch (postStepOrder) {
+			case MNA_SUBCOMP_TASK_ORDER::NO_TASK: break;
+			case MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT: {
+				this->mSubcomponentsBeforePostStep.push_back(mnasubcomp);
+				break;
+			}
+			case MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT: {
+				this->mSubcomponentsAfterPostStep.push_back(mnasubcomp);
+				break;
+			}
 		}
 	}
-	switch postStepOrder {
-		case MNA_SUBCOMP_TASK_ORDER::NO_TASK: break;
-		case MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT: {
-			this->mSubcomponentsBeforePostStep.push_back(subc);
-			break;
+}
+
+// template <typename VarType>
+// void MNASimPowerComp<VarType>::addMNASubComponent(typename MNASimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder) {
+// 	this->mSubComponents.push_back(subc);
+// 	this->mSubcomponentsMNA.push_back(subc);
+// 	switch (preStepOrder) {
+// 		case MNA_SUBCOMP_TASK_ORDER::NO_TASK: break;
+// 		case MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT: {
+// 			this->mSubcomponentsBeforePreStep.push_back(subc);
+// 			break;
+// 		}
+// 		case MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT: {
+// 			this->mSubcomponentsAfterPreStep.push_back(subc);
+// 			break;
+// 		}
+// 	}
+// 	switch (postStepOrder) {
+// 		case MNA_SUBCOMP_TASK_ORDER::NO_TASK: break;
+// 		case MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT: {
+// 			this->mSubcomponentsBeforePostStep.push_back(subc);
+// 			break;
+// 		}
+// 		case MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT: {
+// 			this->mSubcomponentsAfterPostStep.push_back(subc);
+// 			break;
+// 		}
+// 	}
+// }
+
+template <typename VarType>
+void MNASimPowerComp<VarType>::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+	if (this->hasSubComponents()) {
+		for (auto subComp : mSubcomponentsMNA) {
+			subComp->mnaInitialize(omega, timeStep, leftVector);
 		}
-		case MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT: {
-			this->mSubcomponentsAfterPostStep.push_back(subc);
-			break;
+		mnaParentInitialize(omega, timeStep, leftVector);
+	}
+}
+
+template <typename VarType>
+void MNASimPowerComp<VarType>::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
+	if (this->hasSubComponents()) {
+		for (auto subComp : mSubcomponentsMNA) {
+			subComp->mnaApplySystemMatrixStamp(systemMatrix);
 		}
+		mnaParentApplySystemMatrixStamp(systemMatrix);
+	}
+}
+
+template <typename VarType>
+void MNASimPowerComp<VarType>::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
+	if (this->hasSubComponents()) {
+		for (auto subComp : mSubcomponentsMNA) {
+			subComp->mnaApplyRightSideVectorStamp(rightVector);
+		}
+		mnaParentApplyRightSideVectorStamp(rightVector);
+	}
+}
+
+template <typename VarType>
+void MNASimPowerComp<VarType>::mnaPreStep(Real time, Int timeStepCount) {
+	if (this->hasSubComponents()) {
+		for (auto subComp : mSubcomponentsBeforePreStep) {
+			subComp->mnaPreStep(time, timeStepCount);
+		}
+		mnaParentPreStep(time, timeStepCount);
+		for (auto subComp : mSubcomponentsAfterPreStep) {
+			subComp->mnaPreStep(time, timeStepCount);
+		}
+	}
+}
+
+template <typename VarType>
+void MNASimPowerComp<VarType>::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+	if (this->hasSubComponents()) {
+		for (auto subComp : mSubcomponentsBeforePostStep) {
+			subComp->mnaPostStep(time, timeStepCount, leftVector);
+		}
+		mnaParentPostStep(time, timeStepCount, leftVector);
+		for (auto subComp : mSubcomponentsAfterPostStep) {
+			subComp->mnaPostStep(time, timeStepCount, leftVector);
+		}
+	}
+}
+
+template <typename VarType>
+void MNASimPowerComp<VarType>::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+	if (this->hasSubComponents()) {
+		for (auto subComp : mSubcomponentsMNA) {
+			subComp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
+		}
+		mnaParentAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
+	}
+}
+
+template <typename VarType>
+void MNASimPowerComp<VarType>::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
+	if (this->hasSubComponents()) {
+		for (auto subComp : mSubcomponentsMNA) {
+			subComp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
+		}
+		mnaParentAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
 	}
 }
 

--- a/dpsim-models/src/MNASimPowerComp.cpp
+++ b/dpsim-models/src/MNASimPowerComp.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <dpsim-models/MNASimPowerComp.h>
+
+using namespace CPS;
+
+template <typename VarType>
+void MNASimPowerComp<VarType>::addMNASubComponent(typename MNASimPowerComp<VarType>::Ptr subc, MNA_SUBCOMP_TASK_ORDER preStepOrder, MNA_SUBCOMP_TASK_ORDER postStepOrder) {
+	this->mSubComponents.push_back(subc);
+	switch preStepOrder {
+		case MNA_SUBCOMP_TASK_ORDER::NO_TASK: break;
+		case MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT: {
+			this->mSubcomponentsBeforePreStep.push_back(subc);
+			break;
+		}
+		case MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT: {
+			this->mSubcomponentsAfterPreStep.push_back(subc);
+			break;
+		}
+	}
+	switch postStepOrder {
+		case MNA_SUBCOMP_TASK_ORDER::NO_TASK: break;
+		case MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT: {
+			this->mSubcomponentsBeforePostStep.push_back(subc);
+			break;
+		}
+		case MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT: {
+			this->mSubcomponentsAfterPostStep.push_back(subc);
+			break;
+		}
+	}
+}
+
+// Declare specializations to move definitions to .cpp
+template class CPS::MNASimPowerComp<Real>;
+template class CPS::MNASimPowerComp<Complex>;

--- a/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 SP::Ph1::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, String name, Logger::Level logLevel, Bool withTrafo) :
-	SimPowerComp<Complex>(uid, name, logLevel),
+	CompositePowerComp<Complex>(uid, name, logLevel),
 	mOmegaN(Attribute<Real>::create("Omega_nom", mAttributes)),
 	mVnom(Attribute<Real>::create("vnom", mAttributes)),
 	mPref(Attribute<Real>::create("P_ref", mAttributes)),
@@ -29,7 +29,7 @@ SP::Ph1::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, String
 	if (withTrafo) {
 		setVirtualNodeNumber(4);
 		mConnectionTransformer = SP::Ph1::Transformer::make(**mName + "_trans", **mName + "_trans", mLogLevel, false);
-		mSubComponents.push_back(mConnectionTransformer);
+		addMNASubComponent(mConnectionTransformer, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	} else {
 		setVirtualNodeNumber(3);
 	}
@@ -46,11 +46,13 @@ SP::Ph1::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, String
 	mSubCapacitorF = SP::Ph1::Capacitor::make(**mName + "_capF", mLogLevel);
 	mSubInductorF = SP::Ph1::Inductor::make(**mName + "_indF", mLogLevel);
 	mSubCtrledVoltageSource = SP::Ph1::VoltageSource::make(**mName + "_src", mLogLevel);
-	mSubComponents.push_back(mSubResistorF);
-	mSubComponents.push_back(mSubResistorC);
-	mSubComponents.push_back(mSubCapacitorF);
-	mSubComponents.push_back(mSubInductorF);
-	mSubComponents.push_back(mSubCtrledVoltageSource);
+	addMNASubComponent(mSubResistorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubResistorC, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubCapacitorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubInductorF, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+
+	// Pre-step of the subcontrolled voltage source is handled explicitly in mnaParentPreStep
+	addMNASubComponent(mSubCtrledVoltageSource, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	mSLog->info("Electrical subcomponents: ");
 	for (auto subcomp: mSubComponents)
@@ -237,15 +239,10 @@ void SP::Ph1::AvVoltageSourceInverterDQ::initializeFromNodesAndTerminals(Real fr
 		mSLog->info("\n--- Initialization from powerflow finished ---");
 }
 
-void SP::Ph1::AvVoltageSourceInverterDQ::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void SP::Ph1::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
 	mTimeStep = timeStep;
-
-	// initialize electrical subcomponents with MNA interface
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
 
 	// initialize state space controller
 	mPowerControllerVSI->initializeStateSpaceModel(omega, timeStep, leftVector);
@@ -267,13 +264,6 @@ void SP::Ph1::AvVoltageSourceInverterDQ::mnaInitialize(Real omega, Real timeStep
 	mMnaTasks.push_back(std::make_shared<ControlStep>(*this));
 
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-}
-
-
-void SP::Ph1::AvVoltageSourceInverterDQ::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
 }
 
 void SP::Ph1::AvVoltageSourceInverterDQ::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
@@ -325,12 +315,7 @@ void SP::Ph1::AvVoltageSourceInverterDQ::controlStep(Real time, Int timeStepCoun
 	mThetaN = mThetaN + mTimeStep * **mOmegaN;
 }
 
-void SP::Ph1::AvVoltageSourceInverterDQ::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	// add pre-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	// add pre-step dependencies of component itself
+void SP::Ph1::AvVoltageSourceInverterDQ::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	prevStepDependencies.push_back(attribute("Vsref"));
 	prevStepDependencies.push_back(attribute("i_intf"));
 	prevStepDependencies.push_back(attribute("v_intf"));
@@ -339,35 +324,23 @@ void SP::Ph1::AvVoltageSourceInverterDQ::mnaAddPreStepDependencies(AttributeBase
 	modifiedAttributes.push_back(attribute("right_vector"));
 }
 
-void SP::Ph1::AvVoltageSourceInverterDQ::mnaPreStep(Real time, Int timeStepCount) {
+void SP::Ph1::AvVoltageSourceInverterDQ::mnaParentPreStep(Real time, Int timeStepCount) {
 	// pre-steo of subcomponents - controlled source
 	if (mWithControl)
 		mSubCtrledVoltageSource->mVoltageRef->set((**mVsref)(0,0));
-	// pre-step of subcomponents - others
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
+
+	std::dynamic_pointer_cast<MNAInterface>(mSubCtrledVoltageSource)->mnaPreStep(time, timeStepCount);
 	// pre-step of component itself
 	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void SP::Ph1::AvVoltageSourceInverterDQ::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	// add post-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	// add post-step dependencies of component itself
+void SP::Ph1::AvVoltageSourceInverterDQ::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(attribute("v_intf"));
 	modifiedAttributes.push_back(attribute("i_intf"));
 }
 
-void SP::Ph1::AvVoltageSourceInverterDQ::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	// post-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
-	// post-step of component itself
+void SP::Ph1::AvVoltageSourceInverterDQ::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	mnaUpdateCurrent(**leftVector);
 	mnaUpdateVoltage(**leftVector);
 }

--- a/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -64,23 +64,19 @@ SP::Ph1::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, String
 	mVs->setReference(mSubCtrledVoltageSource->mIntfVoltage);
 
 	// PLL
-	///FIXME: Use attribute member variable
-	mPLL->attribute<Real>("input_ref")->setReference(mVcq);
-	///FIXME: Use attribute member variable
-	mPllOutput->setReference(mPLL->attribute<Matrix>("output_curr"));
+	mPLL->mInputRef->setReference(mVcq);
+	mPllOutput->setReference(mPLL->mOutputCurr);
 
 	// Power controller
 	// input references
-	///FIXME: Use attribute member variables
-	mPowerControllerVSI->attribute<Real>("Vc_d")->setReference(mVcd);
-	mPowerControllerVSI->attribute<Real>("Vc_q")->setReference(mVcq);
-	mPowerControllerVSI->attribute<Real>("Irc_d")->setReference(mIrcd);
-	mPowerControllerVSI->attribute<Real>("Irc_q")->setReference(mIrcq);
+	mPowerControllerVSI->mVc_d->setReference(mVcd);
+	mPowerControllerVSI->mVc_q->setReference(mVcq);
+	mPowerControllerVSI->mIrc_d->setReference(mIrcd);
+	mPowerControllerVSI->mIrc_q->setReference(mIrcq);
 	// input, state and output vector for logging
-	///FIXME: Use attribute member variables
-	mPowerctrlInputs->setReference(mPowerControllerVSI->attribute<Matrix>("input_curr"));
-	mPowerctrlStates->setReference(mPowerControllerVSI->attribute<Matrix>("state_curr"));
-	mPowerctrlOutputs->setReference(mPowerControllerVSI->attribute<Matrix>("output_curr"));
+	mPowerctrlInputs->setReference(mPowerControllerVSI->mInputCurr);
+	mPowerctrlStates->setReference(mPowerControllerVSI->mStateCurr);
+	mPowerctrlOutputs->setReference(mPowerControllerVSI->mOutputCurr);
 }
 
 void SP::Ph1::AvVoltageSourceInverterDQ::setParameters(Real sysOmega, Real sysVoltNom, Real Pref, Real Qref) {
@@ -210,7 +206,7 @@ void SP::Ph1::AvVoltageSourceInverterDQ::initializeFromNodesAndTerminals(Real fr
 	// current and voltage inputs to PLL and power controller
 	Complex vcdq, ircdq;
 	vcdq = Math::rotatingFrame2to1(mVirtualNodes[3]->initialSingleVoltage(), std::arg(mVirtualNodes[3]->initialSingleVoltage()), 0);
-	ircdq = Math::rotatingFrame2to1(-1. * mSubResistorC->attribute<MatrixComp>("i_intf")->get()(0, 0), std::arg(mVirtualNodes[3]->initialSingleVoltage()), 0);
+	ircdq = Math::rotatingFrame2to1(-1. * mSubResistorC->mIntfCurrent->get()(0, 0), std::arg(mVirtualNodes[3]->initialSingleVoltage()), 0);
 	**mVcd = vcdq.real();
 	**mVcq = vcdq.imag();
 	**mIrcd = ircdq.real();
@@ -256,11 +252,11 @@ void SP::Ph1::AvVoltageSourceInverterDQ::mnaInitialize(Real omega, Real timeStep
 	mPLL->setSimulationParameters(timeStep);
 
 	// collect right side vectors of subcomponents
-	mRightVectorStamps.push_back(&mSubCapacitorF->attribute<Matrix>("right_vector")->get());
-	mRightVectorStamps.push_back(&mSubInductorF->attribute<Matrix>("right_vector")->get());
-	mRightVectorStamps.push_back(&mSubCtrledVoltageSource->attribute<Matrix>("right_vector")->get());
+	mRightVectorStamps.push_back(&mSubCapacitorF->mRightVector->get());
+	mRightVectorStamps.push_back(&mSubInductorF->mRightVector->get());
+	mRightVectorStamps.push_back(&mSubCtrledVoltageSource->mRightVector->get());
 	if (mWithConnectionTransformer)
-		mRightVectorStamps.push_back(&mConnectionTransformer->attribute<Matrix>("right_vector")->get());
+		mRightVectorStamps.push_back(&mConnectionTransformer->mRightVector->get());
 
 	// collect tasks
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
@@ -303,9 +299,9 @@ void SP::Ph1::AvVoltageSourceInverterDQ::addControlStepDependencies(AttributeBas
 	mPLL->signalAddStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
 	mPowerControllerVSI->signalAddStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
 	// add step dependencies of component itself
-	attributeDependencies.push_back(attribute("i_intf"));
-	attributeDependencies.push_back(attribute("v_intf"));
-	modifiedAttributes.push_back(attribute("Vsref"));
+	attributeDependencies.push_back(mIntfCurrent);
+	attributeDependencies.push_back(mIntfVoltage);
+	modifiedAttributes.push_back(mVsref);
 }
 
 void SP::Ph1::AvVoltageSourceInverterDQ::controlStep(Real time, Int timeStepCount) {

--- a/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 SP::Ph1::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(String uid, String name, Logger::Level logLevel, Bool withTrafo) :
-	CompositePowerComp<Complex>(uid, name, logLevel),
+	CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 	mOmegaN(Attribute<Real>::create("Omega_nom", mAttributes)),
 	mVnom(Attribute<Real>::create("vnom", mAttributes)),
 	mPref(Attribute<Real>::create("P_ref", mAttributes)),
@@ -252,10 +252,6 @@ void SP::Ph1::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real ti
 	mRightVectorStamps.push_back(&mSubCtrledVoltageSource->mRightVector->get());
 	if (mWithConnectionTransformer)
 		mRightVectorStamps.push_back(&mConnectionTransformer->mRightVector->get());
-
-	// collect tasks
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 
 	// TODO: these are actually no MNA tasks
 	mMnaTasks.push_back(std::make_shared<ControlPreStep>(*this));

--- a/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -282,7 +282,7 @@ void SP::Ph1::AvVoltageSourceInverterDQ::mnaApplyRightSideVectorStamp(Matrix& ri
 		rightVector += *stamp;
 }
 
-void SP::Ph1::AvVoltageSourceInverterDQ::addControlPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+void SP::Ph1::AvVoltageSourceInverterDQ::addControlPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) const {
 	// add pre-step dependencies of subcomponents
 	mPLL->signalAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
 	mPowerControllerVSI->signalAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
@@ -294,7 +294,7 @@ void SP::Ph1::AvVoltageSourceInverterDQ::controlPreStep(Real time, Int timeStepC
 	mPowerControllerVSI->signalPreStep(time, timeStepCount);
 }
 
-void SP::Ph1::AvVoltageSourceInverterDQ::addControlStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+void SP::Ph1::AvVoltageSourceInverterDQ::addControlStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) const {
 	// add step dependencies of subcomponents
 	mPLL->signalAddStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
 	mPowerControllerVSI->signalAddStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);

--- a/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -256,8 +256,6 @@ void SP::Ph1::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real ti
 	// TODO: these are actually no MNA tasks
 	mMnaTasks.push_back(std::make_shared<ControlPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<ControlStep>(*this));
-
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 void SP::Ph1::AvVoltageSourceInverterDQ::mnaApplyRightSideVectorStamp(Matrix& rightVector) {

--- a/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -307,8 +307,8 @@ void SP::Ph1::AvVoltageSourceInverterDQ::addControlStepDependencies(AttributeBas
 void SP::Ph1::AvVoltageSourceInverterDQ::controlStep(Real time, Int timeStepCount) {
 	// Transformation interface forward
 	Complex vcdq, ircdq;
-	vcdq = Math::rotatingFrame2to1(mVirtualNodes[3]->singleVoltage(), mPLL->attribute<Matrix>("output_prev")->get()(0, 0), mThetaN);
-	ircdq = Math::rotatingFrame2to1(-1. * mSubResistorC->attribute<MatrixComp>("i_intf")->get()(0, 0), mPLL->attribute<Matrix>("output_prev")->get()(0, 0), mThetaN);
+	vcdq = Math::rotatingFrame2to1(mVirtualNodes[3]->singleVoltage(), mPLL->attributeTyped<Matrix>("output_prev")->get()(0, 0), mThetaN);
+	ircdq = Math::rotatingFrame2to1(-1. * mSubResistorC->attributeTyped<MatrixComp>("i_intf")->get()(0, 0), mPLL->attributeTyped<Matrix>("output_prev")->get()(0, 0), mThetaN);
 	**mVcd = vcdq.real();
 	**mVcq = vcdq.imag();
 	**mIrcd = ircdq.real();
@@ -319,7 +319,7 @@ void SP::Ph1::AvVoltageSourceInverterDQ::controlStep(Real time, Int timeStepCoun
 	mPowerControllerVSI->signalStep(time, timeStepCount);
 
 	// Transformation interface backward
-	(**mVsref)(0,0) = Math::rotatingFrame2to1(Complex(mPowerControllerVSI->attribute<Matrix>("output_curr")->get()(0, 0), mPowerControllerVSI->attribute<Matrix>("output_curr")->get()(1, 0)), mThetaN, mPLL->attribute<Matrix>("output_prev")->get()(0, 0));
+	(**mVsref)(0,0) = Math::rotatingFrame2to1(Complex(mPowerControllerVSI->attributeTyped<Matrix>("output_curr")->get()(0, 0), mPowerControllerVSI->attributeTyped<Matrix>("output_curr")->get()(1, 0)), mThetaN, mPLL->attributeTyped<Matrix>("output_prev")->get()(0, 0));
 
 	// Update nominal system angle
 	mThetaN = mThetaN + mTimeStep * **mOmegaN;
@@ -334,8 +334,8 @@ void SP::Ph1::AvVoltageSourceInverterDQ::mnaAddPreStepDependencies(AttributeBase
 	prevStepDependencies.push_back(attribute("Vsref"));
 	prevStepDependencies.push_back(attribute("i_intf"));
 	prevStepDependencies.push_back(attribute("v_intf"));
-	attributeDependencies.push_back(mPowerControllerVSI->attribute<Matrix>("output_prev"));
-	attributeDependencies.push_back(mPLL->attribute<Matrix>("output_prev"));
+	attributeDependencies.push_back(mPowerControllerVSI->attributeTyped<Matrix>("output_prev"));
+	attributeDependencies.push_back(mPLL->attributeTyped<Matrix>("output_prev"));
 	modifiedAttributes.push_back(attribute("right_vector"));
 }
 
@@ -374,9 +374,9 @@ void SP::Ph1::AvVoltageSourceInverterDQ::mnaPostStep(Real time, Int timeStepCoun
 
 void SP::Ph1::AvVoltageSourceInverterDQ::mnaUpdateCurrent(const Matrix& leftvector) {
 	if (mWithConnectionTransformer)
-		**mIntfCurrent = mConnectionTransformer->attribute<MatrixComp>("i_intf")->get();
+		**mIntfCurrent = mConnectionTransformer->attributeTyped<MatrixComp>("i_intf")->get();
 	else
-		**mIntfCurrent = mSubResistorC->attribute<MatrixComp>("i_intf")->get();
+		**mIntfCurrent = mSubResistorC->attributeTyped<MatrixComp>("i_intf")->get();
 }
 
 void SP::Ph1::AvVoltageSourceInverterDQ::mnaUpdateVoltage(const Matrix& leftVector) {

--- a/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -240,8 +240,6 @@ void SP::Ph1::AvVoltageSourceInverterDQ::initializeFromNodesAndTerminals(Real fr
 }
 
 void SP::Ph1::AvVoltageSourceInverterDQ::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
 	mTimeStep = timeStep;
 
 	// initialize state space controller

--- a/dpsim-models/src/SP/SP_Ph1_Capacitor.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Capacitor.cpp
@@ -11,13 +11,10 @@
 using namespace CPS;
 
 SP::Ph1::Capacitor::Capacitor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Capacitor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	**mIntfVoltage = MatrixComp::Zero(1, 1);
 	**mIntfCurrent = MatrixComp::Zero(1, 1);
 	setTerminalNumber(2);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mCapacitance = CPS::Attribute<Real>::create("C", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr SP::Ph1::Capacitor::clone(String name) {

--- a/dpsim-models/src/SP/SP_Ph1_Inductor.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Inductor.cpp
@@ -11,13 +11,10 @@
 using namespace CPS;
 
 SP::Ph1::Inductor::Inductor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Inductor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	**mIntfVoltage = MatrixComp::Zero(1, 1);
 	**mIntfCurrent = MatrixComp::Zero(1, 1);
 	setTerminalNumber(2);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mInductance = CPS::Attribute<Real>::create("L", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr SP::Ph1::Inductor::clone(String name) {

--- a/dpsim-models/src/SP/SP_Ph1_Load.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Load.cpp
@@ -14,7 +14,7 @@ using namespace CPS;
 // please note that P,Q values can not be passed inside constructor since P,Q are currently read from the terminal,
 // and these values are not yet assigned to the terminals when this constructor was called in reader.
 SP::Ph1::Load::Load(String uid, String name, Logger::Level logLevel)
-	: CompositePowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, false, true, logLevel),
 	mActivePowerPerUnit(Attribute<Real>::create("P_pu", mAttributes)),
 	mReactivePowerPerUnit(Attribute<Real>::create("Q_pu", mAttributes)),
 	mActivePower(Attribute<Real>::createDynamic("P", mAttributes)), //Made dynamic so it can be imported through InterfaceVillas
@@ -164,7 +164,6 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 // #### MNA section ####
 void SP::Ph1::Load::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
 void SP::Ph1::Load::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {

--- a/dpsim-models/src/SP/SP_Ph1_Load.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Load.cpp
@@ -163,8 +163,6 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 
 // #### MNA section ####
 void SP::Ph1::Load::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }

--- a/dpsim-models/src/SP/SP_Ph1_Load.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Load.cpp
@@ -162,9 +162,6 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 
 
 // #### MNA section ####
-void SP::Ph1::Load::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-}
 
 void SP::Ph1::Load::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);

--- a/dpsim-models/src/SP/SP_Ph1_Load.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Load.cpp
@@ -205,7 +205,7 @@ void SP::Ph1::Load::mnaUpdateVoltage(const Matrix& leftVector) {
 void SP::Ph1::Load::mnaUpdateCurrent(const Matrix& leftVector) {
 	(**mIntfCurrent)(0, 0) = 0;
 
-	for (auto subc : mSubComponents) {
+	for (auto& subc : mSubComponents) {
 		(**mIntfCurrent)(0, 0) += subc->intfCurrent()(0, 0);
 	}
 }

--- a/dpsim-models/src/SP/SP_Ph1_Load.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Load.cpp
@@ -89,8 +89,8 @@ void SP::Ph1::Load::updatePQ(Real time) {
 	} else {
 		Real wf = mLoadProfile.weightingFactors.find(time)->second;
 		///THISISBAD: P_nom and Q_nom do not exist as attributes
-		Real P_new = this->attribute<Real>("P_nom")->get()*wf;
-		Real Q_new = this->attribute<Real>("Q_nom")->get()*wf;
+		Real P_new = this->attributeTyped<Real>("P_nom")->get()*wf;
+		Real Q_new = this->attributeTyped<Real>("Q_nom")->get()*wf;
 		**mActivePower = P_new;
 		**mReactivePower = Q_new;
 	}
@@ -143,7 +143,7 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 	}
 
 	(**mIntfVoltage)(0, 0) = mTerminals[0]->initialSingleVoltage();
-	(**mIntfCurrent)(0, 0) = std::conj(Complex(attribute<Real>("P")->get(), attribute<Real>("Q")->get()) / (**mIntfVoltage)(0, 0));
+	(**mIntfCurrent)(0, 0) = std::conj(Complex(attributeTyped<Real>("P")->get(), attributeTyped<Real>("Q")->get()) / (**mIntfVoltage)(0, 0));
 
 	mSLog->info(
 		"\n--- Initialization from powerflow ---"
@@ -156,7 +156,7 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(initialSingleVoltage(0)));
 	mSLog->info(
 		"Updated parameters according to powerflow:\n"
-		"Active Power={} [W] Reactive Power={} [VAr]", attribute<Real>("P")->get(), attribute<Real>("Q")->get());
+		"Active Power={} [W] Reactive Power={} [VAr]", attributeTyped<Real>("P")->get(), attributeTyped<Real>("Q")->get());
 	mSLog->flush();
 }
 

--- a/dpsim-models/src/SP/SP_Ph1_Load.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Load.cpp
@@ -115,7 +115,7 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 		mSubResistor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubResistor->initialize(mFrequencies);
 		mSubResistor->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 	}
 
 	if (**mReactivePower != 0)
@@ -131,7 +131,7 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 		mSubInductor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubInductor->initialize(mFrequencies);
 		mSubInductor->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 	} else if (mReactance < 0) {
 		mCapacitance = -1 / (2 * PI * frequency) / mReactance;
 		mSubCapacitor = std::make_shared<SP::Ph1::Capacitor>(**mUID + "_res", **mName + "_cap", Logger::Level::off);
@@ -139,7 +139,7 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 		mSubCapacitor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubCapacitor->initialize(mFrequencies);
 		mSubCapacitor->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 	}
 
 	(**mIntfVoltage)(0, 0) = mTerminals[0]->initialSingleVoltage();

--- a/dpsim-models/src/SP/SP_Ph1_Load.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Load.cpp
@@ -14,7 +14,7 @@ using namespace CPS;
 // please note that P,Q values can not be passed inside constructor since P,Q are currently read from the terminal,
 // and these values are not yet assigned to the terminals when this constructor was called in reader.
 SP::Ph1::Load::Load(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, logLevel),
 	mActivePowerPerUnit(Attribute<Real>::create("P_pu", mAttributes)),
 	mReactivePowerPerUnit(Attribute<Real>::create("Q_pu", mAttributes)),
 	mActivePower(Attribute<Real>::createDynamic("P", mAttributes)), //Made dynamic so it can be imported through InterfaceVillas
@@ -115,7 +115,7 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 		mSubResistor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubResistor->initialize(mFrequencies);
 		mSubResistor->initializeFromNodesAndTerminals(frequency);
-		mSubComponents.push_back(mSubResistor);
+		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	}
 
 	if (**mReactivePower != 0)
@@ -131,7 +131,7 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 		mSubInductor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubInductor->initialize(mFrequencies);
 		mSubInductor->initializeFromNodesAndTerminals(frequency);
-		mSubComponents.push_back(mSubInductor);
+		addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	} else if (mReactance < 0) {
 		mCapacitance = -1 / (2 * PI * frequency) / mReactance;
 		mSubCapacitor = std::make_shared<SP::Ph1::Capacitor>(**mUID + "_res", **mName + "_cap", Logger::Level::off);
@@ -139,7 +139,7 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 		mSubCapacitor->connect({ SimNode::GND, mTerminals[0]->node() });
 		mSubCapacitor->initialize(mFrequencies);
 		mSubCapacitor->initializeFromNodesAndTerminals(frequency);
-		mSubComponents.push_back(mSubCapacitor);
+		addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	}
 
 	(**mIntfVoltage)(0, 0) = mTerminals[0]->initialSingleVoltage();
@@ -162,45 +162,27 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 
 
 // #### MNA section ####
-void SP::Ph1::Load::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void SP::Ph1::Load::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
-
-void SP::Ph1::Load::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
-}
-
-void SP::Ph1::Load::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
+void SP::Ph1::Load::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfCurrent);
 	modifiedAttributes.push_back(mIntfVoltage);
 };
 
-void SP::Ph1::Load::MnaPostStep::execute(Real time, Int timeStepCount) {
-	for (auto subComp : mLoad.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, mLeftVector);
-	}
-	mLoad.mnaUpdateVoltage(**mLeftVector);
-	mLoad.mnaUpdateCurrent(**mLeftVector);
+void SP::Ph1::Load::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+	mnaUpdateVoltage(**leftVector);
+	mnaUpdateCurrent(**leftVector);
 }
-
 
 void SP::Ph1::Load::mnaUpdateVoltage(const Matrix& leftVector) {
 	(**mIntfVoltage)(0, 0) = Math::complexFromVectorElement(leftVector, matrixNodeIndex(0));
 }
-
 
 void SP::Ph1::Load::mnaUpdateCurrent(const Matrix& leftVector) {
 	(**mIntfCurrent)(0, 0) = 0;

--- a/dpsim-models/src/SP/SP_Ph1_Load.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Load.cpp
@@ -32,7 +32,6 @@ SP::Ph1::Load::Load(String uid, String name, Logger::Level logLevel)
 void SP::Ph1::Load::setParameters(Real activePower, Real reactivePower, Real nominalVoltage) {
 	**mActivePower = activePower;
 	**mReactivePower = reactivePower;
-	mPower = { **mActivePower, **mReactivePower };
 	**mNomVoltage = nominalVoltage;
 
 	mSLog->info("Active Power={} [W] Reactive Power={} [VAr]", **mActivePower, **mReactivePower);

--- a/dpsim-models/src/SP/SP_Ph1_Load.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Load.cpp
@@ -205,7 +205,7 @@ void SP::Ph1::Load::mnaUpdateVoltage(const Matrix& leftVector) {
 void SP::Ph1::Load::mnaUpdateCurrent(const Matrix& leftVector) {
 	(**mIntfCurrent)(0, 0) = 0;
 
-	for (auto& subc : mSubComponents) {
+	for (auto subc : mSubComponents) {
 		(**mIntfCurrent)(0, 0) += subc->intfCurrent()(0, 0);
 	}
 }

--- a/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
@@ -130,8 +130,6 @@ void SP::Ph1::NetworkInjection::initializeFromNodesAndTerminals(Real frequency) 
 void SP::Ph1::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	// collect right side vectors of subcomponents
 	mRightVectorStamps.push_back(&**mSubVoltageSource->mRightVector);
-
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 void SP::Ph1::NetworkInjection::mnaApplyRightSideVectorStamp(Matrix& rightVector) {

--- a/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 
 SP::Ph1::NetworkInjection::NetworkInjection(String uid, String name,
-    Logger::Level logLevel) : CompositePowerComp<Complex>(uid, name, logLevel),
+    Logger::Level logLevel) : CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 	mVoltageRef(Attribute<Complex>::createDynamic("V_ref", mAttributes)),
 	mSrcFreq(Attribute<Real>::createDynamic("f_src", mAttributes)),
 	mVoltageSetPoint(Attribute<Real>::create("V_set", mAttributes)),
@@ -130,10 +130,6 @@ void SP::Ph1::NetworkInjection::initializeFromNodesAndTerminals(Real frequency) 
 void SP::Ph1::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	// collect right side vectors of subcomponents
 	mRightVectorStamps.push_back(&**mSubVoltageSource->mRightVector);
-
-	// collect tasks
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }

--- a/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 
 SP::Ph1::NetworkInjection::NetworkInjection(String uid, String name,
-    Logger::Level logLevel) : SimPowerComp<Complex>(uid, name, logLevel),
+    Logger::Level logLevel) : CompositePowerComp<Complex>(uid, name, logLevel),
 	mVoltageRef(Attribute<Complex>::createDynamic("V_ref", mAttributes)),
 	mSrcFreq(Attribute<Real>::createDynamic("f_src", mAttributes)),
 	mVoltageSetPoint(Attribute<Real>::create("V_set", mAttributes)),
@@ -29,7 +29,7 @@ SP::Ph1::NetworkInjection::NetworkInjection(String uid, String name,
 
 	// Create electrical sub components
 	mSubVoltageSource = std::make_shared<SP::Ph1::VoltageSource>(**mName + "_vs", mLogLevel);
-	mSubComponents.push_back(mSubVoltageSource);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	mSLog->info("Electrical subcomponents: ");
 	for (auto subcomp: mSubComponents)
 		mSLog->info("- {}", subcomp->name());
@@ -127,14 +127,9 @@ void SP::Ph1::NetworkInjection::initializeFromNodesAndTerminals(Real frequency) 
 
 // #### MNA functions ####
 
-void SP::Ph1::NetworkInjection::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void SP::Ph1::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-
-	// initialize electrical subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
 
 	// collect right side vectors of subcomponents
 	mRightVectorStamps.push_back(&**mSubVoltageSource->mRightVector);
@@ -146,12 +141,6 @@ void SP::Ph1::NetworkInjection::mnaInitialize(Real omega, Real timeStep, Attribu
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
-void SP::Ph1::NetworkInjection::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-}
-
 void SP::Ph1::NetworkInjection::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
 	rightVector.setZero();
 	for (auto stamp : mRightVectorStamps)
@@ -161,43 +150,23 @@ void SP::Ph1::NetworkInjection::mnaApplyRightSideVectorStamp(Matrix& rightVector
 				Logger::matrixToString(rightVector));
 }
 
-void SP::Ph1::NetworkInjection::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	// add pre-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	// add pre-step dependencies of component itself
+void SP::Ph1::NetworkInjection::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	prevStepDependencies.push_back(mIntfCurrent);
 	prevStepDependencies.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mRightVector);
 }
 
-void SP::Ph1::NetworkInjection::mnaPreStep(Real time, Int timeStepCount) {
-	// pre-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	// pre-step of component itself
+void SP::Ph1::NetworkInjection::mnaParentPreStep(Real time, Int timeStepCount) {
 	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void SP::Ph1::NetworkInjection::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	// add post-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	// add post-step dependencies of component itself
+void SP::Ph1::NetworkInjection::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfVoltage);
 	modifiedAttributes.push_back(mIntfCurrent);
 }
 
-void SP::Ph1::NetworkInjection::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	// post-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
-	// post-step of component itself
+void SP::Ph1::NetworkInjection::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	mnaUpdateCurrent(**leftVector);
 	mnaUpdateVoltage(**leftVector);
 }

--- a/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
@@ -29,7 +29,7 @@ SP::Ph1::NetworkInjection::NetworkInjection(String uid, String name,
 
 	// Create electrical sub components
 	mSubVoltageSource = std::make_shared<SP::Ph1::VoltageSource>(**mName + "_vs", mLogLevel);
-	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	mSLog->info("Electrical subcomponents: ");
 	for (auto subcomp: mSubComponents)
 		mSLog->info("- {}", subcomp->name());
@@ -126,17 +126,7 @@ void SP::Ph1::NetworkInjection::initializeFromNodesAndTerminals(Real frequency) 
 }
 
 // #### MNA functions ####
-
-void SP::Ph1::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	// collect right side vectors of subcomponents
-	mRightVectorStamps.push_back(&**mSubVoltageSource->mRightVector);
-}
-
-void SP::Ph1::NetworkInjection::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	rightVector.setZero();
-	for (auto stamp : mRightVectorStamps)
-		rightVector += *stamp;
-
+void SP::Ph1::NetworkInjection::mnaParentApplyRightSideVectorStamp(Matrix& rightVector) {
 	mSLog->debug("Right Side Vector: {:s}",
 				Logger::matrixToString(rightVector));
 }

--- a/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
@@ -128,9 +128,6 @@ void SP::Ph1::NetworkInjection::initializeFromNodesAndTerminals(Real frequency) 
 // #### MNA functions ####
 
 void SP::Ph1::NetworkInjection::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	// collect right side vectors of subcomponents
 	mRightVectorStamps.push_back(&**mSubVoltageSource->mRightVector);
 

--- a/dpsim-models/src/SP/SP_Ph1_PVNode.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PVNode.cpp
@@ -23,12 +23,8 @@ SP::Ph1::PVNode::PVNode(String uid, String name, Real power, Real vSetPoint, Rea
 
 	**mPowerSetPoint =  power;
 	**mVoltageSetPoint = vSetPoint;
-	mRatedU = ratedU;
 
 	**mVoltagePerUnit = vSetPoint / ratedU;
-
-	// maxQ=0 means no limit.
-	mQLimit = maxQ;
 
 	mSLog->info("Create PV node for {} P={}, V={}", name, **mPowerSetPoint, **mVoltageSetPoint);
 }

--- a/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
@@ -166,14 +166,14 @@ void SP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubSeriesResistor->connect({ mTerminals[0]->node(), mVirtualNodes[0] });
 	mSubSeriesResistor->initialize(mFrequencies);
 	mSubSeriesResistor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubSeriesResistor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSeriesResistor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 	mSubSeriesInductor = std::make_shared<SP::Ph1::Inductor>(**mName + "_ind", mLogLevel);
 	mSubSeriesInductor->setParameters(**mSeriesInd);
 	mSubSeriesInductor->connect({ mVirtualNodes[0], mTerminals[1]->node() });
 	mSubSeriesInductor->initialize(mFrequencies);
 	mSubSeriesInductor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubSeriesInductor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubSeriesInductor, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	// Create parallel sub components
 	if (**mParallelCond >= 0) {
@@ -182,14 +182,14 @@ void SP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 		mSubParallelResistor0->connect(SimNode::List{ SimNode::GND, mTerminals[0]->node() });
 		mSubParallelResistor0->initialize(mFrequencies);
 		mSubParallelResistor0->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubParallelResistor0, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubParallelResistor0, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 		mSubParallelResistor1 = std::make_shared<SP::Ph1::Resistor>(**mName + "_con1", mLogLevel);
 		mSubParallelResistor1->setParameters(2. / **mParallelCond);
 		mSubParallelResistor1->connect(SimNode::List{ SimNode::GND, mTerminals[1]->node() });
 		mSubParallelResistor1->initialize(mFrequencies);
 		mSubParallelResistor1->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubParallelResistor1, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubParallelResistor1, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 	}
 
 	if (**mParallelCap >= 0) {
@@ -198,14 +198,14 @@ void SP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 		mSubParallelCapacitor0->connect(SimNode::List{ SimNode::GND, mTerminals[0]->node() });
 		mSubParallelCapacitor0->initialize(mFrequencies);
 		mSubParallelCapacitor0->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubParallelCapacitor0, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubParallelCapacitor0, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 		mSubParallelCapacitor1 = std::make_shared<SP::Ph1::Capacitor>(**mName + "_cap1", mLogLevel);
 		mSubParallelCapacitor1->setParameters(**mParallelCap / 2.);
 		mSubParallelCapacitor1->connect(SimNode::List{ SimNode::GND, mTerminals[1]->node() });
 		mSubParallelCapacitor1->initialize(mFrequencies);
 		mSubParallelCapacitor1->initializeFromNodesAndTerminals(frequency);
-		addMNASubComponent(mSubParallelCapacitor1, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubParallelCapacitor1, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	}
 
 	mSLog->info(
@@ -221,21 +221,6 @@ void SP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(initialSingleVoltage(0)),
 		Logger::phasorToString(initialSingleVoltage(1)),
 		Logger::phasorToString(mVirtualNodes[0]->initialSingleVoltage()));
-}
-
-void SP::Ph1::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	mRightVectorStamps.push_back(&**mSubSeriesInductor->mRightVector);
-
-	if (**mParallelCap >= 0) {
-		mRightVectorStamps.push_back(&**mSubParallelCapacitor0->mRightVector);
-		mRightVectorStamps.push_back(&**mSubParallelCapacitor1->mRightVector);
-	}
-}
-
-void SP::Ph1::PiLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	rightVector.setZero();
-	for (auto stamp : mRightVectorStamps)
-		rightVector += *stamp;
 }
 
 void SP::Ph1::PiLine::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {

--- a/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
@@ -16,7 +16,6 @@ SP::Ph1::PiLine::PiLine(String uid, String name, Logger::Level logLevel)
 	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
 	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
 	mReactivePowerBranch(Attribute<Matrix>::create("q_branch_vector", mAttributes)),
-	mStoreNodalPowerInjection(Attribute<Bool>::create("nodal_injection_stored", mAttributes, false)),
 	mActivePowerInjection(Attribute<Real>::create("p_inj", mAttributes)),
 	mReactivePowerInjection(Attribute<Real>::create("q_inj", mAttributes)) {
 
@@ -145,7 +144,6 @@ void SP::Ph1::PiLine::updateBranchFlow(VectorComp& current, VectorComp& powerflo
 void SP::Ph1::PiLine::storeNodalInjection(Complex powerInjection) {
 	**mActivePowerInjection = std::real(powerInjection)*mBaseApparentPower;
 	**mReactivePowerInjection = std::imag(powerInjection)*mBaseApparentPower;
-	**mStoreNodalPowerInjection = true;
 }
 
 MatrixComp SP::Ph1::PiLine::Y_element() {

--- a/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
@@ -224,9 +224,6 @@ void SP::Ph1::PiLine::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void SP::Ph1::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	mRightVectorStamps.push_back(&**mSubSeriesInductor->mRightVector);
 
 	if (**mParallelCap >= 0) {

--- a/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 SP::Ph1::PiLine::PiLine(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: Base::Ph1::PiLine(mAttributes), SimPowerComp<Complex>(uid, name, logLevel),
 	mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes)),
 	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
 	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
@@ -29,11 +29,6 @@ SP::Ph1::PiLine::PiLine(String uid, String name, Logger::Level logLevel)
 	**mCurrent = MatrixComp::Zero(2,1);
 	**mActivePowerBranch = Matrix::Zero(2,1);
 	**mReactivePowerBranch = Matrix::Zero(2,1);
-
-	mSeriesRes = Attribute<Real>::create("R_series", mAttributes);
-	mSeriesInd = Attribute<Real>::create("L_series", mAttributes);
-	mParallelCap = Attribute<Real>::create("C_parallel", mAttributes);
-	mParallelCond = Attribute<Real>::create("G_parallel", mAttributes);
 }
 
 void SP::Ph1::PiLine::setParameters(Real resistance, Real inductance, Real capacitance, Real conductance) {

--- a/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 SP::Ph1::PiLine::PiLine(String uid, String name, Logger::Level logLevel)
-	: Base::Ph1::PiLine(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel),
+	: Base::Ph1::PiLine(mAttributes), CompositePowerComp<Complex>(uid, name, false, true, logLevel),
 	mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes)),
 	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
 	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
@@ -230,8 +230,6 @@ void SP::Ph1::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<M
 		mRightVectorStamps.push_back(&**mSubParallelCapacitor0->mRightVector);
 		mRightVectorStamps.push_back(&**mSubParallelCapacitor1->mRightVector);
 	}
-
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 

--- a/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
@@ -230,7 +230,6 @@ void SP::Ph1::PiLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<M
 		mRightVectorStamps.push_back(&**mSubParallelCapacitor0->mRightVector);
 		mRightVectorStamps.push_back(&**mSubParallelCapacitor1->mRightVector);
 	}
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 
 void SP::Ph1::PiLine::mnaApplyRightSideVectorStamp(Matrix& rightVector) {

--- a/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
@@ -13,7 +13,7 @@ using namespace CPS;
 SP::Ph1::RXLine::RXLine(String uid, String name, Real baseVoltage,
 	Real resistance, Real inductance,
 	Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: Base::Ph1::PiLine(mAttributes), SimPowerComp<Complex>(uid, name, logLevel),
 	mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes, baseVoltage)),
 	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
 	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
@@ -23,10 +23,6 @@ SP::Ph1::RXLine::RXLine(String uid, String name, Real baseVoltage,
 	mInductance(Attribute<Real>::create("L_series", mAttributes))  {
 
 	setTerminalNumber(2);
-
-	mSeriesRes = Attribute<Real>::create("R_series", mAttributes);
-	mParallelCap = Attribute<Real>::create("C_parallel", mAttributes);
-	mParallelCond = Attribute<Real>::create("G_parallel", mAttributes);
 
 	**mSeriesRes = resistance;
 	**mInductance = inductance;
@@ -40,7 +36,7 @@ SP::Ph1::RXLine::RXLine(String uid, String name, Real baseVoltage,
 }
 
 SP::Ph1::RXLine::RXLine(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: Base::Ph1::PiLine(mAttributes), SimPowerComp<Complex>(uid, name, logLevel),
 	mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes)),
 	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
 	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
@@ -53,10 +49,6 @@ SP::Ph1::RXLine::RXLine(String uid, String name, Logger::Level logLevel)
 	setTerminalNumber(2);
 	**mIntfVoltage = MatrixComp::Zero(1, 1);
 	**mIntfCurrent = MatrixComp::Zero(1, 1);
-
-	/// FIXME: Why are these attributes defined differently than in the first constructor?
-	mSeriesRes = Attribute<Real>::create("R", mAttributes);
-	mSeriesInd = Attribute<Real>::create("L", mAttributes);
 }
 
 

--- a/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
@@ -18,7 +18,6 @@ SP::Ph1::RXLine::RXLine(String uid, String name, Real baseVoltage,
 	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
 	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
 	mReactivePowerBranch(Attribute<Matrix>::create("q_branch_vector", mAttributes)),
-	mStoreNodalPowerInjection(Attribute<Bool>::create("nodal_injection_stored", mAttributes, false)),
 	mActivePowerInjection(Attribute<Real>::create("p_inj", mAttributes)),
 	mReactivePowerInjection(Attribute<Real>::create("q_inj", mAttributes)),
 	mInductance(Attribute<Real>::create("L_series", mAttributes))  {
@@ -46,7 +45,6 @@ SP::Ph1::RXLine::RXLine(String uid, String name, Logger::Level logLevel)
 	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
 	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
 	mReactivePowerBranch(Attribute<Matrix>::create("q_branch_vector", mAttributes)),
-	mStoreNodalPowerInjection(Attribute<Bool>::create("nodal_injection_stored", mAttributes, false)),
 	mActivePowerInjection(Attribute<Real>::create("p_inj", mAttributes)),
 	mReactivePowerInjection(Attribute<Real>::create("q_inj", mAttributes)),
 	mInductance(Attribute<Real>::create("L_series", mAttributes))  {
@@ -141,7 +139,6 @@ void SP::Ph1::RXLine::updateBranchFlow(VectorComp& current, VectorComp& powerflo
 void SP::Ph1::RXLine::storeNodalInjection(Complex powerInjection) {
 	**mActivePowerInjection = std::real(powerInjection) * mBaseApparentPower;
 	**mReactivePowerInjection = std::imag(powerInjection) * mBaseApparentPower;
-	**mStoreNodalPowerInjection = true;
 }
 
 

--- a/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
@@ -188,9 +188,6 @@ void SP::Ph1::RXLine::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void SP::Ph1::RXLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);

--- a/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
@@ -187,10 +187,6 @@ void SP::Ph1::RXLine::initializeFromNodesAndTerminals(Real frequency) {
 		Logger::phasorToString(initialSingleVoltage(1)));
 }
 
-void SP::Ph1::RXLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-}
-
 void SP::Ph1::RXLine::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	modifiedAttributes.push_back(mRightVector);
 };

--- a/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
@@ -160,19 +160,19 @@ void SP::Ph1::RXLine::initializeFromNodesAndTerminals(Real frequency) {
 	mSubResistor->setParameters(**mSeriesRes);
 	mSubResistor->connect({ mTerminals[0]->node(), mVirtualNodes[0] });
 	mSubResistor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	mSubInductor = std::make_shared<SP::Ph1::Inductor>(**mName + "_ind", mLogLevel);
 	mSubInductor->setParameters(**mSeriesInd);
 	mSubInductor->connect({ mVirtualNodes[0], mTerminals[1]->node() });
 	mSubInductor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	mInitialResistor = std::make_shared<SP::Ph1::Resistor>(**mName + "_snubber_res", mLogLevel);
 	mInitialResistor->setParameters(1e6);
 	mInitialResistor->connect({ SimNode::GND, mTerminals[1]->node() });
 	mInitialResistor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mInitialResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mInitialResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	mSLog->info(
 		"\n--- Initialization from powerflow ---"

--- a/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
@@ -13,14 +13,16 @@ using namespace CPS;
 SP::Ph1::RXLine::RXLine(String uid, String name, Real baseVoltage,
 	Real resistance, Real inductance,
 	Logger::Level logLevel)
-	: Base::Ph1::PiLine(mAttributes), SimPowerComp<Complex>(uid, name, logLevel),
-	mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes, baseVoltage)),
-	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
-	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
-	mReactivePowerBranch(Attribute<Matrix>::create("q_branch_vector", mAttributes)),
-	mActivePowerInjection(Attribute<Real>::create("p_inj", mAttributes)),
-	mReactivePowerInjection(Attribute<Real>::create("q_inj", mAttributes)),
-	mInductance(Attribute<Real>::create("L_series", mAttributes))  {
+	: 	Base::Ph1::PiLine(mAttributes),
+		SimPowerComp<Complex>(uid, name, logLevel),
+		mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes, baseVoltage)),
+		mInductance(Attribute<Real>::create("L_series", mAttributes)),
+		mActivePowerInjection(Attribute<Real>::create("p_inj", mAttributes)),
+		mReactivePowerInjection(Attribute<Real>::create("q_inj", mAttributes)),
+		mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
+		mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
+		mReactivePowerBranch(Attribute<Matrix>::create("q_branch_vector", mAttributes)) {
+
 
 	setTerminalNumber(2);
 
@@ -36,14 +38,15 @@ SP::Ph1::RXLine::RXLine(String uid, String name, Real baseVoltage,
 }
 
 SP::Ph1::RXLine::RXLine(String uid, String name, Logger::Level logLevel)
-	: Base::Ph1::PiLine(mAttributes), SimPowerComp<Complex>(uid, name, logLevel),
-	mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes)),
-	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
-	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
-	mReactivePowerBranch(Attribute<Matrix>::create("q_branch_vector", mAttributes)),
-	mActivePowerInjection(Attribute<Real>::create("p_inj", mAttributes)),
-	mReactivePowerInjection(Attribute<Real>::create("q_inj", mAttributes)),
-	mInductance(Attribute<Real>::create("L_series", mAttributes))  {
+	: 	Base::Ph1::PiLine(mAttributes),
+		SimPowerComp<Complex>(uid, name, logLevel),
+		mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes)),
+		mInductance(Attribute<Real>::create("L_series", mAttributes)),
+		mActivePowerInjection(Attribute<Real>::create("p_inj", mAttributes)),
+		mReactivePowerInjection(Attribute<Real>::create("q_inj", mAttributes)),
+		mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
+		mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
+		mReactivePowerBranch(Attribute<Matrix>::create("q_branch_vector", mAttributes)) {
 
 	setVirtualNodeNumber(1);
 	setTerminalNumber(2);

--- a/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
@@ -14,7 +14,7 @@ SP::Ph1::RXLine::RXLine(String uid, String name, Real baseVoltage,
 	Real resistance, Real inductance,
 	Logger::Level logLevel)
 	: 	Base::Ph1::PiLine(mAttributes),
-		CompositePowerComp<Complex>(uid, name, logLevel),
+		CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 		mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes, baseVoltage)),
 		mInductance(Attribute<Real>::create("L_series", mAttributes)),
 		mActivePowerInjection(Attribute<Real>::create("p_inj", mAttributes)),
@@ -39,7 +39,7 @@ SP::Ph1::RXLine::RXLine(String uid, String name, Real baseVoltage,
 
 SP::Ph1::RXLine::RXLine(String uid, String name, Logger::Level logLevel)
 	: 	Base::Ph1::PiLine(mAttributes),
-		CompositePowerComp<Complex>(uid, name, logLevel),
+		CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 		mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes)),
 		mInductance(Attribute<Real>::create("L_series", mAttributes)),
 		mActivePowerInjection(Attribute<Real>::create("p_inj", mAttributes)),
@@ -188,8 +188,6 @@ void SP::Ph1::RXLine::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void SP::Ph1::RXLine::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 }
 

--- a/dpsim-models/src/SP/SP_Ph1_Resistor.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Resistor.cpp
@@ -13,13 +13,10 @@ using namespace CPS;
 
 SP::Ph1::Resistor::Resistor(String uid, String name,
 	Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Resistor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	setTerminalNumber(2);
 	**mIntfVoltage = MatrixComp::Zero(1, 1);
 	**mIntfCurrent = MatrixComp::Zero(1, 1);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mResistance = CPS::Attribute<Real>::create("R", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr SP::Ph1::Resistor::clone(String name) {

--- a/dpsim-models/src/SP/SP_Ph1_Shunt.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Shunt.cpp
@@ -36,16 +36,14 @@ void SP::Ph1::Shunt::setBaseVoltage(Real baseVoltage) {
 
 void SP::Ph1::Shunt::calculatePerUnitParameters(Real baseApparentPower, Real baseOmega) {
 	mSLog->info("#### Calculate Per Unit Parameters for {}", **mName);
-	mBaseApparentPower = baseApparentPower;
-	mBaseOmega = baseOmega;
 	mSLog->info("Base Power={} [VA]  Base Omega={} [1/s]", baseApparentPower, baseOmega);
 
-	mBaseImpedance = (mBaseVoltage * mBaseVoltage) / mBaseApparentPower;
-	mBaseAdmittance = 1.0 / mBaseImpedance;
-	mSLog->info("Base Voltage={} [V]  Base Admittance={} [S]", mBaseVoltage, mBaseAdmittance);
+	auto baseImpedance = (mBaseVoltage * mBaseVoltage) / baseApparentPower;
+	auto baseAdmittance = 1.0 / baseImpedance;
+	mSLog->info("Base Voltage={} [V]  Base Admittance={} [S]", mBaseVoltage, baseAdmittance);
 
-	mConductancePerUnit = **mConductance / mBaseAdmittance;
-	mSusceptancePerUnit = **mSusceptance / mBaseAdmittance;
+	mConductancePerUnit = **mConductance / baseAdmittance;
+	mSusceptancePerUnit = **mSusceptance / baseAdmittance;
 	mSLog->info("Susceptance={} [pu] Conductance={} [pu]", mSusceptancePerUnit, mConductancePerUnit);
 };
 

--- a/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 SP::Ph1::SolidStateTransformer::SolidStateTransformer(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, logLevel),
     mPref(Attribute<Real>::create("P_ref", mAttributes, std::numeric_limits<double>::infinity())),
     mQ1ref(Attribute<Real>::create("Q1_ref", mAttributes)),
     mQ2ref(Attribute<Real>::create("Q2_ref", mAttributes)) {
@@ -53,8 +53,8 @@ void SP::Ph1::SolidStateTransformer::initializeFromNodesAndTerminals(Real freque
     mSubLoadSide1->connect({mTerminals[0]->node()});
     mSubLoadSide2->connect({mTerminals[1]->node()});
 
-	mSubComponents.push_back(mSubLoadSide1);
-	mSubComponents.push_back(mSubLoadSide2);
+	addMNASubComponent(mSubLoadSide1, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::NO_TASK);
+	addMNASubComponent(mSubLoadSide2, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::NO_TASK);
 
     mSLog->info(
 		"\n--- Initialization from powerflow ---"

--- a/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 SP::Ph1::SolidStateTransformer::SolidStateTransformer(String uid, String name, Logger::Level logLevel)
-	: CompositePowerComp<Complex>(uid, name, logLevel),
+	: CompositePowerComp<Complex>(uid, name, false, false, logLevel),
     mPref(Attribute<Real>::create("P_ref", mAttributes, std::numeric_limits<double>::infinity())),
     mQ1ref(Attribute<Real>::create("Q1_ref", mAttributes)),
     mQ2ref(Attribute<Real>::create("Q2_ref", mAttributes)) {

--- a/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
@@ -53,6 +53,9 @@ void SP::Ph1::SolidStateTransformer::initializeFromNodesAndTerminals(Real freque
     mSubLoadSide1->connect({mTerminals[0]->node()});
     mSubLoadSide2->connect({mTerminals[1]->node()});
 
+	mSubComponents.push_back(mSubLoadSide1);
+	mSubComponents.push_back(mSubLoadSide2);
+
     mSLog->info(
 		"\n--- Initialization from powerflow ---"
 		"\nTerminal 0 power flow: {:s} VA"

--- a/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
@@ -53,8 +53,8 @@ void SP::Ph1::SolidStateTransformer::initializeFromNodesAndTerminals(Real freque
     mSubLoadSide1->connect({mTerminals[0]->node()});
     mSubLoadSide2->connect({mTerminals[1]->node()});
 
-	addMNASubComponent(mSubLoadSide1, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::NO_TASK);
-	addMNASubComponent(mSubLoadSide2, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::NO_TASK);
+	addMNASubComponent(mSubLoadSide1, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::NO_TASK, false);
+	addMNASubComponent(mSubLoadSide2, MNA_SUBCOMP_TASK_ORDER::NO_TASK, MNA_SUBCOMP_TASK_ORDER::NO_TASK, false);
 
     mSLog->info(
 		"\n--- Initialization from powerflow ---"

--- a/dpsim-models/src/SP/SP_Ph1_Switch.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Switch.cpp
@@ -11,14 +11,10 @@
 using namespace CPS;
 
 SP::Ph1::Switch::Switch(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Switch(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	setTerminalNumber(2);
 	**mIntfVoltage = MatrixComp::Zero(1,1);
 	**mIntfCurrent = MatrixComp::Zero(1,1);
-
-	mOpenResistance = Attribute<Real>::create("R_open", mAttributes);
-	mClosedResistance = Attribute<Real>::create("R_closed", mAttributes);
-	mIsClosed = Attribute<Bool>::create("is_closed", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr SP::Ph1::Switch::clone(String name) {

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGenerator.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGenerator.cpp
@@ -27,14 +27,12 @@ SP::Ph1::SynchronGenerator::SynchronGenerator(String uid, String name, Logger::L
 };
 
 void SP::Ph1::SynchronGenerator::setParameters(Real ratedApparentPower, Real ratedVoltage, Real setPointActivePower, Real setPointVoltage, PowerflowBusType powerflowBusType, Real setPointReactivePower) {
-	mRatedApparentPower = ratedApparentPower;
-    mRatedVoltage = ratedVoltage;
     **mSetPointActivePower = setPointActivePower;
     **mSetPointReactivePower= setPointReactivePower;
     **mSetPointVoltage = setPointVoltage;
     mPowerflowBusType = powerflowBusType;
 
-	mSLog->info("Rated Apparent Power={} [VA] Rated Voltage={} [V]", mRatedApparentPower, mRatedVoltage);
+	mSLog->info("Rated Apparent Power={} [VA] Rated Voltage={} [V]", ratedApparentPower, ratedVoltage);
     mSLog->info("Active Power Set Point={} [W] Voltage Set Point={} [V]", **mSetPointActivePower, **mSetPointVoltage);
 	mSLog->flush();
 }
@@ -47,8 +45,7 @@ void SP::Ph1::SynchronGenerator::setBaseVoltage(Real baseVoltage) {
 void SP::Ph1::SynchronGenerator::calculatePerUnitParameters(Real baseApparentPower, Real baseOmega) {
 	mSLog->info("#### Calculate Per Unit Parameters for {}", **mName);
 	mBaseApparentPower = baseApparentPower;
-	mBaseOmega = baseOmega;
-    mSLog->info("Base Power={} [VA]  Base Omega={} [1/s]", mBaseApparentPower, mBaseOmega);
+    mSLog->info("Base Power={} [VA]  Base Omega={} [1/s]", mBaseApparentPower, baseOmega);
 
 	**mSetPointActivePowerPerUnit = **mSetPointActivePower / mBaseApparentPower;
     **mSetPointReactivePowerPerUnit = **mSetPointReactivePower / mBaseApparentPower;

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
@@ -245,9 +245,6 @@ void SP::Ph1::SynchronGeneratorTrStab::step(Real time) {
 }
 
 void SP::Ph1::SynchronGeneratorTrStab::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	mTimeStep = timeStep;
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
@@ -10,7 +10,7 @@
 using namespace CPS;
 
 SP::Ph1::SynchronGeneratorTrStab::SynchronGeneratorTrStab(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: Base::SynchronGenerator(mAttributes), SimPowerComp<Complex>(uid, name, logLevel),
 	mEp(Attribute<Complex>::create("Ep", mAttributes)),
 	mEp_abs(Attribute<Real>::create("Ep_mag", mAttributes)),
 	mEp_phase(Attribute<Real>::create("Ep_phase", mAttributes)),
@@ -22,18 +22,6 @@ SP::Ph1::SynchronGeneratorTrStab::SynchronGeneratorTrStab(String uid, String nam
 	**mIntfVoltage = MatrixComp::Zero(1, 1);
 	**mIntfCurrent = MatrixComp::Zero(1, 1);
 
-	// Register attributes
-
-	///CHECK: Are all of these used in this class or in subclasses?
-	mRs = Attribute<Real>::create("Rs", mAttributes, 0);
-	mLl = Attribute<Real>::create("Ll", mAttributes, 0);
-	mLd = Attribute<Real>::create("Ld", mAttributes, 0);
-	mLq = Attribute<Real>::create("Lq", mAttributes, 0);
-	mElecActivePower = Attribute<Real>::create("P_elec", mAttributes, 0);
-	mElecReactivePower = Attribute<Real>::create("Q_elec", mAttributes, 0);
-	mMechPower = Attribute<Real>::create("P_mech", mAttributes, 0);
-	mOmMech = Attribute<Real>::create("w_r", mAttributes, 0);
-	mInertia = Attribute<Real>::create("inertia", mAttributes, 0);
 	mStates = Matrix::Zero(10,1);
 }
 

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
@@ -10,7 +10,7 @@
 using namespace CPS;
 
 SP::Ph1::SynchronGeneratorTrStab::SynchronGeneratorTrStab(String uid, String name, Logger::Level logLevel)
-	: Base::SynchronGenerator(mAttributes), SimPowerComp<Complex>(uid, name, logLevel),
+	: Base::SynchronGenerator(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel),
 	mEp(Attribute<Complex>::create("Ep", mAttributes)),
 	mEp_abs(Attribute<Real>::create("Ep_mag", mAttributes)),
 	mEp_phase(Attribute<Real>::create("Ep_phase", mAttributes)),
@@ -183,7 +183,7 @@ void SP::Ph1::SynchronGeneratorTrStab::initializeFromNodesAndTerminals(Real freq
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[1], 0);
 	mSubVoltageSource->initialize(mFrequencies);
 	mSubVoltageSource->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubVoltageSource);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	// Create sub inductor as Xpd
 	mSubInductor = SP::Ph1::Inductor::make(**mName + "_ind", mLogLevel);
@@ -191,7 +191,7 @@ void SP::Ph1::SynchronGeneratorTrStab::initializeFromNodesAndTerminals(Real freq
 	mSubInductor->connect({mVirtualNodes[0], terminal(0)->node()});
 	mSubInductor->initialize(mFrequencies);
 	mSubInductor->initializeFromNodesAndTerminals(frequency);
-	mSubComponents.push_back(mSubInductor);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	mSLog->info("\n--- Initialize according to powerflow ---"
 				"\nTerminal 0 voltage: {:e}<{:e}"
@@ -244,14 +244,9 @@ void SP::Ph1::SynchronGeneratorTrStab::step(Real time) {
 	SPDLOG_LOGGER_DEBUG(mSLog, "\nStates, time {:f}: \n{:s}", time, Logger::matrixToString(mStates));
 }
 
-void SP::Ph1::SynchronGeneratorTrStab::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void SP::Ph1::SynchronGeneratorTrStab::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
-
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-	}
 
 	mTimeStep = timeStep;
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
@@ -261,47 +256,22 @@ void SP::Ph1::SynchronGeneratorTrStab::mnaInitialize(Real omega, Real timeStep, 
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
-void SP::Ph1::SynchronGeneratorTrStab::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplySystemMatrixStamp(systemMatrix);
-	}
-}
-
-void SP::Ph1::SynchronGeneratorTrStab::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
-	}
-}
-
-void SP::Ph1::SynchronGeneratorTrStab::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	}
-
+void SP::Ph1::SynchronGeneratorTrStab::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+	// other attributes generally also influence the pre step,
+	// but aren't marked as writable anyway
+	/// CHECK: Is the upper comment still relevant. Any attribute is writable now...
 	prevStepDependencies.push_back(mIntfVoltage);
 };
 
-void SP::Ph1::SynchronGeneratorTrStab::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	for (auto subComp : mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	}
-
+void SP::Ph1::SynchronGeneratorTrStab::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(mIntfVoltage);
 };
 
-void SP::Ph1::SynchronGeneratorTrStab::MnaPreStep::execute(Real time, Int timeStepCount) {
-	mGenerator.step(time);
+void SP::Ph1::SynchronGeneratorTrStab::mnaParentPreStep(Real time, Int timeStepCount) {
+	step(time);
 	//change V_ref of subvoltage source
-	mGenerator.mSubVoltageSource->mVoltageRef->set(**mGenerator.mEp);
-	for (auto subComp : mGenerator.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	}
+	mSubVoltageSource->mVoltageRef->set(**mEp);
 }
 
 void SP::Ph1::SynchronGeneratorTrStab::AddBStep::execute(Real time, Int timeStepCount) {
@@ -310,14 +280,9 @@ void SP::Ph1::SynchronGeneratorTrStab::AddBStep::execute(Real time, Int timeStep
 		+ mGenerator.mSubVoltageSource->mRightVector->get();
 }
 
-void SP::Ph1::SynchronGeneratorTrStab::MnaPostStep::execute(Real time, Int timeStepCount) {
-	for (auto subComp : mGenerator.mSubComponents) {
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subComp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, mLeftVector);
-	}
-
-	mGenerator.mnaUpdateVoltage(**mLeftVector);
-	mGenerator.mnaUpdateCurrent(**mLeftVector);
+void SP::Ph1::SynchronGeneratorTrStab::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+	mnaUpdateVoltage(**leftVector);
+	mnaUpdateCurrent(**leftVector);
 }
 
 void SP::Ph1::SynchronGeneratorTrStab::mnaUpdateVoltage(const Matrix& leftVector) {

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
@@ -183,7 +183,7 @@ void SP::Ph1::SynchronGeneratorTrStab::initializeFromNodesAndTerminals(Real freq
 	mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[1], 0);
 	mSubVoltageSource->initialize(mFrequencies);
 	mSubVoltageSource->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubVoltageSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 	// Create sub inductor as Xpd
 	mSubInductor = SP::Ph1::Inductor::make(**mName + "_ind", mLogLevel);
@@ -191,7 +191,7 @@ void SP::Ph1::SynchronGeneratorTrStab::initializeFromNodesAndTerminals(Real freq
 	mSubInductor->connect({mVirtualNodes[0], terminal(0)->node()});
 	mSubInductor->initialize(mFrequencies);
 	mSubInductor->initializeFromNodesAndTerminals(frequency);
-	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
 	mSLog->info("\n--- Initialize according to powerflow ---"
 				"\nTerminal 0 voltage: {:e}<{:e}"

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
@@ -246,7 +246,6 @@ void SP::Ph1::SynchronGeneratorTrStab::step(Real time) {
 
 void SP::Ph1::SynchronGeneratorTrStab::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	mTimeStep = timeStep;
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 
 	mMnaTasks.push_back(std::make_shared<AddBStep>(*this));
 }

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
@@ -10,7 +10,7 @@
 using namespace CPS;
 
 SP::Ph1::SynchronGeneratorTrStab::SynchronGeneratorTrStab(String uid, String name, Logger::Level logLevel)
-	: Base::SynchronGenerator(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel),
+	: Base::SynchronGenerator(mAttributes), CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 	mEp(Attribute<Complex>::create("Ep", mAttributes)),
 	mEp_abs(Attribute<Real>::create("Ep_mag", mAttributes)),
 	mEp_phase(Attribute<Real>::create("Ep_phase", mAttributes)),
@@ -248,9 +248,7 @@ void SP::Ph1::SynchronGeneratorTrStab::mnaParentInitialize(Real omega, Real time
 	mTimeStep = timeStep;
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<AddBStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 }
 
 void SP::Ph1::SynchronGeneratorTrStab::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {

--- a/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
@@ -287,9 +287,6 @@ MatrixComp SP::Ph1::Transformer::Y_element() {
 // #### MNA Section ####
 
 void SP::Ph1::Transformer::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	MNAInterface::mnaInitialize(omega, timeStep);
-	updateMatrixNodeIndices();
-
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));

--- a/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
@@ -17,7 +17,6 @@ SP::Ph1::Transformer::Transformer(String uid, String name, Logger::Level logLeve
 	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
 	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
 	mReactivePowerBranch(Attribute<Matrix>::create("q_branch_vector", mAttributes)),
-	mStoreNodalPowerInjection(Attribute<Bool>::create("nodal_injection_stored", mAttributes, false)),
 	mActivePowerInjection(Attribute<Real>::create("p_inj", mAttributes)),
 	mReactivePowerInjection(Attribute<Real>::create("q_inj", mAttributes)) {
 	if (withResistiveLosses)
@@ -57,7 +56,6 @@ void SP::Ph1::Transformer::setParameters(Real nomVoltageEnd1, Real nomVoltageEnd
 
 	mRatioAbs = std::abs(**mRatio);
 	mRatioPhase = std::arg(**mRatio);
-	mConductance = 1 / **mResistance;
 
 	mParametersSet = true;
 }
@@ -84,7 +82,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	mNominalOmega = 2. * PI * frequency;
 	mReactance = mNominalOmega * **mInductance;
 	mSLog->info("Reactance={} [Ohm] (referred to primary side)", mReactance);
-	
+
 	// Component parameters are referred to higher voltage side.
 	// Switch terminals to have terminal 0 at higher voltage side
 	// if transformer is connected the other way around.
@@ -288,7 +286,6 @@ void SP::Ph1::Transformer::updateBranchFlow(VectorComp& current, VectorComp& pow
 void SP::Ph1::Transformer::storeNodalInjection(Complex powerInjection) {
 	**mActivePowerInjection = std::real(powerInjection)*mBaseApparentPower;
 	**mReactivePowerInjection = std::imag(powerInjection)*mBaseApparentPower;
-	**mStoreNodalPowerInjection = true;
 }
 
 MatrixComp SP::Ph1::Transformer::Y_element() {
@@ -366,7 +363,7 @@ void SP::Ph1::Transformer::mnaAddPreStepDependencies(AttributeBase::List &prevSt
 	modifiedAttributes.push_back(attribute("right_vector"));
 }
 
-void SP::Ph1::Transformer::mnaPreStep(Real time, Int timeStepCount) {	
+void SP::Ph1::Transformer::mnaPreStep(Real time, Int timeStepCount) {
 	// pre-step of subcomponents
 	for (auto subcomp: mSubComponents)
 		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))

--- a/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 // #### General ####
 SP::Ph1::Transformer::Transformer(String uid, String name, Logger::Level logLevel, Bool withResistiveLosses)
-	: Base::Ph1::Transformer(mAttributes), SimPowerComp<Complex>(uid, name, logLevel),
+	: Base::Ph1::Transformer(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel),
 	mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes)),
 	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
 	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
@@ -104,7 +104,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	// Create series sub components
 	mSubInductor = std::make_shared<SP::Ph1::Inductor>(**mUID + "_ind", **mName + "_ind", Logger::Level::off);
 	mSubInductor->setParameters(**mInductance);
-	mSubComponents.push_back(mSubInductor);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 	if (mNumVirtualNodes == 3) {
 		mVirtualNodes[2]->setInitialVoltage(initialSingleVoltage(0));
@@ -112,7 +112,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 		mSubResistor->setParameters(**mResistance);
 		mSubResistor->connect({ node(0), mVirtualNodes[2] });
 		mSubInductor->connect({ mVirtualNodes[2], mVirtualNodes[0] });
-		mSubComponents.push_back(mSubResistor);
+		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	} else {
 		mSubInductor->connect({ node(0), mVirtualNodes[0] });
 	}
@@ -130,7 +130,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 		mSubSnubResistor1->connect({ node(0), SP::SimNode::GND });
 		mSLog->info("Snubber Resistance 1 (connected to higher voltage side {}) = {} [Ohm]", node(0)->name(), Logger::realToString(mSnubberResistance1));
 		mSubSnubResistor1->setBaseVoltage(**mNominalVoltageEnd1);
-		mSubComponents.push_back(mSubSnubResistor1);
+		addMNASubComponent(mSubSnubResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 		// A snubber conductance is added on the lower voltage side
 		mSnubberResistance2 = std::pow(std::abs(**mNominalVoltageEnd2),2) / pSnub;
@@ -139,7 +139,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 		mSubSnubResistor2->connect({ node(1), SP::SimNode::GND });
 		mSLog->info("Snubber Resistance 2 (connected to lower voltage side {}) = {} [Ohm]", node(1)->name(), Logger::realToString(mSnubberResistance2));
 		mSubSnubResistor2->setBaseVoltage(**mNominalVoltageEnd2);
-		mSubComponents.push_back(mSubSnubResistor2);
+		addMNASubComponent(mSubSnubResistor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 
 		// // A snubber capacitance is added to higher voltage side (not used as capacitor at high voltage side made it worse)
 		// mSnubberCapacitance1 = qSnub / std::pow(std::abs(mNominalVoltageEnd1),2) / mNominalOmega;
@@ -157,7 +157,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 		mSubSnubCapacitor2->connect({ node(1), SP::SimNode::GND });
 		mSLog->info("Snubber Capacitance 2 (connected to lower voltage side {}) = {} [F]", node(1)->name(), Logger::realToString(mSnubberCapacitance2));
 		mSubSnubCapacitor2->setBaseVoltage(**mNominalVoltageEnd2);
-		mSubComponents.push_back(mSubSnubCapacitor2);
+		addMNASubComponent(mSubSnubCapacitor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
 	}
 
 	// Initialize electrical subcomponents
@@ -286,16 +286,11 @@ MatrixComp SP::Ph1::Transformer::Y_element() {
 
 // #### MNA Section ####
 
-void SP::Ph1::Transformer::mnaInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+void SP::Ph1::Transformer::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	MNAInterface::mnaInitialize(omega, timeStep);
 	updateMatrixNodeIndices();
 
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaInitialize(omega, timeStep, leftVector);
-
 	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
 	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 
@@ -337,50 +332,23 @@ void SP::Ph1::Transformer::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
 	}
 }
 
-void SP::Ph1::Transformer::mnaApplyRightSideVectorStamp(Matrix& rightVector) {
-	// Add subcomps to right side vector
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaApplyRightSideVectorStamp(rightVector);
-}
-
-void SP::Ph1::Transformer::mnaAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
-	// add pre-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPreStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes);
-	// add pre-step dependencies of component itself
+void SP::Ph1::Transformer::mnaParentAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
 	prevStepDependencies.push_back(attribute("i_intf"));
 	prevStepDependencies.push_back(attribute("v_intf"));
 	modifiedAttributes.push_back(attribute("right_vector"));
 }
 
-void SP::Ph1::Transformer::mnaPreStep(Real time, Int timeStepCount) {
-	// pre-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPreStep(time, timeStepCount);
-	// pre-step of component itself
+void SP::Ph1::Transformer::mnaParentPreStep(Real time, Int timeStepCount) {
 	mnaApplyRightSideVectorStamp(**mRightVector);
 }
 
-void SP::Ph1::Transformer::mnaAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
-	// add post-step dependencies of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaAddPostStepDependencies(prevStepDependencies, attributeDependencies, modifiedAttributes, leftVector);
-	// add post-step dependencies of component itself
+void SP::Ph1::Transformer::mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes, Attribute<Matrix>::Ptr &leftVector) {
 	attributeDependencies.push_back(leftVector);
 	modifiedAttributes.push_back(this->attribute("v_intf"));
 	modifiedAttributes.push_back(this->attribute("i_intf"));
 }
 
-void SP::Ph1::Transformer::mnaPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-	// post-step of subcomponents
-	for (auto subcomp: mSubComponents)
-		if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
-			mnasubcomp->mnaPostStep(time, timeStepCount, leftVector);
-	// post-step of component itself
+void SP::Ph1::Transformer::mnaParentPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
 	this->mnaUpdateVoltage(**leftVector);
 	this->mnaUpdateCurrent(**leftVector);
 }

--- a/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 // #### General ####
 SP::Ph1::Transformer::Transformer(String uid, String name, Logger::Level logLevel, Bool withResistiveLosses)
-	: Base::Ph1::Transformer(mAttributes), CompositePowerComp<Complex>(uid, name, logLevel),
+	: Base::Ph1::Transformer(mAttributes), CompositePowerComp<Complex>(uid, name, true, true, logLevel),
 	mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes)),
 	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
 	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
@@ -288,8 +288,6 @@ MatrixComp SP::Ph1::Transformer::Y_element() {
 
 void SP::Ph1::Transformer::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-	mMnaTasks.push_back(std::make_shared<MnaPreStep>(*this));
-	mMnaTasks.push_back(std::make_shared<MnaPostStep>(*this, leftVector));
 
 	mSLog->info(
 		"\nTerminal 0 connected to {:s} = sim node {:d}"

--- a/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
@@ -287,8 +287,6 @@ MatrixComp SP::Ph1::Transformer::Y_element() {
 // #### MNA Section ####
 
 void SP::Ph1::Transformer::mnaParentInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
-	**mRightVector = Matrix::Zero(leftVector->get().rows(), 1);
-
 	mSLog->info(
 		"\nTerminal 0 connected to {:s} = sim node {:d}"
 		"\nTerminal 1 connected to {:s} = sim node {:d}",

--- a/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 // #### General ####
 SP::Ph1::Transformer::Transformer(String uid, String name, Logger::Level logLevel, Bool withResistiveLosses)
-	: SimPowerComp<Complex>(uid, name, logLevel),
+	: Base::Ph1::Transformer(mAttributes), SimPowerComp<Complex>(uid, name, logLevel),
 	mBaseVoltage(Attribute<Real>::create("base_Voltage", mAttributes)),
 	mCurrent(Attribute<MatrixComp>::create("current_vector", mAttributes)),
 	mActivePowerBranch(Attribute<Matrix>::create("p_branch_vector", mAttributes)),
@@ -28,14 +28,6 @@ SP::Ph1::Transformer::Transformer(String uid, String name, Logger::Level logLeve
 	**mIntfVoltage = MatrixComp::Zero(1, 1);
 	**mIntfCurrent = MatrixComp::Zero(1, 1);
 	setTerminalNumber(2);
-
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mNominalVoltageEnd1 = Attribute<Real>::create("nominal_voltage_end1", mAttributes);
-	mNominalVoltageEnd2 = Attribute<Real>::create("nominal_voltage_end2", mAttributes);
-	mRatedPower = Attribute<Real>::create("S", mAttributes);
-	mRatio = Attribute<Complex>::create("ratio", mAttributes);
-	mResistance = Attribute<Real>::create("R", mAttributes);
-	mInductance = Attribute<Real>::create("L", mAttributes);
 
 	**mCurrent = MatrixComp::Zero(2,1);
 	**mActivePowerBranch = Matrix::Zero(2,1);

--- a/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
@@ -104,7 +104,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 	// Create series sub components
 	mSubInductor = std::make_shared<SP::Ph1::Inductor>(**mUID + "_ind", **mName + "_ind", Logger::Level::off);
 	mSubInductor->setParameters(**mInductance);
-	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+	addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 	if (mNumVirtualNodes == 3) {
 		mVirtualNodes[2]->setInitialVoltage(initialSingleVoltage(0));
@@ -112,7 +112,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 		mSubResistor->setParameters(**mResistance);
 		mSubResistor->connect({ node(0), mVirtualNodes[2] });
 		mSubInductor->connect({ mVirtualNodes[2], mVirtualNodes[0] });
-		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	} else {
 		mSubInductor->connect({ node(0), mVirtualNodes[0] });
 	}
@@ -130,7 +130,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 		mSubSnubResistor1->connect({ node(0), SP::SimNode::GND });
 		mSLog->info("Snubber Resistance 1 (connected to higher voltage side {}) = {} [Ohm]", node(0)->name(), Logger::realToString(mSnubberResistance1));
 		mSubSnubResistor1->setBaseVoltage(**mNominalVoltageEnd1);
-		addMNASubComponent(mSubSnubResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubSnubResistor1, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 		// A snubber conductance is added on the lower voltage side
 		mSnubberResistance2 = std::pow(std::abs(**mNominalVoltageEnd2),2) / pSnub;
@@ -139,7 +139,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 		mSubSnubResistor2->connect({ node(1), SP::SimNode::GND });
 		mSLog->info("Snubber Resistance 2 (connected to lower voltage side {}) = {} [Ohm]", node(1)->name(), Logger::realToString(mSnubberResistance2));
 		mSubSnubResistor2->setBaseVoltage(**mNominalVoltageEnd2);
-		addMNASubComponent(mSubSnubResistor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubSnubResistor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
 		// // A snubber capacitance is added to higher voltage side (not used as capacitor at high voltage side made it worse)
 		// mSnubberCapacitance1 = qSnub / std::pow(std::abs(mNominalVoltageEnd1),2) / mNominalOmega;
@@ -157,7 +157,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 		mSubSnubCapacitor2->connect({ node(1), SP::SimNode::GND });
 		mSLog->info("Snubber Capacitance 2 (connected to lower voltage side {}) = {} [F]", node(1)->name(), Logger::realToString(mSnubberCapacitance2));
 		mSubSnubCapacitor2->setBaseVoltage(**mNominalVoltageEnd2);
-		addMNASubComponent(mSubSnubCapacitor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT);
+		addMNASubComponent(mSubSnubCapacitor2, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 	}
 
 	// Initialize electrical subcomponents

--- a/dpsim-models/src/SP/SP_Ph1_varResSwitch.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_varResSwitch.cpp
@@ -11,14 +11,10 @@
 using namespace CPS;
 
 SP::Ph1::varResSwitch::varResSwitch(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph1::Switch(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	setTerminalNumber(2);
     **mIntfVoltage = MatrixComp::Zero(1,1);
 	**mIntfCurrent = MatrixComp::Zero(1,1);
-
-	mOpenResistance = Attribute<Real>::create("R_open", mAttributes);
-	mClosedResistance = Attribute<Real>::create("R_closed", mAttributes);
-	mIsClosed = Attribute<Bool>::create("is_closed", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr SP::Ph1::varResSwitch::clone(String name) {

--- a/dpsim-models/src/SP/SP_Ph3_Capacitor.cpp
+++ b/dpsim-models/src/SP/SP_Ph3_Capacitor.cpp
@@ -11,14 +11,11 @@
 using namespace CPS;
 
 SP::Ph3::Capacitor::Capacitor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph3::Capacitor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
 	**mIntfVoltage = MatrixComp::Zero(3, 1);
 	**mIntfCurrent = MatrixComp::Zero(3, 1);
-	
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mCapacitance = CPS::Attribute<Matrix>::create("C", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr SP::Ph3::Capacitor::clone(String name) {

--- a/dpsim-models/src/SP/SP_Ph3_Inductor.cpp
+++ b/dpsim-models/src/SP/SP_Ph3_Inductor.cpp
@@ -11,13 +11,11 @@
 using namespace CPS;
 
 SP::Ph3::Inductor::Inductor(String uid, String name, Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph3::Inductor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
 	**mIntfVoltage = MatrixComp::Zero(3, 1);
 	**mIntfCurrent = MatrixComp::Zero(3, 1);
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mInductance = CPS::Attribute<Matrix>::create("L", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr SP::Ph3::Inductor::clone(String name) {

--- a/dpsim-models/src/SP/SP_Ph3_Resistor.cpp
+++ b/dpsim-models/src/SP/SP_Ph3_Resistor.cpp
@@ -13,14 +13,11 @@ using namespace CPS;
 
 SP::Ph3::Resistor::Resistor(String uid, String name,
 	Logger::Level logLevel)
-	: SimPowerComp<Complex>(uid, name, logLevel) {
+	: Base::Ph3::Resistor(mAttributes), SimPowerComp<Complex>(uid, name, logLevel) {
 	mPhaseType = PhaseType::ABC;
 	setTerminalNumber(2);
 	**mIntfVoltage = MatrixComp::Zero(3, 1);
 	**mIntfCurrent = MatrixComp::Zero(3, 1);
-	
-	///FIXME: Initialization should happen in the base class declaring the attribute. However, this base class is currently not an AttributeList...
-	mResistance = CPS::Attribute<Matrix>::create("R", mAttributes);
 }
 
 SimPowerComp<Complex>::Ptr SP::Ph3::Resistor::clone(String name) {
@@ -55,7 +52,7 @@ void SP::Ph3::Resistor::mnaInitialize(Real omega, Real timeStep, Attribute<Matri
 }
 
 void SP::Ph3::Resistor::mnaApplySystemMatrixStamp(Matrix& systemMatrix) {
-	
+
 	Matrix conductance = (**mResistance).inverse();
 
 	if (terminalNotGrounded(0)) {

--- a/dpsim-models/src/Signal/CosineFMGenerator.cpp
+++ b/dpsim-models/src/Signal/CosineFMGenerator.cpp
@@ -20,8 +20,8 @@ void Signal::CosineFMGenerator::setParameters(Complex initialPhasor, Real modula
 	// default value, should implement a way to set it during runtime
 	mZigZag = zigzag;
 
-	attribute<Complex>("sigOut")->set(initialPhasor);
-	attribute<Real>("freq")->set(frequency);
+	attributeTyped<Complex>("sigOut")->set(initialPhasor);
+	attributeTyped<Real>("freq")->set(frequency);
 
 	mSLog->info("Parameters:");
 	mSLog->info("\nInitial Phasor={}"
@@ -38,13 +38,13 @@ void Signal::CosineFMGenerator::step(Real time) {
 		Real tmp = 2*time*mModulationFrequency;
 		Real sign = (((int)floor(tmp)) % 2 == 0) ? -1 : 1;
 		phase += 2 * mModulationAmplitude * (pow(2*(tmp - floor(tmp)) - 1, 2) - 1) / PI * sign;
-		attribute<Real>("freq")->set(mBaseFrequency + mModulationAmplitude * (2 * (tmp - floor(tmp)) - 1) * sign);
+		attributeTyped<Real>("freq")->set(mBaseFrequency + mModulationAmplitude * (2 * (tmp - floor(tmp)) - 1) * sign);
 	} else {
 		phase += mModulationAmplitude / mModulationFrequency * sin(2.*PI*mModulationFrequency*time);
-		attribute<Real>("freq")->set(mBaseFrequency + mModulationAmplitude * cos(2.*PI*mModulationFrequency*time));
+		attributeTyped<Real>("freq")->set(mBaseFrequency + mModulationAmplitude * cos(2.*PI*mModulationFrequency*time));
 	}
 
-	attribute<Complex>("sigOut")->set(Complex(
+	attributeTyped<Complex>("sigOut")->set(Complex(
 		mMagnitude * cos(phase),
 		mMagnitude * sin(phase)));
 }

--- a/dpsim-models/src/Signal/FrequencyRampGenerator.cpp
+++ b/dpsim-models/src/Signal/FrequencyRampGenerator.cpp
@@ -23,8 +23,8 @@ void Signal::FrequencyRampGenerator::setParameters(Complex initialPhasor, Real f
 
     mSmoothRamp = smoothRamp;
 
-    attribute<Complex>("sigOut")->set(initialPhasor);
-	attribute<Real>("freq")->set(freqStart);
+    attributeTyped<Complex>("sigOut")->set(initialPhasor);
+	attributeTyped<Real>("freq")->set(freqStart);
 
 	mSLog->info("Parameters:");
 	mSLog->info("\nInitial Phasor={}"
@@ -46,7 +46,7 @@ void Signal::FrequencyRampGenerator::step(Real time) {
     Real timestep = time - mOldTime;
     mOldTime = time;
 
-    currPhase = Math::phase(attribute<Complex>("sigOut")->get());
+    currPhase = Math::phase(attributeTyped<Complex>("sigOut")->get());
 
     if(time <= mTimeStart) {
         currFreq = mFreqStart;
@@ -57,8 +57,8 @@ void Signal::FrequencyRampGenerator::step(Real time) {
     }
     currPhase += 2. * PI * currFreq * timestep;
 
-    attribute<Complex>("sigOut")->set(mMagnitude * Complex(cos(currPhase), sin(currPhase)));
-    attribute<Real>("freq")->set(currFreq);
+    attributeTyped<Complex>("sigOut")->set(mMagnitude * Complex(cos(currPhase), sin(currPhase)));
+    attributeTyped<Real>("freq")->set(currFreq);
 }
 
 void Signal::FrequencyRampGenerator::stepAbsolute(Real time) {
@@ -80,6 +80,6 @@ void Signal::FrequencyRampGenerator::stepAbsolute(Real time) {
         }
     }
 
-    attribute<Complex>("sigOut")->set(mMagnitude * Complex(cos(currPhase), sin(currPhase)));
-    attribute<Real>("freq")->set(currFreq);
+    attributeTyped<Complex>("sigOut")->set(mMagnitude * Complex(cos(currPhase), sin(currPhase)));
+    attributeTyped<Real>("freq")->set(currFreq);
 }

--- a/dpsim-models/src/Signal/Integrator.cpp
+++ b/dpsim-models/src/Signal/Integrator.cpp
@@ -57,7 +57,6 @@ void Integrator::signalAddStepDependencies(AttributeBase::List &prevStepDependen
 };
 
 void Integrator::signalStep(Real time, Int timeStepCount) {
-    ///FIXME: There is no guarantee that mInputRef has been set to reference anything. Otherwise its just constantly 0.
     **mInputCurr = **mInputRef;
 
     mSLog->info("Time {}:", time);

--- a/dpsim-villas/examples/cxx/Shmem_WSCC-9bus.cpp
+++ b/dpsim-villas/examples/cxx/Shmem_WSCC-9bus.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[]) {
 	// Register exportable node voltages
 	UInt o = 0;
 	for (auto n : sys.mNodes) {
-		auto v = n->attribute<Complex>("v");
+		auto v = n->attributeTyped<Complex>("v");
 
 		intf.exportReal(v->deriveMag(),   o+0);
 		intf.exportReal(v->derivePhase(), o+1);

--- a/dpsim-villas/examples/cxx/Shmem_WSCC-9bus_Ctrl.cpp
+++ b/dpsim-villas/examples/cxx/Shmem_WSCC-9bus_Ctrl.cpp
@@ -101,8 +101,8 @@ int main(int argc, char *argv[]) {
 	filtP->setInput(intf.importReal(0));
 	filtP_profile->setInput(intf.importReal(1));
 
-	intf.exportReal(load->attribute<Real>("P"), o++);
-	intf.exportReal(load_profile->attribute<Real>("P"), o++);
+	intf.exportReal(load->attributeTyped<Real>("P"), o++);
+	intf.exportReal(load_profile->attributeTyped<Real>("P"), o++);
 
 	sim.addInterface(std::shared_ptr<Interface>(&intf));
 	sim.addLogger(logger);

--- a/dpsim-villas/examples/cxx/Shmem_WSCC-9bus_CtrlDist.cpp
+++ b/dpsim-villas/examples/cxx/Shmem_WSCC-9bus_CtrlDist.cpp
@@ -81,7 +81,7 @@ int main(int argc, char *argv[]) {
 
 			i--;
 
-			auto v = n->attribute<Complex>("v");
+			auto v = n->attributeTyped<Complex>("v");
 
 			std::cout << "Signal " << (i*2)+0 << ": Mag " << n->name() << std::endl;
 			std::cout << "Signal " << (i*2)+1 << ": Phas " << n->name() << std::endl;

--- a/dpsim/examples/cxx/CIM/CIGRE_MV_PowerFlowTest_LoadProfiles.cpp
+++ b/dpsim/examples/cxx/CIM/CIGRE_MV_PowerFlowTest_LoadProfiles.cpp
@@ -110,8 +110,8 @@ int main(int argc, char** argv){
 		// get nodal injection from specific line or transformer
 		// (the first line obj connected to the node or, if none, the first trafo)
 		if (!lines.empty()) {
-		logger->logAttribute(node->name() + ".Pinj", lines.front()->attribute<Real>("p_inj"));
-		logger->logAttribute(node->name() + ".Qinj", lines.front()->attribute<Real>("q_inj"));
+		logger->logAttribute(node->name() + ".Pinj", lines.front()->attributeTyped<Real>("p_inj"));
+		logger->logAttribute(node->name() + ".Qinj", lines.front()->attributeTyped<Real>("q_inj"));
 		}
 		else
 		{
@@ -119,8 +119,8 @@ int main(int argc, char** argv){
 				if (std::shared_ptr<CPS::SP::Ph1::Transformer> trafo =
 					std::dynamic_pointer_cast<CPS::SP::Ph1::Transformer>(comp))
 				{
-					logger->logAttribute(node->name() + ".Pinj", trafo->attribute<Real>("p_inj"));
-					logger->logAttribute(node->name() + ".Qinj", trafo->attribute<Real>("q_inj"));
+					logger->logAttribute(node->name() + ".Pinj", trafo->attributeTyped<Real>("p_inj"));
+					logger->logAttribute(node->name() + ".Qinj", trafo->attributeTyped<Real>("q_inj"));
 					break;
 				}
 

--- a/dpsim/examples/cxx/CIM/DP_CIGRE_MV_withDG_withLoadStep.cpp
+++ b/dpsim/examples/cxx/CIM/DP_CIGRE_MV_withDG_withLoadStep.cpp
@@ -103,7 +103,7 @@ int main(int argc, char** argv){
 	Examples::Grids::CIGREMV::logPVAttributes(logger, pv);
 
 	// // load step sized relative to nominal load at N11
-	// std::shared_ptr<SwitchEvent> loadStepEvent = Examples::Events::createEventAddPowerConsumption("N11", 2-timeStep, 5*systemPF.component<CPS::SP::Ph1::Load>("LOAD-H-11")->attribute<CPS::Real>("P")->get(), systemDP, Domain::DP, logger);
+	// std::shared_ptr<SwitchEvent> loadStepEvent = Examples::Events::createEventAddPowerConsumption("N11", 2-timeStep, 5*systemPF.component<CPS::SP::Ph1::Load>("LOAD-H-11")->attributeTyped<CPS::Real>("P")->get(), systemDP, Domain::DP, logger);
 
 	// load step sized in absolute terms
 	std::shared_ptr<SwitchEvent> loadStepEvent = Examples::Events::createEventAddPowerConsumption("N11", 2-timeStep, 1500.0e3, systemDP, Domain::DP, logger);

--- a/dpsim/examples/cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_SynGenTrStab_3Bus_Fault.cpp
@@ -124,7 +124,7 @@ void DP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	gen2DP->setInitialValues(initApparentPower_G2, ThreeBus.initMechPower_G2);
 
 	gen2DP->setModelFlags(true);
-	gen2DP->setReferenceOmega(gen1DP->attribute<Real>("w_r"), gen1DP->attribute<Real>("delta_r"));
+	gen2DP->setReferenceOmega(gen1DP->attributeTyped<Real>("w_r"), gen1DP->attributeTyped<Real>("delta_r"));
 
 	///Load
 	auto loadDP=DP::Ph1::RXLoad::make("Load", Logger::Level::debug);

--- a/dpsim/examples/cxx/Circuits/EMT_DP_SP_VS_Init.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_DP_SP_VS_Init.cpp
@@ -126,7 +126,7 @@ void vsSetAttrDP1ph() {
 
 	// Components
 	auto vs = DP::Ph1::VoltageSource::make("vs1");
-	vs->attribute<Complex>("V_ref")->set(vref);
+	vs->attributeTyped<Complex>("V_ref")->set(vref);
 
 	// Topology
 	vs->connect({ SimNode<Complex>::GND, n1 });
@@ -162,7 +162,7 @@ void vsSetAttrSP1ph() {
 
 	// Components
 	auto vs = SP::Ph1::VoltageSource::make("vs1");
-	vs->attribute<Complex>("V_ref")->set(vref);
+	vs->attributeTyped<Complex>("V_ref")->set(vref);
 
 	// Topology
 	vs->connect({ SimNode<Complex>::GND, n1 });
@@ -198,7 +198,7 @@ void vsSetAttrEMT3ph() {
 
 	// Components
 	auto vs = EMT::Ph3::VoltageSource::make("vs1");
-	vs->attribute<MatrixComp>("V_ref")->set(vref);
+	vs->attributeTyped<MatrixComp>("V_ref")->set(vref);
 
 	// Topology
 	vs->connect({ SimNode<Real>::GND, n1 });

--- a/dpsim/examples/cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
@@ -124,7 +124,7 @@ void SP_SynGenTrStab_3Bus_Fault(String simName, Real timeStep, Real finalTime, b
 	gen2SP->setInitialValues(initApparentPower_G2, ThreeBus.initMechPower_G2);
 
 	gen2SP->setModelFlags(true);
-	gen2SP->setReferenceOmega(gen1SP->attribute<Real>("w_r"), gen1SP->attribute<Real>("delta_r"));
+	gen2SP->setReferenceOmega(gen1SP->attributeTyped<Real>("w_r"), gen1SP->attributeTyped<Real>("delta_r"));
 
 	//Load
 	auto loadSP = SP::Ph1::Load::make("Load", Logger::Level::debug);

--- a/dpsim/include/dpsim/DiakopticsSolver.h
+++ b/dpsim/include/dpsim/DiakopticsSolver.h
@@ -112,7 +112,7 @@ namespace DPsim {
 			SubnetSolveTask(DiakopticsSolver<VarType>& solver, UInt net) :
 				Task(solver.mName + ".SubnetSolve_" + std::to_string(net)), mSolver(solver), mSubnet(solver.mSubnets[net]) {
 				for (auto it : mSubnet.components) {
-					if (it->template attribute<Matrix>("right_vector")->get().size() != 0) {
+					if (it->template attributeTyped<Matrix>("right_vector")->get().size() != 0) {
 						mAttributeDependencies.push_back(it->attribute("right_vector"));
 					}
 				}

--- a/dpsim/include/dpsim/MNASolverEigenDense.h
+++ b/dpsim/include/dpsim/MNASolverEigenDense.h
@@ -102,7 +102,7 @@ namespace DPsim {
 				Task(solver.mName + ".Solve"), mSolver(solver) {
 
 				for (auto it : solver.mMNAComponents) {
-					if (it->template attribute<Matrix>("right_vector")->get().size() != 0)
+					if (it->template attributeTyped<Matrix>("right_vector")->get().size() != 0)
 						mAttributeDependencies.push_back(it->attribute("right_vector"));
 				}
 				for (auto node : solver.mNodes) {
@@ -124,7 +124,7 @@ namespace DPsim {
 				Task(solver.mName + ".Solve"), mSolver(solver), mFreqIdx(freqIdx) {
 
 				for (auto it : solver.mMNAComponents) {
-					if (it->template attribute<Matrix>("right_vector")->get().size() != 0)
+					if (it->template attributeTyped<Matrix>("right_vector")->get().size() != 0)
 						mAttributeDependencies.push_back(it->attribute("right_vector"));
 				}
 				for (auto node : solver.mNodes) {

--- a/dpsim/include/dpsim/MNASolverEigenSparse.h
+++ b/dpsim/include/dpsim/MNASolverEigenSparse.h
@@ -47,6 +47,7 @@ namespace DPsim {
 		CPS::LUFactorizedSparse mLuFactorizationVariableSystemMatrix;
 
 		using MnaSolver<VarType>::mSwitches;
+		using MnaSolver<VarType>::mMNAIntfSwitches;
 		using MnaSolver<VarType>::mMNAComponents;
 		using MnaSolver<VarType>::mVariableComps;
 		using MnaSolver<VarType>::mMNAIntfVariableComps;

--- a/dpsim/include/dpsim/MNASolverEigenSparse.h
+++ b/dpsim/include/dpsim/MNASolverEigenSparse.h
@@ -119,7 +119,7 @@ namespace DPsim {
 				Task(solver.mName + ".Solve"), mSolver(solver) {
 
 				for (auto it : solver.mMNAComponents) {
-					if (it->template attribute<Matrix>("right_vector")->get().size() != 0)
+					if (it->template attributeTyped<Matrix>("right_vector")->get().size() != 0)
 						mAttributeDependencies.push_back(it->attribute("right_vector"));
 				}
 				for (auto node : solver.mNodes) {
@@ -141,7 +141,7 @@ namespace DPsim {
 				Task(solver.mName + ".Solve"), mSolver(solver), mFreqIdx(freqIdx) {
 
 				for (auto it : solver.mMNAComponents) {
-					if (it->template attribute<Matrix>("right_vector")->get().size() != 0)
+					if (it->template attributeTyped<Matrix>("right_vector")->get().size() != 0)
 						mAttributeDependencies.push_back(it->attribute("right_vector"));
 				}
 				for (auto node : solver.mNodes) {
@@ -166,11 +166,11 @@ namespace DPsim {
 				Task(solver.mName + ".Solve"), mSolver(solver) {
 
 				for (auto it : solver.mMNAComponents) {
-					if (it->template attribute<Matrix>("right_vector")->get().size() != 0)
+					if (it->template attributeTyped<Matrix>("right_vector")->get().size() != 0)
 						mAttributeDependencies.push_back(it->attribute("right_vector"));
 				}
 				for (auto it : solver.mMNAIntfVariableComps) {
-					if (it->template attribute<Matrix>("right_vector")->get().size() != 0)
+					if (it->template attributeTyped<Matrix>("right_vector")->get().size() != 0)
 						mAttributeDependencies.push_back(it->attribute("right_vector"));
 				}
 				for (auto node : solver.mNodes) {

--- a/dpsim/include/dpsim/MNASolverGpuDense.h
+++ b/dpsim/include/dpsim/MNASolverGpuDense.h
@@ -69,7 +69,7 @@ namespace DPsim {
 				Task(solver.mName + ".Solve"), mSolver(solver) {
 
 				for (auto it : solver.mMNAComponents) {
-					if (it->template attribute<Matrix>("right_vector")->get().size() != 0)
+					if (it->template attributeTyped<Matrix>("right_vector")->get().size() != 0)
 						mAttributeDependencies.push_back(it->attribute("right_vector"));
 				}
 				for (auto node : solver.mNodes) {

--- a/dpsim/include/dpsim/MNASolverGpuMagma.h
+++ b/dpsim/include/dpsim/MNASolverGpuMagma.h
@@ -64,7 +64,7 @@ namespace DPsim {
 				Task(solver.mName + ".Solve"), mSolver(solver) {
 
 				for (auto it : solver.mMNAComponents) {
-					if (it->template attribute<Matrix>("right_vector")->get().size() != 0)
+					if (it->template attributeTyped<Matrix>("right_vector")->get().size() != 0)
 						mAttributeDependencies.push_back(it->attribute("right_vector"));
 				}
 				for (auto node : solver.mNodes) {

--- a/dpsim/include/dpsim/MNASolverGpuSparse.h
+++ b/dpsim/include/dpsim/MNASolverGpuSparse.h
@@ -68,7 +68,7 @@ namespace DPsim {
 				Task(solver.mName + ".Solve"), mSolver(solver) {
 
 				for (auto it : solver.mMNAComponents) {
-					if (it->template attribute<Matrix>("right_vector")->get().size() != 0)
+					if (it->template attributeTyped<Matrix>("right_vector")->get().size() != 0)
 						mAttributeDependencies.push_back(it->attribute("right_vector"));
 				}
 				for (auto node : solver.mNodes) {

--- a/dpsim/include/dpsim/MNASolverPlugin.h
+++ b/dpsim/include/dpsim/MNASolverPlugin.h
@@ -42,7 +42,7 @@ namespace DPsim {
 				Task(solver.mName + ".Solve"), mSolver(solver) {
 
 				for (auto it : solver.mMNAComponents) {
-					if (it->template attribute<Matrix>("right_vector")->get().size() != 0)
+					if (it->template attributeTyped<Matrix>("right_vector")->get().size() != 0)
 						mAttributeDependencies.push_back(it->attribute("right_vector"));
 				}
 				for (auto node : solver.mNodes) {

--- a/dpsim/include/dpsim/pybind/Utils.h
+++ b/dpsim/include/dpsim/pybind/Utils.h
@@ -19,14 +19,14 @@ namespace py = pybind11;
 template <typename T>
 py::cpp_function createAttributeSetter(const std::string name) {
 	return [name](CPS::IdentifiedObject &object, T &value) {
-		object.attribute<T>(name)->set(value);
+		object.attributeTyped<T>(name)->set(value);
 	};
 }
 
 template <typename T>
 py::cpp_function createAttributeGetter(const std::string name) {
 	return [name](CPS::IdentifiedObject &object) {
-		return object.attribute<T>(name)->get();
+		return object.attributeTyped<T>(name)->get();
 	};
 }
 

--- a/dpsim/src/DiakopticsSolver.cpp
+++ b/dpsim/src/DiakopticsSolver.cpp
@@ -254,7 +254,7 @@ void DiakopticsSolver<VarType>::initComponents() {
 		// Initialize MNA specific parts of components.
 		for (auto comp : mSubnets[net].components) {
 			comp->mnaInitialize(mSystem.mSystemOmega, mTimeStep, mSubnets[net].leftVector);
-			const Matrix& stamp = comp->template attribute<Matrix>("right_vector")->get();
+			const Matrix& stamp = comp->template attributeTyped<Matrix>("right_vector")->get();
 			if (stamp.size() != 0) {
 				mSubnets[net].rightVectorStamps.push_back(&stamp);
 			}

--- a/dpsim/src/MNASolver.cpp
+++ b/dpsim/src/MNASolver.cpp
@@ -128,7 +128,7 @@ void MnaSolver<Real>::initializeComponents() {
 		}
 	}
 
-	for (auto comp : mSwitches)
+	for (auto comp : mMNAIntfSwitches)
 		comp->mnaInitialize(mSystem.mSystemOmega, mTimeStep, attributeTyped<Matrix>("left_vector"));
 }
 
@@ -177,7 +177,7 @@ void MnaSolver<Complex>::initializeComponents() {
 			}
 		}
 
-		for (auto comp : mSwitches)
+		for (auto comp : mMNAIntfSwitches)
 			comp->mnaInitialize(mSystem.mSystemOmega, mTimeStep, attributeTyped<Matrix>("left_vector"));
 	}
 }
@@ -544,7 +544,7 @@ Task::List MnaSolver<VarType>::getTasks() {
 			l.push_back(task);
 		}
 	}
-	for (auto comp : mSwitches) {
+	for (auto comp : mMNAIntfSwitches) {
 		for (auto task : comp->mnaTasks()) {
 			l.push_back(task);
 		}

--- a/dpsim/src/MNASolver.cpp
+++ b/dpsim/src/MNASolver.cpp
@@ -121,15 +121,15 @@ void MnaSolver<Real>::initializeComponents() {
 
 	// Initialize MNA specific parts of components.
 	for (auto comp : allMNAComps) {
-		comp->mnaInitialize(mSystem.mSystemOmega, mTimeStep, attribute<Matrix>("left_vector"));
-		const Matrix& stamp = comp->template attribute<Matrix>("right_vector")->get();
+		comp->mnaInitialize(mSystem.mSystemOmega, mTimeStep, attributeTyped<Matrix>("left_vector"));
+		const Matrix& stamp = comp->template attributeTyped<Matrix>("right_vector")->get();
 		if (stamp.size() != 0) {
 			mRightVectorStamps.push_back(&stamp);
 		}
 	}
 
 	for (auto comp : mSwitches)
-		comp->mnaInitialize(mSystem.mSystemOmega, mTimeStep, attribute<Matrix>("left_vector"));
+		comp->mnaInitialize(mSystem.mSystemOmega, mTimeStep, attributeTyped<Matrix>("left_vector"));
 }
 
 template <>
@@ -159,7 +159,7 @@ void MnaSolver<Complex>::initializeComponents() {
 		for (auto comp : mMNAComponents) {
 			// Initialize MNA specific parts of components.
 			comp->mnaInitializeHarm(mSystem.mSystemOmega, mTimeStep, mLeftSideVectorHarm);
-			const Matrix& stamp = comp->template attribute<Matrix>("right_vector")->get();
+			const Matrix& stamp = comp->template attributeTyped<Matrix>("right_vector")->get();
 			if (stamp.size() != 0) mRightVectorStamps.push_back(&stamp);
 		}
 		// Initialize nodes
@@ -170,15 +170,15 @@ void MnaSolver<Complex>::initializeComponents() {
 	else {
 		// Initialize MNA specific parts of components.
 		for (auto comp : allMNAComps) {
-			comp->mnaInitialize(mSystem.mSystemOmega, mTimeStep, attribute<Matrix>("left_vector"));
-			const Matrix& stamp = comp->template attribute<Matrix>("right_vector")->get();
+			comp->mnaInitialize(mSystem.mSystemOmega, mTimeStep, attributeTyped<Matrix>("left_vector"));
+			const Matrix& stamp = comp->template attributeTyped<Matrix>("right_vector")->get();
 			if (stamp.size() != 0) {
 				mRightVectorStamps.push_back(&stamp);
 			}
 		}
 
 		for (auto comp : mSwitches)
-			comp->mnaInitialize(mSystem.mSystemOmega, mTimeStep, attribute<Matrix>("left_vector"));
+			comp->mnaInitialize(mSystem.mSystemOmega, mTimeStep, attributeTyped<Matrix>("left_vector"));
 	}
 }
 

--- a/dpsim/src/MNASolverEigenSparse.cpp
+++ b/dpsim/src/MNASolverEigenSparse.cpp
@@ -60,13 +60,13 @@ void MnaSolverEigenSparse<VarType>::stampVariableSystemMatrix() {
 		statElem->mnaApplySystemMatrixStamp(mBaseSystemMatrix);
 	mSLog->info("Base matrix with only static elements: {}", Logger::matrixToString(mBaseSystemMatrix));
 	mSLog->flush();
-	
+
 	// Use matrix with only static elements as basis for variable system matrix
 	mVariableSystemMatrix = mBaseSystemMatrix;
 
 	// Now stamp switches into matrix
 	mSLog->info("Stamping switches");
-	for (auto sw : mSwitches)
+	for (auto sw : mMNAIntfSwitches)
 		sw->mnaApplySystemMatrixStamp(mVariableSystemMatrix);
 
 	// Now stamp initial state of variable elements into matrix
@@ -86,7 +86,7 @@ template <typename VarType>
 void MnaSolverEigenSparse<VarType>::solveWithSystemMatrixRecomputation(Real time, Int timeStepCount) {
 	// Reset source vector
 	mRightSideVector.setZero();
-	
+
 	// Add together the right side vector (computed by the components'
 	// pre-step tasks)
 	for (auto stamp : mRightVectorStamps)
@@ -112,7 +112,7 @@ void MnaSolverEigenSparse<VarType>::recomputeSystemMatrix(Real time) {
 	mVariableSystemMatrix = mBaseSystemMatrix;
 
 	// Now stamp switches into matrix
-	for (auto sw : mSwitches)
+	for (auto sw : mMNAIntfSwitches)
 		sw->mnaApplySystemMatrixStamp(mVariableSystemMatrix);
 
 	// Now stamp variable elements into matrix

--- a/dpsim/src/MNASolverEigenSparse.cpp
+++ b/dpsim/src/MNASolverEigenSparse.cpp
@@ -36,10 +36,10 @@ void MnaSolverEigenSparse<VarType>::switchedMatrixStamp(std::size_t index, std::
 	auto bit = std::bitset<SWITCH_NUM>(index);
 	auto& sys = mSwitchedMatrices[bit][0];
 	for (auto comp : comp) {
-		comp->mnaApplySystemMatrixStamp(sys);
+		comp->mnaApplySparseSystemMatrixStamp(sys);
 	}
 	for (UInt i = 0; i < mSwitches.size(); ++i)
-		mSwitches[i]->mnaApplySwitchSystemMatrixStamp(bit[i], sys, 0);
+		mSwitches[i]->mnaApplySwitchSparseSystemMatrixStamp(bit[i], sys, 0);
 
 	// Compute LU-factorization for system matrix
 	mLuFactorizations[bit][0]->analyzePattern(sys);
@@ -57,7 +57,7 @@ void MnaSolverEigenSparse<VarType>::stampVariableSystemMatrix() {
 	// Build base matrix with only static elements
 	mBaseSystemMatrix.setZero();
 	for (auto statElem : mMNAComponents)
-		statElem->mnaApplySystemMatrixStamp(mBaseSystemMatrix);
+		statElem->mnaApplySparseSystemMatrixStamp(mBaseSystemMatrix);
 	mSLog->info("Base matrix with only static elements: {}", Logger::matrixToString(mBaseSystemMatrix));
 	mSLog->flush();
 
@@ -67,12 +67,12 @@ void MnaSolverEigenSparse<VarType>::stampVariableSystemMatrix() {
 	// Now stamp switches into matrix
 	mSLog->info("Stamping switches");
 	for (auto sw : mMNAIntfSwitches)
-		sw->mnaApplySystemMatrixStamp(mVariableSystemMatrix);
+		sw->mnaApplySparseSystemMatrixStamp(mVariableSystemMatrix);
 
 	// Now stamp initial state of variable elements into matrix
 	mSLog->info("Stamping variable elements");
 	for (auto varElem : mMNAIntfVariableComps)
-		varElem->mnaApplySystemMatrixStamp(mVariableSystemMatrix);
+		varElem->mnaApplySparseSystemMatrixStamp(mVariableSystemMatrix);
 
 	mSLog->info("Initial system matrix with variable elements {}", Logger::matrixToString(mVariableSystemMatrix));
 	mSLog->flush();
@@ -113,11 +113,11 @@ void MnaSolverEigenSparse<VarType>::recomputeSystemMatrix(Real time) {
 
 	// Now stamp switches into matrix
 	for (auto sw : mMNAIntfSwitches)
-		sw->mnaApplySystemMatrixStamp(mVariableSystemMatrix);
+		sw->mnaApplySparseSystemMatrixStamp(mVariableSystemMatrix);
 
 	// Now stamp variable elements into matrix
 	for (auto comp : mMNAIntfVariableComps)
-		comp->mnaApplySystemMatrixStamp(mVariableSystemMatrix);
+		comp->mnaApplySparseSystemMatrixStamp(mVariableSystemMatrix);
 
 	// Refactorization of matrix assuming that structure remained
 	// constant by omitting analyzePattern

--- a/dpsim/src/MNASolverPlugin.cpp
+++ b/dpsim/src/MNASolverPlugin.cpp
@@ -49,7 +49,7 @@ void MnaSolverPlugin<VarType>::recomputeSystemMatrix(Real time) {
 	this->mVariableSystemMatrix = this->mBaseSystemMatrix;
 
 	// Now stamp switches into matrix
-	for (auto sw : this->mSwitches)
+	for (auto sw : this->mMNAIntfSwitches)
 		sw->mnaApplySystemMatrixStamp(this->mVariableSystemMatrix);
 
 	// Now stamp variable elements into matrix

--- a/dpsim/src/MNASolverPlugin.cpp
+++ b/dpsim/src/MNASolverPlugin.cpp
@@ -50,11 +50,11 @@ void MnaSolverPlugin<VarType>::recomputeSystemMatrix(Real time) {
 
 	// Now stamp switches into matrix
 	for (auto sw : this->mMNAIntfSwitches)
-		sw->mnaApplySystemMatrixStamp(this->mVariableSystemMatrix);
+		sw->mnaApplySparseSystemMatrixStamp(this->mVariableSystemMatrix);
 
 	// Now stamp variable elements into matrix
 	for (auto comp : this->mMNAIntfVariableComps)
-		comp->mnaApplySystemMatrixStamp(this->mVariableSystemMatrix);
+		comp->mnaApplySparseSystemMatrixStamp(this->mVariableSystemMatrix);
 
     int size = this->mRightSideVector.rows();
 	int nnz = this->mVariableSystemMatrix.nonZeros();

--- a/dpsim/src/ODESolver.cpp
+++ b/dpsim/src/ODESolver.cpp
@@ -16,7 +16,7 @@ ODESolver::ODESolver(String name, const CPS::ODEInterface::Ptr &comp, bool impli
 	mComponent(comp),
 	mImplicitIntegration(implicit_integration),
 	mTimestep(timestep) {
-	mProbDim = mComponent->attribute<Matrix>("ode_pre_state")->get().rows();
+	mProbDim = mComponent->attributeTyped<Matrix>("ode_pre_state")->get().rows();
 	initialize();
 }
 
@@ -122,7 +122,7 @@ Real ODESolver::step(Real initial_time) {
 	/// Number of error test fails
 	long int netf;
 
-	mComponent->attribute<Matrix>("ode_post_state")->set(mComponent->attribute<Matrix>("ode_pre_state")->get());
+	mComponent->attributeTyped<Matrix>("ode_post_state")->set(mComponent->attributeTyped<Matrix>("ode_pre_state")->get());
 
 	// Better allocate the arkode memory here to prevent numerical problems
 	mArkode_mem= ARKodeCreate();

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -106,13 +106,13 @@ void PFSolver::setBaseApparentPower() {
 	Real maxPower = 0.;
 	if (!mSynchronGenerators.empty()) {
 		for (auto gen : mSynchronGenerators)
-			if (std::abs(gen->attribute<Real>("P_set")->get()) > maxPower)
-				maxPower = std::abs(gen->attribute<Real>("P_set")->get());
+			if (std::abs(gen->attributeTyped<Real>("P_set")->get()) > maxPower)
+				maxPower = std::abs(gen->attributeTyped<Real>("P_set")->get());
 	}
 	else if (!mTransformers.empty()) {
 		for (auto trafo : mTransformers)
-			if (trafo->attribute<Real>("S")->get() > maxPower)
-				maxPower = trafo->attribute<Real>("S")->get();
+			if (trafo->attributeTyped<Real>("S")->get() > maxPower)
+				maxPower = trafo->attributeTyped<Real>("S")->get();
 	}
     if (maxPower != 0.)
         mBaseApparentPower = pow(10, 1 + floor(log10(maxPower)));
@@ -222,42 +222,42 @@ void PFSolver::determinePFBusType() {
 }
 
 void PFSolver::determineNodeBaseVoltages() {
-	
+
     mSLog->info("-- Determine base voltages for each node according to connected components");
-    mSLog->flush();  
-	
+    mSLog->flush();
+
 	for (auto node : mSystem.mNodes) {
 		CPS::Real baseVoltage_ = 0;
 		for (auto comp : mSystem.mComponentsAtNode[node]) {
             if (std::shared_ptr<CPS::SP::Ph1::AvVoltageSourceInverterDQ> vsi = std::dynamic_pointer_cast<CPS::SP::Ph1::AvVoltageSourceInverterDQ>(comp)) {
-				baseVoltage_=Math::abs(vsi->attribute<CPS::Complex>("vnom")->get());
+				baseVoltage_=Math::abs(vsi->attributeTyped<CPS::Complex>("vnom")->get());
                 mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, vsi->name(), node->name());
                 break;
 			}
             else if (std::shared_ptr<CPS::SP::Ph1::RXLine> rxline = std::dynamic_pointer_cast<CPS::SP::Ph1::RXLine>(comp)) {
-				baseVoltage_ = rxline->attribute<CPS::Real>("base_Voltage")->get();
+				baseVoltage_ = rxline->attributeTyped<CPS::Real>("base_Voltage")->get();
                 mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, rxline->name(), node->name());
                 break;
 			}
             else if (std::shared_ptr<CPS::SP::Ph1::PiLine> line = std::dynamic_pointer_cast<CPS::SP::Ph1::PiLine>(comp)) {
-				baseVoltage_ = line->attribute<CPS::Real>("base_Voltage")->get();
+				baseVoltage_ = line->attributeTyped<CPS::Real>("base_Voltage")->get();
                 mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, line->name(), node->name());
                 break;
 			}
 			else if (std::shared_ptr<CPS::SP::Ph1::Transformer> trans = std::dynamic_pointer_cast<CPS::SP::Ph1::Transformer>(comp)) {
 				if (trans->terminal(0)->node()->name() == node->name()){
-                    baseVoltage_ = trans->attribute<CPS::Real>("nominal_voltage_end1")->get();
+                    baseVoltage_ = trans->attributeTyped<CPS::Real>("nominal_voltage_end1")->get();
                     mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, trans->name(), node->name());
                     break;
                 }
 				else if (trans->terminal(1)->node()->name() == node->name()){
-                    baseVoltage_ = trans->attribute<CPS::Real>("nominal_voltage_end2")->get();
+                    baseVoltage_ = trans->attributeTyped<CPS::Real>("nominal_voltage_end2")->get();
                     mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, trans->name(), node->name());
                     break;
                 }
             }
             else if (std::shared_ptr<CPS::SP::Ph1::SynchronGenerator> gen = std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(comp)) {
-                    baseVoltage_ = gen->attribute<CPS::Real>("base_Voltage")->get();
+                    baseVoltage_ = gen->attributeTyped<CPS::Real>("base_Voltage")->get();
                     mSLog->info("Choose base voltage {}V of {} to convert pu-solution of {}.", baseVoltage_, gen->name(), node->name());
                     break;
                 }

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -37,8 +37,8 @@ void PFSolverPowerPolar::generateInitialSolution(Real time, bool keep_last_solut
 		}
 		for (auto comp : mSystem.mComponentsAtNode[pq]) {
             if (std::shared_ptr<CPS::SP::Ph1::Load> load = std::dynamic_pointer_cast<CPS::SP::Ph1::Load>(comp)) {
-                sol_P(pq->matrixNodeIndex()) -= load->attribute<CPS::Real>("P_pu")->get();
-                sol_Q(pq->matrixNodeIndex()) -= load->attribute<CPS::Real>("Q_pu")->get();
+                sol_P(pq->matrixNodeIndex()) -= load->attributeTyped<CPS::Real>("P_pu")->get();
+                sol_Q(pq->matrixNodeIndex()) -= load->attributeTyped<CPS::Real>("Q_pu")->get();
             }
             else if(std::shared_ptr<CPS::SP::Ph1::SolidStateTransformer> sst =
                 std::dynamic_pointer_cast<CPS::SP::Ph1::SolidStateTransformer>(comp)){
@@ -48,8 +48,8 @@ void PFSolverPowerPolar::generateInitialSolution(Real time, bool keep_last_solut
             else if (std::shared_ptr<CPS::SP::Ph1::AvVoltageSourceInverterDQ> vsi =
 				std::dynamic_pointer_cast<CPS::SP::Ph1::AvVoltageSourceInverterDQ>(comp)) {
                 // TODO: add per-unit attributes to VSI and use here
-				sol_P(pq->matrixNodeIndex()) += vsi->attribute<CPS::Real>("P_ref")->get() / mBaseApparentPower;
-				sol_Q(pq->matrixNodeIndex()) += vsi->attribute<CPS::Real>("Q_ref")->get() / mBaseApparentPower;
+				sol_P(pq->matrixNodeIndex()) += vsi->attributeTyped<CPS::Real>("P_ref")->get() / mBaseApparentPower;
+				sol_Q(pq->matrixNodeIndex()) += vsi->attributeTyped<CPS::Real>("Q_ref")->get() / mBaseApparentPower;
 			}
             sol_S_complex(pq->matrixNodeIndex()) = CPS::Complex(sol_P[pq->matrixNodeIndex()], sol_Q[pq->matrixNodeIndex()]);
 		}
@@ -62,20 +62,20 @@ void PFSolverPowerPolar::generateInitialSolution(Real time, bool keep_last_solut
 		}
 		for (auto comp : mSystem.mComponentsAtNode[pv]) {
 			if (std::shared_ptr<CPS::SP::Ph1::SynchronGenerator> gen = std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(comp)) {
-				sol_P(pv->matrixNodeIndex()) += gen->attribute<CPS::Real>("P_set_pu")->get();
-				sol_V(pv->matrixNodeIndex()) = gen->attribute<CPS::Real>("V_set_pu")->get();
+				sol_P(pv->matrixNodeIndex()) += gen->attributeTyped<CPS::Real>("P_set_pu")->get();
+				sol_V(pv->matrixNodeIndex()) = gen->attributeTyped<CPS::Real>("V_set_pu")->get();
 			}
             else if (std::shared_ptr<CPS::SP::Ph1::Load> load = std::dynamic_pointer_cast<CPS::SP::Ph1::Load>(comp)) {
-				sol_P(pv->matrixNodeIndex()) -= load->attribute<CPS::Real>("P_pu")->get();
+				sol_P(pv->matrixNodeIndex()) -= load->attributeTyped<CPS::Real>("P_pu")->get();
 			}
             else if (std::shared_ptr<CPS::SP::Ph1::AvVoltageSourceInverterDQ> vsi =
 				std::dynamic_pointer_cast<CPS::SP::Ph1::AvVoltageSourceInverterDQ>(comp)) {
-				sol_P(pv->matrixNodeIndex()) += vsi->attribute<CPS::Real>("P_ref")->get() / mBaseApparentPower;
+				sol_P(pv->matrixNodeIndex()) += vsi->attributeTyped<CPS::Real>("P_ref")->get() / mBaseApparentPower;
 			}
             else if (std::shared_ptr<CPS::SP::Ph1::NetworkInjection> extnet =
 				std::dynamic_pointer_cast<CPS::SP::Ph1::NetworkInjection>(comp)) {
-				sol_P(pv->matrixNodeIndex()) += extnet->attribute<CPS::Real>("p_inj")->get() / mBaseApparentPower;
-				sol_V(pv->matrixNodeIndex()) = extnet->attribute<CPS::Real>("V_set_pu")->get();
+				sol_P(pv->matrixNodeIndex()) += extnet->attributeTyped<CPS::Real>("p_inj")->get() / mBaseApparentPower;
+				sol_V(pv->matrixNodeIndex()) = extnet->attributeTyped<CPS::Real>("V_set_pu")->get();
 			}
 			sol_S_complex(pv->matrixNodeIndex()) = CPS::Complex(sol_P[pv->matrixNodeIndex()], sol_Q[pv->matrixNodeIndex()]);
 			sol_V_complex(pv->matrixNodeIndex()) = CPS::Complex(sol_V[pv->matrixNodeIndex()], sol_D[pv->matrixNodeIndex()]);
@@ -91,7 +91,7 @@ void PFSolverPowerPolar::generateInitialSolution(Real time, bool keep_last_solut
         // if external injection at VD bus, reset the voltage to injection's voltage set-point
         for (auto comp : mSystem.mComponentsAtNode[vd]) {
             if (std::shared_ptr<CPS::SP::Ph1::NetworkInjection> extnet = std::dynamic_pointer_cast<CPS::SP::Ph1::NetworkInjection>(comp)) {
-                sol_V(vd->matrixNodeIndex()) = extnet->attribute<CPS::Real>("V_set_pu")->get();
+                sol_V(vd->matrixNodeIndex()) = extnet->attributeTyped<CPS::Real>("V_set_pu")->get();
             }
         }
 
@@ -100,7 +100,7 @@ void PFSolverPowerPolar::generateInitialSolution(Real time, bool keep_last_solut
             for (auto gen : mSynchronGenerators)
             {
                 if (gen->node(0)->matrixNodeIndex() == vd->matrixNodeIndex())
-                    sol_V(vd->matrixNodeIndex()) = gen->attribute<CPS::Real>("V_set_pu")->get();
+                    sol_V(vd->matrixNodeIndex()) = gen->attributeTyped<CPS::Real>("V_set_pu")->get();
             }
         }
 

--- a/dpsim/src/Simulation.cpp
+++ b/dpsim/src/Simulation.cpp
@@ -118,7 +118,7 @@ void Simulation::createSolvers() {
 		if (odeComp) {
 			// TODO explicit / implicit integration
 			auto odeSolver = std::make_shared<ODESolver>(
-				odeComp->attribute<String>("name")->get() + "_ODE", odeComp, false, **mTimeStep);
+				odeComp->attributeTyped<String>("name")->get() + "_ODE", odeComp, false, **mTimeStep);
 			mSolvers.push_back(odeSolver);
 		}
 	}

--- a/dpsim/src/Simulation.cpp
+++ b/dpsim/src/Simulation.cpp
@@ -441,6 +441,9 @@ void Simulation::logIdObjAttribute(const String &comp, const String &attr) {
 }
 
 void Simulation::logAttribute(String name, CPS::AttributeBase::Ptr attr) {
-	//FIXME: Safety: This will crash when no logger is registered
-	mLoggers[0]->logAttribute(name, attr);
+	if (mLoggers.size() > 0) {
+		mLoggers[0]->logAttribute(name, attr);
+	} else {
+		throw SystemError("Cannot log attributes when no logger is configured for this simulation!");
+	}
 }

--- a/dpsim/src/Utils.cpp
+++ b/dpsim/src/Utils.cpp
@@ -455,7 +455,7 @@ void DPsim::Utils::applySynchronousGeneratorParametersFromJson(const json config
 		Bool containsSyngenOptions = false;
 		for (String attrName : syngen->attrParamNames) {
 			if (config["options"].contains(attrName)) {
-				syngen->attribute<Real>(attrName)->set(config["options"][attrName].get<double>());
+				syngen->attributeTyped<Real>(attrName)->set(config["options"][attrName].get<double>());
 				containsSyngenOptions = true;
 			}
 		}

--- a/dpsim/src/pybind/DPComponents.cpp
+++ b/dpsim/src/pybind/DPComponents.cpp
@@ -120,7 +120,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
 		.def("set_model_flags", &CPS::DP::Ph1::SynchronGeneratorTrStab::setModelFlags, "convert_with_omega_mech"_a)
 		.def("set_reference_omega", [](CPS::DP::Ph1::SynchronGeneratorTrStab &gen, std::string refOmegaName, CPS::IdentifiedObject::Ptr refOmegaComp,
 			std::string refDeltaName, CPS::IdentifiedObject::Ptr refDeltaComp) {
-				gen.setReferenceOmega(refOmegaComp->attribute<CPS::Real>(refOmegaName), refDeltaComp->attribute<CPS::Real>(refDeltaName));
+				gen.setReferenceOmega(refOmegaComp->attributeTyped<CPS::Real>(refOmegaName), refDeltaComp->attributeTyped<CPS::Real>(refDeltaName));
 			}, "ref_omega_name"_a="w_r", "ref_omage_comp"_a, "ref_delta_name"_a="delta_r", "ref_delta_comp"_a);
 
 	py::class_<CPS::DP::Ph1::AvVoltageSourceInverterDQ, std::shared_ptr<CPS::DP::Ph1::AvVoltageSourceInverterDQ>, CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "AvVoltageSourceInverterDQ", py::multiple_inheritance())

--- a/dpsim/src/pybind/SPComponents.cpp
+++ b/dpsim/src/pybind/SPComponents.cpp
@@ -114,7 +114,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
 		.def("set_model_flags", &CPS::SP::Ph1::SynchronGeneratorTrStab::setModelFlags, "convert_with_omega_mech"_a)
 		.def("set_reference_omega", [](CPS::SP::Ph1::SynchronGeneratorTrStab &gen, std::string refOmegaName, CPS::IdentifiedObject::Ptr refOmegaComp,
 			std::string refDeltaName, CPS::IdentifiedObject::Ptr refDeltaComp) {
-				gen.setReferenceOmega(refOmegaComp->attribute<CPS::Real>(refOmegaName), refDeltaComp->attribute<CPS::Real>(refDeltaName));
+				gen.setReferenceOmega(refOmegaComp->attributeTyped<CPS::Real>(refOmegaName), refDeltaComp->attributeTyped<CPS::Real>(refDeltaName));
 			}, "ref_omega_name"_a="w_r", "ref_omage_comp"_a, "ref_delta_name"_a="delta_r", "ref_delta_comp"_a);
 
 	py::class_<CPS::SP::Ph1::AvVoltageSourceInverterDQ, std::shared_ptr<CPS::SP::Ph1::AvVoltageSourceInverterDQ>, CPS::SimPowerComp<CPS::Complex>>(mSPPh1, "AvVoltageSourceInverterDQ", py::multiple_inheritance())

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -146,7 +146,7 @@ PYBIND11_MODULE(dpsimpy, m) {
 		/// CHECK: It would be nicer if all the attributes of an IdObject were bound as properties so they show up in the documentation and auto-completion.
 		/// I don't know if this is possible to do because it depends on if the attribute map is filled before or after the code in this file is run.
 		/// Manually adding the attributes would of course be possible but very tedious to do for all existing components / attributes
-		.def("attr", &CPS::IdentifiedObject::attributeBase, "name"_a)
+		.def("attr", &CPS::IdentifiedObject::attribute, "name"_a)
 		.def("print_attribute_list", &printAttributes)
 		.def("print_attribute", &printAttribute, "attribute_name"_a)
 		.def("__str__", &getAttributeList);


### PR DESCRIPTION
Introduces two new base classes, `MNASimPowerComp<T>` and `CompositePowerComp<T>`. For all composite components (as defined in #131), `MNASimPowerComp` provides default implementations for all methods in `MNAInterface`, as well as default `MnaPreStep` and `MnaPostStep` tasks, such that `MNAInterface` is only inherited once in the parent class and not in each component individually. Additionally, `CompositePowerComp` provides `mnaParent...` methods for most of the MNA methods in `MNAInterface`. Via the `addMNASubComponent` method, a component can register subcomponents for which the relevant MNA methods are called automatically by the `CompositePowerComp` parent class. For each MNA method, the child component class can decide to either override the normal `mna...` method and provide subcomponent handling themselves, or override just the `mnaParent...` method and let the subcomponents (and some other common operations) get handled by the parent class methods.

While the `MNASimPowerComp` class is not used for any non-composite components in this PR, the unification of MNA methods for these components is covered in #150 .

Based on #142 
Related to #131 