### PR TITLE
editorconfig: set C++ indentation size to two

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ charset = utf-8
 trim_trailing_whitespace=true
 
 [**.{c,cpp,h,hpp}]
-indent_style = tab
+indent_style = space
 indent_size = 2
 
 [**.{py}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace=true
 
 [**.{c,cpp,h,hpp}]
 indent_style = tab
-indent_size = 4
+indent_size = 2
 
 [**.{py}]
 indent_style = space


### PR DESCRIPTION
At some point the indentation size changed to two, but the editorconfig still  shows four. This fixes that.
We also seem to now use spaces rather than tabs.