### PR TITLE
Fix submodule initialization for CIMpp in Dockerfiles.

### DIFF
--- a/packaging/Docker/Dockerfile.dev
+++ b/packaging/Docker/Dockerfile.dev
@@ -77,9 +77,10 @@ RUN pip3 install -r requirements.txt
 
 # Install CIMpp from source
 RUN cd /tmp && \
-	git clone --recurse-submodules https://github.com/cim-iec/libcimpp.git && \
+	git clone https://github.com/cim-iec/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
 	git checkout ${CIMPP_COMMIT} && \
+	git submodule update --init && \
 	cmake ${CMAKE_OPTS} ..\
 		-DBUILD_SHARED_LIBS=ON \
 		-DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 \

--- a/packaging/Docker/Dockerfile.dev
+++ b/packaging/Docker/Dockerfile.dev
@@ -77,7 +77,7 @@ RUN pip3 install -r requirements.txt
 
 # Install CIMpp from source
 RUN cd /tmp && \
-	git clone https://github.com/cim-iec/libcimpp.git && \
+	git clone https://github.com/sogno-platform/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
 	git checkout ${CIMPP_COMMIT} && \
 	git submodule update --init && \

--- a/packaging/Docker/Dockerfile.dev-debian
+++ b/packaging/Docker/Dockerfile.dev-debian
@@ -81,9 +81,10 @@ RUN pip3 install -r requirements.txt
 
 ## Install CIMpp from source
 RUN cd /tmp && \
-	git clone --recurse-submodules https://github.com/cim-iec/libcimpp.git && \
+	git clone https://github.com/cim-iec/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
 	git checkout ${CIMPP_COMMIT} && \
+	git submodule update --init && \
 	cmake ${CMAKE_OPTS} .. \
 		-DBUILD_SHARED_LIBS=ON \
 		-DCMAKE_INSTALL_LIBDIR=/usr/local/lib \

--- a/packaging/Docker/Dockerfile.dev-debian
+++ b/packaging/Docker/Dockerfile.dev-debian
@@ -81,7 +81,7 @@ RUN pip3 install -r requirements.txt
 
 ## Install CIMpp from source
 RUN cd /tmp && \
-	git clone https://github.com/cim-iec/libcimpp.git && \
+	git clone https://github.com/sogno-platform/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
 	git checkout ${CIMPP_COMMIT} && \
 	git submodule update --init && \

--- a/packaging/Docker/Dockerfile.dev-rocky
+++ b/packaging/Docker/Dockerfile.dev-rocky
@@ -92,9 +92,10 @@ RUN pip3 install gprof2dot
 
 # Install CIMpp from source
 RUN cd /tmp && \
-	git clone --recurse-submodules https://github.com/cim-iec/libcimpp.git && \
+	git clone https://github.com/cim-iec/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
 	git checkout ${CIMPP_COMMIT} && \
+	git submodule update --init && \
 	cmake ${CMAKE_OPTS} ..\
 		-DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 \
 		-DUSE_CIM_VERSION=${CIM_VERSION} \

--- a/packaging/Docker/Dockerfile.dev-rocky
+++ b/packaging/Docker/Dockerfile.dev-rocky
@@ -92,7 +92,7 @@ RUN pip3 install gprof2dot
 
 # Install CIMpp from source
 RUN cd /tmp && \
-	git clone https://github.com/cim-iec/libcimpp.git && \
+	git clone https://github.com/sogno-platform/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
 	git checkout ${CIMPP_COMMIT} && \
 	git submodule update --init && \

--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -69,7 +69,7 @@ RUN pip3 install -r requirements-manylinux.txt
 
 # Install CIMpp from source
 RUN cd /tmp && \
-	git clone https://github.com/cim-iec/libcimpp.git && \
+	git clone https://github.com/sogno-platform/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
 	git checkout ${CIMPP_COMMIT} && \
 	git submodule update --init && \

--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -69,9 +69,10 @@ RUN pip3 install -r requirements-manylinux.txt
 
 # Install CIMpp from source
 RUN cd /tmp && \
-	git clone --recurse-submodules https://github.com/cim-iec/libcimpp.git && \
+	git clone https://github.com/cim-iec/libcimpp.git && \
 	mkdir -p libcimpp/build && cd libcimpp/build && \
 	git checkout ${CIMPP_COMMIT} && \
+	git submodule update --init && \
 	cmake ${CMAKE_OPTS} .. \
 		-DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 \
 		-DUSE_CIM_VERSION=${CIM_VERSION} \


### PR DESCRIPTION
This PR fixes the building process of CIMpp in the Docker files. Since we are now checking out a specific commit of this library, we need to make sure that the git submodules are updated after the checkout.