### PR TITLE
Fix sonar scanner errors due to Java deprecated version

### DIFF
--- a/.github/workflows/sonar_cloud.yaml
+++ b/.github/workflows/sonar_cloud.yaml
@@ -9,17 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     container: sogno/dpsim:dev
     env:
-      SONAR_SCANNER_VERSION: 4.7.0.2747
+      SONAR_SCANNER_VERSION: 5.0.1.3006
       SONAR_SERVER_URL: "https://sonarcloud.io"
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Setup node 20
+        uses: actions/setup-node@v4
         with:
-          java-version: 11
+          node-version: 20
       - name: Download and set up sonar-scanner
         env:
           SONAR_SCANNER_DOWNLOAD_URL: https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}-linux.zip
@@ -36,7 +37,7 @@ jobs:
           unzip -o $HOME/.sonar/build-wrapper-linux-x86.zip -d $HOME/.sonar/
           echo "$HOME/.sonar/build-wrapper-linux-x86" >> $GITHUB_PATH
       - name: Setup sonar cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/sonar-cache
           key: sonar-cache-${{ github.ref }}


### PR DESCRIPTION
Due to end of support of the Java 11 (LTS) in Sonar, this PR updates the version of Sonar Scanner to 5.0.1.3006. Additionally, the warnings because of Node.js (version 16 to be unsupported in the near future) are corrected. Actions `cache` is also updated to `v4`. The action for `setup-java` was removed (we use now the JRE included in `sonar-scanner`).

This closes #251