### PR TITLE
Force gcc 11 in manylinux docker image

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -43,9 +43,9 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Build manylinux docker image # Remove this step as soon as the image is published on docker hub
-      shell: bash
-      run: docker build . --file packaging/Docker/Dockerfile.manylinux -t sogno/dpsim:manylinux
+    # - name: Build manylinux docker image # Remove this step as soon as the image is published on docker hub
+    #   shell: bash
+    #   run: docker build . --file packaging/Docker/Dockerfile.manylinux -t sogno/dpsim:manylinux
 
     - name: Build dpsim wheels for all supported python versions
       uses: pypa/cibuildwheel@v2.11.2

--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -19,7 +19,7 @@ RUN yum install -y epel-release
 
 # Toolchain
 RUN yum install -y \
-	gcc gcc-c++ clang \
+	gcc-toolset-11 clang \
 	git \
 	rpmdevtools rpm-build \
 	make cmake pkgconfig \
@@ -96,5 +96,7 @@ RUN cd /tmp && \
 	git -c submodule.fpga.update=none clone --recursive https://git.rwth-aachen.de/acs/public/villas/node.git villasnode && \	
 	mkdir -p villasnode/build && cd villasnode/build && \
 	git -c submodule.fpga.update=none checkout b94746effb015aa98791c0e319ef11223d18e8b0 && git -c submodule.fpga.update=none submodule update --recursive && \
-	cmake -DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 .. && make -j$(nproc) install && \
+	cmake -DCMAKE_C_COMPILER:FILEPATH=/opt/rh/gcc-toolset-11/root/usr/bin/gcc -DCMAKE_CXX_COMPILER:FILEPATH=/opt/rh/gcc-toolset-11/root/usr/bin/g++ -DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 .. && make -j$(nproc) install && \
 	rm -rf /tmp/villasnode
+
+ENV CMAKE_OPTS="CMAKE_C_COMPILER:FILEPATH=/opt/rh/gcc-toolset-11/root/usr/bin/gcc CMAKE_CXX_COMPILER:FILEPATH=/opt/rh/gcc-toolset-11/root/usr/bin/g++" 


### PR DESCRIPTION
Installs and forces the use of GCC Version 11 in the ManyLinux Docker image.

This is a short-term solution for #145 

It is a follow-up of #139, which added a new workflow for packaging the dpsim source distribution as well as building multiple binary wheels for Python versions 3.6 to 3.11 using [cibuildwheel](https://github.com/pypa/cibuildwheel). Every commit to the master branch will be pushed to TestPyPi while only tagged commits will also be uploaded to production PyPi.