### PR TITLE
Reduce attributes number

### DIFF
--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Transformer.h
@@ -15,11 +15,13 @@ namespace CPS {
 namespace Base {
 namespace Ph1 {
 class Transformer {
-public:
+protected:
   /// Nominal voltage of primary side
-  const Attribute<Real>::Ptr mNominalVoltageEnd1;
+  Real mNominalVoltageEnd1;
   /// Nominal voltage of secondary side
-  const Attribute<Real>::Ptr mNominalVoltageEnd2;
+  Real mNominalVoltageEnd2;
+
+public:
   /// Rated Apparent Power [VA]
   const Attribute<Real>::Ptr mRatedPower;
   /// Complex transformer ratio
@@ -30,20 +32,16 @@ public:
   const Attribute<Real>::Ptr mInductance;
 
   explicit Transformer(CPS::AttributeList::Ptr attributeList)
-      : mNominalVoltageEnd1(
-            attributeList->create<Real>("nominal_voltage_end1")),
-        mNominalVoltageEnd2(
-            attributeList->create<Real>("nominal_voltage_end2")),
-        mRatedPower(attributeList->create<Real>("S")),
+      : mRatedPower(attributeList->create<Real>("S")),
         mRatio(attributeList->create<Complex>("ratio")),
         mResistance(attributeList->create<Real>("R")),
-        mInductance(attributeList->create<Real>("L")){};
+        mInductance(attributeList->create<Real>("L")) {};
 
   ///
   void setParameters(Real nomVoltageEnd1, Real nomVoltageEnd2, Real ratioAbs,
                      Real ratioPhase, Real resistance, Real inductance) {
-    **mNominalVoltageEnd1 = nomVoltageEnd1;
-    **mNominalVoltageEnd2 = nomVoltageEnd2;
+    mNominalVoltageEnd1 = nomVoltageEnd1;
+    mNominalVoltageEnd2 = nomVoltageEnd2;
     **mRatio = std::polar<Real>(ratioAbs, ratioPhase);
     **mResistance = resistance;
     **mInductance = inductance;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Transformer.h
@@ -35,7 +35,7 @@ public:
       : mRatedPower(attributeList->create<Real>("S")),
         mRatio(attributeList->create<Complex>("ratio")),
         mResistance(attributeList->create<Real>("R")),
-        mInductance(attributeList->create<Real>("L")) {};
+        mInductance(attributeList->create<Real>("L")){};
 
   ///
   void setParameters(Real nomVoltageEnd1, Real nomVoltageEnd2, Real ratioAbs,

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_AvVoltageSourceInverterDQ.h
@@ -28,6 +28,7 @@ class AvVoltageSourceInverterDQ
 private:
   /// Nominal voltage
   Real mVnom;
+
 protected:
   // ### General Parameters ###
   /// Nominal system angle

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_AvVoltageSourceInverterDQ.h
@@ -25,6 +25,9 @@ class AvVoltageSourceInverterDQ
     : public CompositePowerComp<Complex>,
       public Base::AvVoltageSourceInverterDQ,
       public SharedFactory<AvVoltageSourceInverterDQ> {
+private:
+  /// Nominal voltage
+  Real mVnom;
 protected:
   // ### General Parameters ###
   /// Nominal system angle
@@ -65,8 +68,6 @@ public:
   // ### General Parameters ###
   /// Nominal frequency
   const Attribute<Real>::Ptr mOmegaN;
-  /// Nominal voltage
-  const Attribute<Real>::Ptr mVnom;
   /// Active power reference
   const Attribute<Real>::Ptr mPref;
   /// Reactive power reference
@@ -126,6 +127,10 @@ public:
                              Real phi_qInit, Real gamma_dInit,
                              Real gamma_qInit);
   void withControl(Bool controlOn) { mWithControl = controlOn; };
+
+  // #### Powerflow section ####
+  /// Get nominal voltage
+  Real getNomVoltage() const;
 
   // #### MNA section ####
   /// Initializes internal variables of the component

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Load.h
@@ -25,8 +25,6 @@ class Load : public CompositePowerComp<Complex>,
              public SharedFactory<Load>,
              public PFSolverInterfaceBus {
 public:
-  /// Nominal voltage [V]
-  const Attribute<Real>::Ptr mNomVoltage;
   /// Active power [Watt]
   const Attribute<Real>::Ptr mActivePower;
   /// Reactive power [VAr]
@@ -37,6 +35,8 @@ public:
   const Attribute<Real>::Ptr mReactivePowerPerUnit;
 
 private:
+  /// Nominal voltage [V]
+  Real mNomVoltage;
   /// base apparent power[VA]
   Real mBaseApparentPower;
   ///base omega [1/s]
@@ -79,6 +79,8 @@ public:
   void updatePQ(Real time);
 
   // #### Powerflow section ####
+  /// Get nominal voltage
+  Real getNomVoltage() const;
   /// Calculates component's parameters in specified per-unit system
   void calculatePerUnitParameters(Real baseApparentPower, Real baseOmega);
   /// Modify powerflow bus type

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_NetworkInjection.h
@@ -39,7 +39,7 @@ private:
 
   // #### Powerflow section ####
   /// Base voltage [V]
-  const Attribute<Real>::Ptr mBaseVoltage;
+  Real mBaseVoltage;
 
 public:
   const Attribute<Complex>::Ptr mVoltageRef;
@@ -71,6 +71,8 @@ public:
   // #### Powerflow section ####
   /// Set parameters relevant for PF solver
   void setParameters(Real vSetPointPerUnit);
+  // Get base voltage
+  Real getBaseVoltage() const;
   /// Set base voltage
   void setBaseVoltage(Real baseVoltage);
   /// Calculates component's parameters in specified per-unit system

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
@@ -28,10 +28,11 @@ class PiLine : public CompositePowerComp<Complex>,
                public MNATearInterface,
                public SharedFactory<PiLine>,
                public PFSolverInterfaceBranch {
-public:
-  ///base voltage [V]
-  const Attribute<Real>::Ptr mBaseVoltage;
+private:
+  /// base voltage [V]
+  Real mBaseVoltage;
 
+public:
   // #### Power flow results ####
   /// branch Current flow [A], coef(0) has data from node 0, coef(1) from node 1.
   const Attribute<MatrixComp>::Ptr mCurrent;
@@ -106,6 +107,8 @@ public:
   void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### Powerflow section ####
+  /// Get base voltage
+  Real getBaseVoltage() const;
   /// Set base voltage
   void setBaseVoltage(Real baseVoltage);
   /// Calculates component's parameters in specified per-unit system

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
@@ -22,6 +22,10 @@ class RXLine : public CompositePowerComp<Complex>,
                public SharedFactory<RXLine>,
                public PFSolverInterfaceBranch,
                public Base::Ph1::PiLine {
+private:
+  ///base voltage [V]
+  Real mBaseVoltage;
+
 protected:
   /// CHECK: Which of these really need to be member variables?
   ///Capacitance of the line in [F]
@@ -59,8 +63,6 @@ protected:
   std::shared_ptr<Resistor> mInitialResistor;
 
 public:
-  ///base voltage [V]
-  const Attribute<Real>::Ptr mBaseVoltage;
   ///Inductance of the line in [H]
   /// CHECK: Why does this not use the base class' attribute mSeriesInd?
   const Attribute<Real>::Ptr mInductance;
@@ -100,9 +102,10 @@ public:
   void transformParametersToPerUnitSystem();
 
   // #### Powerflow section ####
+  /// Get base voltage
+  Real getBaseVoltage() const;
   /// Stamps admittance matrix
   void pfApplyAdmittanceMatrixStamp(SparseMatrixCompRow &Y) override;
-
   /// updates branch current and power flow, input pu value, update with real value
   void updateBranchFlow(VectorComp &current, VectorComp &powerflow);
   /// stores nodal injection power in this line object

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
@@ -20,6 +20,8 @@ class SynchronGenerator : public SimPowerComp<Complex>,
                           public SharedFactory<SynchronGenerator>,
                           public PFSolverInterfaceBus {
 private:
+  /// Base voltage [V]
+  Real mBaseVoltage;
   /// Base apparent power[VA]
   Real mBaseApparentPower;
 
@@ -30,8 +32,6 @@ public:
   const Attribute<Real>::Ptr mSetPointReactivePower;
   /// Voltage set point of the machine [V]
   const Attribute<Real>::Ptr mSetPointVoltage;
-  /// Base voltage [V]
-  const Attribute<Real>::Ptr mBaseVoltage;
   /// Active power set point of the machine [pu]
   const Attribute<Real>::Ptr mSetPointActivePowerPerUnit;
   /// Reactive power set point of the machine [pu]
@@ -51,6 +51,7 @@ public:
                      PowerflowBusType powerflowBusType,
                      Real setPointReactivepower = 0);
   // #### Powerflow section ####
+  Real getBaseVoltage() const;
   /// Set base voltage
   void setBaseVoltage(Real baseVoltage);
   /// Initializes component from power flow data

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Transformer.h
@@ -134,7 +134,10 @@ public:
   void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### Powerflow section ####
-  /// Set base voltage
+  /// Get nominal voltage at end 1
+  Real getNominalVoltageEnd1() const;
+  /// Get nominal voltage at end 2
+  Real getNominalVoltageEnd2() const;
   void setBaseVoltage(Real baseVoltage);
   /// Initializes component from power flow data
   void calculatePerUnitParameters(Real baseApparentPower, Real baseOmega);

--- a/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
@@ -30,7 +30,7 @@ DP::Ph1::Transformer::Transformer(String uid, String name,
 /// DEPRECATED: Delete method
 SimPowerComp<Complex>::Ptr DP::Ph1::Transformer::clone(String name) {
   auto copy = Transformer::make(name, mLogLevel);
-  copy->setParameters(**mNominalVoltageEnd1, **mNominalVoltageEnd2,
+  copy->setParameters(mNominalVoltageEnd1, mNominalVoltageEnd2,
                       std::abs(**mRatio), std::arg(**mRatio), **mResistance,
                       **mInductance);
   return copy;
@@ -47,7 +47,7 @@ void DP::Ph1::Transformer::setParameters(Real nomVoltageEnd1,
 
   SPDLOG_LOGGER_INFO(
       mSLog, "Nominal Voltage End 1={} [V] Nominal Voltage End 2={} [V]",
-      **mNominalVoltageEnd1, **mNominalVoltageEnd2);
+      mNominalVoltageEnd1, mNominalVoltageEnd2);
   SPDLOG_LOGGER_INFO(
       mSLog,
       "Resistance={} [Ohm] Inductance={} [Ohm] (referred to primary side)",
@@ -81,14 +81,14 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
     std::shared_ptr<SimTerminal<Complex>> tmp = mTerminals[0];
     mTerminals[0] = mTerminals[1];
     mTerminals[1] = tmp;
-    Real tmpVolt = **mNominalVoltageEnd1;
-    **mNominalVoltageEnd1 = **mNominalVoltageEnd2;
-    **mNominalVoltageEnd2 = tmpVolt;
+    Real tmpVolt = mNominalVoltageEnd1;
+    mNominalVoltageEnd1 = mNominalVoltageEnd2;
+    mNominalVoltageEnd2 = tmpVolt;
     SPDLOG_LOGGER_INFO(mSLog, "Switching terminals to have first terminal at "
                               "higher voltage side. Updated parameters: ");
     SPDLOG_LOGGER_INFO(
         mSLog, "Nominal Voltage End 1 = {} [V] Nominal Voltage End 2 = {} [V]",
-        **mNominalVoltageEnd1, **mNominalVoltageEnd2);
+        mNominalVoltageEnd1, mNominalVoltageEnd2);
     SPDLOG_LOGGER_INFO(mSLog, "Tap Ratio = {} [ ] Phase Shift = {} [deg]",
                        std::abs(**mRatio), std::arg(**mRatio));
   }
@@ -130,7 +130,7 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
   Real qSnub = Q_SNUB_TRANSFORMER * **mRatedPower;
 
   // A snubber conductance is added on the higher voltage side
-  mSnubberResistance1 = std::pow(std::abs(**mNominalVoltageEnd1), 2) / pSnub;
+  mSnubberResistance1 = std::pow(std::abs(mNominalVoltageEnd1), 2) / pSnub;
   mSubSnubResistor1 =
       std::make_shared<DP::Ph1::Resistor>(**mName + "_snub_res1", mLogLevel);
   mSubSnubResistor1->setParameters(mSnubberResistance1);
@@ -144,7 +144,7 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
   // A snubber conductance is added on the lower voltage side
-  mSnubberResistance2 = std::pow(std::abs(**mNominalVoltageEnd2), 2) / pSnub;
+  mSnubberResistance2 = std::pow(std::abs(mNominalVoltageEnd2), 2) / pSnub;
   mSubSnubResistor2 =
       std::make_shared<DP::Ph1::Resistor>(**mName + "_snub_res2", mLogLevel);
   mSubSnubResistor2->setParameters(mSnubberResistance2);
@@ -167,7 +167,7 @@ void DP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 
   // A snubber capacitance is added to lower voltage side
   mSnubberCapacitance2 =
-      qSnub / std::pow(std::abs(**mNominalVoltageEnd2), 2) / omega;
+      qSnub / std::pow(std::abs(mNominalVoltageEnd2), 2) / omega;
   mSubSnubCapacitor2 =
       std::make_shared<DP::Ph1::Capacitor>(**mName + "_snub_cap2", mLogLevel);
   mSubSnubCapacitor2->setParameters(mSnubberCapacitance2);

--- a/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_AvVoltageSourceInverterDQ.cpp
@@ -14,7 +14,6 @@ SP::Ph1::AvVoltageSourceInverterDQ::AvVoltageSourceInverterDQ(
     String uid, String name, Logger::Level logLevel, Bool withTrafo)
     : CompositePowerComp<Complex>(uid, name, true, true, logLevel),
       mOmegaN(mAttributes->create<Real>("Omega_nom")),
-      mVnom(mAttributes->create<Real>("vnom")),
       mPref(mAttributes->create<Real>("P_ref")),
       mQref(mAttributes->create<Real>("Q_ref")),
       mVcd(mAttributes->create<Real>("Vc_d", 0)),
@@ -107,7 +106,7 @@ void SP::Ph1::AvVoltageSourceInverterDQ::setParameters(Real sysOmega,
   mPowerControllerVSI->setParameters(Pref, Qref);
 
   **mOmegaN = sysOmega;
-  **mVnom = sysVoltNom;
+  mVnom = sysVoltNom;
   **mPref = Pref;
   **mQref = Qref;
 }
@@ -294,6 +293,8 @@ void SP::Ph1::AvVoltageSourceInverterDQ::initializeFromNodesAndTerminals(
         Logger::phasorToString(mVirtualNodes[3]->initialSingleVoltage()));
   SPDLOG_LOGGER_INFO(mSLog, "\n--- Initialization from powerflow finished ---");
 }
+
+Real SP::Ph1::AvVoltageSourceInverterDQ::getNomVoltage() const { return mVnom; }
 
 void SP::Ph1::AvVoltageSourceInverterDQ::mnaParentInitialize(
     Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {

--- a/dpsim-models/src/SP/SP_Ph1_Load.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Load.cpp
@@ -20,9 +20,8 @@ SP::Ph1::Load::Load(String uid, String name, Logger::Level logLevel)
       mActivePower(mAttributes->createDynamic<Real>(
           "P")), //Made dynamic so it can be imported through InterfaceVillas
       mReactivePower(mAttributes->createDynamic<Real>(
-          "Q")), //Made dynamic so it can be imported through InterfaceVillas
-      mNomVoltage(mAttributes->create<Real>("V_nom")) {
-
+          "Q")) //Made dynamic so it can be imported through InterfaceVillas
+{
   SPDLOG_LOGGER_INFO(mSLog, "Create {} of type {}", **mName, this->type());
   mSLog->flush();
   **mIntfVoltage = MatrixComp::Zero(1, 1);
@@ -34,18 +33,20 @@ void SP::Ph1::Load::setParameters(Real activePower, Real reactivePower,
                                   Real nominalVoltage) {
   **mActivePower = activePower;
   **mReactivePower = reactivePower;
-  **mNomVoltage = nominalVoltage;
+  mNomVoltage = nominalVoltage;
 
   SPDLOG_LOGGER_INFO(
       mSLog,
       "Active Power={} [W]  Reactive Power={} [VAr]  Nominal Voltage={} [V]",
-      **mActivePower, **mReactivePower, **mNomVoltage);
+      **mActivePower, **mReactivePower, mNomVoltage);
   mSLog->flush();
 
   mParametersSet = true;
 }
 
 // #### Powerflow section ####
+Real SP::Ph1::Load::getNomVoltage() const { return mNomVoltage; }
+
 void SP::Ph1::Load::calculatePerUnitParameters(Real baseApparentPower,
                                                Real baseOmega) {
   SPDLOG_LOGGER_INFO(mSLog, "#### Calculate Per Unit Parameters for {}",
@@ -107,7 +108,7 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
 
   // instantiate subResistor for active power consumption
   if (**mActivePower != 0) {
-    mResistance = std::pow(**mNomVoltage, 2) / **mActivePower;
+    mResistance = std::pow(mNomVoltage, 2) / **mActivePower;
     mConductance = 1.0 / mResistance;
     mSubResistor = std::make_shared<SP::Ph1::Resistor>(
         **mUID + "_res", **mName + "_res", Logger::Level::off);
@@ -120,7 +121,7 @@ void SP::Ph1::Load::initializeFromNodesAndTerminals(Real frequency) {
   }
 
   if (**mReactivePower != 0)
-    mReactance = std::pow(**mNomVoltage, 2) / **mReactivePower;
+    mReactance = std::pow(mNomVoltage, 2) / **mReactivePower;
   else
     mReactance = 0;
 

--- a/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
@@ -15,7 +15,6 @@ SP::Ph1::NetworkInjection::NetworkInjection(String uid, String name,
     : CompositePowerComp<Complex>(uid, name, true, true, logLevel),
       mVoltageRef(mAttributes->createDynamic<Complex>("V_ref")),
       mSrcFreq(mAttributes->createDynamic<Real>("f_src")),
-      mBaseVoltage(mAttributes->create<Real>("base_Voltage")),
       mVoltageSetPoint(mAttributes->create<Real>("V_set")),
       mVoltageSetPointPerUnit(mAttributes->create<Real>("V_set_pu", 1.0)),
       mActivePowerInjection(mAttributes->create<Real>("p_inj")),
@@ -92,17 +91,21 @@ void SP::Ph1::NetworkInjection::setParameters(Complex initialPhasor,
                      Logger::realToString(baseFrequency));
 }
 
+Real SP::Ph1::NetworkInjection::getBaseVoltage() const{
+  return mBaseVoltage;
+}
+
 void SP::Ph1::NetworkInjection::setBaseVoltage(Real baseVoltage) {
-  **mBaseVoltage = baseVoltage;
+  mBaseVoltage = baseVoltage;
 }
 
 void SP::Ph1::NetworkInjection::calculatePerUnitParameters(
     Real baseApparentPower, Real baseOmega) {
   SPDLOG_LOGGER_INFO(mSLog, "#### Calculate Per Unit Parameters for {}",
                      **mName);
-  SPDLOG_LOGGER_INFO(mSLog, "Base Voltage={} [V]", **mBaseVoltage);
+  SPDLOG_LOGGER_INFO(mSLog, "Base Voltage={} [V]", mBaseVoltage);
 
-  **mVoltageSetPointPerUnit = **mVoltageSetPoint / **mBaseVoltage;
+  **mVoltageSetPointPerUnit = **mVoltageSetPoint / mBaseVoltage;
 
   SPDLOG_LOGGER_INFO(mSLog, "Voltage Set-Point ={} [pu]",
                      **mVoltageSetPointPerUnit);

--- a/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_NetworkInjection.cpp
@@ -91,9 +91,7 @@ void SP::Ph1::NetworkInjection::setParameters(Complex initialPhasor,
                      Logger::realToString(baseFrequency));
 }
 
-Real SP::Ph1::NetworkInjection::getBaseVoltage() const{
-  return mBaseVoltage;
-}
+Real SP::Ph1::NetworkInjection::getBaseVoltage() const { return mBaseVoltage; }
 
 void SP::Ph1::NetworkInjection::setBaseVoltage(Real baseVoltage) {
   mBaseVoltage = baseVoltage;

--- a/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
@@ -13,7 +13,6 @@ using namespace CPS;
 SP::Ph1::PiLine::PiLine(String uid, String name, Logger::Level logLevel)
     : Base::Ph1::PiLine(mAttributes),
       CompositePowerComp<Complex>(uid, name, false, true, logLevel),
-      mBaseVoltage(mAttributes->create<Real>("base_Voltage")),
       mCurrent(mAttributes->create<MatrixComp>("current_vector")),
       mActivePowerBranch(mAttributes->create<Matrix>("p_branch_vector")),
       mReactivePowerBranch(mAttributes->create<Matrix>("q_branch_vector")),
@@ -77,8 +76,10 @@ SimPowerComp<Complex>::Ptr SP::Ph1::PiLine::clone(String name) {
 }
 
 // #### Powerflow section ####
+Real SP::Ph1::PiLine::getBaseVoltage() const { return mBaseVoltage; }
+
 void SP::Ph1::PiLine::setBaseVoltage(Real baseVoltage) {
-  **mBaseVoltage = baseVoltage;
+  mBaseVoltage = baseVoltage;
 }
 
 void SP::Ph1::PiLine::calculatePerUnitParameters(Real baseApparentPower,
@@ -90,15 +91,15 @@ void SP::Ph1::PiLine::calculatePerUnitParameters(Real baseApparentPower,
   SPDLOG_LOGGER_INFO(mSLog, "Base Power={} [VA]  Base Omega={} [1/s]",
                      baseApparentPower, baseOmega);
 
-  mBaseImpedance = (**mBaseVoltage * **mBaseVoltage) / mBaseApparentPower;
+  mBaseImpedance = (mBaseVoltage * mBaseVoltage) / mBaseApparentPower;
   mBaseAdmittance = 1.0 / mBaseImpedance;
   mBaseInductance = mBaseImpedance / mBaseOmega;
   mBaseCapacitance = 1.0 / mBaseOmega / mBaseImpedance;
   mBaseCurrent = baseApparentPower /
-                 (**mBaseVoltage *
+                 (mBaseVoltage *
                   sqrt(3)); // I_base=(S_threephase/3)/(V_line_to_line/sqrt(3))
   SPDLOG_LOGGER_INFO(mSLog, "Base Voltage={} [V]  Base Impedance={} [Ohm]",
-                     **mBaseVoltage, mBaseImpedance);
+                     mBaseVoltage, mBaseImpedance);
 
   mSeriesResPerUnit = **mSeriesRes / mBaseImpedance;
   mSeriesIndPerUnit = **mSeriesInd / mBaseInductance;

--- a/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
@@ -15,7 +15,6 @@ SP::Ph1::RXLine::RXLine(String uid, String name, Real baseVoltage,
                         Logger::Level logLevel)
     : Base::Ph1::PiLine(mAttributes),
       CompositePowerComp<Complex>(uid, name, true, true, logLevel),
-      mBaseVoltage(mAttributes->create<Real>("base_Voltage", baseVoltage)),
       mInductance(mAttributes->create<Real>("L_series")),
       mActivePowerInjection(mAttributes->create<Real>("p_inj")),
       mReactivePowerInjection(mAttributes->create<Real>("q_inj")),
@@ -41,7 +40,6 @@ SP::Ph1::RXLine::RXLine(String uid, String name, Real baseVoltage,
 SP::Ph1::RXLine::RXLine(String uid, String name, Logger::Level logLevel)
     : Base::Ph1::PiLine(mAttributes),
       CompositePowerComp<Complex>(uid, name, true, true, logLevel),
-      mBaseVoltage(mAttributes->create<Real>("base_Voltage")),
       mInductance(mAttributes->create<Real>("L_series")),
       mActivePowerInjection(mAttributes->create<Real>("p_inj")),
       mReactivePowerInjection(mAttributes->create<Real>("q_inj")),
@@ -58,11 +56,11 @@ SP::Ph1::RXLine::RXLine(String uid, String name, Logger::Level logLevel)
 void SP::Ph1::RXLine::setPerUnitSystem(Real baseApparentPower, Real baseOmega) {
   mBaseApparentPower = baseApparentPower;
   mBaseOmega = baseOmega;
-  mBaseImpedance = (**mBaseVoltage * **mBaseVoltage) / mBaseApparentPower;
+  mBaseImpedance = (mBaseVoltage * mBaseVoltage) / mBaseApparentPower;
   mBaseAdmittance = 1.0 / mBaseImpedance;
   mBaseInductance = mBaseImpedance / mBaseOmega;
   /// I_base = S_base / V_line
-  mBaseCurrent = baseApparentPower / (**mBaseVoltage * sqrt(3));
+  mBaseCurrent = baseApparentPower / (mBaseVoltage * sqrt(3));
 
 #if 0
   mLog.Log(Logger::Level::INFO) << "#### Set Per Unit System for " << **mName << std::endl;
@@ -79,6 +77,8 @@ void SP::Ph1::RXLine::setPerUnitSystem(Real baseApparentPower, Real baseOmega) {
     mLog.Log(Logger::Level::INFO)  << "r " << mSeriesResPerUnit << std::endl << "  x: " << mBaseOmega * mInductance / mBaseImpedance<<std::endl;
 #endif
 }
+
+Real SP::Ph1::RXLine::getBaseVoltage() const { return mBaseVoltage; }
 
 void SP::Ph1::RXLine::pfApplyAdmittanceMatrixStamp(SparseMatrixCompRow &Y) {
   updateMatrixNodeIndices();

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGenerator.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGenerator.cpp
@@ -13,7 +13,6 @@ using namespace CPS;
 SP::Ph1::SynchronGenerator::SynchronGenerator(String uid, String name,
                                               Logger::Level logLevel)
     : SimPowerComp<Complex>(uid, name, logLevel),
-      mBaseVoltage(mAttributes->create<Real>("base_Voltage")),
       mSetPointActivePower(mAttributes->create<Real>("P_set")),
       mSetPointReactivePower(mAttributes->create<Real>("Q_set")),
       mSetPointVoltage(mAttributes->create<Real>("V_set")),
@@ -45,8 +44,11 @@ void SP::Ph1::SynchronGenerator::setParameters(
 }
 
 // #### Powerflow section ####
+
+Real SP::Ph1::SynchronGenerator::getBaseVoltage() const { return mBaseVoltage; }
+
 void SP::Ph1::SynchronGenerator::setBaseVoltage(Real baseVoltage) {
-  **mBaseVoltage = baseVoltage;
+  mBaseVoltage = baseVoltage;
 }
 
 void SP::Ph1::SynchronGenerator::calculatePerUnitParameters(
@@ -60,7 +62,7 @@ void SP::Ph1::SynchronGenerator::calculatePerUnitParameters(
   **mSetPointActivePowerPerUnit = **mSetPointActivePower / mBaseApparentPower;
   **mSetPointReactivePowerPerUnit =
       **mSetPointReactivePower / mBaseApparentPower;
-  **mSetPointVoltagePerUnit = **mSetPointVoltage / **mBaseVoltage;
+  **mSetPointVoltagePerUnit = **mSetPointVoltage / mBaseVoltage;
   SPDLOG_LOGGER_INFO(mSLog,
                      "Active Power Set Point={} [pu] Voltage Set Point={} [pu]",
                      **mSetPointActivePowerPerUnit, **mSetPointVoltagePerUnit);

--- a/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
@@ -78,9 +78,9 @@ void SP::Ph1::Transformer::setParameters(Real nomVoltageEnd1,
 /// DEPRECATED: Delete method
 SimPowerComp<Complex>::Ptr SP::Ph1::Transformer::clone(String name) {
   auto copy = Transformer::make(name, mLogLevel);
-  copy->setParameters(mNominalVoltageEnd1, mNominalVoltageEnd2,
-                      **mRatedPower, std::abs(**mRatio), std::arg(**mRatio),
-                      **mResistance, **mInductance);
+  copy->setParameters(mNominalVoltageEnd1, mNominalVoltageEnd2, **mRatedPower,
+                      std::abs(**mRatio), std::arg(**mRatio), **mResistance,
+                      **mInductance);
   return copy;
 }
 

--- a/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
@@ -49,7 +49,7 @@ void SP::Ph1::Transformer::setParameters(Real nomVoltageEnd1,
 
   SPDLOG_LOGGER_INFO(
       mSLog, "Nominal Voltage End 1={} [V] Nominal Voltage End 2={} [V]",
-      **mNominalVoltageEnd1, **mNominalVoltageEnd2);
+      mNominalVoltageEnd1, mNominalVoltageEnd2);
   SPDLOG_LOGGER_INFO(
       mSLog, "Resistance={} [Ohm] Inductance={} [H] (referred to primary side)",
       **mResistance, **mInductance);
@@ -78,7 +78,7 @@ void SP::Ph1::Transformer::setParameters(Real nomVoltageEnd1,
 /// DEPRECATED: Delete method
 SimPowerComp<Complex>::Ptr SP::Ph1::Transformer::clone(String name) {
   auto copy = Transformer::make(name, mLogLevel);
-  copy->setParameters(**mNominalVoltageEnd1, **mNominalVoltageEnd2,
+  copy->setParameters(mNominalVoltageEnd1, mNominalVoltageEnd2,
                       **mRatedPower, std::abs(**mRatio), std::arg(**mRatio),
                       **mResistance, **mInductance);
   return copy;
@@ -100,14 +100,14 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
     std::shared_ptr<SimTerminal<Complex>> tmp = mTerminals[0];
     mTerminals[0] = mTerminals[1];
     mTerminals[1] = tmp;
-    Real tmpVolt = **mNominalVoltageEnd1;
-    **mNominalVoltageEnd1 = **mNominalVoltageEnd2;
-    **mNominalVoltageEnd2 = tmpVolt;
+    Real tmpVolt = mNominalVoltageEnd1;
+    mNominalVoltageEnd1 = mNominalVoltageEnd2;
+    mNominalVoltageEnd2 = tmpVolt;
     SPDLOG_LOGGER_INFO(mSLog, "Switching terminals to have first terminal at "
                               "higher voltage side. Updated parameters: ");
     SPDLOG_LOGGER_INFO(
         mSLog, "Nominal Voltage End 1 = {} [V] Nominal Voltage End 2 = {} [V]",
-        **mNominalVoltageEnd1, **mNominalVoltageEnd2);
+        mNominalVoltageEnd1, mNominalVoltageEnd2);
     SPDLOG_LOGGER_INFO(mSLog, "Tap Ratio = {} [ ] Phase Shift = {} [deg]",
                        mRatioAbs, mRatioPhase);
   }
@@ -149,7 +149,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
     Real qSnub = Q_SNUB_TRANSFORMER * **mRatedPower;
 
     // A snubber conductance is added on the higher voltage side
-    mSnubberResistance1 = std::pow(std::abs(**mNominalVoltageEnd1), 2) / pSnub;
+    mSnubberResistance1 = std::pow(std::abs(mNominalVoltageEnd1), 2) / pSnub;
     mSubSnubResistor1 =
         std::make_shared<SP::Ph1::Resistor>(**mName + "_snub_res1", mLogLevel);
     mSubSnubResistor1->setParameters(mSnubberResistance1);
@@ -158,13 +158,13 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
         mSLog,
         "Snubber Resistance 1 (connected to higher voltage side {}) = {} [Ohm]",
         node(0)->name(), Logger::realToString(mSnubberResistance1));
-    mSubSnubResistor1->setBaseVoltage(**mNominalVoltageEnd1);
+    mSubSnubResistor1->setBaseVoltage(mNominalVoltageEnd1);
     addMNASubComponent(mSubSnubResistor1,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
     // A snubber conductance is added on the lower voltage side
-    mSnubberResistance2 = std::pow(std::abs(**mNominalVoltageEnd2), 2) / pSnub;
+    mSnubberResistance2 = std::pow(std::abs(mNominalVoltageEnd2), 2) / pSnub;
     mSubSnubResistor2 =
         std::make_shared<SP::Ph1::Resistor>(**mName + "_snub_res2", mLogLevel);
     mSubSnubResistor2->setParameters(mSnubberResistance2);
@@ -173,7 +173,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
         mSLog,
         "Snubber Resistance 2 (connected to lower voltage side {}) = {} [Ohm]",
         node(1)->name(), Logger::realToString(mSnubberResistance2));
-    mSubSnubResistor2->setBaseVoltage(**mNominalVoltageEnd2);
+    mSubSnubResistor2->setBaseVoltage(mNominalVoltageEnd2);
     addMNASubComponent(mSubSnubResistor2,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -189,7 +189,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 
     // A snubber capacitance is added to lower voltage side
     mSnubberCapacitance2 =
-        qSnub / std::pow(std::abs(**mNominalVoltageEnd2), 2) / mNominalOmega;
+        qSnub / std::pow(std::abs(mNominalVoltageEnd2), 2) / mNominalOmega;
     mSubSnubCapacitor2 =
         std::make_shared<SP::Ph1::Capacitor>(**mName + "_snub_cap2", mLogLevel);
     mSubSnubCapacitor2->setParameters(mSnubberCapacitance2);
@@ -198,7 +198,7 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
         mSLog,
         "Snubber Capacitance 2 (connected to lower voltage side {}) = {} [F]",
         node(1)->name(), Logger::realToString(mSnubberCapacitance2));
-    mSubSnubCapacitor2->setBaseVoltage(**mNominalVoltageEnd2);
+    mSubSnubCapacitor2->setBaseVoltage(mNominalVoltageEnd2);
     addMNASubComponent(mSubSnubCapacitor2,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -229,6 +229,14 @@ void SP::Ph1::Transformer::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 // #### Powerflow section ####
+
+Real SP::Ph1::Transformer::getNominalVoltageEnd1() const {
+  return mNominalVoltageEnd1;
+}
+
+Real SP::Ph1::Transformer::getNominalVoltageEnd2() const {
+  return mNominalVoltageEnd2;
+}
 
 void SP::Ph1::Transformer::setBaseVoltage(Real baseVoltage) {
   // Note: to be consistent set base voltage to higher voltage (and impedance values must be referred to high voltage side)
@@ -264,7 +272,7 @@ void SP::Ph1::Transformer::calculatePerUnitParameters(Real baseApparentPower,
   mLeakagePerUnit = Complex(mResistancePerUnit, 1. * mInductancePerUnit);
   SPDLOG_LOGGER_INFO(mSLog, "Leakage Impedance={} [pu] ", mLeakagePerUnit);
 
-  mRatioAbsPerUnit = mRatioAbs / **mNominalVoltageEnd1 * **mNominalVoltageEnd2;
+  mRatioAbsPerUnit = mRatioAbs / mNominalVoltageEnd1 * mNominalVoltageEnd2;
   SPDLOG_LOGGER_INFO(mSLog, "Tap Ratio={} [pu]", mRatioAbsPerUnit);
 
   // Calculate per unit parameters of subcomps

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -269,8 +269,7 @@ void PFSolver::determineNodeBaseVoltages() {
       if (std::shared_ptr<CPS::SP::Ph1::AvVoltageSourceInverterDQ> vsi =
               std::dynamic_pointer_cast<
                   CPS::SP::Ph1::AvVoltageSourceInverterDQ>(comp)) {
-        baseVoltage_ =
-            Math::abs(vsi->attributeTyped<CPS::Complex>("vnom")->get());
+        baseVoltage_ = vsi->getNomVoltage();
         SPDLOG_LOGGER_INFO(
             mSLog,
             "Choose base voltage {}V of {} to convert pu-solution of {}.",
@@ -278,7 +277,7 @@ void PFSolver::determineNodeBaseVoltages() {
         break;
       } else if (std::shared_ptr<CPS::SP::Ph1::RXLine> rxline =
                      std::dynamic_pointer_cast<CPS::SP::Ph1::RXLine>(comp)) {
-        baseVoltage_ = rxline->attributeTyped<CPS::Real>("base_Voltage")->get();
+        baseVoltage_ = rxline->getBaseVoltage();
         SPDLOG_LOGGER_INFO(
             mSLog,
             "Choose base voltage {}V of {} to convert pu-solution of {}.",
@@ -286,7 +285,7 @@ void PFSolver::determineNodeBaseVoltages() {
         break;
       } else if (std::shared_ptr<CPS::SP::Ph1::PiLine> line =
                      std::dynamic_pointer_cast<CPS::SP::Ph1::PiLine>(comp)) {
-        baseVoltage_ = line->attributeTyped<CPS::Real>("base_Voltage")->get();
+        baseVoltage_ = line->getBaseVoltage();
         SPDLOG_LOGGER_INFO(
             mSLog,
             "Choose base voltage {}V of {} to convert pu-solution of {}.",
@@ -296,16 +295,14 @@ void PFSolver::determineNodeBaseVoltages() {
                      std::dynamic_pointer_cast<CPS::SP::Ph1::Transformer>(
                          comp)) {
         if (trans->terminal(0)->node()->name() == node->name()) {
-          baseVoltage_ =
-              trans->attributeTyped<CPS::Real>("nominal_voltage_end1")->get();
+          baseVoltage_ = trans->getNominalVoltageEnd1();
           SPDLOG_LOGGER_INFO(
               mSLog,
               "Choose base voltage {}V of {} to convert pu-solution of {}.",
               baseVoltage_, trans->name(), node->name());
           break;
         } else if (trans->terminal(1)->node()->name() == node->name()) {
-          baseVoltage_ =
-              trans->attributeTyped<CPS::Real>("nominal_voltage_end2")->get();
+          baseVoltage_ = trans->getNominalVoltageEnd2();
           SPDLOG_LOGGER_INFO(
               mSLog,
               "Choose base voltage {}V of {} to convert pu-solution of {}.",
@@ -315,7 +312,7 @@ void PFSolver::determineNodeBaseVoltages() {
       } else if (std::shared_ptr<CPS::SP::Ph1::SynchronGenerator> gen =
                      std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(
                          comp)) {
-        baseVoltage_ = gen->attributeTyped<CPS::Real>("base_Voltage")->get();
+        baseVoltage_ = gen->getBaseVoltage();
         SPDLOG_LOGGER_INFO(
             mSLog,
             "Choose base voltage {}V of {} to convert pu-solution of {}.",
@@ -323,7 +320,7 @@ void PFSolver::determineNodeBaseVoltages() {
         break;
       } else if (std::shared_ptr<CPS::SP::Ph1::Load> load =
                      std::dynamic_pointer_cast<CPS::SP::Ph1::Load>(comp)) {
-        baseVoltage_ = load->attributeTyped<CPS::Real>("V_nom")->get();
+        baseVoltage_ = load->getNomVoltage();
         SPDLOG_LOGGER_INFO(
             mSLog, "Choose base voltage of {} V to convert pu-solution of {}.",
             baseVoltage_, load->name(), node->name());
@@ -331,7 +328,7 @@ void PFSolver::determineNodeBaseVoltages() {
       } else if (std::shared_ptr<CPS::SP::Ph1::NetworkInjection> extnet =
                      std::dynamic_pointer_cast<CPS::SP::Ph1::NetworkInjection>(
                          comp)) {
-        baseVoltage_ = extnet->attributeTyped<CPS::Real>("base_Voltage")->get();
+        baseVoltage_ = extnet->getBaseVoltage();
         SPDLOG_LOGGER_INFO(
             mSLog, "Choose base voltage of {}V to convert pu-solution of {}.",
             baseVoltage_, extnet->name(), node->name());


### PR DESCRIPTION
This PR aims at reducing the number of unnecessarily used attributes, as discussed in #330. The PR does the following:

1. Declares base/nominal voltages of SP components, used in PFSolver, as `private Real` member variables instead of `Attribute<Real>`.
2. Adds getter functions in these components to get base/nominal voltages.
3. Uses getter functions instead of` get() `function of TypedAttribute to get base voltage in PFSolver.