### PR TITLE
feat(ci): Use trusted / OIDC publishing to PyPi.org

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -52,6 +52,7 @@ jobs:
   publish:
     name: Publish wheels and source distribution to PyPI
     runs-on: ubuntu-24.04
+    if: github.event_name == 'push'
     permissions:
       id-token: write
     needs:

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -52,6 +52,8 @@ jobs:
   publish:
     name: Publish wheels and source distribution to PyPI
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
     needs:
     - build-wheels
     - build-sdist
@@ -67,12 +69,9 @@ jobs:
     - name: Publish distribution to Test PyPI
       uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
 
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1.12.4
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -30,23 +30,29 @@ jobs:
         path: dist/
 
   build-wheels:
-    name: Build DPsim wheels
+    name: Build DPsim Python wheel
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        platform: [manylinux_x86_64]
+        python: [cp39, cp310, cp311, cp312, cp313]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:
         submodules: recursive
 
-    - name: Build DPsim wheels for all supported Python versions
+    - name: Build wheel
       uses: pypa/cibuildwheel@v2.23.2
+      env:
+        CIBW_BUILD: "${{ matrix.python }}-${{ matrix.platform }}"
       with:
         output-dir: dist
 
-    - name: Archive Python wheels
+    - name: Upload wheel as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: dist-wheels
+        name: dist-wheels-${{ matrix.python }}-${{ matrix.platform }}
         path: dist/
 
   publish:
@@ -60,7 +66,7 @@ jobs:
     - build-sdist
 
     steps:
-    - name: Download artifacts from build jobs
+    - name: Download wheels from build jobs
       uses: actions/download-artifact@v4
       with:
         pattern: dist-*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,9 @@ requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build-verbosity = "3"
-build = "[cp]p3{8,9,10,11}-manylinux_x86_64"
+build-verbosity = 3
+build = "cp3{9,10,11,12,13}-manylinux_x86_64"
 manylinux-x86_64-image = "sogno/dpsim:manylinux"
-manylinux-pypy_x86_64-image = "sogno/dpsim:manylinux"
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]


### PR DESCRIPTION
See: https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing

Closes #367, #366