### PR TITLE
Trigger actions for PRs and pin the version of libcimpp

### DIFF
--- a/.github/workflows/build_test_linux_fedora.yaml
+++ b/.github/workflows/build_test_linux_fedora.yaml
@@ -2,6 +2,8 @@ name: Build & Test Fedora
 
 on:
   push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 ## Build ##
 

--- a/.github/workflows/build_test_linux_fedora_minimal.yaml
+++ b/.github/workflows/build_test_linux_fedora_minimal.yaml
@@ -2,6 +2,8 @@ name: Build & Test Fedora Minimal
 
 on:
   push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 ## Build ##
 

--- a/.github/workflows/build_test_linux_rocky.yaml
+++ b/.github/workflows/build_test_linux_rocky.yaml
@@ -2,6 +2,8 @@ name: Build & Test RockyLinux
 
 on:
   push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 ## Build ##
 

--- a/.github/workflows/build_test_windows.yaml
+++ b/.github/workflows/build_test_windows.yaml
@@ -2,6 +2,8 @@ name: Build & Test Windows
 
 on:
   push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 ## Build ##
 

--- a/.github/workflows/sonar_cloud.yaml
+++ b/.github/workflows/sonar_cloud.yaml
@@ -6,51 +6,86 @@ on:
     branches:
       - master
   pull_request:
-      types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
+
 jobs:
   sonarcloud:
     name: Prepare and run Sonar Scan
     runs-on: ubuntu-latest
     container: sogno/dpsim:dev
+    outputs:
+      skip: ${{ steps.check-token.outputs.skip }} # Output to indicate if the job was skipped
     env:
-      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
+      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
     steps:
-    - name: Fetch repository
-      uses: actions/checkout@v4
-      with:
-        # Disabling shallow clone is recommended for improving relevancy of reporting
-        fetch-depth: 0
-    - name: Setup Node 20
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20
-    - name: Install sonar-scanner and build-wrapper
-      uses: sonarsource/sonarcloud-github-c-cpp@v2
-    - name: Create Build Folder
-      run: mkdir build
-    - name: Setup build directory cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ github.workspace }}/build
-        key: wrapper-dir-cache-${{ github.ref }}
-    - name: Setup sonar cache
-      uses: actions/cache@v4
-      with:
-        path: |
-          .scannerwork
-          sonar-cache
-        key: sonar-cache-${{ github.ref }}
-    - name: Configure CMake
-      shell: bash
-      working-directory: ${{ github.workspace }}/build
-      run: |
-        cmake -DCIM_VERSION=CGMES_2.4.15_16FEB2016 $GITHUB_WORKSPACE
-    - name: Run build-wrapper
-      run: |
-        build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ -j $(nproc)
-    - name: Run sonar-scanner
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: |
-        sonar-scanner --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json
+      - name: Check for SONAR_TOKEN
+        id: check_token
+        run: |
+          if [ -z "${{ secrets.SONAR_TOKEN }}" ]; then
+            echo "SONAR_TOKEN is not set. Skipping the job."
+            echo "::set-output name=skip::true"
+          else
+            echo "::set-output name=skip::false"
+          fi
+
+      - name: Skip Job if Token is Missing
+        if: steps.check_token.outputs.skip == 'true'
+        run: |
+          echo "Skipping the SonarCloud analysis due to missing SONAR_TOKEN."
+          exit 0
+
+      - name: Fetch repository
+        if: steps.check_token.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 20
+        if: steps.check_token.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install sonar-scanner and build-wrapper
+        if: steps.check_token.outputs.skip != 'true'
+        uses: sonarsource/sonarcloud-github-c-cpp@v2
+
+      - name: Create Build Folder
+        if: steps.check_token.outputs.skip != 'true'
+        run: mkdir build
+
+      - name: Setup build directory cache
+        if: steps.check_token.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/build
+          key: wrapper-dir-cache-${{ github.ref }}
+
+      - name: Setup sonar cache
+        if: steps.check_token.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            .scannerwork
+            sonar-cache
+          key: sonar-cache-${{ github.ref }}
+
+      - name: Configure CMake
+        if: steps.check_token.outputs.skip != 'true'
+        shell: bash
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          cmake -DCIM_VERSION=CGMES_2.4.15_16FEB2016 $GITHUB_WORKSPACE
+
+      - name: Run build-wrapper
+        if: steps.check_token.outputs.skip != 'true'
+        run: |
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ -j $(nproc)
+
+      - name: Run sonar-scanner
+        if: steps.check_token.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          sonar-scanner --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json

--- a/cmake/FetchCIMpp.cmake
+++ b/cmake/FetchCIMpp.cmake
@@ -2,6 +2,11 @@ if(NOT CIM_VERSION)
 	set(CIM_VERSION "CGMES_2.4.15_16FEB2016")
 endif()
 
+# Allow overriding the commit hash externally
+if(NOT DEFINED CIMPP_COMMIT)
+    set(CIMPP_COMMIT "1b11d5c17bedf0ae042628b42ecb4e49df70b2f6") # Default commit
+endif()
+
 message(STATUS "CIM Version: ${CIM_VERSION}")
 
 if(CIM_VERSION STREQUAL "16v29a")
@@ -16,8 +21,8 @@ set(CIMPP_BUILD_DOC OFF)
 include(FetchContent)
 FetchContent_Declare(cimpp-module
 	GIT_REPOSITORY https://github.com/sogno-platform/libcimpp.git
-	GIT_SHALLOW    TRUE
 	GIT_PROGRESS   TRUE
+	GIT_TAG        ${CIMPP_COMMIT}
 )
 
 FetchContent_MakeAvailable(cimpp-module)

--- a/packaging/Docker/Dockerfile.dev
+++ b/packaging/Docker/Dockerfile.dev
@@ -1,6 +1,7 @@
 FROM fedora:36 AS base
 
 ARG CIM_VERSION=CGMES_2.4.15_16FEB2016
+ARG CIMPP_COMMIT=1b11d5c17bedf0ae042628b42ecb4e49df70b2f6
 ARG VILLAS_VERSION=18cdd2a6364d05fbf413ca699616cd324abfcb54
 
 ARG CMAKE_OPTS
@@ -76,8 +77,9 @@ RUN pip3 install -r requirements.txt
 
 # Install CIMpp from source
 RUN cd /tmp && \
-	git clone --recurse-submodules --depth 1 https://github.com/cim-iec/libcimpp.git && \
+	git clone --recurse-submodules https://github.com/cim-iec/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
+	git checkout ${CIMPP_COMMIT} && \
 	cmake ${CMAKE_OPTS} ..\
 		-DBUILD_SHARED_LIBS=ON \
 		-DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 \

--- a/packaging/Docker/Dockerfile.dev-debian
+++ b/packaging/Docker/Dockerfile.dev-debian
@@ -1,6 +1,7 @@
 FROM debian:11
 
 ARG CIM_VERSION=CGMES_2.4.15_16FEB2016
+ARG CIMPP_COMMIT=1b11d5c17bedf0ae042628b42ecb4e49df70b2f6
 ARG VILLAS_VERSION=18cdd2a6364d05fbf413ca699616cd324abfcb54
 
 ARG CMAKE_OPTS
@@ -80,8 +81,9 @@ RUN pip3 install -r requirements.txt
 
 ## Install CIMpp from source
 RUN cd /tmp && \
-	git clone --recurse-submodules --depth 1 https://github.com/cim-iec/libcimpp.git && \
+	git clone --recurse-submodules https://github.com/cim-iec/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
+	git checkout ${CIMPP_COMMIT} && \
 	cmake ${CMAKE_OPTS} .. \
 		-DBUILD_SHARED_LIBS=ON \
 		-DCMAKE_INSTALL_LIBDIR=/usr/local/lib \

--- a/packaging/Docker/Dockerfile.dev-rocky
+++ b/packaging/Docker/Dockerfile.dev-rocky
@@ -1,6 +1,7 @@
 FROM rockylinux:9
 
 ARG CIM_VERSION=CGMES_2.4.15_16FEB2016
+ARG CIMPP_COMMIT=1b11d5c17bedf0ae042628b42ecb4e49df70b2f6
 
 ARG CMAKE_OPTS
 ARG MAKE_OPTS=-j4
@@ -93,6 +94,7 @@ RUN pip3 install gprof2dot
 RUN cd /tmp && \
 	git clone --recurse-submodules https://github.com/cim-iec/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
+	git checkout ${CIMPP_COMMIT} && \
 	cmake ${CMAKE_OPTS} ..\
 		-DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 \
 		-DUSE_CIM_VERSION=${CIM_VERSION} \

--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -6,6 +6,7 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
 ARG CIM_VERSION=CGMES_2.4.15_16FEB2016
+ARG CIMPP_COMMIT=1b11d5c17bedf0ae042628b42ecb4e49df70b2f6
 ARG VILLAS_VERSION=18cdd2a6364d05fbf413ca699616cd324abfcb54
 
 ARG CMAKE_OPTS
@@ -52,7 +53,7 @@ RUN dnf -y debuginfo-install \
 
 # Build & Install sundials
 RUN cd /tmp && \
-	git clone --branch v3.2.1 --recurse-submodules --depth 1 https://github.com/LLNL/sundials.git && \
+	git clone --branch v3.2.1 --recurse-submodules https://github.com/LLNL/sundials.git && \
 	mkdir -p sundials/build && cd sundials/build && \
 	cmake ${CMAKE_OPTS} .. \
 		-DCMAKE_BUILD_TYPE=Release && \
@@ -68,8 +69,9 @@ RUN pip3 install -r requirements-manylinux.txt
 
 # Install CIMpp from source
 RUN cd /tmp && \
-	git clone --recurse-submodules --depth 1 https://github.com/cim-iec/libcimpp.git && \
+	git clone --recurse-submodules https://github.com/cim-iec/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
+	git checkout ${CIMPP_COMMIT} && \
 	cmake ${CMAKE_OPTS} .. \
 		-DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 \
 		-DUSE_CIM_VERSION=${CIM_VERSION} \


### PR DESCRIPTION
- Since we work now mainly from forks, I extended the actions triggered `on: push` to be additionally triggered `on: pull_request`. Activity types set to `types: [opened, synchronize, reopened]`. For more details see [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request). An optimised version of this is to additionally prevent feature branches to trigger on push when they already have a PR: `on: [push, pull_request]`
- Pin the version of libcimpp to avoid failure of windows workflow caused by [sogno-platform/libcimpp#29](https://github.com/sogno-platform/libcimpp/pull/29).