### PR TITLE
Trigger PyPi-Workflow for tags

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '*'
 
 jobs:
   build-and-publish-sdist:


### PR DESCRIPTION
Triggers the publish_to_pypi workflow for every push to a tag. This means that every time a new tag is created, the workflow will attempt to build the code associated with this tag and push the finished package to TestPyPi and PyPi. Because tags and branches are independent, the workflow will not check whether the tagged commit also exists on the master branch.