### PR TITLE
Remove further RWTH gitlab dependencies

### DIFF
--- a/cmake/FetchGridData.cmake
+++ b/cmake/FetchGridData.cmake
@@ -1,6 +1,6 @@
 include(FetchContent)
 FetchContent_Declare(cim-data
-	GIT_REPOSITORY https://git.rwth-aachen.de/acs/public/grid-data/cim-grid-data.git
+	GIT_REPOSITORY https://github.com/dpsim-simulator/cim-grid-data.git
 	GIT_TAG        master
 	GIT_SHALLOW    TRUE
 	GIT_PROGRESS   TRUE
@@ -9,7 +9,7 @@ FetchContent_Declare(cim-data
 FetchContent_MakeAvailable(cim-data)
 
 FetchContent_Declare(profile-data
-	GIT_REPOSITORY https://git.rwth-aachen.de/acs/public/grid-data/grid-profiles.git
+	GIT_REPOSITORY https://github.com/dpsim-simulator/example-profile-data.git
 	GIT_TAG        master
 	GIT_SHALLOW    TRUE
 	GIT_PROGRESS   TRUE

--- a/docs/hugo/content/en/docs/Overview/_index.md
+++ b/docs/hugo/content/en/docs/Overview/_index.md
@@ -4,13 +4,13 @@ linkTitle: "Overview"
 weight: 1
 ---
 
-DPsim is a real-time capable power system simulator that supports dynamic phasor and electromagnetic transient simulation as well as continuous powerflow. It primarily targets large-scale scenarios on commercial off-the-sheld hardware that require deterministic time steps in the range of micro- to milliseconds. 
+DPsim is a real-time capable power system simulator that supports dynamic phasor and electromagnetic transient simulation as well as continuous powerflow. It primarily targets large-scale scenarios on commercial off-the-sheld hardware that require deterministic time steps in the range of micro- to milliseconds.
 
-DPsim supports the CIM format as native input for the description of electrical network topologies, component parameters and load flow data, which is used for initialization. For this purpose, CIM++ is integrated in DPsim. 
+DPsim supports the CIM format as native input for the description of electrical network topologies, component parameters and load flow data, which is used for initialization. For this purpose, CIM++ is integrated in DPsim.
 Users interact with the C++ simulation kernel via Python bindings, which can be used to script the execution, schedule events, change parameters and retrieve results. Supported by the availability of existing Python frameworks like Numpy, Pandas and Matplotlib, Python scripts have been proven as an easy and flexible way to codify the complete workflow of a simulation from modelling to analysis and plotting, for example in Jupyter notebooks.
 
 The DPsim simulation kernel is implemented in C++ and uses the Eigen linear algebra library. By using a system programming language like C++ and a highly optimized math library, optimal performance and real-time execution can be guaranteed.
-The integration into the [VILLASframework](https://git.rwth-aachen.de/acs/public/villas/node) allows DPsim to be used in large-scale co-simulations.
+The integration into the [VILLASframework](https://github.com/VILLASframework/node) allows DPsim to be used in large-scale co-simulations.
 
 ## Licensing
 


### PR DESCRIPTION
This PR removes further dependencies on archived RWTH gitlab repositories by making instead use of the corresponding github repositories.