### PR TITLE
Change python to python3 to run the building for pypi

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Build dpsim source dist
       shell: bash
-      run: python -m build --sdist --outdir dist/
+      run: python3 -m build --sdist --outdir dist/
 
     - name: Publish distribution to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR ensures that python is found for the building process for pypi.

Closes #255 