### PR TITLE
New queueless VILLAS interface / improve real-time performance

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,6 +4,6 @@
 ---
 BasedOnStyle: LLVM
 
-# Disable automatic line-breaks in comments
-# as this breaks SPDX headers
-ReflowComments: false
+# Increase ColumnLimit to avoid breaking SPDX headers
+ColumnLimit: 200
+

--- a/dpsim-models/include/dpsim-models/Attribute.h
+++ b/dpsim-models/include/dpsim-models/Attribute.h
@@ -353,6 +353,7 @@ public:
   AttributeBase::Ptr cloneValueOntoNewAttribute() override {
     return AttributePointer<AttributeBase>(
         AttributeStatic<T>::make(this->get()));
+    //TODO: This is in the real time path. We should not use heap here.
   };
 
   /**

--- a/dpsim-models/include/dpsim-models/Attribute.h
+++ b/dpsim-models/include/dpsim-models/Attribute.h
@@ -353,7 +353,7 @@ public:
   AttributeBase::Ptr cloneValueOntoNewAttribute() override {
     return AttributePointer<AttributeBase>(
         AttributeStatic<T>::make(this->get()));
-    //TODO: This is in the real time path. We should not use heap here.
+    // TODO: This is in the real time path. We should not use heap here.
   };
 
   /**

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_ProfileVoltageSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_ProfileVoltageSource.h
@@ -16,7 +16,6 @@
 #include <dpsim-models/Solver/DAEInterface.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 #include <filesystem>
-#include <villas/formats/protobuf.hpp>
 #include <villas/sample.hpp>
 
 namespace CPS {

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_ProfileVoltageSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_ProfileVoltageSource.h
@@ -1,0 +1,112 @@
+/* Voltage Source that reads references from a file and replays them.
+ *
+ * Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2024 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Signal/CosineFMGenerator.h>
+#include <dpsim-models/Signal/DCGenerator.h>
+#include <dpsim-models/Signal/FrequencyRampGenerator.h>
+#include <dpsim-models/Signal/SignalGenerator.h>
+#include <dpsim-models/Signal/SineWaveGenerator.h>
+#include <dpsim-models/Solver/DAEInterface.h>
+#include <dpsim-models/Solver/MNAInterface.h>
+#include <filesystem>
+#include <villas/formats/protobuf.hpp>
+#include <villas/sample.hpp>
+
+namespace CPS {
+namespace DP {
+namespace Ph1 {
+
+class ProfileVoltageSource : public MNASimPowerComp<Complex>, public DAEInterface, public SharedFactory<ProfileVoltageSource> {
+private:
+  ///
+  void updateVoltage(Real time);
+  ///
+  // CPS::Signal::SignalGenerator::Ptr mSrcSig;
+  std::filesystem::path mSourceFile;
+  size_t mSourceIndex = 0;
+  std::vector<double> mSamples;
+
+  void readFromFile();
+
+public:
+  const CPS::Attribute<Complex>::Ptr mVoltage;
+
+  /// Defines UID, name, component parameters and logging level
+  ProfileVoltageSource(String uid, String name, std::filesystem::path sourceFile, Logger::Level loglevel = Logger::Level::off);
+  /// Defines UID, name, component parameters and logging level
+  ProfileVoltageSource(String name, std::filesystem::path sourceFile, Logger::Level logLevel = Logger::Level::off) : ProfileVoltageSource(name, name, sourceFile, logLevel) {}
+  ///
+  SimPowerComp<Complex>::Ptr clone(String name) override;
+
+  // #### General ####
+  /// Initializes component from power flow data
+  void initializeFromNodesAndTerminals(Real frequency) override;
+  ///
+  void setSourceFile(std::filesystem::path file, size_t index = 0);
+
+  // #### MNA Section ####
+  /// Initializes internal variables of the component
+  void mnaCompInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) override;
+  void mnaCompInitializeHarm(Real omega, Real timeStep, std::vector<Attribute<Matrix>::Ptr> leftVectors) override;
+  /// Stamps system matrix
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
+  void mnaCompApplySystemMatrixStampHarm(SparseMatrixRow &systemMatrix, Int freqIdx) override;
+  /// Stamps right side (source) vector
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
+  void mnaCompApplyRightSideVectorStampHarm(Matrix &rightVector) override;
+  /// Returns current through the component
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
+  /// MNA pre step operations
+  void mnaCompPreStep(Real time, Int timeStepCount) override;
+  /// MNA post step operations
+  void mnaCompPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) override;
+  /// Add MNA pre step dependencies
+  void mnaCompAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) override;
+  /// Add MNA post step dependencies
+  void mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes,
+                                      Attribute<Matrix>::Ptr &leftVector) override;
+
+  class MnaPreStepHarm : public CPS::Task {
+  public:
+    MnaPreStepHarm(ProfileVoltageSource &voltageSource) : Task(**voltageSource.mName + ".MnaPreStepHarm"), mVoltageSource(voltageSource) {
+      mAttributeDependencies.push_back(mVoltageSource.mVoltage);
+      mModifiedAttributes.push_back(mVoltageSource.mRightVector);
+      mModifiedAttributes.push_back(mVoltageSource.mIntfVoltage);
+    }
+    void execute(Real time, Int timeStepCount);
+
+  private:
+    ProfileVoltageSource &mVoltageSource;
+  };
+
+  class MnaPostStepHarm : public CPS::Task {
+  public:
+    MnaPostStepHarm(ProfileVoltageSource &voltageSource, const std::vector<Attribute<Matrix>::Ptr> &leftVectors)
+        : Task(**voltageSource.mName + ".MnaPostStepHarm"), mVoltageSource(voltageSource), mLeftVectors(leftVectors) {
+      for (UInt i = 0; i < mLeftVectors.size(); i++)
+        mAttributeDependencies.push_back(mLeftVectors[i]);
+      mModifiedAttributes.push_back(mVoltageSource.mIntfCurrent);
+    }
+    void execute(Real time, Int timeStepCount);
+
+  private:
+    ProfileVoltageSource &mVoltageSource;
+    std::vector<Attribute<Matrix>::Ptr> mLeftVectors;
+  };
+
+  // #### DAE Section ####
+  /// Residual function for DAE Solver
+  void daeResidual(double ttime, const double state[], const double dstate_dt[], double resid[], std::vector<int> &off) override;
+  /// Voltage Getter
+  Complex daeInitialize() override;
+};
+} // namespace Ph1
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSource.h
@@ -10,6 +10,7 @@
 
 #include <dpsim-models/MNASimPowerComp.h>
 #include <dpsim-models/Signal/CosineFMGenerator.h>
+#include <dpsim-models/Signal/DCGenerator.h>
 #include <dpsim-models/Signal/FrequencyRampGenerator.h>
 #include <dpsim-models/Signal/SignalGenerator.h>
 #include <dpsim-models/Signal/SineWaveGenerator.h>

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSource.h
@@ -80,6 +80,10 @@ public:
   void setParameters(Complex initialPhasor, Real modulationFrequency,
                      Real modulationAmplitude, Real baseFrequency = 0.0,
                      bool zigzag = false);
+  /// Setter for reference voltage with a real valued generator
+  /// This will initialize the values of mVoltageRef to match the given parameters
+  /// However, the attributes can be modified during the simulation to dynamically change the value of the output voltage.
+  void setParameters(Real voltageRef);
 
   // #### MNA Section ####
   /// Initializes internal variables of the component

--- a/dpsim-models/include/dpsim-models/Signal/DCGenerator.h
+++ b/dpsim-models/include/dpsim-models/Signal/DCGenerator.h
@@ -1,0 +1,30 @@
+/* Copyright 2014 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#pragma once
+
+#include <dpsim-models/Signal/SignalGenerator.h>
+
+namespace CPS {
+namespace Signal {
+/// \brief Model to generate sinusoidal signals
+///
+/// Inherits from the abstract SignalGenerator class.
+/// The generated signal must be characterised by its initial complex phasor and its frequency.
+class DCGenerator : public SignalGenerator, public SharedFactory<DCGenerator> {
+public:
+  const Attribute<Complex>::Ptr mVoltageRef;
+  /// init the identified object
+  DCGenerator(String name, Logger::Level logLevel = Logger::Level::off);
+  /// set the source's parameters
+  void setParameters(Real initialReference = 0.0);
+  /// implementation of inherited method step to update and return the current signal value
+  void step(Real time);
+};
+} // namespace Signal
+} // namespace CPS

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -151,6 +151,7 @@ list(APPEND MODELS_SOURCES
 	Signal/SignalGenerator.cpp
 	Signal/FrequencyRampGenerator.cpp
 	Signal/CosineFMGenerator.cpp
+	Signal/DCGenerator.cpp
 )
 
 if(WITH_CIM)

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND MODELS_SOURCES
 	DP/DP_Ph1_Resistor.cpp
 	DP/DP_Ph1_Transformer.cpp
 	DP/DP_Ph1_VoltageSource.cpp
+	DP/DP_Ph1_ProfileVoltageSource.cpp
 	DP/DP_Ph1_VoltageSourceRamp.cpp
 	DP/DP_Ph1_VoltageSourceNorton.cpp
 	DP/DP_Ph1_Switch.cpp
@@ -153,6 +154,7 @@ list(APPEND MODELS_SOURCES
 	Signal/CosineFMGenerator.cpp
 	Signal/DCGenerator.cpp
 )
+list(APPEND MODELS_INCLUDE_DIRS "/home/eiling/projects/villas-node/build/lib/formats")
 
 if(WITH_CIM)
 	list(APPEND MODELS_SOURCES CIM/Reader.cpp)

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -30,7 +30,6 @@ list(APPEND MODELS_SOURCES
 	DP/DP_Ph1_Resistor.cpp
 	DP/DP_Ph1_Transformer.cpp
 	DP/DP_Ph1_VoltageSource.cpp
-	DP/DP_Ph1_ProfileVoltageSource.cpp
 	DP/DP_Ph1_VoltageSourceRamp.cpp
 	DP/DP_Ph1_VoltageSourceNorton.cpp
 	DP/DP_Ph1_Switch.cpp
@@ -179,6 +178,10 @@ endif()
 if(WITH_GSL)
 	list(APPEND MODELS_INCLUDE_DIRS ${GSL_INCLUDE_DIRS})
 	list(APPEND MODELS_LIBRARIES ${GSL_LIBRARIES})
+endif()
+
+if(WITH_VILLAS)
+	list(APPEND MODELS_SOURCES DP/DP_Ph1_ProfileVoltageSource.cpp)
 endif()
 
 target_link_libraries(dpsim-models PUBLIC ${MODELS_LIBRARIES})

--- a/dpsim-models/src/DP/DP_Ph1_ProfileVoltageSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_ProfileVoltageSource.cpp
@@ -1,0 +1,248 @@
+/* Voltage Source that reads references from a file and replays them.
+ *
+ * Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2024 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dpsim-models/DP/DP_Ph1_ProfileVoltageSource.h>
+
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <villas/format.hpp>
+#include <villas/formats/protobuf.hpp>
+#include <villas/signal_list.hpp>
+#include <villas/signal_type.hpp>
+
+using namespace CPS;
+
+DP::Ph1::ProfileVoltageSource::ProfileVoltageSource(String uid, String name, std::filesystem::path sourceFile, Logger::Level logLevel)
+    : MNASimPowerComp<Complex>(uid, name, true, true, logLevel), mVoltage(mAttributes->createDynamic<Complex>("V")), mSourceFile(sourceFile), mSourceIndex(0), mSamples() {
+  setVirtualNodeNumber(1);
+  setTerminalNumber(2);
+  **mIntfVoltage = MatrixComp::Zero(1, 1);
+  **mIntfCurrent = MatrixComp::Zero(1, 1);
+
+  readFromFile();
+}
+
+void DP::Ph1::ProfileVoltageSource::readFromFile() {
+  mSamples.clear();
+  std::ifstream file(mSourceFile, std::ios::binary | std::ios::ate);
+
+  if (!file.is_open()) {
+    throw SystemError("ProfileVoltageSource::ProfileVoltageSource could not open file " + mSourceFile.string());
+  }
+
+  std::streamsize size = file.tellg();
+  file.seekg(0, std::ios::beg);
+
+  size_t sample_num = size / (sizeof(struct villas::node::Sample) + SAMPLE_DATA_LENGTH(1));
+  std::vector<char> buffer(size);
+  if (!file.read(buffer.data(), size)) {
+    throw SystemError("ProfileVoltageSource::ProfileVoltageSource could not read file " + mSourceFile.string());
+  }
+
+  unsigned i, j;
+  Villas__Node__Message *pb_msg;
+
+  pb_msg = villas__node__message__unpack(nullptr, size, (uint8_t *)buffer.data());
+  if (!pb_msg)
+    throw SystemError("ProfileVoltageSource::ProfileVoltageSource could not unpack Protobuf message");
+
+  for (i = 0; i < pb_msg->n_samples; i++) {
+    Villas__Node__Sample *pb_smp = pb_msg->samples[i];
+
+    if (pb_smp->type != VILLAS__NODE__SAMPLE__TYPE__DATA)
+      throw SystemError("ProfileVoltageSource::ProfileVoltageSource could not unpack Protobuf message");
+
+    if (pb_smp->n_values != 1) {
+      throw SystemError("ProfileVoltageSource::ProfileVoltageSource could not unpack Protobuf message");
+    }
+
+    for (j = 0; j < pb_smp->n_values; j++) {
+      Villas__Node__Value *pb_val = pb_smp->values[j];
+
+      if (pb_val->value_case != VILLAS__NODE__VALUE__VALUE_F)
+        throw SystemError("ProfileVoltageSource::ProfileVoltageSource could not unpack Protobuf message");
+      mSamples.push_back(pb_val->f);
+    }
+  }
+
+  villas__node__message__free_unpacked(pb_msg, nullptr);
+
+  std::cout << "Read " << mSamples.size() << " samples from file " << mSourceFile << std::endl;
+  for (double sample : mSamples) {
+    std::cout << sample << std::endl;
+  }
+}
+
+void DP::Ph1::ProfileVoltageSource::setSourceFile(std::filesystem::path file, size_t index) {
+  mSourceFile = file;
+  mSourceIndex = index;
+  readFromFile();
+}
+
+SimPowerComp<Complex>::Ptr DP::Ph1::ProfileVoltageSource::clone(String name) {
+  auto copy = ProfileVoltageSource::make(name, mSourceFile, mLogLevel);
+  copy->setSourceFile(mSourceFile, mSourceIndex);
+  return copy;
+}
+
+void DP::Ph1::ProfileVoltageSource::initializeFromNodesAndTerminals(Real frequency) {
+  /// CHECK: The frequency parameter is unused
+  if (**mVoltage == Complex(0, 0))
+    **mVoltage = initialSingleVoltage(1) - initialSingleVoltage(0);
+}
+
+// #### MNA functions ####
+
+void DP::Ph1::ProfileVoltageSource::mnaCompAddPreStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes) {
+  attributeDependencies.push_back(mVoltage);
+  modifiedAttributes.push_back(mRightVector);
+  modifiedAttributes.push_back(mIntfVoltage);
+}
+
+void DP::Ph1::ProfileVoltageSource::mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies, AttributeBase::List &attributeDependencies, AttributeBase::List &modifiedAttributes,
+                                                                   Attribute<Matrix>::Ptr &leftVector) {
+  attributeDependencies.push_back(leftVector);
+  modifiedAttributes.push_back(mIntfCurrent);
+};
+
+void DP::Ph1::ProfileVoltageSource::mnaCompInitialize(Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+  updateMatrixNodeIndices();
+
+  (**mIntfVoltage)(0, 0) = *mVoltage;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- MNA initialization ---"
+                     "\nInitial voltage {:s}"
+                     "\nInitial current {:s}"
+                     "\n--- MNA initialization finished ---",
+                     Logger::phasorToString((**mIntfVoltage)(0, 0)), Logger::phasorToString((**mIntfCurrent)(0, 0)));
+}
+
+void DP::Ph1::ProfileVoltageSource::mnaCompInitializeHarm(Real omega, Real timeStep, std::vector<Attribute<Matrix>::Ptr> leftVectors) {
+  updateMatrixNodeIndices();
+
+  (**mIntfVoltage)(0, 0) = *mVoltage;
+
+  mMnaTasks.push_back(std::make_shared<MnaPreStepHarm>(*this));
+  mMnaTasks.push_back(std::make_shared<MnaPostStepHarm>(*this, leftVectors));
+  **mRightVector = Matrix::Zero(leftVectors[0]->get().rows(), mNumFreqs);
+}
+
+void DP::Ph1::ProfileVoltageSource::mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) {
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    if (terminalNotGrounded(0)) {
+      Math::setMatrixElement(systemMatrix, mVirtualNodes[0]->matrixNodeIndex(), matrixNodeIndex(0), Complex(-1, 0), mNumFreqs, freq);
+      Math::setMatrixElement(systemMatrix, matrixNodeIndex(0), mVirtualNodes[0]->matrixNodeIndex(), Complex(-1, 0), mNumFreqs, freq);
+    }
+    if (terminalNotGrounded(1)) {
+      Math::setMatrixElement(systemMatrix, mVirtualNodes[0]->matrixNodeIndex(), matrixNodeIndex(1), Complex(1, 0), mNumFreqs, freq);
+      Math::setMatrixElement(systemMatrix, matrixNodeIndex(1), mVirtualNodes[0]->matrixNodeIndex(), Complex(1, 0), mNumFreqs, freq);
+    }
+
+    SPDLOG_LOGGER_INFO(mSLog, "-- Stamp frequency {:d} ---", freq);
+    if (terminalNotGrounded(0)) {
+      SPDLOG_LOGGER_INFO(mSLog, "Add {:f} to system at ({:d},{:d})", -1., matrixNodeIndex(0), mVirtualNodes[0]->matrixNodeIndex());
+      SPDLOG_LOGGER_INFO(mSLog, "Add {:f} to system at ({:d},{:d})", -1., mVirtualNodes[0]->matrixNodeIndex(), matrixNodeIndex(0));
+    }
+    if (terminalNotGrounded(1)) {
+      SPDLOG_LOGGER_INFO(mSLog, "Add {:f} to system at ({:d},{:d})", 1., mVirtualNodes[0]->matrixNodeIndex(), matrixNodeIndex(1));
+      SPDLOG_LOGGER_INFO(mSLog, "Add {:f} to system at ({:d},{:d})", 1., matrixNodeIndex(1), mVirtualNodes[0]->matrixNodeIndex());
+    }
+  }
+}
+
+void DP::Ph1::ProfileVoltageSource::mnaCompApplySystemMatrixStampHarm(SparseMatrixRow &systemMatrix, Int freqIdx) {
+  if (terminalNotGrounded(0)) {
+    Math::setMatrixElement(systemMatrix, mVirtualNodes[0]->matrixNodeIndex(), matrixNodeIndex(0), Complex(-1, 0));
+    Math::setMatrixElement(systemMatrix, matrixNodeIndex(0), mVirtualNodes[0]->matrixNodeIndex(), Complex(-1, 0));
+  }
+  if (terminalNotGrounded(1)) {
+    Math::setMatrixElement(systemMatrix, mVirtualNodes[0]->matrixNodeIndex(), matrixNodeIndex(1), Complex(1, 0));
+    Math::setMatrixElement(systemMatrix, matrixNodeIndex(1), mVirtualNodes[0]->matrixNodeIndex(), Complex(1, 0));
+  }
+
+  SPDLOG_LOGGER_INFO(mSLog, "-- Stamp frequency {:d} ---", freqIdx);
+  if (terminalNotGrounded(0)) {
+    SPDLOG_LOGGER_INFO(mSLog, "Add {:f} to system at ({:d},{:d})", -1., matrixNodeIndex(0), mVirtualNodes[0]->matrixNodeIndex());
+    SPDLOG_LOGGER_INFO(mSLog, "Add {:f} to system at ({:d},{:d})", -1., mVirtualNodes[0]->matrixNodeIndex(), matrixNodeIndex(0));
+  }
+  if (terminalNotGrounded(1)) {
+    SPDLOG_LOGGER_INFO(mSLog, "Add {:f} to system at ({:d},{:d})", 1., mVirtualNodes[0]->matrixNodeIndex(), matrixNodeIndex(1));
+    SPDLOG_LOGGER_INFO(mSLog, "Add {:f} to system at ({:d},{:d})", 1., matrixNodeIndex(1), mVirtualNodes[0]->matrixNodeIndex());
+  }
+}
+
+void DP::Ph1::ProfileVoltageSource::mnaCompApplyRightSideVectorStamp(Matrix &rightVector) {
+  // TODO: Is this correct with two nodes not gnd?
+  Math::setVectorElement(rightVector, mVirtualNodes[0]->matrixNodeIndex(), (**mIntfVoltage)(0, 0), mNumFreqs);
+  SPDLOG_LOGGER_DEBUG(mSLog, "Add {:s} to source vector at {:d}", Logger::complexToString((**mIntfVoltage)(0, 0)), mVirtualNodes[0]->matrixNodeIndex());
+}
+
+void DP::Ph1::ProfileVoltageSource::mnaCompApplyRightSideVectorStampHarm(Matrix &rightVector) {
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    // TODO: Is this correct with two nodes not gnd?
+    Math::setVectorElement(rightVector, mVirtualNodes[0]->matrixNodeIndex(), (**mIntfVoltage)(0, freq), 1, 0, freq);
+    SPDLOG_LOGGER_DEBUG(mSLog, "Add {:s} to source vector at {:d}", Logger::complexToString((**mIntfVoltage)(0, freq)), mVirtualNodes[0]->matrixNodeIndex());
+  }
+}
+
+void DP::Ph1::ProfileVoltageSource::updateVoltage(Real time) {
+  (**mIntfVoltage)(0, 0) = mSamples[mSourceIndex];
+  mSourceIndex = (mSourceIndex + 1) % mSamples.size();
+  // std::cout << "Update voltage to " << (**mIntfVoltage)(0, 0) << " at " << time << std::endl;
+}
+
+void DP::Ph1::ProfileVoltageSource::mnaCompPreStep(Real time, Int timeStepCount) {
+  updateVoltage(time);
+  mnaCompApplyRightSideVectorStamp(**mRightVector);
+}
+
+void DP::Ph1::ProfileVoltageSource::MnaPreStepHarm::execute(Real time, Int timeStepCount) {
+  mVoltageSource.updateVoltage(time);
+  mVoltageSource.mnaCompApplyRightSideVectorStampHarm(**mVoltageSource.mRightVector);
+}
+
+void DP::Ph1::ProfileVoltageSource::mnaCompPostStep(Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) { mnaCompUpdateCurrent(**leftVector); }
+
+void DP::Ph1::ProfileVoltageSource::MnaPostStepHarm::execute(Real time, Int timeStepCount) { mVoltageSource.mnaCompUpdateCurrent(**mLeftVectors[0]); }
+
+void DP::Ph1::ProfileVoltageSource::mnaCompUpdateCurrent(const Matrix &leftVector) {
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    (**mIntfCurrent)(0, freq) = Math::complexFromVectorElement(leftVector, mVirtualNodes[0]->matrixNodeIndex(), mNumFreqs, freq);
+  }
+}
+
+void DP::Ph1::ProfileVoltageSource::daeResidual(double ttime, const double state[], const double dstate_dt[], double resid[], std::vector<int> &off) {
+  /* new state vector definintion:
+                state[0]=node0_voltage
+                state[1]=node1_voltage
+                ....
+                state[n]=noden_voltage
+                state[n+1]=component0_voltage
+                state[n+2]=component0_inductance (not yet implemented)
+                ...
+                state[m-1]=componentm_voltage
+                state[m]=componentm_inductance
+        */
+
+  int Pos1 = matrixNodeIndex(0);
+  int Pos2 = matrixNodeIndex(1);
+  int c_offset = off[0] + off[1];                                  // current offset for component
+  int n_offset_1 = c_offset + Pos1 + 1;                            // current offset for first nodal equation
+  int n_offset_2 = c_offset + Pos2 + 1;                            // current offset for second nodal equation
+  resid[c_offset] = (state[Pos2] - state[Pos1]) - state[c_offset]; // Voltage equation for Resistor
+  // resid[++c_offset] = ; //TODO : add inductance equation
+  resid[n_offset_1] += (**mIntfCurrent)(0, 0).real();
+  resid[n_offset_2] += (**mIntfCurrent)(0, 0).real();
+  off[1] += 1;
+}
+
+Complex DP::Ph1::ProfileVoltageSource::daeInitialize() {
+  (**mIntfVoltage)(0, 0) = *mVoltage;
+  return *mVoltage;
+}

--- a/dpsim-models/src/DP/DP_Ph1_ProfileVoltageSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_ProfileVoltageSource.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <memory>
 #include <villas/format.hpp>
-#include <villas/formats/protobuf.hpp>
+#include <villas/formats/villas.pb-c.h>
 #include <villas/signal_list.hpp>
 #include <villas/signal_type.hpp>
 

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
@@ -31,12 +31,20 @@ SimPowerComp<Complex>::Ptr DP::Ph1::VoltageSource::clone(String name) {
 }
 
 void DP::Ph1::VoltageSource::setParameters(Complex voltageRef, Real srcFreq) {
-  auto srcSigSine = Signal::SineWaveGenerator::make(**mName + "_sw");
-  srcSigSine->mVoltageRef->setReference(mVoltageRef);
-  srcSigSine->mFreq->setReference(mSrcFreq);
-  srcSigSine->setParameters(voltageRef, srcFreq);
+  if (srcFreq == 0.0) {
+    auto srcDC = Signal::DCGenerator::make(**mName + "_dc");
+    srcDC->mVoltageRef->setReference(mVoltageRef);
+    srcDC->setParameters(voltageRef.real());
 
-  mSrcSig = srcSigSine;
+    mSrcSig = srcDC;
+  } else {
+    auto srcSigSine = Signal::SineWaveGenerator::make(**mName + "_sw");
+    srcSigSine->mVoltageRef->setReference(mVoltageRef);
+    srcSigSine->mFreq->setReference(mSrcFreq);
+    srcSigSine->setParameters(voltageRef, srcFreq);
+
+    mSrcSig = srcSigSine;
+  }
   mParametersSet = true;
 }
 

--- a/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_VoltageSource.cpp
@@ -30,21 +30,23 @@ SimPowerComp<Complex>::Ptr DP::Ph1::VoltageSource::clone(String name) {
   return copy;
 }
 
+void DP::Ph1::VoltageSource::setParameters(Real voltageRef) {
+  auto srcDC = Signal::DCGenerator::make(**mName + "_dc");
+  srcDC->mVoltageRef->setReference(mVoltageRef);
+  srcDC->setParameters(voltageRef);
+
+  mSrcSig = srcDC;
+  mParametersSet = true;
+}
+
 void DP::Ph1::VoltageSource::setParameters(Complex voltageRef, Real srcFreq) {
-  if (srcFreq == 0.0) {
-    auto srcDC = Signal::DCGenerator::make(**mName + "_dc");
-    srcDC->mVoltageRef->setReference(mVoltageRef);
-    srcDC->setParameters(voltageRef.real());
+  auto srcSigSine = Signal::SineWaveGenerator::make(**mName + "_sw");
+  srcSigSine->mVoltageRef->setReference(mVoltageRef);
+  srcSigSine->mFreq->setReference(mSrcFreq);
+  srcSigSine->setParameters(voltageRef, srcFreq);
 
-    mSrcSig = srcDC;
-  } else {
-    auto srcSigSine = Signal::SineWaveGenerator::make(**mName + "_sw");
-    srcSigSine->mVoltageRef->setReference(mVoltageRef);
-    srcSigSine->mFreq->setReference(mSrcFreq);
-    srcSigSine->setParameters(voltageRef, srcFreq);
+  mSrcSig = srcSigSine;
 
-    mSrcSig = srcSigSine;
-  }
   mParametersSet = true;
 }
 

--- a/dpsim-models/src/Signal/DCGenerator.cpp
+++ b/dpsim-models/src/Signal/DCGenerator.cpp
@@ -1,0 +1,25 @@
+/* Copyright 2024 Institute for Automation of Complex Power Systems,
+ *                EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <dpsim-models/Signal/DCGenerator.h>
+
+using namespace CPS;
+
+Signal::DCGenerator::DCGenerator(String name, Logger::Level logLevel)
+    : SignalGenerator(name, logLevel),
+      mVoltageRef(mAttributes->createDynamic<Complex>("V_ref")) {
+  **mFreq = 0.0;
+  SPDLOG_LOGGER_INFO(mSLog, "Create {} {}", type(), name);
+}
+
+void Signal::DCGenerator::setParameters(Real initialReference) {
+  **mVoltageRef = initialReference;
+  **mSigOut = initialReference;
+}
+
+void Signal::DCGenerator::step(Real time) { **mSigOut = **mVoltageRef; }

--- a/dpsim-models/src/Signal/DCGenerator.cpp
+++ b/dpsim-models/src/Signal/DCGenerator.cpp
@@ -1,10 +1,7 @@
-/* Copyright 2024 Institute for Automation of Complex Power Systems,
- *                EONERC, RWTH Aachen University
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- *********************************************************************************/
+/* Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2023-2024 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-License-Identifier: MPL-2.0
+ */
 
 #include <dpsim-models/Signal/DCGenerator.h>
 

--- a/dpsim-villas/examples/cxx/FpgaExample.cpp
+++ b/dpsim-villas/examples/cxx/FpgaExample.cpp
@@ -9,9 +9,11 @@
 #include <fstream>
 
 #include <DPsim.h>
+#include <dpsim-models/Attribute.h>
 #include <dpsim-models/DP/DP_Ph1_CurrentSource.h>
 #include <dpsim-models/SimNode.h>
 #include <dpsim-villas/InterfaceVillas.h>
+#include <dpsim-villas/InterfaceVillasQueueless.h>
 #include <dpsim/Utils.h>
 
 using namespace DPsim;
@@ -21,11 +23,17 @@ using namespace CPS::DP::Ph1;
 const std::string buildFpgaConfig(CommandLineArgs &args) {
   std::filesystem::path fpgaIpPath =
       "/usr/local/etc/villas/node/etc/fpga/vc707-xbar-pcie-dino/"
-      "vc707-xbar-pcie-dino.json";
+      "vc707-xbar-pcie-dino-v2.json";
 
   if (args.options.find("ips") != args.options.end()) {
     fpgaIpPath = std::filesystem::path(args.getOptionString("ips"));
   }
+  std::string loopbackConfig = fmt::format(
+      R"STRING(
+      "queuelen": 1024,
+      "samplelen": 1024,
+      "mode": "polling"
+    )STRING");
   std::string cardConfig = fmt::format(
       R"STRING("card": {{
       "interface": "pcie",
@@ -48,7 +56,8 @@ const std::string buildFpgaConfig(CommandLineArgs &args) {
       "signals": [{{
         "name": "from_dpsim",
         "type": "complex",
-        "unit": "V"
+        "unit": "V",
+        "builtin": false
       }}],
       "hooks": [{{
         "type": "dp",
@@ -63,12 +72,18 @@ const std::string buildFpgaConfig(CommandLineArgs &args) {
   std::string signalInConfig = fmt::format(
       R"STRING("in": {{
       "signals": [{{
+        "name": "seqnum",
+        "type": "integer",
+        "unit": "",
+        "builtin": false
+      }},
+      {{
         "name": "to_dpsim",
         "type": "float",
         "unit": "V",
         "builtin": false
       }}],
-      "hooks": ["print", {{
+      "hooks": [{{
         "type": "dp",
         "signal": "to_dpsim",
         "f0": {},
@@ -91,37 +106,39 @@ const std::string buildFpgaConfig(CommandLineArgs &args) {
 }
 
 SystemTopology loopbackTopology(CommandLineArgs &args,
-                                std::shared_ptr<InterfaceVillas> intf,
+                                std::shared_ptr<Interface> intf,
                                 std::shared_ptr<DataLogger> logger) {
   // Nodes
   auto n1 = SimNode::make("n1");
 
   // Components
   auto vs = VoltageSource::make("v_s");
-  vs->setParameters(Complex(10, 0), args.sysFreq);
+  vs->setParameters(Complex(10, 0), 0);
   auto rl = Resistor::make("r_l");
   rl->setParameters(1);
 
   // Topology
-  vs->connect({SimNode::GND, n1});
+  vs->connect({n1, SimNode::GND});
   rl->connect({n1, SimNode::GND});
 
   // Interface
-  intf->importAttribute(vs->mVoltageRef, 0, false, false, "from_dino", "A");
-  intf->exportAttribute(n1->mVoltage->deriveCoeff<Complex>(0, 0), 0, true,
-                        "to_dino", "V");
-  intf->printVillasSignals();
+  auto seqnumAttribute = CPS::AttributeStatic<Int>::make(0);
+  intf->addImport(seqnumAttribute, true, true);
+  intf->addImport(vs->mVoltageRef, true, true);
+  intf->addExport(n1->mVoltage->deriveCoeff<Complex>(0, 0));
 
   // Logger
-  logger->logAttribute("v1", n1->mVoltage);
-  logger->logAttribute("rl_i", rl->mIntfCurrent);
+  if (logger) {
+    logger->logAttribute("v1", n1->mVoltage);
+    logger->logAttribute("rl_i", rl->mIntfCurrent);
+  }
 
   return SystemTopology(args.sysFreq, SystemNodeList{SimNode::GND, n1},
                         SystemComponentList{vs, rl});
 }
 
 SystemTopology hilTopology(CommandLineArgs &args,
-                           std::shared_ptr<InterfaceVillas> intf,
+                           std::shared_ptr<Interface> intf,
                            std::shared_ptr<DataLogger> logger) {
   // Nodes
   auto n1 = SimNode::make("n1");
@@ -137,27 +154,26 @@ SystemTopology hilTopology(CommandLineArgs &args,
   cs->setParameters(Complex(0, 0));
 
   // Topology
-  vs->connect({SimNode::GND, n1});
-  rs->connect({n1, n2});
-  cs->connect({n2, SimNode::GND});
 
   // Interface
-  intf->importAttribute(cs->mCurrentRef, 0, false, false, "from_dino", "A");
-  intf->exportAttribute(n2->mVoltage->deriveCoeff<Complex>(0, 0), 0, true,
-                        "to_dino", "V");
-  intf->printVillasSignals();
+  auto seqnumAttribute = CPS::AttributeStatic<uint32_t>::make(0);
+  intf->addImport(seqnumAttribute, true, false);
+  intf->addImport(cs->mCurrentRef, true, false);
+  intf->addExport(n2->mVoltage->deriveCoeff<Complex>(0, 0));
 
   // Logger
-  logger->logAttribute("v1", n1->mVoltage);
-  logger->logAttribute("v2", n2->mVoltage);
-  logger->logAttribute("cs_i", cs->mIntfCurrent);
+  if (logger) {
+    logger->logAttribute("v1", n1->mVoltage);
+    logger->logAttribute("v2", n2->mVoltage);
+    logger->logAttribute("cs_i", cs->mIntfCurrent);
+  }
 
   return SystemTopology(args.sysFreq, SystemNodeList{SimNode::GND, n1, n2},
                         SystemComponentList{vs, rs, cs});
 }
 
 SystemTopology getTopology(CommandLineArgs &args,
-                           std::shared_ptr<InterfaceVillas> intf,
+                           std::shared_ptr<Interface> intf,
                            std::shared_ptr<DataLogger> logger) {
   if (args.options.find("topology") != args.options.end()) {
     std::string topology = args.getOptionString("topology");
@@ -174,16 +190,20 @@ int main(int argc, char *argv[]) {
   CommandLineArgs args(argc, argv, "FpgaExample", 0.01, 10 * 60, 5.);
   CPS::Logger::setLogDir("logs/" + args.name);
 
-  auto intf = std::make_shared<InterfaceVillas>(buildFpgaConfig(args));
+  auto intf = std::make_shared<InterfaceVillasQueueless>(
+      buildFpgaConfig(args), "FpgaExample", spdlog::level::off);
   auto logger = DataLogger::make(args.name);
 
-  auto sys = getTopology(args, intf, logger);
+  auto sys = getTopology(args, intf, nullptr);
 
-  RealTimeSimulation sim(args.name, args);
+  Simulation sim(args.name, args);
   sim.setSystem(sys);
   sim.addInterface(intf);
-  sim.addLogger(logger);
+  //sim.addLogger(logger);
   sim.run();
+
+  CPS::Logger::get("FpgaExample")->info("Simulation finished.");
+  sim.logStepTimes("FpgaExample");
 
   //std::ofstream of("task_dependencies.svg");
   //sim.dependencyGraph().render(of);

--- a/dpsim-villas/examples/cxx/FpgaExample.cpp
+++ b/dpsim-villas/examples/cxx/FpgaExample.cpp
@@ -199,7 +199,8 @@ int main(int argc, char *argv[]) {
   Simulation sim(args.name, args);
   sim.setSystem(sys);
   sim.addInterface(intf);
-  //sim.addLogger(logger);
+  // If you want to add loggging (slows down the execution) add
+  // sim.addLogger(logger);
   sim.run();
 
   CPS::Logger::get("FpgaExample")->info("Simulation finished.");

--- a/dpsim-villas/examples/cxx/FpgaExample.cpp
+++ b/dpsim-villas/examples/cxx/FpgaExample.cpp
@@ -116,7 +116,7 @@ SystemTopology loopbackTopology(CommandLineArgs &args,
 
   // Components
   auto vs = VoltageSource::make("v_s");
-  vs->setParameters(Complex(10, 0), 0);
+  vs->setParameters(10.);
   auto rl = Resistor::make("r_l");
   rl->setParameters(1);
 
@@ -147,7 +147,7 @@ SystemTopology hilTopology(CommandLineArgs &args, std::shared_ptr<Interface> int
 
   // Components
   auto vs = VoltageSource::make("v_s");
-  vs->setParameters(Complex(1, 0), 50);
+  vs->setParameters(1.);
   auto rs = Resistor::make("r_s");
   rs->setParameters(1);
 

--- a/dpsim-villas/examples/cxx/FpgaExample.cpp
+++ b/dpsim-villas/examples/cxx/FpgaExample.cpp
@@ -11,6 +11,7 @@
 #include <DPsim.h>
 #include <dpsim-models/Attribute.h>
 #include <dpsim-models/DP/DP_Ph1_CurrentSource.h>
+#include <dpsim-models/DP/DP_Ph1_ProfileVoltageSource.h>
 #include <dpsim-models/SimNode.h>
 #include <dpsim-villas/InterfaceVillas.h>
 #include <dpsim-villas/InterfaceVillasQueueless.h>
@@ -21,9 +22,11 @@ using namespace CPS::DP;
 using namespace CPS::DP::Ph1;
 
 const std::string buildFpgaConfig(CommandLineArgs &args) {
-  std::filesystem::path fpgaIpPath =
-      "/usr/local/etc/villas/node/etc/fpga/vc707-xbar-pcie-dino/"
-      "vc707-xbar-pcie-dino-v2.json";
+  // std::filesystem::path fpgaIpPath =
+  //     "/usr/local/etc/villas/node/etc/fpga/vc707-xbar-pcie-dino/"
+  //     "vc707-xbar-pcie-dino-v2.json";
+  std::filesystem::path fpgaIpPath = "/home/eiling/projects/villas-node/etc/fpga/vc707-xbar-pcie-dino/"
+                                     "vc707-xbar-pcie.json";
 
   if (args.options.find("ips") != args.options.end()) {
     fpgaIpPath = std::filesystem::path(args.getOptionString("ips"));
@@ -137,16 +140,14 @@ SystemTopology loopbackTopology(CommandLineArgs &args,
                         SystemComponentList{vs, rl});
 }
 
-SystemTopology hilTopology(CommandLineArgs &args,
-                           std::shared_ptr<Interface> intf,
-                           std::shared_ptr<DataLogger> logger) {
+SystemTopology hilTopology(CommandLineArgs &args, std::shared_ptr<Interface> intf, std::shared_ptr<DataLogger> logger) {
   // Nodes
   auto n1 = SimNode::make("n1");
   auto n2 = SimNode::make("n2");
 
   // Components
   auto vs = VoltageSource::make("v_s");
-  vs->setParameters(Complex(10, 0), args.sysFreq);
+  vs->setParameters(Complex(1, 0), 50);
   auto rs = Resistor::make("r_s");
   rs->setParameters(1);
 
@@ -154,12 +155,15 @@ SystemTopology hilTopology(CommandLineArgs &args,
   cs->setParameters(Complex(0, 0));
 
   // Topology
+  vs->connect({n1, SimNode::GND});
+  cs->connect({n1, n2});
+  rs->connect({n2, SimNode::GND});
 
   // Interface
-  auto seqnumAttribute = CPS::AttributeStatic<uint32_t>::make(0);
-  intf->addImport(seqnumAttribute, true, false);
-  intf->addImport(cs->mCurrentRef, true, false);
-  intf->addExport(n2->mVoltage->deriveCoeff<Complex>(0, 0));
+  auto seqnumAttribute = CPS::AttributeStatic<Int>::make(0);
+  intf->addImport(seqnumAttribute, true, true);
+  intf->addImport(cs->mCurrentRef, true, true);
+  intf->addExport(n1->mVoltage->deriveCoeff<Complex>(0, 0));
 
   // Logger
   if (logger) {
@@ -168,8 +172,41 @@ SystemTopology hilTopology(CommandLineArgs &args,
     logger->logAttribute("cs_i", cs->mIntfCurrent);
   }
 
-  return SystemTopology(args.sysFreq, SystemNodeList{SimNode::GND, n1, n2},
-                        SystemComponentList{vs, rs, cs});
+  return SystemTopology(args.sysFreq, SystemNodeList{SimNode::GND, n1, n2}, SystemComponentList{vs, rs, cs});
+}
+
+SystemTopology profileTopology(CommandLineArgs &args, std::shared_ptr<Interface> intf, std::shared_ptr<DataLogger> logger) {
+  // Nodes
+  auto n1 = SimNode::make("n1");
+  auto n2 = SimNode::make("n2");
+
+  // Components
+  auto vs = ProfileVoltageSource::make("v_s", "data.bin");
+  auto rs = Resistor::make("r_s");
+  rs->setParameters(1);
+
+  auto cs = CurrentSource::make("i_l");
+  cs->setParameters(Complex(0, 0));
+
+  // Topology
+  vs->connect({n1, SimNode::GND});
+  cs->connect({n1, n2});
+  rs->connect({n2, SimNode::GND});
+
+  // Interface
+  auto seqnumAttribute = CPS::AttributeStatic<Int>::make(0);
+  intf->addImport(seqnumAttribute, true, true);
+  intf->addImport(cs->mCurrentRef, true, true);
+  intf->addExport(n1->mVoltage->deriveCoeff<Complex>(0, 0));
+
+  // Logger
+  if (logger) {
+    logger->logAttribute("v1", n1->mVoltage);
+    logger->logAttribute("v2", n2->mVoltage);
+    logger->logAttribute("cs_i", cs->mIntfCurrent);
+  }
+
+  return SystemTopology(args.sysFreq, SystemNodeList{SimNode::GND, n1, n2}, SystemComponentList{vs, rs, cs});
 }
 
 SystemTopology getTopology(CommandLineArgs &args,
@@ -181,6 +218,8 @@ SystemTopology getTopology(CommandLineArgs &args,
       return hilTopology(args, intf, logger);
     } else if (topology == "loopback") {
       return loopbackTopology(args, intf, logger);
+    } else if (topology == "profile") {
+      return profileTopology(args, intf, logger);
     }
   }
   return hilTopology(args, intf, logger);

--- a/dpsim-villas/include/dpsim-villas/InterfaceVillas.h
+++ b/dpsim-villas/include/dpsim-villas/InterfaceVillas.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <dpsim-models/PtrFactory.h>
-#include <dpsim/Interface.h>
+#include <dpsim/InterfaceQueued.h>
 
 #include <villas/kernel/rt.hpp>
 #include <villas/node.hpp>
@@ -18,7 +18,7 @@ using namespace villas;
 
 namespace DPsim {
 /// Interface type that can be used to import and export simulation attributes over any node type supported by VILLASnode
-class InterfaceVillas : public Interface,
+class InterfaceVillas : public InterfaceQueued,
                         public SharedFactory<InterfaceVillas> {
 
 public:
@@ -28,19 +28,21 @@ public:
   /// @param sampleLength sample length configured for the node
   /// @param name Name of this interface. Currently only used for naming the simulation tasks
   /// @param downsampling Only import and export attributes on every nth timestep
-  InterfaceVillas(const String &nodeConfig, UInt queueLength = 512,
-                  UInt sampleLength = 64, const String &name = "",
-                  UInt downsampling = 1);
+  InterfaceVillas(
+      const String &nodeConfig, UInt queueLength = 512, UInt sampleLength = 64,
+      const String &name = "", UInt downsampling = 1,
+      spdlog::level::level_enum logLevel = spdlog::level::level_enum::info);
 
   /// @brief configure an attribute import
   /// @param attr the attribute that should be updated with the imported values
   /// @param idx The id given to the attribute within VILLASnode samples
   /// @param blockOnRead Whether the simulation should block on every import until the attribute has been updated
   /// @param syncOnSimulationStart Whether the simulation should block before the first timestep until this attribute has been updated
-  void importAttribute(CPS::AttributeBase::Ptr attr, UInt idx,
-                       Bool blockOnRead = false,
-                       Bool syncOnSimulationStart = true,
-                       const String &name = "", const String &unit = "");
+  virtual void importAttribute(CPS::AttributeBase::Ptr attr, UInt idx,
+                               Bool blockOnRead = false,
+                               Bool syncOnSimulationStart = true,
+                               const String &name = "",
+                               const String &unit = "");
 
   /// @brief configure an attribute export
   /// @param attr the attribute which's value should be exported
@@ -48,10 +50,10 @@ public:
   /// @param waitForOnWrite Whether a sample that is sent from this interface is required to contain an updated value of this attribute
   /// @param name Name given to the attribute within VILLASnode samples
   /// @param unit Unit given to the attribute within VILLASnode samples
-  void exportAttribute(CPS::AttributeBase::Ptr attr, UInt idx,
-                       Bool waitForOnWrite, const String &name = "",
-                       const String &unit = "");
+  virtual void exportAttribute(CPS::AttributeBase::Ptr attr, UInt idx,
+                               Bool waitForOnWrite, const String &name = "",
+                               const String &unit = "");
 
-  void printVillasSignals() const;
+  virtual void printVillasSignals() const;
 };
 } // namespace DPsim

--- a/dpsim-villas/include/dpsim-villas/InterfaceVillasQueueless.h
+++ b/dpsim-villas/include/dpsim-villas/InterfaceVillasQueueless.h
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <dpsim-models/Attribute.h>
+#include <dpsim-models/Logger.h>
+#include <dpsim-models/PtrFactory.h>
+#include <dpsim-models/Task.h>
+#include <dpsim/Config.h>
+#include <dpsim/Definitions.h>
+#include <dpsim/Interface.h>
+#include <dpsim/Scheduler.h>
+
+#include <memory>
+#include <villas/kernel/rt.hpp>
+#include <villas/node.hpp>
+#include <villas/node/exceptions.hpp>
+#include <villas/node/memory.hpp>
+#include <villas/pool.hpp>
+#include <villas/sample.hpp>
+#include <villas/signal.hpp>
+#include <villas/signal_list.hpp>
+
+using namespace villas;
+
+namespace DPsim {
+/// Interface type that can be used to import and export simulation attributes over any node type supported by VILLASnode
+class InterfaceVillasQueueless
+    : public Interface,
+      public SharedFactory<InterfaceVillasQueueless> {
+
+public:
+  typedef std::shared_ptr<InterfaceVillasQueueless> Ptr;
+
+  /// @brief create a new InterfaceVillasQueueless instance
+  /// @param nodeConfig VILLASnode node configuration in JSON format
+  /// @param name Name of this interface. Currently only used for naming the simulation tasks
+  InterfaceVillasQueueless(
+      const String &nodeConfig, const String &name = "",
+      spdlog::level::level_enum logLevel = spdlog::level::level_enum::info);
+
+  virtual void open() override;
+  virtual void close() override;
+
+  // Function called by the Simulation to perform interface synchronization
+  virtual void syncExports() override;
+  /// Function called by the Simulation to perform interface synchronization
+  virtual void syncImports() override;
+
+  virtual CPS::Task::List getTasks() override;
+
+  virtual void printVillasSignals() const;
+
+  virtual ~InterfaceVillasQueueless() {
+    if (mOpened)
+      close();
+  }
+
+protected:
+  const String mNodeConfig;
+  node::Node *mNode;
+  node::Pool mSamplePool;
+
+  virtual void writeToVillas();
+  virtual Int readFromVillas();
+  void createNode();
+  void createSignals();
+  Int mSequenceToDpsim;
+  Int mSequenceFromDpsim;
+
+public:
+  class PreStep : public CPS::Task {
+  public:
+    explicit PreStep(InterfaceVillasQueueless &intf)
+        : Task(intf.mName + ".Read"), mIntf(intf) {
+      for (const auto &[attr, _seqId, _blockOnRead, _syncOnStart] :
+           intf.mImportAttrsDpsim) {
+        mModifiedAttributes.push_back(attr);
+      }
+    }
+
+    void execute(Real time, Int timeStepCount) override;
+
+  private:
+    InterfaceVillasQueueless &mIntf;
+  };
+
+  class PostStep : public CPS::Task {
+  public:
+    explicit PostStep(InterfaceVillasQueueless &intf)
+        : Task(intf.mName + ".Write"), mIntf(intf) {
+      for (const auto &[attr, _seqId] : intf.mExportAttrsDpsim) {
+        mAttributeDependencies.push_back(attr);
+      }
+      mModifiedAttributes.push_back(Scheduler::external);
+    }
+
+    void execute(Real time, Int timeStepCount) override;
+
+  private:
+    InterfaceVillasQueueless &mIntf;
+  };
+};
+} // namespace DPsim

--- a/dpsim-villas/include/dpsim-villas/InterfaceVillasQueueless.h
+++ b/dpsim-villas/include/dpsim-villas/InterfaceVillasQueueless.h
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/* Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2023-2024 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-License-Identifier: MPL-2.0
+ */
 
 #pragma once
 
@@ -44,7 +47,7 @@ public:
 
   // Function called by the Simulation to perform interface synchronization
   virtual void syncExports() override;
-  /// Function called by the Simulation to perform interface synchronization
+  // Function called by the Simulation to perform interface synchronization
   virtual void syncImports() override;
 
   virtual CPS::Task::List getTasks() override;

--- a/dpsim-villas/include/dpsim-villas/InterfaceVillasQueueless.h
+++ b/dpsim-villas/include/dpsim-villas/InterfaceVillasQueueless.h
@@ -55,8 +55,13 @@ public:
   virtual void printVillasSignals() const;
 
   virtual ~InterfaceVillasQueueless() {
-    if (mOpened)
-      close();
+    if (mOpened) {
+      try {
+        close();
+      } catch (const std::exception &e) {
+        SPDLOG_LOGGER_ERROR(mLog, "Error closing interface: {}", e.what());
+      }
+    }
   }
 
 protected:

--- a/dpsim-villas/include/dpsim-villas/InterfaceWorkerVillas.h
+++ b/dpsim-villas/include/dpsim-villas/InterfaceWorkerVillas.h
@@ -3,8 +3,10 @@
 #pragma once
 
 #include <dpsim-models/PtrFactory.h>
+#include <dpsim/InterfaceQueued.h>
 #include <dpsim/InterfaceWorker.h>
 
+#include <spdlog/common.h>
 #include <villas/kernel/rt.hpp>
 #include <villas/node.hpp>
 #include <villas/node/exceptions.hpp>
@@ -53,16 +55,22 @@ private:
   std::map<int, node::Signal::Ptr> mImportSignals;
 
 public:
-  InterfaceWorkerVillas(const String &nodeConfig, UInt queueLenght = 512,
-                        UInt sampleLenght = 64);
+  InterfaceWorkerVillas(
+      const String &nodeConfig, UInt queueLenght = 512, UInt sampleLenght = 64,
+      spdlog::level::level_enum logLevel = spdlog::level::level_enum::info);
 
   void open() override;
   void close() override;
 
   void readValuesFromEnv(
-      std::vector<Interface::AttributePacket> &updatedAttrs) override;
+      std::vector<InterfaceQueued::AttributePacket> &updatedAttrs) override;
+  void readValuesFromEnv(
+      std::vector<std::tuple<CPS::AttributeBase::Ptr, UInt, bool, bool>>
+          &updatedAttrs);
   void writeValuesToEnv(
-      std::vector<Interface::AttributePacket> &updatedAttrs) override;
+      std::vector<InterfaceQueued::AttributePacket> &updatedAttrs) override;
+  void writeValuesToEnv(
+      std::vector<std::tuple<CPS::AttributeBase::Ptr, UInt>> &updatedAttrs);
 
   virtual void configureImport(UInt attributeId, const std::type_info &type,
                                UInt idx, const String &name = "",

--- a/dpsim-villas/src/CMakeLists.txt
+++ b/dpsim-villas/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(DPSIM_VILLAS_SOURCES
 	InterfaceVillas.cpp
 	InterfaceWorkerVillas.cpp
+	InterfaceVillasQueueless.cpp
 )
 
 add_library(dpsim-villas ${DPSIM_VILLAS_SOURCES})

--- a/dpsim-villas/src/InterfaceVillas.cpp
+++ b/dpsim-villas/src/InterfaceVillas.cpp
@@ -9,10 +9,11 @@ namespace DPsim {
 
 InterfaceVillas::InterfaceVillas(const String &nodeConfig, UInt queueLength,
                                  UInt sampleLength, const String &name,
-                                 UInt downsampling)
-    : Interface(
-          InterfaceWorkerVillas::make(nodeConfig, queueLength, sampleLength),
-          name, downsampling) {}
+                                 UInt downsampling,
+                                 spdlog::level::level_enum logLevel)
+    : InterfaceQueued(InterfaceWorkerVillas::make(nodeConfig, queueLength,
+                                                  sampleLength, logLevel),
+                      name, downsampling) {}
 
 void InterfaceVillas::importAttribute(CPS::AttributeBase::Ptr attr, UInt idx,
                                       Bool blockOnRead,

--- a/dpsim-villas/src/InterfaceVillasQueueless.cpp
+++ b/dpsim-villas/src/InterfaceVillasQueueless.cpp
@@ -138,8 +138,8 @@ void InterfaceVillasQueueless::open() {
   createNode();
   createSignals();
 
-  mNode->getFactory()->start(
-      nullptr); //We have no SuperNode, so just hope type_start doesnt use it...
+  // We have no SuperNode, so just hope type_start doesn't use it...
+  mNode->getFactory()->start(nullptr);
 
   auto ret = mNode->start();
   if (ret < 0) {
@@ -343,17 +343,17 @@ void InterfaceVillasQueueless::writeToVillas() {
           "Failed to write samples to InterfaceVillas. Write returned code {}",
           ret);
 
-    /* Don't throw here, because we managed to send something */
+    // Don't throw here, because we managed to send something
   }
 }
 
 void InterfaceVillasQueueless::syncImports() {
-  //Block on read until all attributes with syncOnSimulationStart are read
+  // Block on read until all attributes with syncOnSimulationStart are read
   mSequenceToDpsim = this->readFromVillas();
 }
 
 void InterfaceVillasQueueless::syncExports() {
-  //Just push all the attributes
+  // Just push all the attributes
   this->writeToVillas();
 }
 

--- a/dpsim-villas/src/InterfaceVillasQueueless.cpp
+++ b/dpsim-villas/src/InterfaceVillasQueueless.cpp
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "villas/node/memory.hpp"
+#include "villas/node/memory_type.hpp"
+#include "villas/path.hpp"
+#include "villas/signal_type.hpp"
+#include <dpsim-villas/InterfaceVillasQueueless.h>
+#include <dpsim-villas/InterfaceWorkerVillas.h>
+#include <memory>
+#include <spdlog/spdlog.h>
+#include <typeinfo>
+#include <villas/node.h>
+
+using namespace CPS;
+using namespace villas;
+
+namespace DPsim {
+
+InterfaceVillasQueueless::InterfaceVillasQueueless(
+    const String &nodeConfig, const String &name,
+    spdlog::level::level_enum logLevel)
+    : Interface(name, logLevel), mNodeConfig(nodeConfig), mNode(nullptr),
+      mSamplePool(), mSequenceToDpsim(0), mSequenceFromDpsim(0) {}
+
+void InterfaceVillasQueueless::createNode() {
+  if (villas::node::memory::init(100) != 0) {
+    SPDLOG_LOGGER_ERROR(mLog, "Error: Failed to initialize memory subsystem!");
+    std::exit(1);
+  }
+  json_error_t error;
+  json_t *config = json_loads(mNodeConfig.c_str(), 0, &error);
+  if (config == nullptr) {
+    SPDLOG_LOGGER_ERROR(mLog, "Error: Failed to parse node config! Error: {}",
+                        error.text);
+    throw JsonError(config, error);
+  }
+
+  const json_t *nodeType = json_object_get(config, "type");
+  if (nodeType == nullptr) {
+    SPDLOG_LOGGER_ERROR(mLog, "Error: Node config does not contain type-key!");
+    std::exit(1);
+  }
+  String nodeTypeString = json_string_value(nodeType);
+
+  mNode = node::NodeFactory::make(nodeTypeString);
+
+  int ret = 0;
+  ret = mNode->parse(config);
+  if (ret < 0) {
+    SPDLOG_LOGGER_ERROR(mLog,
+                        "Error: Node in InterfaceVillas failed to parse "
+                        "config. Parse returned code {}",
+                        ret);
+    std::exit(1);
+  }
+  ret = mNode->check();
+  if (ret < 0) {
+    SPDLOG_LOGGER_ERROR(
+        mLog,
+        "Error: Node in InterfaceVillas failed check. Check returned code {}",
+        ret);
+    std::exit(1);
+  }
+  struct villas::node::memory::Type *pool_mt = &villas::node::memory::heap;
+  ret = node::pool_init(&mSamplePool, 16,
+                        sizeof(node::Sample) + SAMPLE_DATA_LENGTH(64), pool_mt);
+  if (ret < 0) {
+    SPDLOG_LOGGER_ERROR(mLog,
+                        "Error: InterfaceVillas failed to init sample pool. "
+                        "pool_init returned code {}",
+                        ret);
+    std::exit(1);
+  }
+
+  ret = mNode->prepare();
+  if (ret < 0) {
+    SPDLOG_LOGGER_ERROR(mLog,
+                        "Error: Node in InterfaceVillas failed to prepare. "
+                        "Prepare returned code {}",
+                        ret);
+    std::exit(1);
+  }
+  SPDLOG_LOGGER_INFO(mLog, "Node: {}", mNode->getNameFull());
+}
+
+static node::SignalType stdTypeToNodeType(const std::type_info &type) {
+  if (type == typeid(Real)) {
+    return node::SignalType::FLOAT;
+  } else if (type == typeid(Int)) {
+    return node::SignalType::INTEGER;
+  } else if (type == typeid(Bool)) {
+    return node::SignalType::BOOLEAN;
+  } else if (type == typeid(Complex)) {
+    return node::SignalType::COMPLEX;
+  } else {
+    return node::SignalType::INVALID;
+  }
+}
+
+void InterfaceVillasQueueless::createSignals() {
+  mNode->out.path = new node::Path();
+  mNode->out.path->signals = std::make_shared<node::SignalList>();
+  node::SignalList::Ptr nodeOutputSignals =
+      mNode->out.path->getOutputSignals(false);
+  nodeOutputSignals->clear();
+  unsigned int idx = 0;
+  for (const auto &[attr, id] : mExportAttrsDpsim) {
+    while (id > idx) {
+      nodeOutputSignals->push_back(
+          std::make_shared<node::Signal>("", "", node::SignalType::INVALID));
+      idx++;
+    }
+    nodeOutputSignals->push_back(std::make_shared<node::Signal>(
+        "", "", stdTypeToNodeType(attr->getType())));
+  }
+
+  node::SignalList::Ptr nodeInputSignals = mNode->getInputSignals(true);
+  if (nodeInputSignals == nullptr) {
+    nodeInputSignals = std::make_shared<node::SignalList>();
+  } else {
+    nodeInputSignals->clear();
+  }
+  idx = 0;
+  for (const auto &[attr, id, blockOnRead, syncOnSimulationStart] :
+       mImportAttrsDpsim) {
+    while (id > idx) {
+      nodeInputSignals->push_back(
+          std::make_shared<node::Signal>("", "", node::SignalType::INVALID));
+      idx++;
+    }
+    nodeInputSignals->push_back(std::make_shared<node::Signal>(
+        "", "", stdTypeToNodeType(attr->getType())));
+    idx++;
+  }
+}
+
+void InterfaceVillasQueueless::open() {
+  createNode();
+  createSignals();
+
+  mNode->getFactory()->start(
+      nullptr); //We have no SuperNode, so just hope type_start doesnt use it...
+
+  auto ret = mNode->start();
+  if (ret < 0) {
+    SPDLOG_LOGGER_ERROR(mLog,
+                        "Fatal error: failed to start node in InterfaceVillas. "
+                        "Start returned code {}",
+                        ret);
+    close();
+    std::exit(1);
+  }
+  mOpened = true;
+  mSequenceFromDpsim = 0;
+  mSequenceToDpsim = 0;
+}
+
+void InterfaceVillasQueueless::close() {
+  SPDLOG_LOGGER_INFO(mLog, "Closing InterfaceVillas...");
+  int ret = mNode->stop();
+  if (ret < 0) {
+    SPDLOG_LOGGER_ERROR(
+        mLog,
+        "Error: failed to stop node in InterfaceVillas. Stop returned code {}",
+        ret);
+    std::exit(1);
+  }
+  mOpened = false;
+  ret = node::pool_destroy(&mSamplePool);
+  if (ret < 0) {
+    SPDLOG_LOGGER_ERROR(mLog,
+                        "Error: failed to destroy SamplePool in "
+                        "InterfaceVillas. pool_destroy returned code {}",
+                        ret);
+    std::exit(1);
+  }
+
+  mNode->getFactory()->stop();
+
+  delete mNode;
+  mOpened = false;
+}
+
+CPS::Task::List InterfaceVillasQueueless::getTasks() {
+  auto tasks = CPS::Task::List();
+  if (!mImportAttrsDpsim.empty()) {
+    tasks.push_back(std::make_shared<InterfaceVillasQueueless::PreStep>(*this));
+  }
+  if (!mExportAttrsDpsim.empty()) {
+    tasks.push_back(
+        std::make_shared<InterfaceVillasQueueless::PostStep>(*this));
+  }
+  return tasks;
+}
+
+void InterfaceVillasQueueless::PreStep::execute(Real time, Int timeStepCount) {
+  auto seqnum = mIntf.readFromVillas();
+  if (seqnum != mIntf.mSequenceToDpsim + 1) {
+    SPDLOG_LOGGER_WARN(mIntf.mLog, "{} Overrun(s) detected!",
+                       seqnum - mIntf.mSequenceToDpsim - 1);
+  }
+  mIntf.mSequenceToDpsim = seqnum;
+}
+
+Int InterfaceVillasQueueless::readFromVillas() {
+  node::Sample *sample = nullptr;
+  Int seqnum = 0;
+  int ret = 0;
+  if (mImportAttrsDpsim.size() == 0) {
+    return 0;
+  }
+  try {
+    sample = node::sample_alloc(&mSamplePool);
+    ret = 0;
+    while (ret == 0) {
+      ret = mNode->read(&sample, 1);
+      if (ret < 0) {
+        SPDLOG_LOGGER_ERROR(mLog,
+                            "Fatal error: failed to read sample from "
+                            "InterfaceVillas. Read returned code {}",
+                            ret);
+        close();
+        std::exit(1);
+      } else if (ret == 0) {
+        SPDLOG_LOGGER_WARN(mLog,
+                           "InterfaceVillas read returned 0. Retrying...");
+      }
+    }
+
+    if (sample->length != mImportAttrsDpsim.size()) {
+      SPDLOG_LOGGER_ERROR(mLog,
+                          "Error: Received Sample length ({}) does not match "
+                          "configured attributes length ({})",
+                          sample->length, mImportAttrsDpsim.size());
+      throw RuntimeError(
+          "Received Sample length does not match configured attributes length");
+    }
+
+    for (size_t i = 0; i < mImportAttrsDpsim.size(); i++) {
+      auto attr = std::get<0>(mImportAttrsDpsim[i]);
+      if (attr->getType() == typeid(Real)) {
+        auto attrReal =
+            std::dynamic_pointer_cast<Attribute<Real>>(attr.getPtr());
+        attrReal->set(sample->data[i].f);
+      } else if (attr->getType() == typeid(Int)) {
+        auto attrInt = std::dynamic_pointer_cast<Attribute<Int>>(attr.getPtr());
+        attrInt->set(sample->data[i].i);
+        if (i == 0) {
+          seqnum = sample->data[i].i;
+        }
+      } else if (attr->getType() == typeid(Bool)) {
+        auto attrBool =
+            std::dynamic_pointer_cast<Attribute<Bool>>(attr.getPtr());
+        attrBool->set(sample->data[i].b);
+      } else if (attr->getType() == typeid(Complex)) {
+        auto attrComplex =
+            std::dynamic_pointer_cast<Attribute<Complex>>(attr.getPtr());
+        attrComplex->set(
+            Complex(sample->data[i].z.real(), sample->data[i].z.imag()));
+      } else {
+        SPDLOG_LOGGER_ERROR(mLog, "Error: Unsupported attribute type!");
+        throw RuntimeError("Unsupported attribute type!");
+      }
+    }
+
+    sample_decref(sample);
+  } catch (const std::exception &) {
+    if (sample)
+      sample_decref(sample);
+
+    throw;
+  }
+  return seqnum;
+}
+
+void InterfaceVillasQueueless::PostStep::execute(Real time, Int timeStepCount) {
+  mIntf.writeToVillas();
+}
+
+void InterfaceVillasQueueless::writeToVillas() {
+  if (mExportAttrsDpsim.size() == 0) {
+    return;
+  }
+  node::Sample *sample = nullptr;
+  Int ret = 0;
+  try {
+    sample = node::sample_alloc(&mSamplePool);
+    if (sample == nullptr) {
+      SPDLOG_LOGGER_ERROR(mLog, "InterfaceVillas could not allocate a new "
+                                "sample! Not sending any data!");
+      return;
+    }
+
+    sample->signals = mNode->getOutputSignals(false);
+
+    for (size_t i = 0; i < mExportAttrsDpsim.size(); i++) {
+      auto attr = std::get<0>(mExportAttrsDpsim[i]);
+      if (attr->getType() == typeid(Real)) {
+        auto attrReal =
+            std::dynamic_pointer_cast<Attribute<Real>>(attr.getPtr());
+        sample->data[i].f = attrReal->get();
+      } else if (attr->getType() == typeid(Int)) {
+        auto attrInt = std::dynamic_pointer_cast<Attribute<Int>>(attr.getPtr());
+        sample->data[i].i = attrInt->get();
+      } else if (attr->getType() == typeid(Bool)) {
+        auto attrBool =
+            std::dynamic_pointer_cast<Attribute<Bool>>(attr.getPtr());
+        sample->data[i].b = attrBool->get();
+      } else if (attr->getType() == typeid(Complex)) {
+        auto attrComplex =
+            std::dynamic_pointer_cast<Attribute<Complex>>(attr.getPtr());
+        sample->data[i].z = std::complex<float>(attrComplex->get().real(),
+                                                attrComplex->get().imag());
+      } else {
+        SPDLOG_LOGGER_ERROR(mLog, "Error: Unsupported attribute type!");
+        throw RuntimeError("Unsupported attribute type!");
+      }
+    }
+
+    sample->length = mExportAttrsDpsim.size();
+    sample->sequence = mSequenceFromDpsim++;
+    sample->flags |= (int)villas::node::SampleFlags::HAS_SEQUENCE;
+    sample->flags |= (int)villas::node::SampleFlags::HAS_DATA;
+    clock_gettime(CLOCK_REALTIME, &sample->ts.origin);
+    sample->flags |= (int)villas::node::SampleFlags::HAS_TS_ORIGIN;
+
+    do {
+      ret = mNode->write(&sample, 1);
+    } while (ret == 0);
+    if (ret < 0)
+      SPDLOG_LOGGER_ERROR(mLog,
+                          "Failed to write samples to InterfaceVillas. Write "
+                          "returned code {}",
+                          ret);
+
+    sample_decref(sample);
+  } catch (const std::exception &) {
+    sample_decref(sample);
+
+    if (ret < 0)
+      SPDLOG_LOGGER_ERROR(
+          mLog,
+          "Failed to write samples to InterfaceVillas. Write returned code {}",
+          ret);
+
+    /* Don't throw here, because we managed to send something */
+  }
+}
+
+void InterfaceVillasQueueless::syncImports() {
+  //Block on read until all attributes with syncOnSimulationStart are read
+  mSequenceToDpsim = this->readFromVillas();
+}
+
+void InterfaceVillasQueueless::syncExports() {
+  //Just push all the attributes
+  this->writeToVillas();
+}
+
+void InterfaceVillasQueueless::printVillasSignals() const {
+  SPDLOG_LOGGER_INFO(mLog, "Export signals:");
+  for (const auto &signal : *mNode->getOutputSignals(true)) {
+    SPDLOG_LOGGER_INFO(mLog, "Name: {}, Unit: {}, Type: {}", signal->name,
+                       signal->unit, node::signalTypeToString(signal->type));
+  }
+
+  SPDLOG_LOGGER_INFO(mLog, "Import signals:");
+  for (const auto &signal : *mNode->getInputSignals(true)) {
+    SPDLOG_LOGGER_INFO(mLog, "Name: {}, Unit: {}, Type: {}", signal->name,
+                       signal->unit, node::signalTypeToString(signal->type));
+  }
+}
+
+} // namespace DPsim

--- a/dpsim-villas/src/InterfaceVillasQueueless.cpp
+++ b/dpsim-villas/src/InterfaceVillasQueueless.cpp
@@ -1,15 +1,18 @@
-// SPDX-License-Identifier: Apache-2.0
+/* Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2023-2024 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-License-Identifier: MPL-2.0
+ */
 
-#include "villas/node/memory.hpp"
-#include "villas/node/memory_type.hpp"
-#include "villas/path.hpp"
-#include "villas/signal_type.hpp"
 #include <dpsim-villas/InterfaceVillasQueueless.h>
 #include <dpsim-villas/InterfaceWorkerVillas.h>
 #include <memory>
 #include <spdlog/spdlog.h>
 #include <typeinfo>
 #include <villas/node.h>
+#include <villas/node/memory.hpp>
+#include <villas/node/memory_type.hpp>
+#include <villas/path.hpp>
+#include <villas/signal_type.hpp>
 
 using namespace CPS;
 using namespace villas;

--- a/dpsim-villas/src/InterfaceWorkerVillas.cpp
+++ b/dpsim-villas/src/InterfaceWorkerVillas.cpp
@@ -35,7 +35,7 @@ InterfaceWorkerVillas::InterfaceWorkerVillas(const String &nodeConfig,
 
 void InterfaceWorkerVillas::open() {
   SPDLOG_LOGGER_INFO(mLog, "Opening InterfaceWorkerVillas...");
-  logging.setLevel(mLog->level());
+  Log::getInstance().setLevel(mLog->level());
 
   if (!InterfaceWorkerVillas::villasInitialized) {
     SPDLOG_LOGGER_INFO(mLog, "Initializing Villas...");

--- a/dpsim-villas/src/InterfaceWorkerVillas.cpp
+++ b/dpsim-villas/src/InterfaceWorkerVillas.cpp
@@ -289,14 +289,14 @@ void InterfaceWorkerVillas::readValuesFromEnv(
 
 void InterfaceWorkerVillas::writeValuesToEnv(
     std::vector<InterfaceQueued::AttributePacket> &updatedAttrs) {
-  //Update export sequence IDs
+  // Update export sequence IDs
   for (const auto &packet : updatedAttrs) {
     if (std::get<1>(mExports[packet.attributeId]) < packet.sequenceId) {
       std::get<1>(mExports[packet.attributeId]) = packet.sequenceId;
     }
   }
 
-  //Remove outdated packets
+  // Remove outdated packets
   auto beginOutdated = std::remove_if(
       updatedAttrs.begin(), updatedAttrs.end(), [this](auto packet) {
         return std::get<1>(mExports[packet.attributeId]) > packet.sequenceId;

--- a/dpsim/include/dpsim/Interface.h
+++ b/dpsim/include/dpsim/Interface.h
@@ -12,8 +12,6 @@
 #include <dpsim/Interface.h>
 #include <dpsim/Scheduler.h>
 
-#include <readerwriterqueue.h>
-
 namespace DPsim {
 
 class InterfaceWorker;
@@ -23,53 +21,25 @@ class Interface : public SharedFactory<Interface> {
 public:
   typedef std::shared_ptr<Interface> Ptr;
 
-  using AttributePacket = struct AttributePacket {
-    CPS::AttributeBase::Ptr value;
-    UInt
-        attributeId; //Used to identify the attribute. Defined by the position in the `mExportAttrsDpsim` and `mImportAttrsDpsim` lists
-    UInt
-        sequenceId; //Increasing ID used to discern multiple consecutive updates of a single attribute
-    unsigned char flags; //Bit 0 set: Close interface
+  Interface(const String &name = "", spdlog::level::level_enum logLevel =
+                                         spdlog::level::level_enum::info)
+      : mName(name), mOpened(false) {
+    mLog = CPS::Logger::get("Interface", logLevel);
   };
 
-  enum AttributePacketFlags {
-    PACKET_NO_FLAGS = 0,
-    PACKET_CLOSE_INTERFACE = 1,
-  };
-
-  Interface(std::shared_ptr<InterfaceWorker> intf, const String &name = "",
-            UInt downsampling = 1)
-      : mInterfaceWorker(intf), mName(name), mDownsampling(downsampling),
-        mOpened(false) {
-    mQueueDpsimToInterface = std::make_shared<
-        moodycamel::BlockingReaderWriterQueue<AttributePacket>>();
-    mQueueInterfaceToDpsim = std::make_shared<
-        moodycamel::BlockingReaderWriterQueue<AttributePacket>>();
-  };
-
-  virtual void open();
-  virtual void close();
-
-  // Function used in the interface's simulation task to read all imported attributes from the queue
-  // Called once before every simulation timestep
-  virtual void pushDpsimAttrsToQueue();
-  // Function used in the interface's simulation task to write all exported attributes to the queue
-  // Called once after every simulation timestep
-  virtual void popDpsimAttrsFromQueue(bool isSync = false);
+  virtual void open() = 0;
+  virtual void close() = 0;
 
   // Function called by the Simulation to perform interface synchronization
-  virtual void syncExports();
+  virtual void syncExports() = 0;
   /// Function called by the Simulation to perform interface synchronization
-  virtual void syncImports();
+  virtual void syncImports() = 0;
 
-  virtual CPS::Task::List getTasks();
+  virtual CPS::Task::List getTasks() = 0;
 
-  void setLogger(CPS::Logger::Log log);
+  virtual void setLogger(CPS::Logger::Log log);
 
-  virtual ~Interface() {
-    if (mOpened)
-      close();
-  }
+  virtual String &getName() { return mName; }
 
   // Attributes used in the DPsim simulation. Should only be accessed by the dpsim-thread
   // Tuple attributes: Attribute to be imported, Current sequenceID, blockOnRead, syncOnSimulationStart
@@ -78,91 +48,16 @@ public:
   // Tuple attributes: Attribute to be exported, Current Sequence ID
   std::vector<std::tuple<CPS::AttributeBase::Ptr, UInt>> mExportAttrsDpsim;
 
+  virtual void addImport(CPS::AttributeBase::Ptr attr, bool blockOnRead = false,
+                         bool syncOnSimulationStart = true);
+  virtual void addExport(CPS::AttributeBase::Ptr attr);
+
 protected:
-  std::shared_ptr<InterfaceWorker> mInterfaceWorker;
   CPS::Logger::Log mLog;
   String mName;
   bool mSyncOnSimulationStart;
   UInt mCurrentSequenceDpsimToInterface = 1;
   UInt mNextSequenceInterfaceToDpsim = 1;
-  UInt mDownsampling;
   std::atomic<bool> mOpened;
-  std::thread mInterfaceWriterThread;
-  std::thread mInterfaceReaderThread;
-
-  std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
-      mQueueDpsimToInterface;
-  std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
-      mQueueInterfaceToDpsim;
-
-  virtual void addImport(CPS::AttributeBase::Ptr attr, bool blockOnRead = false,
-                         bool syncOnSimulationStart = true);
-  virtual void addExport(CPS::AttributeBase::Ptr attr);
-
-public:
-  class WriterThread {
-  private:
-    std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
-        mQueueDpsimToInterface;
-    std::shared_ptr<InterfaceWorker> mInterfaceWorker;
-
-  public:
-    WriterThread(
-        std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
-            queueDpsimToInterface,
-        std::shared_ptr<InterfaceWorker> intf)
-        : mQueueDpsimToInterface(queueDpsimToInterface),
-          mInterfaceWorker(intf){};
-    void operator()() const;
-  };
-
-  class ReaderThread {
-  private:
-    std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
-        mQueueInterfaceToDpsim;
-    std::shared_ptr<InterfaceWorker> mInterfaceWorker;
-    std::atomic<bool> &mOpened;
-
-  public:
-    ReaderThread(
-        std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
-            queueInterfaceToDpsim,
-        std::shared_ptr<InterfaceWorker> intf, std::atomic<bool> &opened)
-        : mQueueInterfaceToDpsim(queueInterfaceToDpsim), mInterfaceWorker(intf),
-          mOpened(opened){};
-    void operator()() const;
-  };
-
-  class PreStep : public CPS::Task {
-  public:
-    explicit PreStep(Interface &intf)
-        : Task(intf.mName + ".Read"), mIntf(intf) {
-      for (const auto &[attr, _seqId, _blockOnRead, _syncOnStart] :
-           intf.mImportAttrsDpsim) {
-        mModifiedAttributes.push_back(attr);
-      }
-    }
-
-    void execute(Real time, Int timeStepCount) override;
-
-  private:
-    Interface &mIntf;
-  };
-
-  class PostStep : public CPS::Task {
-  public:
-    explicit PostStep(Interface &intf)
-        : Task(intf.mName + ".Write"), mIntf(intf) {
-      for (const auto &[attr, _seqId] : intf.mExportAttrsDpsim) {
-        mAttributeDependencies.push_back(attr);
-      }
-      mModifiedAttributes.push_back(Scheduler::external);
-    }
-
-    void execute(Real time, Int timeStepCount) override;
-
-  private:
-    Interface &mIntf;
-  };
 };
 } // namespace DPsim

--- a/dpsim/include/dpsim/InterfaceQueued.h
+++ b/dpsim/include/dpsim/InterfaceQueued.h
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <thread>
+
+#include <dpsim-models/Attribute.h>
+#include <dpsim-models/Logger.h>
+#include <dpsim-models/Task.h>
+#include <dpsim/Config.h>
+#include <dpsim/Definitions.h>
+#include <dpsim/Interface.h>
+#include <dpsim/Scheduler.h>
+
+#include <readerwriterqueue.h>
+
+namespace DPsim {
+
+class InterfaceWorker;
+
+class InterfaceQueued : public Interface,
+                        public SharedFactory<InterfaceQueued> {
+
+public:
+  typedef std::shared_ptr<InterfaceQueued> Ptr;
+
+  using AttributePacket = struct AttributePacket {
+    CPS::AttributeBase::Ptr value;
+    UInt
+        attributeId; //Used to identify the attribute. Defined by the position in the `mExportAttrsDpsim` and `mImportAttrsDpsim` lists
+    UInt
+        sequenceId; //Increasing ID used to discern multiple consecutive updates of a single attribute
+    unsigned char flags; //Bit 0 set: Close interface
+  };
+
+  enum AttributePacketFlags {
+    PACKET_NO_FLAGS = 0,
+    PACKET_CLOSE_INTERFACE = 1,
+  };
+
+  InterfaceQueued(std::shared_ptr<InterfaceWorker> intf,
+                  const String &name = "", UInt downsampling = 1)
+      : Interface(name), mInterfaceWorker(intf), mDownsampling(downsampling) {
+    mQueueDpsimToInterface = std::make_shared<
+        moodycamel::BlockingReaderWriterQueue<AttributePacket>>();
+    mQueueInterfaceToDpsim = std::make_shared<
+        moodycamel::BlockingReaderWriterQueue<AttributePacket>>();
+  };
+
+  virtual void open() override;
+  virtual void close() override;
+
+  // Function used in the interface's simulation task to read all imported attributes from the queue
+  // Called once before every simulation timestep
+  virtual void pushDpsimAttrsToQueue();
+  // Function used in the interface's simulation task to write all exported attributes to the queue
+  // Called once after every simulation timestep
+  virtual void popDpsimAttrsFromQueue(bool isSync = false);
+
+  // Function called by the Simulation to perform interface synchronization
+  virtual void syncExports() override;
+  /// Function called by the Simulation to perform interface synchronization
+  virtual void syncImports() override;
+
+  virtual CPS::Task::List getTasks() override;
+
+  virtual void setLogger(CPS::Logger::Log log) override;
+
+  virtual ~InterfaceQueued() {
+    if (mOpened)
+      close();
+  }
+
+protected:
+  std::shared_ptr<InterfaceWorker> mInterfaceWorker;
+  UInt mDownsampling;
+  std::thread mInterfaceWriterThread;
+  std::thread mInterfaceReaderThread;
+
+  std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
+      mQueueDpsimToInterface;
+  std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
+      mQueueInterfaceToDpsim;
+
+public:
+  class WriterThread {
+  private:
+    std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
+        mQueueDpsimToInterface;
+    std::shared_ptr<InterfaceWorker> mInterfaceWorker;
+
+  public:
+    WriterThread(
+        std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
+            queueDpsimToInterface,
+        std::shared_ptr<InterfaceWorker> intf)
+        : mQueueDpsimToInterface(queueDpsimToInterface),
+          mInterfaceWorker(intf){};
+    void operator()() const;
+  };
+
+  class ReaderThread {
+  private:
+    std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
+        mQueueInterfaceToDpsim;
+    std::shared_ptr<InterfaceWorker> mInterfaceWorker;
+    std::atomic<bool> &mOpened;
+
+  public:
+    ReaderThread(
+        std::shared_ptr<moodycamel::BlockingReaderWriterQueue<AttributePacket>>
+            queueInterfaceToDpsim,
+        std::shared_ptr<InterfaceWorker> intf, std::atomic<bool> &opened)
+        : mQueueInterfaceToDpsim(queueInterfaceToDpsim), mInterfaceWorker(intf),
+          mOpened(opened){};
+    void operator()() const;
+  };
+
+  class PreStep : public CPS::Task {
+  public:
+    explicit PreStep(InterfaceQueued &intf)
+        : Task(intf.getName() + ".Read"), mIntf(intf) {
+      for (const auto &[attr, _seqId, _blockOnRead, _syncOnStart] :
+           intf.mImportAttrsDpsim) {
+        mModifiedAttributes.push_back(attr);
+      }
+    }
+
+    void execute(Real time, Int timeStepCount) override;
+
+  private:
+    InterfaceQueued &mIntf;
+  };
+
+  class PostStep : public CPS::Task {
+  public:
+    explicit PostStep(InterfaceQueued &intf)
+        : Task(intf.getName() + ".Write"), mIntf(intf) {
+      for (const auto &[attr, _seqId] : intf.mExportAttrsDpsim) {
+        mAttributeDependencies.push_back(attr);
+      }
+      mModifiedAttributes.push_back(Scheduler::external);
+    }
+
+    void execute(Real time, Int timeStepCount) override;
+
+  private:
+    InterfaceQueued &mIntf;
+  };
+};
+} // namespace DPsim

--- a/dpsim/include/dpsim/InterfaceWorker.h
+++ b/dpsim/include/dpsim/InterfaceWorker.h
@@ -10,6 +10,7 @@
 #include <dpsim/Config.h>
 #include <dpsim/Definitions.h>
 #include <dpsim/Interface.h>
+#include <dpsim/InterfaceQueued.h>
 #include <dpsim/Scheduler.h>
 
 namespace DPsim {
@@ -33,8 +34,8 @@ public:
          * Should be used to read values from the environment and push them into `updatedAttrs`
          * `updatedAttrs` will always be empty when this function is invoked
          */
-  virtual void
-  readValuesFromEnv(std::vector<Interface::AttributePacket> &updatedAttrs) = 0;
+  virtual void readValuesFromEnv(
+      std::vector<InterfaceQueued::AttributePacket> &updatedAttrs) = 0;
 
   /**
 		 * Function that will be called on loop in its separate thread.
@@ -42,8 +43,8 @@ public:
          * The `updatedAttrs` list will not be cleared by the caller in between function calls
          * When this function is called, `updatedAttrs` will include at least one value
 		 */
-  virtual void
-  writeValuesToEnv(std::vector<Interface::AttributePacket> &updatedAttrs) = 0;
+  virtual void writeValuesToEnv(
+      std::vector<InterfaceQueued::AttributePacket> &updatedAttrs) = 0;
 
   /**
          * Open the interface and set up the connection to the environment

--- a/dpsim/include/dpsim/Simulation.h
+++ b/dpsim/include/dpsim/Simulation.h
@@ -247,6 +247,8 @@ public:
   void addLogger(DataLogger::Ptr logger) { mLoggers.push_back(logger); }
   /// Write step time measurements to log file
   void logStepTimes(String logName);
+  /// Check for overruns
+  void checkForOverruns(String logName);
 
   /// Write LU decomposition times measurements to log file
   void logLUTimes();

--- a/dpsim/src/CMakeLists.txt
+++ b/dpsim/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(DPSIM_SOURCES
 	ThreadListScheduler.cpp
 	DiakopticsSolver.cpp
 	Interface.cpp
+	InterfaceQueued.cpp
 )
 
 list(APPEND DPSIM_LIBRARIES

--- a/dpsim/src/Interface.cpp
+++ b/dpsim/src/Interface.cpp
@@ -1,61 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <dpsim/Interface.h>
-#include <dpsim/InterfaceWorker.h>
 
 using namespace CPS;
 
 namespace DPsim {
-
-void Interface::open() {
-  mInterfaceWorker->open();
-  mOpened = true;
-
-  if (!mImportAttrsDpsim.empty()) {
-    mInterfaceReaderThread = std::thread(Interface::ReaderThread(
-        mQueueInterfaceToDpsim, mInterfaceWorker, mOpened));
-  }
-  if (!mExportAttrsDpsim.empty()) {
-    mInterfaceWriterThread = std::thread(
-        Interface::WriterThread(mQueueDpsimToInterface, mInterfaceWorker));
-  }
-}
-
-void Interface::close() {
-  mOpened = false;
-  mQueueDpsimToInterface->emplace(AttributePacket{
-      nullptr, 0, 0, AttributePacketFlags::PACKET_CLOSE_INTERFACE});
-
-  if (!mExportAttrsDpsim.empty()) {
-    mInterfaceWriterThread.join();
-  }
-
-  if (!mImportAttrsDpsim.empty()) {
-    mInterfaceReaderThread.join();
-  }
-  mInterfaceWorker->close();
-}
-
-CPS::Task::List Interface::getTasks() {
-  auto tasks = CPS::Task::List();
-  if (!mImportAttrsDpsim.empty()) {
-    tasks.push_back(std::make_shared<Interface::PreStep>(*this));
-  }
-  if (!mExportAttrsDpsim.empty()) {
-    tasks.push_back(std::make_shared<Interface::PostStep>(*this));
-  }
-  return tasks;
-}
-
-void Interface::PreStep::execute(Real time, Int timeStepCount) {
-  if (timeStepCount % mIntf.mDownsampling == 0)
-    mIntf.popDpsimAttrsFromQueue();
-}
-
-void Interface::PostStep::execute(Real time, Int timeStepCount) {
-  if (timeStepCount % mIntf.mDownsampling == 0)
-    mIntf.pushDpsimAttrsToQueue();
-}
 
 void Interface::addImport(CPS::AttributeBase::Ptr attr, bool blockOnRead,
                           bool syncOnSimulationStart) {
@@ -78,111 +27,6 @@ void Interface::addExport(CPS::AttributeBase::Ptr attr) {
   mExportAttrsDpsim.emplace_back(attr, 0);
 }
 
-void Interface::setLogger(CPS::Logger::Log log) {
-  mLog = log;
-  if (mInterfaceWorker != nullptr) {
-    mInterfaceWorker->mLog = log;
-  }
-}
-
-void Interface::syncImports() {
-  //Block on read until all attributes with syncOnSimulationStart are read
-  this->popDpsimAttrsFromQueue(true);
-}
-
-void Interface::syncExports() {
-  //Just push all the attributes
-  this->pushDpsimAttrsToQueue();
-}
-
-void Interface::popDpsimAttrsFromQueue(bool isSync) {
-  AttributePacket receivedPacket = {nullptr, 0, 0,
-                                    AttributePacketFlags::PACKET_NO_FLAGS};
-  UInt currentSequenceId = mNextSequenceInterfaceToDpsim;
-
-  //Wait for and dequeue all attributes that read should block on
-  //The std::find_if will look for all attributes that have not been updated in the current while loop (i. e. whose sequence ID is lower than the next expected sequence ID)
-  while (std::find_if(mImportAttrsDpsim.cbegin(), mImportAttrsDpsim.cend(),
-                      [currentSequenceId, isSync](auto attrTuple) {
-                        auto &[_attr, seqId, blockOnRead, syncOnStart] =
-                            attrTuple;
-                        if (isSync) {
-                          return syncOnStart && seqId < currentSequenceId;
-                        } else {
-                          return blockOnRead && seqId < currentSequenceId;
-                        }
-                      }) != mImportAttrsDpsim.cend()) {
-    mQueueInterfaceToDpsim->wait_dequeue(receivedPacket);
-    if (!std::get<0>(mImportAttrsDpsim[receivedPacket.attributeId])
-             ->copyValue(receivedPacket.value)) {
-      SPDLOG_LOGGER_WARN(
-          mLog, "Failed to copy received value onto attribute in Interface!");
-    }
-    std::get<1>(mImportAttrsDpsim[receivedPacket.attributeId]) =
-        receivedPacket.sequenceId;
-    mNextSequenceInterfaceToDpsim = receivedPacket.sequenceId + 1;
-  }
-
-  //Fetch all remaining queue packets
-  while (mQueueInterfaceToDpsim->try_dequeue(receivedPacket)) {
-    if (!std::get<0>(mImportAttrsDpsim[receivedPacket.attributeId])
-             ->copyValue(receivedPacket.value)) {
-      SPDLOG_LOGGER_WARN(
-          mLog, "Failed to copy received value onto attribute in Interface!");
-    }
-    std::get<1>(mImportAttrsDpsim[receivedPacket.attributeId]) =
-        receivedPacket.sequenceId;
-    mNextSequenceInterfaceToDpsim = receivedPacket.sequenceId + 1;
-  }
-}
-
-void Interface::pushDpsimAttrsToQueue() {
-  for (UInt i = 0; i < mExportAttrsDpsim.size(); i++) {
-    mQueueDpsimToInterface->emplace(AttributePacket{
-        std::get<0>(mExportAttrsDpsim[i])->cloneValueOntoNewAttribute(), i,
-        std::get<1>(mExportAttrsDpsim[i]),
-        AttributePacketFlags::PACKET_NO_FLAGS});
-    std::get<1>(mExportAttrsDpsim[i]) = mCurrentSequenceDpsimToInterface;
-    mCurrentSequenceDpsimToInterface++;
-  }
-}
-
-void Interface::WriterThread::operator()() const {
-  bool interfaceClosed = false;
-  std::vector<Interface::AttributePacket> attrsToWrite;
-  while (!interfaceClosed) {
-    AttributePacket nextPacket = {nullptr, 0, 0,
-                                  AttributePacketFlags::PACKET_NO_FLAGS};
-
-    //Wait for at least one packet
-    mQueueDpsimToInterface->wait_dequeue(nextPacket);
-    if (nextPacket.flags & AttributePacketFlags::PACKET_CLOSE_INTERFACE) {
-      interfaceClosed = true;
-    } else {
-      attrsToWrite.push_back(nextPacket);
-    }
-
-    //See if there are more packets
-    while (mQueueDpsimToInterface->try_dequeue(nextPacket)) {
-      if (nextPacket.flags & AttributePacketFlags::PACKET_CLOSE_INTERFACE) {
-        interfaceClosed = true;
-      } else {
-        attrsToWrite.push_back(nextPacket);
-      }
-    }
-    mInterfaceWorker->writeValuesToEnv(attrsToWrite);
-  }
-}
-
-void Interface::ReaderThread::operator()() const {
-  std::vector<Interface::AttributePacket> attrsRead;
-  while (mOpened) {
-    mInterfaceWorker->readValuesFromEnv(attrsRead);
-    for (const auto &packet : attrsRead) {
-      mQueueInterfaceToDpsim->enqueue(packet);
-    }
-    attrsRead.clear();
-  }
-}
+void Interface::setLogger(CPS::Logger::Log log) { mLog = log; }
 
 } // namespace DPsim

--- a/dpsim/src/InterfaceQueued.cpp
+++ b/dpsim/src/InterfaceQueued.cpp
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/* Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2023-2024 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-License-Identifier: MPL-2.0
+ */
 
 #include <dpsim/InterfaceQueued.h>
 #include <dpsim/InterfaceWorker.h>
@@ -12,19 +15,16 @@ void InterfaceQueued::open() {
   mOpened = true;
 
   if (!mImportAttrsDpsim.empty()) {
-    mInterfaceReaderThread = std::thread(InterfaceQueued::ReaderThread(
-        mQueueInterfaceToDpsim, mInterfaceWorker, mOpened));
+    mInterfaceReaderThread = std::thread(InterfaceQueued::ReaderThread(mQueueInterfaceToDpsim, mInterfaceWorker, mOpened));
   }
   if (!mExportAttrsDpsim.empty()) {
-    mInterfaceWriterThread = std::thread(InterfaceQueued::WriterThread(
-        mQueueDpsimToInterface, mInterfaceWorker));
+    mInterfaceWriterThread = std::thread(InterfaceQueued::WriterThread(mQueueDpsimToInterface, mInterfaceWorker));
   }
 }
 
 void InterfaceQueued::close() {
   mOpened = false;
-  mQueueDpsimToInterface->emplace(AttributePacket{
-      nullptr, 0, 0, AttributePacketFlags::PACKET_CLOSE_INTERFACE});
+  mQueueDpsimToInterface->emplace(AttributePacket{nullptr, 0, 0, AttributePacketFlags::PACKET_CLOSE_INTERFACE});
 
   if (!mExportAttrsDpsim.empty()) {
     mInterfaceWriterThread.join();
@@ -65,71 +65,58 @@ void InterfaceQueued::setLogger(CPS::Logger::Log log) {
 }
 
 void InterfaceQueued::syncImports() {
-  //Block on read until all attributes with syncOnSimulationStart are read
+  // Block on read until all attributes with syncOnSimulationStart are read
   this->popDpsimAttrsFromQueue(true);
 }
 
 void InterfaceQueued::syncExports() {
-  //Just push all the attributes
+  // Just push all the attributes
   this->pushDpsimAttrsToQueue();
 }
 
 void InterfaceQueued::popDpsimAttrsFromQueue(bool isSync) {
-  AttributePacket receivedPacket = {nullptr, 0, 0,
-                                    AttributePacketFlags::PACKET_NO_FLAGS};
+  AttributePacket receivedPacket = {nullptr, 0, 0, AttributePacketFlags::PACKET_NO_FLAGS};
   UInt currentSequenceId = mNextSequenceInterfaceToDpsim;
 
-  //Wait for and dequeue all attributes that read should block on
-  //The std::find_if will look for all attributes that have not been updated in the current while loop (i. e. whose sequence ID is lower than the next expected sequence ID)
-  while (std::find_if(mImportAttrsDpsim.cbegin(), mImportAttrsDpsim.cend(),
-                      [currentSequenceId, isSync](auto attrTuple) {
-                        auto &[_attr, seqId, blockOnRead, syncOnStart] =
-                            attrTuple;
-                        if (isSync) {
-                          return syncOnStart && seqId < currentSequenceId;
-                        } else {
-                          return blockOnRead && seqId < currentSequenceId;
-                        }
-                      }) != mImportAttrsDpsim.cend()) {
+  // Wait for and dequeue all attributes that read should block on
+  // The std::find_if will look for all attributes that have not been updated in the current while loop (i. e. whose sequence ID is lower than the next expected sequence ID)
+  while (std::find_if(mImportAttrsDpsim.cbegin(), mImportAttrsDpsim.cend(), [currentSequenceId, isSync](auto attrTuple) {
+           auto &[_attr, seqId, blockOnRead, syncOnStart] = attrTuple;
+           if (isSync) {
+             return syncOnStart && seqId < currentSequenceId;
+           } else {
+             return blockOnRead && seqId < currentSequenceId;
+           }
+         }) != mImportAttrsDpsim.cend()) {
     if (mQueueInterfaceToDpsim->try_dequeue(receivedPacket) != false) {
       int i = 0;
       while (mQueueInterfaceToDpsim->try_dequeue(receivedPacket)) {
         i++;
       }
-      SPDLOG_LOGGER_WARN(mLog,
-                         "Overrun detected! Discarding {} overrun packets!", i);
+      SPDLOG_LOGGER_WARN(mLog, "Overrun detected! Discarding {} overrun packets!", i);
     } else {
       mQueueInterfaceToDpsim->wait_dequeue(receivedPacket);
     }
-    if (!std::get<0>(mImportAttrsDpsim[receivedPacket.attributeId])
-             ->copyValue(receivedPacket.value)) {
-      SPDLOG_LOGGER_WARN(
-          mLog, "Failed to copy received value onto attribute in Interface!");
+    if (!std::get<0>(mImportAttrsDpsim[receivedPacket.attributeId])->copyValue(receivedPacket.value)) {
+      SPDLOG_LOGGER_WARN(mLog, "Failed to copy received value onto attribute in Interface!");
     }
-    std::get<1>(mImportAttrsDpsim[receivedPacket.attributeId]) =
-        receivedPacket.sequenceId;
+    std::get<1>(mImportAttrsDpsim[receivedPacket.attributeId]) = receivedPacket.sequenceId;
     mNextSequenceInterfaceToDpsim = receivedPacket.sequenceId + 1;
   }
 
-  //Fetch all remaining queue packets
+  // Fetch all remaining queue packets
   while (mQueueInterfaceToDpsim->try_dequeue(receivedPacket)) {
-    if (!std::get<0>(mImportAttrsDpsim[receivedPacket.attributeId])
-             ->copyValue(receivedPacket.value)) {
-      SPDLOG_LOGGER_WARN(
-          mLog, "Failed to copy received value onto attribute in Interface!");
+    if (!std::get<0>(mImportAttrsDpsim[receivedPacket.attributeId])->copyValue(receivedPacket.value)) {
+      SPDLOG_LOGGER_WARN(mLog, "Failed to copy received value onto attribute in Interface!");
     }
-    std::get<1>(mImportAttrsDpsim[receivedPacket.attributeId]) =
-        receivedPacket.sequenceId;
+    std::get<1>(mImportAttrsDpsim[receivedPacket.attributeId]) = receivedPacket.sequenceId;
     mNextSequenceInterfaceToDpsim = receivedPacket.sequenceId + 1;
   }
 }
 
 void InterfaceQueued::pushDpsimAttrsToQueue() {
   for (UInt i = 0; i < mExportAttrsDpsim.size(); i++) {
-    mQueueDpsimToInterface->emplace(AttributePacket{
-        std::get<0>(mExportAttrsDpsim[i])->cloneValueOntoNewAttribute(), i,
-        std::get<1>(mExportAttrsDpsim[i]),
-        AttributePacketFlags::PACKET_NO_FLAGS});
+    mQueueDpsimToInterface->emplace(AttributePacket{std::get<0>(mExportAttrsDpsim[i])->cloneValueOntoNewAttribute(), i, std::get<1>(mExportAttrsDpsim[i]), AttributePacketFlags::PACKET_NO_FLAGS});
     std::get<1>(mExportAttrsDpsim[i]) = mCurrentSequenceDpsimToInterface;
     mCurrentSequenceDpsimToInterface++;
   }
@@ -139,10 +126,9 @@ void InterfaceQueued::WriterThread::operator()() const {
   bool interfaceClosed = false;
   std::vector<InterfaceQueued::AttributePacket> attrsToWrite;
   while (!interfaceClosed) {
-    AttributePacket nextPacket = {nullptr, 0, 0,
-                                  AttributePacketFlags::PACKET_NO_FLAGS};
+    AttributePacket nextPacket = {nullptr, 0, 0, AttributePacketFlags::PACKET_NO_FLAGS};
 
-    //Wait for at least one packet
+    // Wait for at least one packet
     mQueueDpsimToInterface->wait_dequeue(nextPacket);
     if (nextPacket.flags & AttributePacketFlags::PACKET_CLOSE_INTERFACE) {
       interfaceClosed = true;
@@ -150,7 +136,7 @@ void InterfaceQueued::WriterThread::operator()() const {
       attrsToWrite.push_back(nextPacket);
     }
 
-    //See if there are more packets
+    // See if there are more packets
     while (mQueueDpsimToInterface->try_dequeue(nextPacket)) {
       if (nextPacket.flags & AttributePacketFlags::PACKET_CLOSE_INTERFACE) {
         interfaceClosed = true;

--- a/dpsim/src/InterfaceQueued.cpp
+++ b/dpsim/src/InterfaceQueued.cpp
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <dpsim/InterfaceQueued.h>
+#include <dpsim/InterfaceWorker.h>
+
+using namespace CPS;
+
+namespace DPsim {
+
+void InterfaceQueued::open() {
+  mInterfaceWorker->open();
+  mOpened = true;
+
+  if (!mImportAttrsDpsim.empty()) {
+    mInterfaceReaderThread = std::thread(InterfaceQueued::ReaderThread(
+        mQueueInterfaceToDpsim, mInterfaceWorker, mOpened));
+  }
+  if (!mExportAttrsDpsim.empty()) {
+    mInterfaceWriterThread = std::thread(InterfaceQueued::WriterThread(
+        mQueueDpsimToInterface, mInterfaceWorker));
+  }
+}
+
+void InterfaceQueued::close() {
+  mOpened = false;
+  mQueueDpsimToInterface->emplace(AttributePacket{
+      nullptr, 0, 0, AttributePacketFlags::PACKET_CLOSE_INTERFACE});
+
+  if (!mExportAttrsDpsim.empty()) {
+    mInterfaceWriterThread.join();
+  }
+
+  if (!mImportAttrsDpsim.empty()) {
+    mInterfaceReaderThread.join();
+  }
+  mInterfaceWorker->close();
+}
+
+CPS::Task::List InterfaceQueued::getTasks() {
+  auto tasks = CPS::Task::List();
+  if (!mImportAttrsDpsim.empty()) {
+    tasks.push_back(std::make_shared<InterfaceQueued::PreStep>(*this));
+  }
+  if (!mExportAttrsDpsim.empty()) {
+    tasks.push_back(std::make_shared<InterfaceQueued::PostStep>(*this));
+  }
+  return tasks;
+}
+
+void InterfaceQueued::PreStep::execute(Real time, Int timeStepCount) {
+  if (timeStepCount % mIntf.mDownsampling == 0)
+    mIntf.popDpsimAttrsFromQueue();
+}
+
+void InterfaceQueued::PostStep::execute(Real time, Int timeStepCount) {
+  if (timeStepCount % mIntf.mDownsampling == 0)
+    mIntf.pushDpsimAttrsToQueue();
+}
+
+void InterfaceQueued::setLogger(CPS::Logger::Log log) {
+  Interface::setLogger(log);
+  if (mInterfaceWorker != nullptr) {
+    mInterfaceWorker->mLog = log;
+  }
+}
+
+void InterfaceQueued::syncImports() {
+  //Block on read until all attributes with syncOnSimulationStart are read
+  this->popDpsimAttrsFromQueue(true);
+}
+
+void InterfaceQueued::syncExports() {
+  //Just push all the attributes
+  this->pushDpsimAttrsToQueue();
+}
+
+void InterfaceQueued::popDpsimAttrsFromQueue(bool isSync) {
+  AttributePacket receivedPacket = {nullptr, 0, 0,
+                                    AttributePacketFlags::PACKET_NO_FLAGS};
+  UInt currentSequenceId = mNextSequenceInterfaceToDpsim;
+
+  //Wait for and dequeue all attributes that read should block on
+  //The std::find_if will look for all attributes that have not been updated in the current while loop (i. e. whose sequence ID is lower than the next expected sequence ID)
+  while (std::find_if(mImportAttrsDpsim.cbegin(), mImportAttrsDpsim.cend(),
+                      [currentSequenceId, isSync](auto attrTuple) {
+                        auto &[_attr, seqId, blockOnRead, syncOnStart] =
+                            attrTuple;
+                        if (isSync) {
+                          return syncOnStart && seqId < currentSequenceId;
+                        } else {
+                          return blockOnRead && seqId < currentSequenceId;
+                        }
+                      }) != mImportAttrsDpsim.cend()) {
+    if (mQueueInterfaceToDpsim->try_dequeue(receivedPacket) != false) {
+      int i = 0;
+      while (mQueueInterfaceToDpsim->try_dequeue(receivedPacket)) {
+        i++;
+      }
+      SPDLOG_LOGGER_WARN(mLog,
+                         "Overrun detected! Discarding {} overrun packets!", i);
+    } else {
+      mQueueInterfaceToDpsim->wait_dequeue(receivedPacket);
+    }
+    if (!std::get<0>(mImportAttrsDpsim[receivedPacket.attributeId])
+             ->copyValue(receivedPacket.value)) {
+      SPDLOG_LOGGER_WARN(
+          mLog, "Failed to copy received value onto attribute in Interface!");
+    }
+    std::get<1>(mImportAttrsDpsim[receivedPacket.attributeId]) =
+        receivedPacket.sequenceId;
+    mNextSequenceInterfaceToDpsim = receivedPacket.sequenceId + 1;
+  }
+
+  //Fetch all remaining queue packets
+  while (mQueueInterfaceToDpsim->try_dequeue(receivedPacket)) {
+    if (!std::get<0>(mImportAttrsDpsim[receivedPacket.attributeId])
+             ->copyValue(receivedPacket.value)) {
+      SPDLOG_LOGGER_WARN(
+          mLog, "Failed to copy received value onto attribute in Interface!");
+    }
+    std::get<1>(mImportAttrsDpsim[receivedPacket.attributeId]) =
+        receivedPacket.sequenceId;
+    mNextSequenceInterfaceToDpsim = receivedPacket.sequenceId + 1;
+  }
+}
+
+void InterfaceQueued::pushDpsimAttrsToQueue() {
+  for (UInt i = 0; i < mExportAttrsDpsim.size(); i++) {
+    mQueueDpsimToInterface->emplace(AttributePacket{
+        std::get<0>(mExportAttrsDpsim[i])->cloneValueOntoNewAttribute(), i,
+        std::get<1>(mExportAttrsDpsim[i]),
+        AttributePacketFlags::PACKET_NO_FLAGS});
+    std::get<1>(mExportAttrsDpsim[i]) = mCurrentSequenceDpsimToInterface;
+    mCurrentSequenceDpsimToInterface++;
+  }
+}
+
+void InterfaceQueued::WriterThread::operator()() const {
+  bool interfaceClosed = false;
+  std::vector<InterfaceQueued::AttributePacket> attrsToWrite;
+  while (!interfaceClosed) {
+    AttributePacket nextPacket = {nullptr, 0, 0,
+                                  AttributePacketFlags::PACKET_NO_FLAGS};
+
+    //Wait for at least one packet
+    mQueueDpsimToInterface->wait_dequeue(nextPacket);
+    if (nextPacket.flags & AttributePacketFlags::PACKET_CLOSE_INTERFACE) {
+      interfaceClosed = true;
+    } else {
+      attrsToWrite.push_back(nextPacket);
+    }
+
+    //See if there are more packets
+    while (mQueueDpsimToInterface->try_dequeue(nextPacket)) {
+      if (nextPacket.flags & AttributePacketFlags::PACKET_CLOSE_INTERFACE) {
+        interfaceClosed = true;
+      } else {
+        attrsToWrite.push_back(nextPacket);
+      }
+    }
+    mInterfaceWorker->writeValuesToEnv(attrsToWrite);
+  }
+}
+
+void InterfaceQueued::ReaderThread::operator()() const {
+  std::vector<InterfaceQueued::AttributePacket> attrsRead;
+  while (mOpened) {
+    mInterfaceWorker->readValuesFromEnv(attrsRead);
+    for (const auto &packet : attrsRead) {
+      mQueueInterfaceToDpsim->enqueue(packet);
+    }
+    attrsRead.clear();
+  }
+}
+
+} // namespace DPsim

--- a/dpsim/src/KLUAdapter.cpp
+++ b/dpsim/src/KLUAdapter.cpp
@@ -149,6 +149,8 @@ void KLUAdapter::partialRefactorize(
 }
 
 Matrix KLUAdapter::solve(Matrix &rightSideVector) {
+  // TODO: this calls malloc, which is not allowed in the simulation loop
+  // We should preallocate this buffer.
   Matrix x = rightSideVector;
 
   /* number of right hands sides

--- a/dpsim/src/Simulation.cpp
+++ b/dpsim/src/Simulation.cpp
@@ -202,7 +202,7 @@ void Simulation::prepSchedule() {
     mTasks.push_back(logger->getTask());
   }
   if (!mScheduler) {
-    mScheduler = std::make_shared<SequentialScheduler>();
+    mScheduler = std::make_shared<SequentialScheduler>("taskTimes");
   }
   mScheduler->resolveDeps(mTasks, mTaskInEdges, mTaskOutEdges);
 }
@@ -429,6 +429,21 @@ void Simulation::logStepTimes(String logName) {
   }
   SPDLOG_LOGGER_INFO(mLog, "Average step time: {:.9f}",
                      stepTimeSum / mStepTimes.size());
+}
+
+void Simulation::checkForOverruns(String logName) {
+  auto stepTimeLog = Logger::get(logName, Logger::Level::info);
+  Logger::setLogPattern(stepTimeLog, "%v");
+  stepTimeLog->info("overruns");
+
+  int overruns = 0;
+  for (auto meas : mStepTimes) {
+    if (meas > **mTimeStep) {
+      overruns++;
+      SPDLOG_LOGGER_INFO(mLog, "overrun detected {}: {:.9f}", overruns, meas);
+    }
+  }
+  SPDLOG_LOGGER_INFO(mLog, "Detected {} overruns.", overruns);
 }
 
 void Simulation::logLUTimes() {

--- a/packaging/Docker/Dockerfile.dev
+++ b/packaging/Docker/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM fedora:36 AS base
 
 ARG CIM_VERSION=CGMES_2.4.15_16FEB2016
-ARG VILLAS_VERSION=411b0ad49e2629ad41c6918d2a6c51e9a72220b4
+ARG VILLAS_VERSION=18cdd2a6364d05fbf413ca699616cd324abfcb54
 
 ARG CMAKE_OPTS
 ARG MAKE_OPTS=-j4
@@ -65,7 +65,9 @@ RUN dnf -y install \
 RUN dnf -y install \
 	mosquitto-devel \
 	libconfig-devel \
-	libnl3-devel
+	libnl3-devel \
+	protobuf-devel \
+	protobuf-c-devel
 
 # Python dependencies
 ADD requirements.txt .

--- a/packaging/Docker/Dockerfile.dev-debian
+++ b/packaging/Docker/Dockerfile.dev-debian
@@ -1,7 +1,7 @@
 FROM debian:11
 
 ARG CIM_VERSION=CGMES_2.4.15_16FEB2016
-ARG VILLAS_VERSION=411b0ad49e2629ad41c6918d2a6c51e9a72220b4
+ARG VILLAS_VERSION=18cdd2a6364d05fbf413ca699616cd324abfcb54
 
 ARG CMAKE_OPTS
 ARG MAKE_OPTS=-j4
@@ -59,7 +59,9 @@ RUN apt-get -y install \
 RUN apt-get -y install \
 	libmosquitto-dev \
 	libconfig-dev \
-	libnl-3-dev
+	libnl-3-dev \
+	protobuf-dev \
+	libprotobuf-c-dev
 
 ## Install libiec61850 from source
 RUN cd /tmp && \

--- a/packaging/Docker/Dockerfile.dev-rocky
+++ b/packaging/Docker/Dockerfile.dev-rocky
@@ -116,15 +116,15 @@ RUN cd /tmp && \
 # CIMpp and VILLASnode are installed here
 ENV LD_LIBRARY_PATH="/usr/local/lib64:${LD_LIBRARY_PATH}"
 
-# Python dependencies
-ADD requirements.txt .
-RUN pip3 install -U setuptools
-RUN pip3 install -U wheel
-RUN pip3 install -r requirements.txt
+# # Python dependencies
+# ADD requirements.txt .
+# RUN pip3 install -U setuptools
+# RUN pip3 install -U wheel
+# RUN pip3 install -r requirements.txt
 
-# Remove this part in the future and use dedicated Jupyter Dockerfile
-# Activate Jupyter extensions
-RUN dnf -y --refresh install npm
-RUN pip3 install jupyter jupyter_contrib_nbextensions nbconvert nbformat
+# # Remove this part in the future and use dedicated Jupyter Dockerfile
+# # Activate Jupyter extensions
+# RUN dnf -y --refresh install npm
+# RUN pip3 install jupyter jupyter_contrib_nbextensions nbconvert nbformat
 
 EXPOSE 8888

--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -6,7 +6,7 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
 ARG CIM_VERSION=CGMES_2.4.15_16FEB2016
-ARG VILLAS_VERSION=411b0ad49e2629ad41c6918d2a6c51e9a72220b4
+ARG VILLAS_VERSION=18cdd2a6364d05fbf413ca699616cd324abfcb54
 
 ARG CMAKE_OPTS
 ARG MAKE_OPTS=-j4
@@ -87,7 +87,9 @@ RUN yum install -y \
 	libwebsockets-devel \
 	mosquitto-devel \
 	libconfig-devel \
-	libnl3-devel
+	libnl3-devel \
+	protobuf-devel \
+	protobuf-c-devel
 
 # Install spdlog from source
 RUN cd /tmp && \


### PR DESCRIPTION
 villas interface: improve real-time capability

The original villas interface was not real-time capable because of the queue it uses. This commit creates an interface for villas interfaces, moves the old implementation to InterfaceQueued and adds a new queueless, threadless implementation InterfaceQueueless.


models: Add DC voltage source

The DP_Ph1_VoltageSource always calculates a sinusoidal signal, even if we only want to set a DC value. This commit adds a DC generator for the model so it can be significantly faster if we do not need the sinusoidal signal.

 FpgaExample: use new villas interface and make logging optional.
