### PR TITLE
Disable VILLASfpga to remove libxil dependency

### DIFF
--- a/packaging/Docker/Dockerfile.dev
+++ b/packaging/Docker/Dockerfile.dev
@@ -91,6 +91,7 @@ RUN cd /tmp && \
 	git checkout ${VILLAS_VERSION} && \
 	cmake ${CMAKE_OPTS} .. \
 		-DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 \
+		-DWITH_FPGA=OFF \
 		-DDOWNLOAD_GO=OFF && \
 	make ${MAKE_OPTS} install && \
 	rm -rf /tmp/villas-node


### PR DESCRIPTION
Sets the `WITH_FPGA=OFF` compile flag for VILLASnode in the Dockerfile.dev to remove a dependency on the shared library `libxil`, which is currently not installed in the container. Merging this PR should probably be followed by an update for the images on Docker Hub via the `container` workflow.
Closes #231 