### PR TITLE
Reuse stamp code for EMT synchron. generators

### DIFF
--- a/dpsim-models/include/dpsim-models/MNAStampUtils.h
+++ b/dpsim-models/include/dpsim-models/MNAStampUtils.h
@@ -26,6 +26,15 @@ public:
                                      Bool isTerminal2NotGrounded,
                                      const Logger::Log &mSLog);
 
+  static void stamp3x3ConductanceMatrixBetween2Nodes(
+      const Matrix &conductanceMat, SparseMatrixRow &mat, UInt node1Index,
+      UInt node2Index, const Logger::Log &mSLog);
+
+  static void stamp3x3ConductanceMatrixNodeToGround(const Matrix &conductanceMat,
+                                             SparseMatrixRow &mat,
+                                             UInt nodeIndex,
+                                             const Logger::Log &mSLog);
+
   static void stampAdmittanceMatrix(
       const MatrixComp &admittanceMat, SparseMatrixRow &mat, UInt node1Index,
       UInt node2Index, Bool isTerminal1NotGrounded, Bool isTerminal2NotGrounded,
@@ -56,6 +65,19 @@ private:
                           Bool isTerminal1NotGrounded,
                           Bool isTerminal2NotGrounded, Int maxFreq, Int freqIdx,
                           const Logger::Log &mSLog);
+
+  template <typename T>
+  static void stampMatrixBetween2Nodes(const MatrixVar<T> &matrix,
+                                       UInt sizeOfMatrix, SparseMatrixRow &mat,
+                                       UInt node1Index, UInt node2Index,
+                                       Int maxFreq, Int freqIdx,
+                                       const Logger::Log &mSLog);
+
+  template <typename T>
+  static void stampMatrixNodeToGround(const MatrixVar<T> &matrix,
+                                      UInt sizeOfMatrix, SparseMatrixRow &mat,
+                                      UInt nodeIndex, Int maxFreq, Int freqIdx,
+                                      const Logger::Log &mSLog);
 
   template <typename T>
   static void stampValueAsScalarMatrix(T value, UInt sizeOfScalarMatrix,

--- a/dpsim-models/include/dpsim-models/MNAStampUtils.h
+++ b/dpsim-models/include/dpsim-models/MNAStampUtils.h
@@ -66,23 +66,9 @@ private:
                                        Int freqIdx, const Logger::Log &mSLog);
 
   template <typename T>
-  static void stampValueNoConditions(T value, SparseMatrixRow &mat,
-                                     UInt node1Index, UInt node2Index,
-                                     Int maxFreq, Int freqIdx,
-                                     const Logger::Log &mSLog);
-
-  template <typename T>
-  static void stampValueOnDiagonalNoConditions(T value, SparseMatrixRow &mat,
-                                               UInt nodeIndex, Int maxFreq,
-                                               Int freqIdx,
-                                               const Logger::Log &mSLog);
-
-  template <typename T>
-  static void stampValueOffDiagonalNoConditions(T value, SparseMatrixRow &mat,
-                                                UInt node1Index,
-                                                UInt node2Index, Int maxFreq,
-                                                Int freqIdx,
-                                                const Logger::Log &mSLog);
+  static void stampToMatrix(T value, SparseMatrixRow &mat, UInt row1,
+                            UInt column1, UInt row2, UInt column2, Int maxFreq,
+                            Int freqIdx, const Logger::Log &mSLog);
 
   static void addToMatrixElement(SparseMatrixRow &mat, Matrix::Index row,
                                  Matrix::Index column, Real value, Int maxFreq,

--- a/dpsim-models/src/EMT/EMT_Ph3_ReducedOrderSynchronGeneratorVBR.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_ReducedOrderSynchronGeneratorVBR.cpp
@@ -184,25 +184,8 @@ void EMT::Ph3::ReducedOrderSynchronGeneratorVBR::mnaCompApplySystemMatrixStamp(
     SparseMatrixRow &systemMatrix) {
 
   if (mModelAsNortonSource) {
-    // Stamp conductance matrix
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             matrixNodeIndex(0, 0), mConductanceMatrix(0, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             matrixNodeIndex(0, 1), mConductanceMatrix(0, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             matrixNodeIndex(0, 2), mConductanceMatrix(0, 2));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             matrixNodeIndex(0, 0), mConductanceMatrix(1, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             matrixNodeIndex(0, 1), mConductanceMatrix(1, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             matrixNodeIndex(0, 2), mConductanceMatrix(1, 2));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             matrixNodeIndex(0, 0), mConductanceMatrix(2, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             matrixNodeIndex(0, 1), mConductanceMatrix(2, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             matrixNodeIndex(0, 2), mConductanceMatrix(2, 2));
+    MNAStampUtils::stamp3x3ConductanceMatrixNodeToGround(
+        mConductanceMatrix, systemMatrix, matrixNodeIndex(0), mSLog);
   } else {
     // Stamp voltage source
     Math::addToMatrixElement(
@@ -225,121 +208,10 @@ void EMT::Ph3::ReducedOrderSynchronGeneratorVBR::mnaCompApplySystemMatrixStamp(
         mVirtualNodes[0]->matrixNodeIndex(PhaseType::C), 1);
 
     // Stamp conductance matrix
-
-    // set upper left block, 3x3 entries
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             mConductanceMatrix(0, 0));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             mConductanceMatrix(0, 1));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             mConductanceMatrix(0, 2));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             mConductanceMatrix(1, 0));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             mConductanceMatrix(1, 1));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             mConductanceMatrix(1, 2));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             mConductanceMatrix(2, 0));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             mConductanceMatrix(2, 1));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             mConductanceMatrix(2, 2));
-
-    // set buttom right block, 3x3 entries
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             matrixNodeIndex(0, 0), mConductanceMatrix(0, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             matrixNodeIndex(0, 1), mConductanceMatrix(0, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             matrixNodeIndex(0, 2), mConductanceMatrix(0, 2));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             matrixNodeIndex(0, 0), mConductanceMatrix(1, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             matrixNodeIndex(0, 1), mConductanceMatrix(1, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             matrixNodeIndex(0, 2), mConductanceMatrix(1, 2));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             matrixNodeIndex(0, 0), mConductanceMatrix(2, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             matrixNodeIndex(0, 1), mConductanceMatrix(2, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             matrixNodeIndex(0, 2), mConductanceMatrix(2, 2));
-
-    // Set off diagonal blocks
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             matrixNodeIndex(0, 0), -mConductanceMatrix(0, 0));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             matrixNodeIndex(0, 1), -mConductanceMatrix(0, 1));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             matrixNodeIndex(0, 2), -mConductanceMatrix(0, 2));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             matrixNodeIndex(0, 0), -mConductanceMatrix(1, 0));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             matrixNodeIndex(0, 1), -mConductanceMatrix(1, 1));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             matrixNodeIndex(0, 2), -mConductanceMatrix(1, 2));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             matrixNodeIndex(0, 0), -mConductanceMatrix(2, 0));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             matrixNodeIndex(0, 1), -mConductanceMatrix(2, 1));
-    Math::addToMatrixElement(systemMatrix,
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             matrixNodeIndex(0, 2), -mConductanceMatrix(2, 2));
-
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             -mConductanceMatrix(0, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             -mConductanceMatrix(0, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             -mConductanceMatrix(0, 2));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             -mConductanceMatrix(1, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             -mConductanceMatrix(1, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             -mConductanceMatrix(1, 2));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::A),
-                             -mConductanceMatrix(2, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::B),
-                             -mConductanceMatrix(2, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             -mConductanceMatrix(2, 2));
+    MNAStampUtils::stamp3x3ConductanceMatrixBetween2Nodes(
+        mConductanceMatrix, systemMatrix,
+        mVirtualNodes[0]->matrixNodeIndex(PhaseType::A), matrixNodeIndex(0),
+        mSLog);
   }
 }
 

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
@@ -258,27 +258,8 @@ void EMT::Ph3::SynchronGeneratorVBR::mnaCompPreStep(Real time,
 void EMT::Ph3::SynchronGeneratorVBR::mnaCompApplySystemMatrixStamp(
     SparseMatrixRow &systemMatrix) {
   if (terminalNotGrounded(0)) {
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             matrixNodeIndex(0, 0), mConductanceMat(0, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             matrixNodeIndex(0, 1), mConductanceMat(0, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 0),
-                             matrixNodeIndex(0, 2), mConductanceMat(0, 2));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             matrixNodeIndex(0, 0), mConductanceMat(1, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             matrixNodeIndex(0, 1), mConductanceMat(1, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 1),
-                             matrixNodeIndex(0, 2), mConductanceMat(1, 2));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             matrixNodeIndex(0, 0), mConductanceMat(2, 0));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             matrixNodeIndex(0, 1), mConductanceMat(2, 1));
-    Math::addToMatrixElement(systemMatrix, matrixNodeIndex(0, 2),
-                             matrixNodeIndex(0, 2), mConductanceMat(2, 2));
-    // SPDLOG_LOGGER_INFO(mSLog, "Add {} to {}, {}", conductance, matrixNodeIndex(0,0), matrixNodeIndex(0,0));
-    // SPDLOG_LOGGER_INFO(mSLog, "Add {} to {}, {}", conductance, matrixNodeIndex(0,1), matrixNodeIndex(0,1));
-    // SPDLOG_LOGGER_INFO(mSLog, "Add {} to {}, {}", conductance, matrixNodeIndex(0,2), matrixNodeIndex(0,2));
+    MNAStampUtils::stamp3x3ConductanceMatrixNodeToGround(
+        mConductanceMat, systemMatrix, matrixNodeIndex(0), mSLog);
   }
 }
 

--- a/dpsim-models/src/MNAStampUtils.cpp
+++ b/dpsim-models/src/MNAStampUtils.cpp
@@ -95,14 +95,14 @@ void MNAStampUtils::stampValue(T value, SparseMatrixRow &mat, UInt node1Index,
                                Bool isTerminal2NotGrounded, Int maxFreq,
                                Int freqIdx, const Logger::Log &mSLog) {
   if (isTerminal1NotGrounded && isTerminal2NotGrounded) {
-    stampValueNoConditions(value, mat, node1Index, node2Index, maxFreq, freqIdx,
-                           mSLog);
+    stampToMatrix(value, mat, node1Index, node1Index, node2Index, node2Index,
+                  maxFreq, freqIdx, mSLog);
   } else if (isTerminal1NotGrounded) {
-    stampValueOnDiagonalNoConditions(value, mat, node1Index, maxFreq, freqIdx,
-                                     mSLog);
+    addToMatrixElement(mat, node1Index, node1Index, value, maxFreq, freqIdx,
+                       mSLog);
   } else if (isTerminal2NotGrounded) {
-    stampValueOnDiagonalNoConditions(value, mat, node2Index, maxFreq, freqIdx,
-                                     mSLog);
+    addToMatrixElement(mat, node2Index, node2Index, value, maxFreq, freqIdx,
+                       mSLog);
   }
 }
 
@@ -121,22 +121,22 @@ void MNAStampUtils::stampMatrix(const MatrixVar<T> &matrix,
   if (isTerminal1NotGrounded && isTerminal2NotGrounded) {
     for (UInt i = 0; i < numRows; i++) {
       for (UInt j = 0; j < numCols; j++) {
-        stampValueNoConditions(matrix(i, j), mat, node1Index + i,
-                               node2Index + j, maxFreq, freqIdx, mSLog);
+        stampToMatrix(matrix(i, j), mat, node1Index + i, node1Index + j,
+                      node2Index + i, node2Index + j, maxFreq, freqIdx, mSLog);
       }
     }
   } else if (isTerminal1NotGrounded) {
     for (UInt i = 0; i < numRows; i++) {
       for (UInt j = 0; j < numCols; j++) {
-        stampValueOnDiagonalNoConditions(matrix(i, j), mat, node1Index + i,
-                                         maxFreq, freqIdx, mSLog);
+        addToMatrixElement(mat, node1Index + i, node1Index + j, matrix(i, j),
+                           maxFreq, freqIdx, mSLog);
       }
     }
   } else if (isTerminal2NotGrounded) {
     for (UInt i = 0; i < numRows; i++) {
       for (UInt j = 0; j < numCols; j++) {
-        stampValueOnDiagonalNoConditions(matrix(i, j), mat, node2Index + j,
-                                         maxFreq, freqIdx, mSLog);
+        addToMatrixElement(mat, node2Index + i, node2Index + j, matrix(i, j),
+                           maxFreq, freqIdx, mSLog);
       }
     }
   }
@@ -149,52 +149,31 @@ void MNAStampUtils::stampValueAsScalarMatrix(
     Int maxFreq, Int freqIdx, const Logger::Log &mSLog) {
   if (isTerminal1NotGrounded && isTerminal2NotGrounded) {
     for (UInt i = 0; i < sizeOfScalarMatrix; i++) {
-      stampValueNoConditions(value, mat, node1Index + i, node2Index + i,
-                             maxFreq, freqIdx, mSLog);
+      stampToMatrix(value, mat, node1Index + i, node1Index + i, node2Index + i,
+                    node2Index + i, maxFreq, freqIdx, mSLog);
     }
   } else if (isTerminal1NotGrounded) {
     for (UInt i = 0; i < sizeOfScalarMatrix; i++) {
-      stampValueOnDiagonalNoConditions(value, mat, node1Index + i, maxFreq,
-                                       freqIdx, mSLog);
+      addToMatrixElement(mat, node1Index + i, node1Index + i, value, maxFreq,
+                         freqIdx, mSLog);
     }
   } else if (isTerminal2NotGrounded) {
     for (UInt i = 0; i < sizeOfScalarMatrix; i++) {
-      stampValueOnDiagonalNoConditions(value, mat, node2Index + i, maxFreq,
-                                       freqIdx, mSLog);
+      addToMatrixElement(mat, node2Index + i, node2Index + i, value, maxFreq,
+                         freqIdx, mSLog);
     }
   }
 }
 
 template <typename T>
-void MNAStampUtils::stampValueNoConditions(T value, SparseMatrixRow &mat,
-                                           UInt node1Index, UInt node2Index,
-                                           Int maxFreq, Int freqIdx,
-                                           const Logger::Log &mSLog) {
-  stampValueOnDiagonalNoConditions(value, mat, node1Index, maxFreq, freqIdx,
-                                   mSLog);
-  stampValueOnDiagonalNoConditions(value, mat, node2Index, maxFreq, freqIdx,
-                                   mSLog);
-  stampValueOffDiagonalNoConditions(value, mat, node1Index, node2Index, maxFreq,
-                                    freqIdx, mSLog);
-}
-
-template <typename T>
-void MNAStampUtils::stampValueOnDiagonalNoConditions(T value,
-                                                     SparseMatrixRow &mat,
-                                                     UInt nodeIndex,
-                                                     Int maxFreq, Int freqIdx,
-                                                     const Logger::Log &mSLog) {
-  addToMatrixElement(mat, nodeIndex, nodeIndex, value, maxFreq, freqIdx, mSLog);
-}
-
-template <typename T>
-void MNAStampUtils::stampValueOffDiagonalNoConditions(
-    T value, SparseMatrixRow &mat, UInt node1Index, UInt node2Index,
-    Int maxFreq, Int freqIdx, const Logger::Log &mSLog) {
-  addToMatrixElement(mat, node1Index, node2Index, -value, maxFreq, freqIdx,
-                     mSLog);
-  addToMatrixElement(mat, node2Index, node1Index, -value, maxFreq, freqIdx,
-                     mSLog);
+void MNAStampUtils::stampToMatrix(T value, SparseMatrixRow &mat, UInt row1,
+                                  UInt column1, UInt row2, UInt column2,
+                                  Int maxFreq, Int freqIdx,
+                                  const Logger::Log &mSLog) {
+  addToMatrixElement(mat, row1, column1, value, maxFreq, freqIdx, mSLog);
+  addToMatrixElement(mat, row1, column2, -value, maxFreq, freqIdx, mSLog);
+  addToMatrixElement(mat, row2, column1, -value, maxFreq, freqIdx, mSLog);
+  addToMatrixElement(mat, row2, column2, value, maxFreq, freqIdx, mSLog);
 }
 
 // These wrapper functions standardize the signatures of "Math::addToMatrixElement" for Real and Complex "value" parameters,


### PR DESCRIPTION
### Summary
This PR fixes and extends functionality of `MNAStampUtils` and reuses the stamping logic for EMT synchronous generators.

### Details

- **MNAStampUtils: Fix stamping of full matrices (i.e., matrices with non-zero off-diagonal elements)** 
The incorrect logic for full matrices in `MNAStampUtils` was not previously recognized because 3-phase components that already used `MNAStampUtils`  (i.e. 3-phase R, L, C components) do not have coupling between the phases (their conductance matrix is diagonal). The incorrect logic became apparent when the code was reused for stamping synchronous generator's conductance matrix. 
- **MNAStampUtils: add matrix stamp functions with optimized logic**
Added functions `stamp3x3ConductanceMatrixBetween2Nodes` and `stamp3x3ConductanceMatrixNodeToGround,` that do not check if a terminal is grounded. This check is usually skipped in components, implementing `MNAVariableCompInterface`.
- **Reuse conductance stamping logic for EMT synchronous generators**
The commit does not include `EMT_Ph3_SynchronGeneratorDQ`. Conductance stamping is never called in `EMT_Ph3_SynchronGeneratorDQ,` due to hard-coded `mCompensationOn` data member. Therefore, it is not covered by tests and examples.

### Related work
- **Issue Reference**: These changes were discussed in an issue: https://github.com/sogno-platform/dpsim/issues/288
- **Previous PR**: This PR continues the work of: https://github.com/sogno-platform/dpsim/pull/306
- **Future Plans**: There are plans for future PRs to reuse stamp code for other components deriving from the `MNASimPowerComp` class.