### PR TITLE
Fix initialization rxload

### DIFF
--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
@@ -53,8 +53,6 @@ namespace Ph1 {
 		RXLoad(String name,
 			Logger::Level logLevel = Logger::Level::off);
 
-		SimPowerComp<Complex>::Ptr clone(String name);
-
 		// #### General ####
 		/// Initialize component from power flow data
 		void initializeFromNodesAndTerminals(Real frequency);

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
@@ -60,8 +60,6 @@ namespace CPS {
 					Matrix activePower, Matrix reactivePower, Real volt,
 					Logger::Level logLevel = Logger::Level::off);
 
-				SimPowerComp<Real>::Ptr clone(String name);
-
 				// #### General ####
 				///
 				void setParameters(Matrix activePower, Matrix reactivePower, Real volt);

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
@@ -67,8 +67,6 @@ namespace Ph1 {
 			: Load(name, name, logLevel) { }
 		///
 		void setParameters(Real activePower, Real reactivePower, Real nominalVoltage);
-		///
-		SimPowerComp<Complex>::Ptr clone(String name) override;
 
 		// #### General ####
 		/// Initializes component from power flow data

--- a/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
@@ -26,14 +26,6 @@ DP::Ph1::RXLoad::RXLoad(String name, Logger::Level logLevel)
 	: RXLoad(name, name, logLevel) {
 }
 
-/// DEPRECATED: Delete method
-SimPowerComp<Complex>::Ptr DP::Ph1::RXLoad::clone(String name) {
-	auto copy = RXLoad::make(name, mLogLevel);
-	if (mParametersSet)
-		copy->setParameters(**mActivePower, **mReactivePower, **mNomVoltage);
-	return copy;
-}
-
 void DP::Ph1::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 
 	if(!mParametersSet){

--- a/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
@@ -66,11 +66,6 @@ void EMT::Ph3::RXLoad::setParameters(Matrix activePower, Matrix reactivePower, R
 	initPowerFromTerminal = false;
 }
 
-SimPowerComp<Real>::Ptr EMT::Ph3::RXLoad::clone(String name) {
-	// everything set by initializeFromNodesAndTerminals
-	return RXLoad::make(name, mLogLevel);
-}
-
 void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 
 	if (initPowerFromTerminal) {

--- a/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
@@ -73,7 +73,7 @@ SimPowerComp<Real>::Ptr EMT::Ph3::RXLoad::clone(String name) {
 
 void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 
-		if (initPowerFromTerminal) {
+	if (initPowerFromTerminal) {
 		**mActivePower = Matrix::Zero(3, 3);
 		(**mActivePower)(0, 0) = mTerminals[0]->singleActivePower() / 3.;
 		(**mActivePower)(1, 1) = mTerminals[0]->singleActivePower() / 3.;
@@ -107,6 +107,7 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubResistor->initialize(mFrequencies);
 		mSubResistor->initializeFromNodesAndTerminals(frequency);
 		addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
+		**mIntfCurrent += mSubResistor->intfCurrent();
 	}
 
 	if ((**mReactivePower)(0, 0) != 0)
@@ -123,6 +124,7 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubInductor->initialize(mFrequencies);
 		mSubInductor->initializeFromNodesAndTerminals(frequency);
 		addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
+		**mIntfCurrent += mSubInductor->intfCurrent();
 	}
 	else if (mReactance(0,0) < 0) {
 		mCapacitance = -1 / (2 * PI * frequency) * mReactance.inverse();
@@ -133,6 +135,7 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 		mSubCapacitor->initialize(mFrequencies);
 		mSubCapacitor->initializeFromNodesAndTerminals(frequency);
 		addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
+		**mIntfCurrent += mSubCapacitor->intfCurrent();
 	}
 
 	MatrixComp vInitABC = MatrixComp::Zero(3, 1);
@@ -140,16 +143,6 @@ void EMT::Ph3::RXLoad::initializeFromNodesAndTerminals(Real frequency) {
 	vInitABC(1, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_B;
 	vInitABC(2, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_C;
 	**mIntfVoltage = vInitABC.real();
-
-	MatrixComp iInitABC = MatrixComp::Zero(3, 1);
-	// v i^T* = S
-	// v^T v i^T* = v^T S
-	// i^T*= (|v|^2)^(-1) v^T S
-
-	Complex v_ = vInitABC(0, 0)*vInitABC(0, 0) + vInitABC(1, 0)*vInitABC(1, 0) + vInitABC(2, 0)*vInitABC(2, 0);
-	MatrixComp rhs_ = Complex(1, 0) / v_ * vInitABC.transpose() * mPower;
-	iInitABC = rhs_.conjugate().transpose();
-	**mIntfCurrent = iInitABC.real();
 
 	SPDLOG_LOGGER_INFO(mSLog, 
 		"\n--- Initialization from powerflow ---"

--- a/dpsim-models/src/SP/SP_Ph1_Load.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Load.cpp
@@ -40,13 +40,6 @@ void SP::Ph1::Load::setParameters(Real activePower, Real reactivePower, Real nom
 	mParametersSet = true;
 }
 
-
-SimPowerComp<Complex>::Ptr SP::Ph1::Load::clone(String name) {
-	// everything set by initializeFromNodesAndTerminals
-	return Load::make(name, mLogLevel);
-}
-
-
  // #### Powerflow section ####
 void SP::Ph1::Load::calculatePerUnitParameters(Real baseApparentPower, Real baseOmega) {
 	SPDLOG_LOGGER_INFO(mSLog, "#### Calculate Per Unit Parameters for {}", **mName);


### PR DESCRIPTION
This PR fixes the initialization of the interface current of `RXLoad` in EMT. Moreover, the deprecated fuctions `clone` of `SP_Load`, `DP_RXLoad` and `EMT_Load` are deleted.

Closes #240