### PR TITLE
fix gitlab ci using old docker syntax

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ docker:rocky:
   stage: prepare
   needs: []
   script:
-    - docker build
+    - docker build .
         --file packaging/Docker/Dockerfile.dev-rocky
         --tag ${DOCKER_IMAGE_DEV_ROCKY}:${CI_COMMIT_REF_NAME}
   tags:


### PR DESCRIPTION
to make docker happy we have to specify the context directory. The other dockerfiles probably need this patch as well.
This fixes the gitlab CI.

Signed-off-by: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>