### PR TITLE
Disable test actions for PRs

### DIFF
--- a/.github/workflows/build_test_linux_fedora.yaml
+++ b/.github/workflows/build_test_linux_fedora.yaml
@@ -2,8 +2,6 @@ name: Build & Test Fedora
 
 on:
   push:
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 ## Build ##
 

--- a/.github/workflows/build_test_linux_fedora_minimal.yaml
+++ b/.github/workflows/build_test_linux_fedora_minimal.yaml
@@ -2,8 +2,6 @@ name: Build & Test Fedora Minimal
 
 on:
   push:
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 ## Build ##
 

--- a/.github/workflows/build_test_linux_rocky.yaml
+++ b/.github/workflows/build_test_linux_rocky.yaml
@@ -2,8 +2,6 @@ name: Build & Test RockyLinux
 
 on:
   push:
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 ## Build ##
 

--- a/.github/workflows/build_test_windows.yaml
+++ b/.github/workflows/build_test_windows.yaml
@@ -2,8 +2,6 @@ name: Build & Test Windows
 
 on:
   push:
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 ## Build ##
 


### PR DESCRIPTION
Disables all actions except SonarCloud when opening or updating a PR. Actions are still run on every push, so whenever a new commit is pushed onto the PRs base branch, the results of these actions will also show up in the PR.