### PR TITLE
Fix workflow: option for parallel in make and error in publish to PyPI

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -23,8 +23,8 @@ jobs:
 
     - name: Make reference docs
       run: |
-        make --parallel $(nproc) -C build docs
-        make --parallel $(nproc) -C build docs_cxx
+        make --jobs $(nproc) -C build docs
+        make --jobs $(nproc) -C build docs_cxx
 
     - name: Copy reference
       run: |

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -23,7 +23,7 @@ jobs:
       run: python3 -m build --sdist --outdir dist/
 
     - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1.8.14
+      uses: pypa/gh-action-pypi-publish@release/v1.8
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
@@ -31,7 +31,7 @@ jobs:
 
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1.8.14
+      uses: pypa/gh-action-pypi-publish@release/v1.8
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
@@ -55,7 +55,7 @@ jobs:
         output-dir: dist
 
     - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1.8.14
+      uses: pypa/gh-action-pypi-publish@release/v1.8
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
@@ -63,6 +63,6 @@ jobs:
 
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1.8.14
+      uses: pypa/gh-action-pypi-publish@release/v1.8
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This fixes the current problems in the workflow:
- The option for `make` to be parallel was `--jobs`
- The version for publishing has now a different release tag, updated