### PR TITLE
Replace CentOS badge with RockyLinux badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="docs/images/dpsim.png" width=40 /> DPsim
 
-[![Build & Test CentOS](https://github.com/sogno-platform/dpsim/actions/workflows/build_test_linux_centos.yaml/badge.svg)](https://github.com/sogno-platform/dpsim/actions/workflows/build_test_linux_centos.yaml)
+[![Build & Test RockyLinux](https://github.com/sogno-platform/dpsim/actions/workflows/build_test_linux_rocky.yaml/badge.svg)](https://github.com/sogno-platform/dpsim/actions/workflows/build_test_linux_rocky.yaml)
 
 [![Build & Test Fedora](https://github.com/sogno-platform/dpsim/actions/workflows/build_test_linux_fedora.yaml/badge.svg)](https://github.com/sogno-platform/dpsim/actions/workflows/build_test_linux_fedora.yaml)
 


### PR DESCRIPTION
Changing the badge without status from CentOS times, to the one pointing to the RockyLinux used in the pipeline.