### PR TITLE
Upgrade Fedora dockerfiles to v42

### DIFF
--- a/dpsim-models/src/SystemTopology.cpp
+++ b/dpsim-models/src/SystemTopology.cpp
@@ -244,9 +244,12 @@ void SystemTopology::reset() {
 }
 
 void SystemTopology::removeComponent(const String &name) {
-  for (auto it = mComponents.begin(); it != mComponents.end(); ++it) {
+  for (auto it = mComponents.begin(); it != mComponents.end();) {
     if ((*it)->name() == name) {
-      mComponents.erase(it);
+      it = mComponents.erase(
+          it); // safe: returns next valid iterator when erasing
+    } else {
+      ++it;
     }
   }
 }

--- a/dpsim/include/dpsim/Timer.h
+++ b/dpsim/include/dpsim/Timer.h
@@ -10,6 +10,7 @@
 
 #include <chrono>
 
+#include <dpsim-models/Logger.h>
 #include <dpsim/Config.h>
 
 namespace DPsim {
@@ -42,10 +43,15 @@ protected:
   long long mTicks;
   int mFlags;
 
+  /// Timer log level
+  CPS::Logger::Level mLogLevel;
+  /// Logger
+  CPS::Logger::Log mSLog;
+
 public:
   enum Flags : int { fail_on_overrun = 1 };
 
-  Timer(int flags = 0);
+  Timer(int flags = 0, CPS::Logger::Level logLevel = CPS::Logger::Level::debug);
 
   ~Timer();
 

--- a/dpsim/src/KLUAdapter.cpp
+++ b/dpsim/src/KLUAdapter.cpp
@@ -62,9 +62,22 @@ void KLUAdapter::preprocessing(
   }
 
   // This call also works if mVaryingColumns, mVaryingRows are empty
-  mSymbolic =
-      klu_analyze_partial(n, Ap, Ai, &mVaryingColumns[0], &mVaryingRows[0],
-                          varying_entries, mPreordering, &mCommon);
+  int *colPtr = mVaryingColumns.empty() ? nullptr : &mVaryingColumns[0];
+  int *rowPtr = mVaryingRows.empty() ? nullptr : &mVaryingRows[0];
+
+  mSymbolic = klu_analyze_partial(n, Ap, Ai, colPtr, rowPtr, varying_entries,
+                                  mPreordering, &mCommon);
+
+  if (mVaryingColumns.empty()) {
+    SPDLOG_LOGGER_INFO(
+        mSLog,
+        "KLUAdapter: No variable COLUMN entries passed to klu_analyze_partial");
+  }
+  if (mVaryingRows.empty()) {
+    SPDLOG_LOGGER_INFO(
+        mSLog,
+        "KLUAdapter: No variable ROW entries passed to klu_analyze_partial");
+  }
 
   /* Store non-zero value of current preprocessed matrix. only used until
    * to-do in refactorize-function is resolved. Can be removed then.

--- a/dpsim/src/Timer.cpp
+++ b/dpsim/src/Timer.cpp
@@ -35,7 +35,11 @@ Timer::Timer(int flags)
 
 Timer::~Timer() {
   if (mState == State::running)
-    stop();
+    try {
+      stop();
+    } catch (SystemError &e) {
+      std::cerr << "ERROR: The timer was not stopped properly: " << std::endl;
+    }
 
 #ifdef HAVE_TIMERFD
   close(mTimerFd);

--- a/dpsim/src/Timer.cpp
+++ b/dpsim/src/Timer.cpp
@@ -23,6 +23,7 @@ using CPS::SystemError;
 Timer::Timer(int flags, CPS::Logger::Level logLevel)
     : mState(stopped), mOverruns(0), mTicks(0), mFlags(flags),
       mLogLevel(logLevel) {
+  mSLog = CPS::Logger::get("Timer");
 #ifdef HAVE_TIMERFD
   mTimerFd = timerfd_create(CLOCK_MONOTONIC, 0);
   if (mTimerFd < 0) {

--- a/packaging/Docker/Dockerfile
+++ b/packaging/Docker/Dockerfile
@@ -4,10 +4,10 @@ ARG BASE_IMAGE=sogno/dpsim:dev
 FROM ${BASE_IMAGE}
 
 LABEL \
-	org.opencontainers.image.title = "DPsim" \
-	org.opencontainers.image.licenses = "MPL 2.0" \
-	org.opencontainers.image.url = "http://dpsim.fein-aachen.org/" \
-	org.opencontainers.image.source = "https://github.com/sogno-platform/dpsim"
+	org.opencontainers.image.title="DPsim" \
+	org.opencontainers.image.licenses="MPL 2.0" \
+	org.opencontainers.image.url="http://dpsim.fein-aachen.org/" \
+	org.opencontainers.image.source="https://github.com/sogno-platform/dpsim"
 
 COPY . /dpsim/
 RUN rm -rf /dpsim/build && mkdir /dpsim/build

--- a/packaging/Docker/Dockerfile.dev
+++ b/packaging/Docker/Dockerfile.dev
@@ -71,7 +71,8 @@ RUN dnf -y install \
 	libconfig-devel \
 	libnl3-devel \
 	protobuf-devel \
-	protobuf-c-devel
+	protobuf-c-devel \
+	libre-devel
 
 # Python dependencies
 COPY requirements.txt .

--- a/packaging/Docker/Dockerfile.dev
+++ b/packaging/Docker/Dockerfile.dev
@@ -1,8 +1,8 @@
-FROM fedora:36 AS base
+FROM fedora:42 AS base
 
 ARG CIM_VERSION=CGMES_2.4.15_16FEB2016
 ARG CIMPP_COMMIT=1b11d5c17bedf0ae042628b42ecb4e49df70b2f6
-ARG VILLAS_VERSION=18cdd2a6364d05fbf413ca699616cd324abfcb54
+ARG VILLAS_VERSION=825237cb11f687169a9455ecaa97b5dc6cbce26e
 
 ARG CMAKE_OPTS
 ARG MAKE_OPTS=-j4
@@ -22,7 +22,10 @@ RUN dnf -y install \
 	rpmdevtools rpm-build \
 	make cmake pkgconfig \
 	python3-pip \
-	cppcheck
+	cppcheck \
+	flex bison \
+	protobuf-compiler protobuf-c-compiler \
+	clang-tools-extra
 
 # Tools needed for developement
 RUN dnf -y install \
@@ -71,9 +74,8 @@ RUN dnf -y install \
 	protobuf-c-devel
 
 # Python dependencies
-ADD requirements.txt .
-RUN pip3 install --upgrade wheel build setuptools packaging
-RUN pip3 install -r requirements.txt
+COPY requirements.txt .
+RUN pip3 install --upgrade wheel build setuptools packaging && pip3 install -r requirements.txt
 
 # Install CIMpp from source
 RUN cd /tmp && \
@@ -89,14 +91,14 @@ RUN cd /tmp && \
 	make ${MAKE_OPTS} install && \
 	rm -rf /tmp/libcimpp
 
-# Install VILLASnode from source
+# Install VILLASnode from source (with fpga support)
 RUN cd /tmp && \
 	git clone --recurse-submodules https://github.com/VILLASframework/node.git villas-node && \
 	mkdir -p villas-node/build && cd villas-node/build && \
 	git checkout ${VILLAS_VERSION} && \
 	cmake ${CMAKE_OPTS} .. \
 		-DCMAKE_INSTALL_LIBDIR=/usr/local/lib64 \
-		-DDOWNLOAD_GO=OFF && \
+		-DCMAKE_BUILD_TYPE=Release && \
 	make ${MAKE_OPTS} install && \
 	rm -rf /tmp/villas-node
 

--- a/packaging/Docker/Dockerfile.dev-minimal
+++ b/packaging/Docker/Dockerfile.dev-minimal
@@ -1,10 +1,10 @@
-FROM fedora:36
+FROM fedora:42
 
 LABEL \
-	org.opencontainers.image.title = "DPsim" \
-	org.opencontainers.image.licenses = "MPL 2.0" \
-	org.opencontainers.image.url = "http://dpsim.fein-aachen.org/" \
-	org.opencontainers.image.source = "https://github.com/sogno-platform/dpsim"
+	org.opencontainers.image.title="DPsim" \
+	org.opencontainers.image.licenses="MPL 2.0" \
+	org.opencontainers.image.url="http://dpsim.fein-aachen.org/" \
+	org.opencontainers.image.source="https://github.com/sogno-platform/dpsim"
 
 RUN dnf -y update
 
@@ -22,8 +22,7 @@ RUN dnf --refresh -y install \
 	spdlog-devel
 
 # Python dependencies
-ADD requirements.txt .
-RUN pip3 install --upgrade wheel build setuptools packaging
-RUN pip3 install -r requirements.txt
+COPY requirements.txt .
+RUN pip3 install --upgrade wheel build setuptools packaging && pip3 install -r requirements.txt
 
 EXPOSE 8888


### PR DESCRIPTION
This upgrades the versions of Fedora based containers to 42, with the newest villas version.

This gave me a few extra work:

- Catch exception throw in destructor of Timer
- Add logger to Timer
- Fix iterator when deleting components
- Avoid accessing empty vectors in KLUAdapter when checking for path in partial refactorization

This solves #371