### PR TITLE
Remove Python versions 3.6 and 3.7 for PyPi upload 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Please keep 3.14 as minimum requirement for building on OPAL-RT targets
 cmake_minimum_required(VERSION 3.14...3.23)
 project(DPsim
-		VERSION 1.1.0
+		VERSION 1.1.1
 		DESCRIPTION "C++ Power System Simulation Library"
 		LANGUAGES CXX
 		HOMEPAGE_URL "https://dpsim.fein-aachen.org/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,12 @@ set(PROJECT_VCS_URL "https://github.com/sogno-platform/dpsim")
 if(POLICY CMP0076)
 	cmake_policy(SET CMP0076 NEW)
 endif()
+
+# Solve DOWNLOAD_EXTRACT_TIMESTAMP warning
+if(POLICY CMP0135)
+	cmake_policy(SET CMP0135 NEW)
+endif()
+
 # Allow setting Graphviz_ROOT for windows builds
 if(WIN32)
 	cmake_policy(SET CMP0074 NEW)

--- a/cmake/FetchKLU.cmake
+++ b/cmake/FetchKLU.cmake
@@ -5,24 +5,4 @@ FetchContent_Declare(
 	URL https://github.com/dpsim-simulator/SuiteSparse/releases/download/release-v5.10.6/SuiteSparse-release-v5.10.6.tar.gz
 )
 
-FetchContent_GetProperties(klu-module)
-if(NOT klu-module_POPULATED)
-  FetchContent_Populate(klu-module)
-endif()
-
-FetchContent_GetProperties(klu-module)
-
-add_subdirectory(${klu-module_SOURCE_DIR} ${klu-module_BINARY_DIR})
-
-set(SS_PATH ${CMAKE_SOURCE_DIR}/build)
-
-if (CMAKE_BUILD_TYPE MATCHES Debug)
-  set(KLU_LIBRARY ${SS_PATH}/libklu_debug.a ${SS_PATH}/libbtf_debug.a ${SS_PATH}/libamd_debug.a ${SS_PATH}/libcolamd_debug.a ${SS_PATH}/libsuitesparseconfig_debug.a)
-else()
-  set(KLU_LIBRARY ${SS_PATH}/libklu.a ${SS_PATH}/libbtf.a ${SS_PATH}/libamd.a ${SS_PATH}/libcolamd.a ${SS_PATH}/libsuitesparseconfig.a)
-endif(CMAKE_BUILD_TYPE MATCHES Debug)
-
-set(KLU_LIBRARIES ${KLU_LIBRARY})
-set(KLU_INCLUDE_DIR ${klu-module_SOURCE_DIR}/KLU/Include ${klu-module_SOURCE_DIR}/BTF/Include ${klu-module_SOURCE_DIR}/COLAMD/Include ${klu-module_SOURCE_DIR}/AMD/Include ${klu-module_SOURCE_DIR}/SuiteSparse_config/)
-set(KLU_INCLUDE_DIRS ${KLU_INCLUDE_DIR})
-message(STATUS "Path to klu-module: " ${klu-module_SOURCE_DIR})
+FetchContent_MakeAvailable(klu-module)

--- a/dpsim-models/CMakeLists.txt
+++ b/dpsim-models/CMakeLists.txt
@@ -13,7 +13,6 @@ set(MODELS_LIBRARIES
 	Threads::Threads
 	Eigen3::Eigen
 	spdlog::spdlog
-	klu
 )
 
 add_subdirectory(src)

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -170,11 +170,6 @@ if(WITH_GSL)
 	list(APPEND MODELS_LIBRARIES ${GSL_LIBRARIES})
 endif()
 
-if(WITH_KLU)
-	list(APPEND MODELS_INCLUDE_DIRS ${KLU_INCLUDE_DIRS})
-	list(APPEND MODELS_LIBRARIES ${KLU_LIBRARIES})
-endif()
-
 target_link_libraries(dpsim-models PUBLIC ${MODELS_LIBRARIES})
 target_include_directories(dpsim-models PUBLIC ${MODELS_INCLUDE_DIRS})
 target_sources(dpsim-models PRIVATE ${MODELS_SOURCES})

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -214,19 +214,9 @@ if(WITH_CIM)
 	endif()
 endif()
 
-if(WITH_PYBIND)
-	#list(APPEND LIBRARIES ${PYTHON_LIBRARIES})
-	list(APPEND INCLUDE_DIRS ${Python_INCLUDE_DIRS})
-endif()
-
 if(WITH_OPENMP)
 	list(APPEND DPSIM_CXX_FLAGS ${OpenMP_CXX_FLAGS})
 	list(APPEND LIBRARIES ${OpenMP_CXX_FLAGS})
-endif()
-
-if(WITH_KLU)
-	list(APPEND INCLUDE_DIRS ${KLU_INCLUDE_DIR})
-	list(APPEND LIBRARIES ${KLU_LIBRARIES})
 endif()
 
 add_custom_target(tests)

--- a/dpsim/src/CMakeLists.txt
+++ b/dpsim/src/CMakeLists.txt
@@ -55,6 +55,7 @@ if(WITH_JSON)
 endif()
 
 if(WITH_KLU)
+	list(APPEND DPSIM_LIBRARIES klu)
 	list(APPEND DPSIM_SOURCES
 		KLUAdapter.cpp
 	)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build-verbosity = "3"
-build="[cp]p3{6,7,8,9,10,11}-manylinux_x86_64"
+build="[cp]p3{8,9,10,11}-manylinux_x86_64"
 manylinux-x86_64-image = "sogno/dpsim:manylinux"
 manylinux-pypy_x86_64-image = "sogno/dpsim:manylinux"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dpsim
-version = 1.1.0
+version = 1.1.1
 author = The DPsim Authors
 author_email = mmirz@eonerc.rwth-aachen.de
 description = dynamic real-time power system simulator

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ class CMakeBuild(build_ext):
 setup(
     packages=find_packages('python/src'),
     package_dir={"dpsim": "python/src/dpsim"},
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     setup_requires=[
         'pytest-runner',
         'wheel'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.cfamily.cache.enabled=true
 sonar.cfamily.cache.path=sonar-cache
 
 # Sonar Python Version
-sonar.python.version=3.7, 3.8, 3.9, 3.10
+sonar.python.version=3.8, 3.9, 3.10
 
 # Patterns excluded from duplication detection
 sonar.cpd.exclusions=dpsim/examples/**/*,examples/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,7 @@ sonar.cpd.exclusions=dpsim/examples/**/*,examples/**/*
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=DPsim
-sonar.projectVersion=1.1.0
+sonar.projectVersion=1.1.1
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 #sonar.sources=.


### PR DESCRIPTION
Removes the Python versions 3.6 and 3.7 from the PyPi build action. To ensure that the KLU libraries can be found during the wheel build, the FetchKLU cmake action is changed to use `FetchContent_MakeAvailable`. Finally, DPsim's version number is increased to v1.1.1 and a corresponding PyPi package uploaded.

Closes #228 