### PR TITLE
Hotfix: missing simulation stop

### DIFF
--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -88,6 +88,7 @@ PYBIND11_MODULE(dpsimpy, m) {
 		.def("set_domain", &DPsim::Simulation::setDomain)
 		.def("start", &DPsim::Simulation::start)
 		.def("next", &DPsim::Simulation::next)
+		.def("stop", &DPsim::Simulation::stop)
 		.def("get_idobj_attr", &DPsim::Simulation::getIdObjAttribute, "comp"_a, "attr"_a)
 		.def("add_interface", &DPsim::Simulation::addInterface, "interface"_a)
 		.def("log_idobj_attribute", &DPsim::Simulation::logIdObjAttribute, "comp"_a, "attr"_a)


### PR DESCRIPTION
This PR fixes an error when using the dpsim python interface `dpsimpy`. The `stop` function was not declared in the `pybind/main.cpp` and then not exposed in python. Now, a line was added to expose the `stop` function.

Closes #248
