### PR TITLE
Update actions in workflow and improve parallelisation and cache handling

### DIFF
--- a/.github/workflows/build_test_linux_fedora.yaml
+++ b/.github/workflows/build_test_linux_fedora.yaml
@@ -118,7 +118,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: pytest-output-${{ github.sha }}
-        path: outputs/examples/Notebooks/
+        path: outputs/
 
   compare-notebook-results:
     name: Compare Notebook results

--- a/.github/workflows/build_test_linux_fedora.yaml
+++ b/.github/workflows/build_test_linux_fedora.yaml
@@ -7,17 +7,23 @@ on:
 
 jobs:
   linux-fedora-dpsimpy:
-    name: Build dpsimpy on Fedora Linux
+    name: Build dpsimpy and tests examples on Fedora Linux
     runs-on: ubuntu-latest
     container: sogno/dpsim:dev
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Create Build Environment
       run: mkdir build
+
+    - name: Setup build directory cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/build
+        key: build-fedora-dir-cache-${{ github.ref }}
 
     - name: Configure CMake
       shell: bash
@@ -27,15 +33,13 @@ jobs:
     - name: Build dpsimpy and test examples
       shell: bash
       working-directory: ${{ github.workspace }}/build
-      run: cmake --build . --target dpsimpy --target tests --target dpsimpyvillas
-      env:
-        MAKEFLAGS: "-j2"
+      run: cmake --build . --target dpsimpy --target tests --target dpsimpyvillas --parallel $(nproc)
 
     - name: Archive build directory
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ${{ github.workspace }}/build
-        name: build-cache
+        name: build-fedora-examples-cache-${{ github.sha }}
         retention-days: 1
 
   linux-fedora-examples:
@@ -45,28 +49,26 @@ jobs:
     container: sogno/dpsim:dev
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Restore build archive
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-       name: build-cache
+       name: build-fedora-examples-cache-${{ github.sha }}
        path: ${{ github.workspace }}/build
 
     - name: Build every target
       shell: bash
       working-directory: ${{ github.workspace }}/build
-      run: cmake --build .
-      env:
-        MAKEFLAGS: "-j2"
+      run: cmake --build . --parallel $(nproc)
 
     - name: Archive build directory
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ${{ github.workspace }}/build
-        name: build-cache
+        name: build-cache-examples-cpp-${{ github.sha }}
         retention-days: 1
 
 ## Tests ##
@@ -77,12 +79,12 @@ jobs:
     container: sogno/dpsim:dev
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Restore build archive
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-       name: build-cache
+       name: build-fedora-examples-cache-${{ github.sha }}
        path: ${{ github.workspace }}/build
 
     - name: Prepare binary permissions
@@ -99,6 +101,10 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: ls -l ./build/dpsim/examples/cxx/
 
+    - name: Install parallel testing
+      shell: bash
+      run: pip install pytest-xdist
+
     - name: Run pytest
       shell: bash
       working-directory: ${{ github.workspace }}
@@ -106,12 +112,12 @@ jobs:
         PYTHONPATH: "${{ github.workspace }}/build"
       run: |
         cp -r python/src/dpsim build/
-        pytest -v examples/Notebooks
+        pytest -v examples/Notebooks -n auto
 
     - name: Archive notebook outputs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: pytest-output
+        name: pytest-output-${{ github.sha }}
         path: outputs/examples/Notebooks/
 
   compare-notebook-results:
@@ -120,13 +126,13 @@ jobs:
     needs: [test-jupyter-notebooks]
     steps:
     - name: Download new notebook results
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-       name: pytest-output
+       name: pytest-output-${{ github.sha }}
        path: ${{ github.workspace }}/notebooks-new
 
     - name: Download master notebook results
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/notebooks-master
         key: notebook-output-cache-master-${{ github.sha }}
@@ -134,7 +140,7 @@ jobs:
           notebook-output-cache-master-
 
     - name: Download previous commit notebook results
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/notebooks-previous
         key: notebook-output-cache-commit-${{ github.ref }}-${{ github.sha }}
@@ -165,15 +171,15 @@ jobs:
         cp -R ${{ github.workspace }}/notebooks-new ${{ github.workspace }}/notebooks-master
 
   test-binaries:
-    name: Execute Example
+    name: Execute WSCC 9 bus example
     runs-on: ubuntu-latest
     container: sogno/dpsim:dev
     needs: [linux-fedora-examples]
     steps:
     - name: Restore build archive
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-       name: build-cache
+       name: build-cache-examples-cpp-${{ github.sha }}
        path: ${{ github.workspace }}/build
 
     - name: Prepare binary permissions
@@ -194,7 +200,7 @@ jobs:
     #needs: [linux-fedora]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Run cppcheck
       working-directory: ${{ github.workspace }}
@@ -202,7 +208,7 @@ jobs:
       id: cppcheck
       run: |
         set -o pipefail
-        cppcheck --max-configs=32 -j 32 --inline-suppr --error-exitcode=1 -q --enable=warning,performance,portability,information,missingInclude --std=c++17 -I dpsim/include/ -I dpsim-models/include/ -I dpsim-villas/include dpsim/src/ dpsim-models/src/ dpsim-villas/src/ 2>&1 | tee cppcheck-output.log
+        cppcheck --max-configs=32 -j $(nproc) --inline-suppr --error-exitcode=1 -q --enable=warning,performance,portability,information,missingInclude --std=c++17 -I dpsim/include/ -I dpsim-models/include/ -I dpsim-villas/include dpsim/src/ dpsim-models/src/ dpsim-villas/src/ 2>&1 | tee cppcheck-output.log
       continue-on-error: true
 
     - name: Print cppcheck errors
@@ -262,7 +268,7 @@ jobs:
 
   test-villas-examples-1:
     name: Run dpsim-mqtt VILLASnode example
-    needs: [linux-fedora-dpsimpy]
+    needs: [linux-fedora-examples]
     uses: ./.github/workflows/run_villas_example.yaml
     with:
       compose_file_path: examples/villas/docker-compose-tests
@@ -274,7 +280,7 @@ jobs:
 
   test-villas-examples-2:
     name: Run dpsim-mqtt-import-export VILLASnode example
-    needs: [linux-fedora-dpsimpy]
+    needs: [linux-fedora-examples]
     uses: ./.github/workflows/run_villas_example.yaml
     with:
       compose_file_path: examples/villas/docker-compose-tests
@@ -284,7 +290,7 @@ jobs:
 
   test-villas-examples-3:
     name: Run dpsim-mqtt-import-export-MIMO VILLASnode example
-    needs: [linux-fedora-dpsimpy]
+    needs: [linux-fedora-examples]
     uses: ./.github/workflows/run_villas_example.yaml
     with:
       compose_file_path: examples/villas/docker-compose-tests
@@ -295,7 +301,7 @@ jobs:
 
   test-villas-examples-4:
     name: Run dpsim-file VILLASnode example
-    needs: [linux-fedora-dpsimpy]
+    needs: [linux-fedora-examples]
     uses: ./.github/workflows/run_villas_example.yaml
     with:
       compose_file_path: examples/villas/docker-compose-tests
@@ -306,7 +312,7 @@ jobs:
 
   test-villas-examples-5:
     name: Run mqtt-cigre-mv-pf-profiles VILLASnode example
-    needs: [linux-fedora-dpsimpy]
+    needs: [linux-fedora-examples]
     uses: ./.github/workflows/run_villas_example.yaml
     with:
       compose_file_path: examples/villas/docker-compose-tests

--- a/.github/workflows/build_test_linux_fedora_minimal.yaml
+++ b/.github/workflows/build_test_linux_fedora_minimal.yaml
@@ -12,12 +12,18 @@ jobs:
     container: sogno/dpsim:dev-minimal
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Create Build Environment
       run: mkdir build
+
+    - name: Cache build directory
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/build
+        key: build-cache-fedora-minimal-${{ github.ref }}
 
     - name: Configure CMake
       shell: bash
@@ -27,14 +33,7 @@ jobs:
     - name: Build every target
       shell: bash
       working-directory: ${{ github.workspace }}/build
-      run: cmake --build .
-      env:
-        MAKEFLAGS: "-j2"
+      run: cmake --build . --parallel $(nproc)
 
-    - name: Cache build directory
-      uses: actions/cache@v3
-      with:
-        path: ${{ github.workspace }}/build
-        key: build-cache-fedora-minimal-${{ github.sha }}
 ## Tests ##
   #TODO

--- a/.github/workflows/build_test_linux_rocky.yaml
+++ b/.github/workflows/build_test_linux_rocky.yaml
@@ -12,12 +12,18 @@ jobs:
     container: sogno/dpsim:dev-rocky
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Create Build Environment
       run: mkdir build
+
+    - name: Cache build directory
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/build
+        key: build-cache-rocky-${{ github.ref }}
 
     - name: Configure CMake
       shell: bash
@@ -27,15 +33,7 @@ jobs:
     - name: Build every target
       shell: bash
       working-directory: ${{ github.workspace }}/build
-      run: cmake --build .
-      env:
-        MAKEFLAGS: "-j2"
-
-    - name: Cache build directory
-      uses: actions/cache@v3
-      with:
-        path: ${{ github.workspace }}/build
-        key: build-cache-rocky-${{ github.sha }}
+      run: cmake --build . --parallel $(nproc)
 
   linux-rocky-clang:
     name: Build on Rocky Linux using Clang
@@ -43,12 +41,18 @@ jobs:
     container: sogno/dpsim:dev-rocky
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Create Build Environment
       run: mkdir build
+
+    - name: Cache build directory
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/build
+        key: build-cache-rocky-clang-${{ github.ref }}
 
     - name: Configure CMake
       shell: bash
@@ -58,15 +62,8 @@ jobs:
     - name: Build every target
       shell: bash
       working-directory: ${{ github.workspace }}/build
-      run: cmake --build .
-      env:
-        MAKEFLAGS: "-j2"
+      run: cmake --build . --parallel $(nproc)
 
-    - name: Cache build directory
-      uses: actions/cache@v3
-      with:
-        path: ${{ github.workspace }}/build
-        key: build-cache-rocky-${{ github.sha }}
 
   profiling:
     name: Build with Profiling options
@@ -74,12 +71,18 @@ jobs:
     container: sogno/dpsim:dev-rocky
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Create Build Environment
       run: mkdir build
+
+    - name: Cache build directory
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/build
+        key: build-cache-rocky-profiling-${{ github.ref }}
 
     - name: Configure CMake
       shell: bash
@@ -89,15 +92,8 @@ jobs:
     - name: Build every target
       shell: bash
       working-directory: ${{ github.workspace }}/build
-      run: cmake --build .
-      env:
-        MAKEFLAGS: "-j2"
+      run: cmake --build . --parallel $(nproc)
 
-    - name: Cache build directory
-      uses: actions/cache@v3
-      with:
-        path: ${{ github.workspace }}/build
-        key: build-cache-rocky-profiling-${{ github.sha }}
 
 ## Tests ##
   test-examples-1:

--- a/.github/workflows/build_test_windows.yaml
+++ b/.github/workflows/build_test_windows.yaml
@@ -11,13 +11,23 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
-    - id: build
+    - name: Create build folder
       run: |
         cd ${{ github.workspace }}
         mkdir build
+
+    - name: Setup build directory cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/build
+        key: build-windows-cache-${{ github.ref }}
+
+    - name: Build DPsim
+      run: |
+        cd ${{ github.workspace }}
         cd build
         git describe --tags --abbrev=0 --match "v*"
         cmake -DWITH_PYBIND=OFF ..
-        cmake --build . --target dpsim
+        cmake --build . --target dpsim --parallel

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -8,17 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev_rocky
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
          file: packaging/Docker/Dockerfile.dev-rocky
          push: true
@@ -28,17 +28,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_release
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
          file: packaging/Docker/Dockerfile
          push: true
@@ -48,17 +48,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
          file: packaging/Docker/Dockerfile.dev
          push: true
@@ -68,17 +68,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
          file: packaging/Docker/Dockerfile.dev-minimal
          push: true
@@ -88,17 +88,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
          file: packaging/Docker/Dockerfile.manylinux
          push: true

--- a/.github/workflows/documentation-fein.yaml
+++ b/.github/workflows/documentation-fein.yaml
@@ -9,21 +9,21 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
         hugo-version: '0.108.0'
         extended: true
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '14'
+        node-version: '20'
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -34,7 +34,7 @@ jobs:
     - run: cd docs/hugo && hugo --minify --baseURL "https://dpsim.fein-aachen.org"
 
     - name: Deploy dpsim-simulator / FEIN
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         deploy_key: ${{ secrets.HUGO_ACTIONS_DEPLOY_KEY }}  
         external_repository: dpsim-simulator/dpsim-simulator.github.io

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -11,7 +11,7 @@ jobs:
     container: sogno/dpsim:dev
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Create Build Environment
       run: mkdir build
@@ -23,8 +23,8 @@ jobs:
 
     - name: Make reference docs
       run: |
-        make -j$(nproc) -C build docs
-        make -j$(nproc) -C build docs_cxx
+        make --parallel $(nproc) -C build docs
+        make --parallel $(nproc) -C build docs_cxx
 
     - name: Copy reference
       run: |
@@ -33,7 +33,7 @@ jobs:
         cp -r build/docs/doxygen/html/. reference/doxygen
 
     - name: Archive reference directory
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ${{ github.workspace }}/reference
         name: reference-cache
@@ -43,21 +43,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-reference]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
         hugo-version: '0.108.0'
         extended: true
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '14'
+        node-version: '20'
 
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -68,7 +68,7 @@ jobs:
     - run: cd docs/hugo && hugo --minify
 
     - name: Restore reference archive
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
        name: reference-cache
        path: ${{ github.workspace }}/reference
@@ -79,7 +79,7 @@ jobs:
         cp -r docs/hugo/public/. public
 
     - name: Deploy page
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}     
         publish_dir: ./public

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -14,7 +14,7 @@ jobs:
     container: sogno/dpsim:dev
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -23,7 +23,7 @@ jobs:
       run: python3 -m build --sdist --outdir dist/
 
     - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@release/v1.8.14
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
@@ -31,7 +31,7 @@ jobs:
 
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@release/v1.8.14
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -50,12 +50,12 @@ jobs:
     #   run: docker build . --file packaging/Docker/Dockerfile.manylinux -t sogno/dpsim:manylinux
 
     - name: Build dpsim wheels for all supported python versions
-      uses: pypa/cibuildwheel@v2.11.2
+      uses: pypa/cibuildwheel@v2.18.0
       with:
         output-dir: dist
 
     - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@release/v1.8.14
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
@@ -63,6 +63,6 @@ jobs:
 
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@release/v1.8.14
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/run_and_profile_example.yaml
+++ b/.github/workflows/run_and_profile_example.yaml
@@ -17,13 +17,13 @@ jobs:
   profiling-examples:
     name: Run example with profiling
     runs-on: ubuntu-latest
-    container: sogno/dpsim:dev-centos
+    container: sogno/dpsim:dev-rocky
     steps:
     - name: Restore Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/build
-        key: build-cache-centos-profiling-${{ github.sha }}
+        key: build-cache-rocky-profiling-${{ github.sha }}
 
     - name: Run Binary
       run: ${{ inputs.path }} 2>&1 | tee output.log
@@ -40,7 +40,7 @@ jobs:
       run: gprof ${{ inputs.path }} | gprof2dot -s | dot -Tpng -o profiling.png || true
 
     - name: Archive profiler output
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: profiler-output-${{ inputs.name }}
         path: |

--- a/.github/workflows/run_and_profile_example.yaml
+++ b/.github/workflows/run_and_profile_example.yaml
@@ -1,7 +1,7 @@
 name: Run the profiler for an example
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       path:
         description: 'Path to the example to be run'

--- a/.github/workflows/run_villas_example.yaml
+++ b/.github/workflows/run_villas_example.yaml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Restore build archive
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-       name: build-cache
+       name: build-cache-examples-cpp-${{ github.sha }}
        path: ${{ github.workspace }}/build
 
     - name: Start containers


### PR DESCRIPTION
Changelog
===

In general, the versions of the actions were updated for checkout, cache, download and upload artifacts. Aditionally, the parallel build with a static value in an environment variable `-j2` was changed to the `--parallel $(nproc)` argument to the command to pick automatically the value.

In particular, other changes were done:
- `build_test_linux_fedora_minimal.yaml`
  - the build cache is updated with a new name to preserve for the same reference (branch, push) and not for the same commit
- `build_test_linux_fedora.yaml`
  - setup a build cache for dpsimpy & examples
    - archive in a different cache (not overwriting the others) per commit sha
  - changes to the archiving of build of cxx examples
    - input from the previous stage and recompile and save for the current compilation
  - jupyter notebook tests were parallelized 
    - the package pytest-xdist is installed
    - cache is changed to separate per commit sha
  - comparison of results
    - previous cached result is used
  - test of binaries
    - the output of the cxx compilation is used as cache
  - villas examples
    - the needs is changed to examples (dpsimpy probably worked due old overwrites in the cache, when chaining the compilation outputs it started failing)
- `build_test_linux_rocky.yaml`
  - added cache to the clang compilation
  - added cache to the profiling compilation
- `build_test_windows.yaml`
  - added cache to the build directory per reference
- `documentation-fein.yaml`
  - changed node to v20
  - updated hugo and gh-pages actions
- `run_and_profile_example.yaml`
  - changed the container to sogno/dpsim.dev-rocky (we were still on centos)
- `run_villas_example.yaml`
  - changed the cache to the cxx examples build