### PR TITLE
Fix PyPi-Upload CI workflow

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -11,14 +11,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev_centos
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
          file: packaging/Docker/Dockerfile.dev-centos
          push: true
@@ -31,14 +31,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_release
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
          file: packaging/Docker/Dockerfile
          push: true
@@ -51,14 +51,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
          file: packaging/Docker/Dockerfile.dev
          push: true
@@ -71,14 +71,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
          file: packaging/Docker/Dockerfile.dev-minimal
          push: true
@@ -91,14 +91,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
          file: packaging/Docker/Dockerfile.manylinux
          push: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11...3.23)
+cmake_minimum_required(VERSION 3.12...3.23)
 project(DPsim
 		VERSION 1.1.0
 		DESCRIPTION "C++ Power System Simulation Library"
@@ -126,7 +126,7 @@ find_package(MAGMA)
 
 include(cmake/GetReaderWriterQueue.cmake)
 
-find_package (Python COMPONENTS Interpreter Development)
+find_package (Python3 COMPONENTS Interpreter Development)
 if (WITH_PYBIND_MODULE)
 	include(cmake/GetPybindModule.cmake)
 else()

--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -99,4 +99,4 @@ RUN cd /tmp && \
 	cmake -DCMAKE_C_COMPILER:FILEPATH=/opt/rh/gcc-toolset-11/root/usr/bin/gcc -DCMAKE_CXX_COMPILER:FILEPATH=/opt/rh/gcc-toolset-11/root/usr/bin/g++ -DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 .. && make -j$(nproc) install && \
 	rm -rf /tmp/villasnode
 
-ENV CMAKE_OPTS="CMAKE_C_COMPILER:FILEPATH=/opt/rh/gcc-toolset-11/root/usr/bin/gcc CMAKE_CXX_COMPILER:FILEPATH=/opt/rh/gcc-toolset-11/root/usr/bin/g++" 
+ENV CMAKE_OPTS="-DCMAKE_C_COMPILER:FILEPATH=/opt/rh/gcc-toolset-11/root/usr/bin/gcc -DCMAKE_CXX_COMPILER:FILEPATH=/opt/rh/gcc-toolset-11/root/usr/bin/g++" 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
+build-verbosity = "3"
 build="[cp]p3{6,7,8,9,10,11}-manylinux_x86_64"
 manylinux-x86_64-image = "sogno/dpsim:manylinux"
 manylinux-pypy_x86_64-image = "sogno/dpsim:manylinux"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dpsim
-version = 1.0.0
+version = 1.1.0
 author = The DPsim Authors
 author_email = mmirz@eonerc.rwth-aachen.de
 description = dynamic real-time power system simulator


### PR DESCRIPTION
Attempts to fix the wheel building and uploading process for the publish_to_pypi workflow. Now correctly enforces the use of the GCC 11 compiler in Python builds (see #145) and employs the CMake FindPython3 function which somehow works better than the previously used FindPython function. Also updates the Python Version number to 1.1.0 which allows for an actual upload to PyPi (Version 1.0.0 is already present there). 