### PR TITLE
Allow builds without nlohmann/json library

### DIFF
--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -64,7 +64,6 @@ set(CIRCUIT_SOURCES
 	Circuits/DP_SynGenTrStab_SMIB_Fault.cpp
 	Circuits/EMT_SynGenDQ7odTrapez_SMIB_Fault.cpp
 	Circuits/EMT_SynGenDQ7odTrapez_OperationalParams_SMIB_Fault.cpp
-	Circuits/EMT_SynGenDQ7odTrapez_OperationalParams_SMIB_Fault_JsonSyngenParams.cpp
 	Circuits/EMT_SynGenDQ7odTrapez_DP_SynGenTrStab_SMIB_Fault.cpp
 	Circuits/EMT_SynGenTrStab_SMIB_Fault.cpp
 	Circuits/SP_SynGenTrStab_SMIB_Fault_KundurExample1.cpp
@@ -92,6 +91,12 @@ set(CIRCUIT_SOURCES
 	Circuits/SP_SynGenTrStab_3Bus_Fault.cpp
 
 )
+
+if(WITH_JSON)
+	list(APPEND CIRCUIT_SOURCES
+		Circuits/EMT_SynGenDQ7odTrapez_OperationalParams_SMIB_Fault_JsonSyngenParams.cpp
+	)
+endif()
 
 set(SYNCGEN_SOURCES
 	Components/DP_SynGenDq7odTrapez_SteadyState.cpp

--- a/dpsim/include/dpsim/Config.h.in
+++ b/dpsim/include/dpsim/Config.h.in
@@ -29,6 +29,7 @@
 #cmakedefine WITH_MAGMA
 #cmakedefine WITH_KLU
 #cmakedefine WITH_MNASOLVERPLUGIN
+#cmakedefine WITH_JSON
 #cmakedefine CGMES_BUILD
 
 #cmakedefine HAVE_GETOPT

--- a/dpsim/include/dpsim/Simulation.h
+++ b/dpsim/include/dpsim/Simulation.h
@@ -16,13 +16,10 @@
 #include <dpsim/Interface.h>
 #include <dpsim/Scheduler.h>
 #include <dpsim/Solver.h>
-#include <nlohmann/json.hpp>
 
 #ifdef WITH_GRAPHVIZ
 #include <dpsim-models/Graph.h>
 #endif
-
-using json = nlohmann::json;
 
 namespace DPsim {
 /// Forward declaration of CommandLineArgs from Utils

--- a/dpsim/include/dpsim/Utils.h
+++ b/dpsim/include/dpsim/Utils.h
@@ -17,7 +17,6 @@
 
 #include <cstdlib>
 #include <list>
-#include <nlohmann/json.hpp>
 #include <vector>
 
 #include <dpsim-models/Components.h>
@@ -28,7 +27,10 @@
 #include <dpsim/Solver.h>
 #include <dpsim/Timer.h>
 
+#ifdef WITH_JSON
+#include <nlohmann/json.hpp>
 using json = nlohmann::json;
+#endif
 
 namespace DPsim {
 
@@ -133,10 +135,12 @@ public:
 
 namespace Utils {
 
+#ifdef WITH_JSON
 void applySimulationParametersFromJson(const json config, Simulation &sim);
 void applySynchronousGeneratorParametersFromJson(
     const json config,
     std::shared_ptr<CPS::EMT::Ph3::SynchronGeneratorDQ> syngen);
+#endif
 
 String encodeXml(String &data);
 

--- a/dpsim/src/Utils.cpp
+++ b/dpsim/src/Utils.cpp
@@ -427,6 +427,7 @@ std::list<fs::path> DPsim::Utils::findFiles(std::list<fs::path> filennames,
   return foundnames;
 }
 
+#ifdef WITH_JSON
 void DPsim::Utils::applySimulationParametersFromJson(const json config,
                                                      Simulation &sim) {
   if (config.contains("timestep"))
@@ -451,3 +452,4 @@ void DPsim::Utils::applySynchronousGeneratorParametersFromJson(
       syngen->applyParametersOperationalPerUnit();
   }
 }
+#endif

--- a/dpsim/src/pybind/EMTComponents.cpp
+++ b/dpsim/src/pybind/EMTComponents.cpp
@@ -14,6 +14,11 @@
 #include <dpsim/pybind/EMTComponents.h>
 #include <dpsim/pybind/Utils.h>
 
+#ifdef WITH_JSON
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+#endif
+
 namespace py = pybind11;
 using namespace pybind11::literals;
 
@@ -253,12 +258,14 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
            "Llkq2"_a, "inertia"_a, "init_active_power"_a,
            "init_reactive_power"_a, "init_terminal_volt"_a, "init_volt_angle"_a,
            "init_mech_power"_a)
+#ifdef WITH_JSON
       .def("apply_parameters_from_json",
            [](std::shared_ptr<CPS::EMT::Ph3::SynchronGeneratorDQTrapez> syngen,
               const CPS::String json) {
              DPsim::Utils::applySynchronousGeneratorParametersFromJson(
                  json::parse(json), syngen);
            })
+#endif
       .def("set_initial_values",
            &CPS::EMT::Ph3::SynchronGeneratorDQTrapez::setInitialValues,
            "init_active_power"_a, "init_reactive_power"_a,
@@ -379,12 +386,14 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
            "Llkq2"_a, "inertia"_a, "init_active_power"_a,
            "init_reactive_power"_a, "init_terminal_volt"_a, "init_volt_angle"_a,
            "init_mech_power"_a)
+#ifdef WITH_JSON
       .def("apply_parameters_from_json",
            [](std::shared_ptr<CPS::EMT::Ph3::SynchronGeneratorDQODE> syngen,
               const CPS::String json) {
              DPsim::Utils::applySynchronousGeneratorParametersFromJson(
                  json::parse(json), syngen);
            })
+#endif
       .def("set_initial_values",
            &CPS::EMT::Ph3::SynchronGeneratorDQODE::setInitialValues,
            "init_active_power"_a, "init_reactive_power"_a,


### PR DESCRIPTION
We actually depend in a very few places on this library.

Lets make it optional.

Depends on #342 to be merged first.