### PR TITLE
Fix compilation missing override warnings and function declarations 

### DIFF
--- a/dpsim-models/include/dpsim-models/Attribute.h
+++ b/dpsim-models/include/dpsim-models/Attribute.h
@@ -555,7 +555,7 @@ public:
     throw TypeException();
   }
 
-  virtual std::shared_ptr<T> asRawPointer() { return this->mData; }
+  virtual std::shared_ptr<T> asRawPointer() override { return this->mData; }
 
   virtual void appendDependencies(AttributeBase::Set *deps) override {
     deps->insert(this->shared_from_this());
@@ -649,7 +649,7 @@ public:
     }
   }
 
-  virtual std::shared_ptr<T> asRawPointer() {
+  virtual std::shared_ptr<T> asRawPointer() override {
     for (typename AttributeUpdateTaskBase<T>::Ptr task : updateTasksOnGet) {
       task->executeUpdate(this->mData);
     }

--- a/dpsim-models/include/dpsim-models/Base/Base_ReducedOrderSynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_ReducedOrderSynchronGenerator.h
@@ -112,7 +112,7 @@ protected:
   ///
   virtual void initializeResistanceMatrix() = 0;
   ///
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
   /// Function to initialize the specific variables of each SG model
   virtual void specificInitialization() = 0;
   /// Model specific step
@@ -138,7 +138,8 @@ protected:
                        Attribute<Matrix>::Ptr &leftVector) final;
   virtual void mnaCompPostStep(const Matrix &leftVector) = 0;
   /// Stamps system matrix
-  virtual void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) = 0;
+  virtual void
+  mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   /// Model flag indicating whether the machine is modelled as Norton or Thevenin equivalent
   Bool mModelAsNortonSource;
   // Model flag indicating the SG order to be used

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_AvVoltageSourceInverterDQ.h
@@ -108,7 +108,7 @@ public:
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
   /// Setter for general parameters of inverter
   void setParameters(Real sysOmega, Real sysVoltNom, Real Pref, Real Qref);
   /// Setter for parameters of control loops

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Capacitor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Capacitor.h
@@ -40,13 +40,13 @@ public:
   Capacitor(String name, Logger::Level logLevel = Logger::Level::off)
       : Capacitor(name, name, logLevel) {}
 
-  SimPowerComp<Complex>::Ptr clone(String name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
   ///
-  void initialize(Matrix frequencies);
+  void initialize(Matrix frequencies) override;
 
   // #### MNA section ####
   /// Initializes internal variables of the component
@@ -56,9 +56,9 @@ public:
       Real omega, Real timeStep,
       std::vector<Attribute<Matrix>::Ptr> leftVector) override;
   /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix);
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   void mnaCompApplySystemMatrixStampHarm(SparseMatrixRow &systemMatrix,
-                                         Int freqIdx);
+                                         Int freqIdx) override;
   /// Stamps right side (source) vector
   void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
   void mnaCompApplyRightSideVectorStampHarm(Matrix &rightVector) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inductor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inductor.h
@@ -46,11 +46,11 @@ public:
 
   // #### General ####
   /// Return new instance with the same parameters
-  SimPowerComp<Complex>::Ptr clone(String name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
   /// Initializes state variables considering the number of frequencies
-  void initialize(Matrix frequencies);
+  void initialize(Matrix frequencies) override;
   /// Initializes states from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
   /// Initializes MNA specific variables
@@ -60,9 +60,9 @@ public:
       Real omega, Real timeStep,
       std::vector<Attribute<Matrix>::Ptr> leftVectors) override;
   /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix);
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   void mnaCompApplySystemMatrixStampHarm(SparseMatrixRow &systemMatrix,
-                                         Int freqIdx);
+                                         Int freqIdx) override;
   /// Stamps right side (source) vector
   void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
   void mnaCompApplyRightSideVectorStampHarm(Matrix &rightVector) override;
@@ -90,10 +90,10 @@ public:
                                  Attribute<Matrix>::Ptr &leftVector) override;
 
   // #### Tearing methods ####
-  void mnaTearInitialize(Real omega, Real timestep);
-  void mnaTearApplyMatrixStamp(SparseMatrixRow &tearMatrix);
-  void mnaTearApplyVoltageStamp(Matrix &voltageVector);
-  void mnaTearPostStep(Complex voltage, Complex current);
+  void mnaTearInitialize(Real omega, Real timestep) override;
+  void mnaTearApplyMatrixStamp(SparseMatrixRow &tearMatrix) override;
+  void mnaTearApplyVoltageStamp(Matrix &voltageVector) override;
+  void mnaTearPostStep(Complex voltage, Complex current) override;
 
   class MnaPreStepHarm : public Task {
   public:

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inverter.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inverter.h
@@ -95,9 +95,9 @@ public:
 
   // #### General ####
   ///
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
   ///
-  void initialize(Matrix frequencies);
+  void initialize(Matrix frequencies) override;
   ///
   void setParameters(const std::vector<Int> &carrierHarms,
                      const std::vector<Int> &modulHarms, Real inputVoltage,
@@ -108,17 +108,19 @@ public:
   // #### MNA Functions ####
   /// Initializes internal variables of the component
   void mnaCompInitialize(Real omega, Real timeStep,
-                         Attribute<Matrix>::Ptr leftVector);
-  void mnaCompInitializeHarm(Real omega, Real timeStep,
-                             std::vector<Attribute<Matrix>::Ptr> leftVectors);
+                         Attribute<Matrix>::Ptr leftVector) override;
+  void mnaCompInitializeHarm(
+      Real omega, Real timeStep,
+      std::vector<Attribute<Matrix>::Ptr> leftVectors) override;
   /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix);
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   void mnaCompApplySystemMatrixStampHarm(SparseMatrixRow &systemMatrix,
-                                         Int freqIdx);
+                                         Int freqIdx) override;
   /// Stamps right side (source) vector
-  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector);
-  void mnaCompApplyRightSideVectorStampHarm(Matrix &rightVector);
-  void mnaCompApplyRightSideVectorStampHarm(Matrix &sourceVector, Int freqIdx);
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
+  void mnaCompApplyRightSideVectorStampHarm(Matrix &rightVector) override;
+  void mnaCompApplyRightSideVectorStampHarm(Matrix &sourceVector,
+                                            Int freqIdx) override;
   /// Add MNA pre step dependencies
   void mnaCompAddPreStepDependencies(
       AttributeBase::List &prevStepDependencies,

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_NetworkInjection.h
@@ -49,11 +49,11 @@ public:
   NetworkInjection(String name, Complex voltage,
                    Logger::Level logLevel = Logger::Level::off);
   ///
-  SimPowerComp<Complex>::Ptr clone(String name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
   /// Setter for reference voltage and frequency with a sine wave generator
   /// This will initialize the values of mVoltageRef and mSrcFreq to match the given parameters
   /// However, the attributes can be modified during the simulation to dynamically change the magnitude, frequency, and phase of the sine wave.
@@ -97,9 +97,9 @@ public:
   // #### DAE Section ####
   /// Residual function for DAE Solver
   void daeResidual(double ttime, const double state[], const double dstate_dt[],
-                   double resid[], std::vector<int> &off);
+                   double resid[], std::vector<int> &off) override;
   ///Voltage Getter
-  Complex daeInitialize();
+  Complex daeInitialize() override;
 };
 } // namespace Ph1
 } // namespace DP

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PQLoadCS.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PQLoadCS.h
@@ -44,11 +44,11 @@ public:
            Real nomVolt, Logger::Level logLevel = Logger::Level::off);
 
   void setParameters(Real activePower, Real reactivePower, Real nomVolt);
-  SimPowerComp<Complex>::Ptr clone(String name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
   /// MNA pre and post step operations

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
@@ -53,7 +53,7 @@ public:
 
   // #### General ####
   /// Initialize component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
   /// Set model specific parameters
   void setParameters(Real activePower, Real ReactivePower, Real volt);
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator4OrderPCM.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator4OrderPCM.h
@@ -31,7 +31,7 @@ public:
   SynchronGenerator4OrderPCM(const String &name,
                              Logger::Level logLevel = Logger::Level::off);
   ///
-  SimPowerComp<Complex>::Ptr clone(const String &name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General Functions ####
   ///

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator6OrderPCM.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator6OrderPCM.h
@@ -29,7 +29,7 @@ public:
   SynchronGenerator6OrderPCM(const String &name,
                              Logger::Level logLevel = Logger::Level::off);
   ///
-  SimPowerComp<Complex>::Ptr clone(const String &name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General Functions ####
   ///

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGeneratorTrStab.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGeneratorTrStab.h
@@ -68,7 +68,7 @@ public:
                           Logger::Level logLevel = Logger::Level::off)
       : SynchronGeneratorTrStab(name, name, logLevel) {}
 
-  SimPowerComp<Complex>::Ptr clone(String name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General Functions ####
   /// Flags to modify model behavior
@@ -89,7 +89,7 @@ public:
   ///
   void step(Real time);
   ///
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA Functions ####
   /// Initializes variables of component

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Transformer.h
@@ -58,7 +58,7 @@ public:
   Transformer(String name, Logger::Level logLevel = Logger::Level::off)
       : Transformer(name, name, logLevel) {}
 
-  SimPowerComp<Complex>::Ptr clone(String name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General ####
   /// Defines component parameters
@@ -69,7 +69,7 @@ public:
                      Real ratioAbs, Real ratioPhase, Real resistance,
                      Real inductance);
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
   /// Initializes internal variables of the component

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSource.h
@@ -59,11 +59,11 @@ public:
   VoltageSource(String name, Complex voltage,
                 Logger::Level logLevel = Logger::Level::off);
   ///
-  SimPowerComp<Complex>::Ptr clone(String name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
   ///
   void setSourceValue(Complex voltage);
   /// Setter for reference voltage and frequency with a sine wave generator
@@ -148,9 +148,9 @@ public:
   // #### DAE Section ####
   /// Residual function for DAE Solver
   void daeResidual(double ttime, const double state[], const double dstate_dt[],
-                   double resid[], std::vector<int> &off);
+                   double resid[], std::vector<int> &off) override;
   ///Voltage Getter
-  Complex daeInitialize();
+  Complex daeInitialize() override;
 };
 } // namespace Ph1
 } // namespace DP

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_Inductor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_Inductor.h
@@ -47,23 +47,23 @@ public:
   Inductor(String name, Real inductance,
            Logger::Level logLevel = Logger::Level::off);
 
-  SimPowerComp<Complex>::Ptr clone(String name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
   // #### MNA section ####
   /// Initializes internal variables of the component
   void mnaCompInitialize(Real omega, Real timeStep,
-                         Attribute<Matrix>::Ptr leftVector);
+                         Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix);
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   /// Stamps right side (source) vector
-  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector);
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
   /// Update interface voltage from MNA system result
-  void mnaCompUpdateVoltage(const Matrix &leftVector);
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
   /// Update interface current from MNA system result
-  void mnaCompUpdateCurrent(const Matrix &leftVector);
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
   void mnaCompPreStep(Real time, Int timeStepCount) override;
   void mnaCompPostStep(Real time, Int timeStepCount,
                        Attribute<Matrix>::Ptr &leftVector) override;
@@ -80,10 +80,10 @@ public:
                                  AttributeBase::List &modifiedAttributes,
                                  Attribute<Matrix>::Ptr &leftVector) override;
 
-  void mnaTearInitialize(Real omega, Real timestep);
-  void mnaTearApplyMatrixStamp(SparseMatrixRow &tearMatrix);
-  void mnaTearApplyVoltageStamp(Matrix &voltageVector);
-  void mnaTearPostStep(Complex voltage, Complex current);
+  void mnaTearInitialize(Real omega, Real timestep) override;
+  void mnaTearApplyMatrixStamp(SparseMatrixRow &tearMatrix) override;
+  void mnaTearApplyVoltageStamp(Matrix &voltageVector) override;
+  void mnaTearPostStep(Complex voltage, Complex current) override;
 };
 } // namespace Ph3
 } // namespace DP

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesSwitch.h
@@ -39,26 +39,26 @@ public:
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### General MNA section ####
   ///
   void mnaCompInitialize(Real omega, Real timeStep,
-                         Attribute<Matrix>::Ptr leftVector);
+                         Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix);
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   /// Update interface voltage from MNA system result
-  void mnaCompUpdateVoltage(const Matrix &leftVector);
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
   /// Update interface current from MNA system result
-  void mnaCompUpdateCurrent(const Matrix &leftVector);
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
 
   // #### MNA section for switches ####
   /// Check if switch is closed
-  Bool mnaIsClosed();
+  Bool mnaIsClosed() override;
   /// Stamps system matrix considering the defined switch position
   void mnaCompApplySwitchSystemMatrixStamp(Bool closed,
                                            SparseMatrixRow &systemMatrix,
-                                           Int freqIdx);
+                                           Int freqIdx) override;
 
   /// Add MNA post step dependencies
   void

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_SynchronGeneratorDQ.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_SynchronGeneratorDQ.h
@@ -61,7 +61,7 @@ public:
   /// Function parameters have to be given in Real units.
   void initialize(Real omega, Real timeStep);
   ///
-  void initialize(Matrix frequencies);
+  void initialize(Matrix frequencies) override;
   ///
   Real electricalTorque() const;
   ///
@@ -73,19 +73,19 @@ public:
 
   // #### MNA Functions ####
   /// Initializes variables of component
-  virtual void mnaCompInitialize(Real omega, Real timeStep,
-                                 Attribute<Matrix>::Ptr) = 0;
+  void mnaCompInitialize(Real omega, Real timeStep,
+                         Attribute<Matrix>::Ptr leftVector) override = 0;
   /// Performs with the model of a synchronous generator
   /// to calculate the flux and current from the voltage vector.
   void mnaStep(Matrix &systemMatrix, Matrix &rightVector, Matrix &leftVector,
                Real time);
   ///
-  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector);
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
   ///
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix);
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
 
   /// Retrieves calculated voltage from simulation for next step
-  virtual void mnaCompUpdateVoltage(const Matrix &leftVector);
+  virtual void mnaCompUpdateVoltage(const Matrix &leftVector) override;
 
   /// Add MNA post step dependencies
   void

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_SynchronGeneratorDQTrapez.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_SynchronGeneratorDQTrapez.h
@@ -26,7 +26,7 @@ public:
 
   // #### MNA Section ####
   void mnaCompInitialize(Real omega, Real timeStep,
-                         Attribute<Matrix>::Ptr leftVector);
+                         Attribute<Matrix>::Ptr leftVector) override;
 
   /// Add MNA pre step dependencies
   void mnaCompAddPreStepDependencies(

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_Inductor.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_Inductor.h
@@ -39,24 +39,24 @@ public:
   Inductor(String name, Logger::Level logLevel = Logger::Level::off)
       : Inductor(name, name, logLevel) {}
 
-  SimPowerComp<Real>::Ptr clone(String name);
+  SimPowerComp<Real>::Ptr clone(String name) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
   /// Initializes internal variables of the component
   void mnaCompInitialize(Real omega, Real timeStep,
-                         Attribute<Matrix>::Ptr leftVector);
+                         Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix);
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   /// Stamps right side (source) vector
-  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector);
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
   /// Update interface voltage from MNA system result
-  void mnaCompUpdateVoltage(const Matrix &leftVector);
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
   /// Update interface current from MNA system result
-  void mnaCompUpdateCurrent(const Matrix &leftVector);
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
 
   void mnaCompPreStep(Real time, Int timeStepCount) override;
   void mnaCompPostStep(Real time, Int timeStepCount,

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSource.h
@@ -42,21 +42,21 @@ public:
 
   void setParameters(Complex voltageRef, Real srcFreq = -1);
 
-  SimPowerComp<Real>::Ptr clone(String name);
+  SimPowerComp<Real>::Ptr clone(String name) override;
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency) {}
+  void initializeFromNodesAndTerminals(Real frequency) override {}
 
   // #### MNA section ####
   /// Initializes internal variables of the component
   void mnaCompInitialize(Real omega, Real timeStep,
-                         Attribute<Matrix>::Ptr leftVector);
+                         Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix);
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   /// Stamps right side (source) vector
-  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector);
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
   /// Returns current through the component
-  void mnaCompUpdateCurrent(const Matrix &leftVector);
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
 
   void mnaCompPreStep(Real time, Int timeStepCount) override;
   void mnaCompPostStep(Real time, Int timeStepCount,

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceRamp.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_VoltageSourceRamp.h
@@ -41,16 +41,16 @@ public:
   VoltageSourceRamp(String name, Logger::Level logLevel = Logger::Level::off)
       : VoltageSourceRamp(name, name, logLevel) {}
 
-  SimPowerComp<Real>::Ptr clone(String name);
+  SimPowerComp<Real>::Ptr clone(String name) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency) {}
+  void initializeFromNodesAndTerminals(Real frequency) override {}
   ///
   void setParameters(Complex voltage, Complex addVoltage, Real srcFreq,
                      Real addSrcFreq, Real switchTime, Real rampTime);
   ///
-  void initialize(Matrix frequencies);
+  void initialize(Matrix frequencies) override;
 
   // #### MNA section ####
   void mnaParentPreStep(Real time, Int timeStepCount) override;

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.h
@@ -111,7 +111,7 @@ public:
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
   /// Setter for gengit eral parameters of inverter
   void setParameters(Real sysOmega, Real sysVoltNom, Real Pref, Real Qref);
   /// Setter for parameters of control loops

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Capacitor.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Capacitor.h
@@ -39,11 +39,11 @@ public:
   Capacitor(String name, Logger::Level logLevel = Logger::Level::off)
       : Capacitor(name, name, logLevel) {}
 
-  SimPowerComp<Real>::Ptr clone(String name);
+  SimPowerComp<Real>::Ptr clone(String name) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
   /// Initializes internal variables of the component

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Inductor.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Inductor.h
@@ -39,11 +39,11 @@ public:
   Inductor(String name, Logger::Level logLevel = Logger::Level::off)
       : Inductor(name, name, logLevel) {}
 
-  SimPowerComp<Real>::Ptr clone(String name);
+  SimPowerComp<Real>::Ptr clone(String name) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
   /// Initializes internal variables of the component

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_PiLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_PiLine.h
@@ -48,11 +48,11 @@ public:
   PiLine(String name, Logger::Level logLevel = Logger::Level::off)
       : PiLine(name, name, logLevel) {}
 
-  SimPowerComp<Real>::Ptr clone(String copySuffix);
+  SimPowerComp<Real>::Ptr clone(String copySuffix) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
   /// Updates internal current variable of the component

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RXLoad.h
@@ -60,7 +60,7 @@ public:
   ///
   void setParameters(Matrix activePower, Matrix reactivePower, Real volt);
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Switch.h
@@ -34,23 +34,23 @@ public:
   Switch(String name, Logger::Level logLevel = Logger::Level::off)
       : Switch(name, name, logLevel) {}
 
-  SimPowerComp<Real>::Ptr clone(String name);
+  SimPowerComp<Real>::Ptr clone(String name) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### General MNA section ####
   void mnaCompInitialize(Real omega, Real timeStep,
-                         Attribute<Matrix>::Ptr leftVector);
+                         Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix);
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   /// Stamps right side (source) vector
-  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector);
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
   /// Update interface voltage from MNA system result
-  void mnaCompUpdateVoltage(const Matrix &leftVector);
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
   /// Update interface current from MNA system result
-  void mnaCompUpdateCurrent(const Matrix &leftVector);
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
 
   // #### MNA section for switches ####
   /// Check if switch is closed
@@ -58,7 +58,7 @@ public:
   /// Stamps system matrix considering the defined switch position
   void mnaCompApplySwitchSystemMatrixStamp(Bool closed,
                                            SparseMatrixRow &systemMatrix,
-                                           Int freqIdx);
+                                           Int freqIdx) override;
 
   void mnaCompPostStep(Real time, Int timeStepCount,
                        Attribute<Matrix>::Ptr &leftVector) override;

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Transformer.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Transformer.h
@@ -58,7 +58,7 @@ public:
   Transformer(String name, Logger::Level logLevel = Logger::Level::off)
       : Transformer(name, name, logLevel) {}
 
-  SimPowerComp<Real>::Ptr clone(String name);
+  SimPowerComp<Real>::Ptr clone(String name) override;
 
   // #### General ####
   /// Defines component parameters
@@ -66,7 +66,7 @@ public:
                      Real ratioAbs, Real ratioPhase, Matrix resistance,
                      Matrix inductance);
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
   /// Initializes internal variables of the component

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_VoltageSource.h
@@ -112,7 +112,7 @@ public:
   void daeResidual(double ttime, const double state[], const double dstate_dt[],
                    double resid[], std::vector<int> &off);
   ///Voltage Getter
-  Complex daeInitialize();
+  Complex daeInitialize() override;
 };
 } // namespace Ph1
 } // namespace SP

--- a/dpsim-models/include/dpsim-models/SimNode.h
+++ b/dpsim-models/include/dpsim-models/SimNode.h
@@ -69,7 +69,7 @@ public:
   /// Initialize state matrices with size according to phase type and frequency number
   void initialize(Matrix frequencies);
   /// Returns matrix index for specified phase
-  UInt matrixNodeIndex(PhaseType phaseType = PhaseType::Single);
+  UInt matrixNodeIndex(PhaseType phaseType = PhaseType::Single) override;
   /// Returns all matrix indices
   std::vector<UInt> matrixNodeIndices() override;
   ///

--- a/dpsim-models/src/Base/Base_ReducedOrderSynchronGenerator.cpp
+++ b/dpsim-models/src/Base/Base_ReducedOrderSynchronGenerator.cpp
@@ -471,6 +471,10 @@ void Base::ReducedOrderSynchronGenerator<
 }
 
 template <typename VarType>
+void Base::ReducedOrderSynchronGenerator<
+    VarType>::mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) {}
+
+template <typename VarType>
 void Base::ReducedOrderSynchronGenerator<VarType>::mnaCompInitialize(
     Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
 

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGenerator4OrderPCM.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGenerator4OrderPCM.cpp
@@ -31,7 +31,7 @@ DP::Ph1::SynchronGenerator4OrderPCM::SynchronGenerator4OrderPCM(
     : SynchronGenerator4OrderPCM(name, name, logLevel) {}
 
 SimPowerComp<Complex>::Ptr
-DP::Ph1::SynchronGenerator4OrderPCM::clone(const String &name) {
+DP::Ph1::SynchronGenerator4OrderPCM::clone(String name) {
   auto copy = SynchronGenerator4OrderPCM::make(name, mLogLevel);
 
   return copy;

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGenerator6OrderPCM.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGenerator6OrderPCM.cpp
@@ -33,7 +33,7 @@ DP::Ph1::SynchronGenerator6OrderPCM::SynchronGenerator6OrderPCM(
     : SynchronGenerator6OrderPCM(name, name, logLevel) {}
 
 SimPowerComp<Complex>::Ptr
-DP::Ph1::SynchronGenerator6OrderPCM::clone(const String &name) {
+DP::Ph1::SynchronGenerator6OrderPCM::clone(String name) {
   auto copy = SynchronGenerator6OrderPCM::make(name, mLogLevel);
 
   return copy;

--- a/dpsim/examples/cxx/cim_graphviz/cimviz.cpp
+++ b/dpsim/examples/cxx/cim_graphviz/cimviz.cpp
@@ -35,7 +35,7 @@ struct GVC_s {
   GVCOMMON_t common;
 
   char *config_path;
-  boolean config_found;
+  bool config_found;
 
   /* gvParseArgs */
   char **input_filenames;

--- a/dpsim/include/dpsim/DAESolver.h
+++ b/dpsim/include/dpsim/DAESolver.h
@@ -42,6 +42,9 @@ protected:
   /// Nodes of the Problem
   CPS::SimNode<Complex>::List mNodes;
 
+  // Initial time t0
+  Real mT0;
+
   // IDA simulation variables
   /// Memory block allocated by IDA
   void *mem = NULL;
@@ -72,11 +75,12 @@ protected:
 
 public:
   /// Create solve object with given parameters
-  DAESolver(String name, const CPS::SystemTopology &system, Real dt, Real t0);
+  DAESolver(String name, const CPS::SystemTopology &system, Real dt, Real mT0);
   /// Deallocate all memory
   ~DAESolver();
   /// Initialize Components & Nodes with inital values
-  void initialize(Real t0);
+  void initialize() override;
+
   /// Solve system for the current time
   Real step(Real time);
 

--- a/dpsim/include/dpsim/DiakopticsSolver.h
+++ b/dpsim/include/dpsim/DiakopticsSolver.h
@@ -94,7 +94,7 @@ private:
   void initMatrices();
   void applyTearComponentStamp(UInt compIdx);
 
-  void log(Real time);
+  void log(Real time, Int timeStepCount) override;
 
 public:
   /// Currents through the removed network (as "seen" from the other subnets)

--- a/dpsim/src/DAESolver.cpp
+++ b/dpsim/src/DAESolver.cpp
@@ -66,10 +66,11 @@ DAESolver::DAESolver(String name, const CPS::SystemTopology &system, Real dt,
   }
 
   std::cout << "Nodes Setup Done" << std::endl;
-  initialize(t0);
+  mT0 = t0;
+  initialize();
 }
 
-void DAESolver::initialize(Real t0) {
+void DAESolver::initialize() {
   int ret;
   int counter = 0;
   realtype *sval = NULL, *s_dtval = NULL;
@@ -148,27 +149,22 @@ void DAESolver::initialize(Real t0) {
   std::cout << "Define Userdata" << std::endl;
   // This passes the solver instance as the user_data argument to the residual functions
   ret = IDASetUserData(mem, this);
-  //	if (check_flag(&ret, "IDASetUserData", 1)) {
-  //		throw CPS::Exception();
-  //	}
+
   std::cout << "Call IDAInit" << std::endl;
 
-  ret = IDAInit(mem, &DAESolver::residualFunctionWrapper, t0, state, dstate_dt);
-  //	if (check_flag(&ret, "IDAInit", 1)) {
-  //		throw CPS::Exception();
-  //	}
+  ret =
+      IDAInit(mem, &DAESolver::residualFunctionWrapper, mT0, state, dstate_dt);
+
   std::cout << "Call IDATolerances" << std::endl;
   ret = IDASStolerances(mem, rtol, abstol);
-  // 	if (check_flag(&ret, "IDASStolerances", 1)) {
-  //		throw CPS::Exception();
-  //	}
+
   std::cout << "Call IDA Solver Stuff" << std::endl;
   // Allocate and connect Matrix A and solver LS to IDA
   A = SUNDenseMatrix(mNEQ, mNEQ);
   LS = SUNDenseLinearSolver(state, A);
   ret = IDADlsSetLinearSolver(mem, LS, A);
 
-  //Optional IDA input functions
+  //TODO: Optional IDA input functions
   //ret = IDASetMaxNumSteps(mem, -1);  //Max. number of timesteps until tout (-1 = unlimited)
   //ret = IDASetMaxConvFails(mem, 100); //Max. number of convergence failures at one step
   (void)ret;

--- a/dpsim/src/DiakopticsSolver.cpp
+++ b/dpsim/src/DiakopticsSolver.cpp
@@ -459,19 +459,19 @@ void DiakopticsSolver<VarType>::PostSolveTask::execute(Real time,
   }
 }
 
-template <> void DiakopticsSolver<Real>::log(Real time) {
+template <> void DiakopticsSolver<Real>::log(Real time, Int timeStepCount) {
   mLeftVectorLog->logEMTNodeValues(time, mLeftSideVector);
   mRightVectorLog->logEMTNodeValues(time, mRightSideVector);
 }
 
-template <> void DiakopticsSolver<Complex>::log(Real time) {
+template <> void DiakopticsSolver<Complex>::log(Real time, Int timeStepCount) {
   mLeftVectorLog->logPhasorNodeValues(time, mLeftSideVector);
   mRightVectorLog->logPhasorNodeValues(time, mRightSideVector);
 }
 
 template <typename VarType>
 void DiakopticsSolver<VarType>::LogTask::execute(Real time, Int timeStepCount) {
-  mSolver.log(time);
+  mSolver.log(time, timeStepCount);
 }
 
 template class DiakopticsSolver<Real>;


### PR DESCRIPTION
This PR changes the signature of the `log` function in the `DiakopticsSolver` files to match the current ones used in the other solvers, where we have now two arguments.

On the other side, the overrides on the `SynchronGenerator` files of the function `clone` had a different signature compared to all the rest of the classes (and did not override the Base class virtual function.

This PR fixes issue #256 