### PR TITLE
Windows: build with pybind and add workflow for wheels

### DIFF
--- a/.github/workflows/build_test_windows.yaml
+++ b/.github/workflows/build_test_windows.yaml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/build
-        key: build-windows-cache-${{ github.ref }}
+        key: build-windows-bindings-cache-${{ github.ref }}
 
     - name: Build DPsim
       run: |
@@ -62,4 +62,4 @@ jobs:
         git describe --tags --abbrev=0 --match "v*"
         # TODO: Remove '-DCMAKE_POLICY_VERSION_MINIMUM=3.5' once spdlog version has been bumped
         cmake -DWITH_PYBIND=ON -DCMAKE_POLICY_VERSION_MINIMUM="3.5" ..
-        cmake --build . --target dpsim --parallel
+        cmake --build . --target dpsimpy --parallel

--- a/.github/workflows/build_test_windows.yaml
+++ b/.github/workflows/build_test_windows.yaml
@@ -35,3 +35,31 @@ jobs:
         # TODO: Remove '-DCMAKE_POLICY_VERSION_MINIMUM=3.5' once spdlog version has been bumped
         cmake -DWITH_PYBIND=OFF -DCMAKE_POLICY_VERSION_MINIMUM="3.5" ..
         cmake --build . --target dpsim --parallel
+
+  windows-bindings:
+    name: Build on Windows with Pybind
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Create build folder
+      run: |
+        cd ${{ github.workspace }}
+        mkdir build
+
+    - name: Setup build directory cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/build
+        key: build-windows-cache-${{ github.ref }}
+
+    - name: Build DPsim
+      run: |
+        pip install pybind11[global]
+        cd ${{ github.workspace }}
+        cd build
+        git describe --tags --abbrev=0 --match "v*"
+        # TODO: Remove '-DCMAKE_POLICY_VERSION_MINIMUM=3.5' once spdlog version has been bumped
+        cmake -DWITH_PYBIND=ON -DCMAKE_POLICY_VERSION_MINIMUM="3.5" ..
+        cmake --build . --target dpsim --parallel

--- a/.github/workflows/build_test_windows.yaml
+++ b/.github/workflows/build_test_windows.yaml
@@ -34,7 +34,7 @@ jobs:
         git describe --tags --abbrev=0 --match "v*"
         # TODO: Remove '-DCMAKE_POLICY_VERSION_MINIMUM=3.5' once spdlog version has been bumped
         cmake -DWITH_PYBIND=OFF -DCMAKE_POLICY_VERSION_MINIMUM="3.5" ..
-        cmake --build . --target dpsim --parallel
+        cmake --build . --target dpsim --target dpsim-models --parallel
 
   windows-bindings:
     name: Build on Windows with Pybind

--- a/.github/workflows/publish_to_pypi_win.yaml
+++ b/.github/workflows/publish_to_pypi_win.yaml
@@ -1,0 +1,109 @@
+name: Publish DPsim Windows package to Python Package Index (PyPI)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  build-sdist:
+    name: Build DPsim source distribution in Windows
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install build tool
+      run: python -m pip install --upgrade build
+
+    - name: Build DPsim source distribution
+      run: python -m build --sdist --outdir dist/
+
+    - name: Archive Python source distribution
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-source-win
+        path: dist/
+
+  build-wheels:
+    name: Build DPsim Python wheel for Windows
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            python: cp313
+            arch: amd64
+            cibw_arch: AMD64
+
+          - os: windows-latest
+            python: cp313
+            arch: win32
+            cibw_arch: x86
+
+          - os: windows-latest
+            python: cp313
+            arch: win_arm64
+            cibw_arch: ARM64
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Build wheel
+      uses: pypa/cibuildwheel@v2.23.2
+      env:
+        CIBW_BUILD: "${{ matrix.python }}-*"
+        CIBW_ARCHS: "${{ matrix.cibw_arch }}"
+      with:
+        output-dir: dist
+
+    - name: Upload wheel as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-${{ matrix.python }}-${{ matrix.os }}-${{ matrix.arch }}
+        path: dist/
+
+  publish:
+    name: Publish wheels and source distribution to PyPI
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'push'
+    permissions:
+      id-token: write
+    needs:
+    - build-wheels
+    - build-sdist
+
+    steps:
+    - name: Download wheels from build jobs
+      uses: actions/download-artifact@v4
+      with:
+        pattern: dist-*
+        merge-multiple: true
+        path: dist/
+
+    - name: Publish distribution to Test PyPI
+      uses: pypa/gh-action-pypi-publish@v1.12.4
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
+
+    - name: Publish distribution to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@v1.12.4

--- a/.github/workflows/publish_to_pypi_win.yaml
+++ b/.github/workflows/publish_to_pypi_win.yaml
@@ -71,6 +71,9 @@ jobs:
       env:
         CIBW_BUILD: "${{ matrix.python }}-*"
         CIBW_ARCHS: "${{ matrix.cibw_arch }}"
+        CIBW_ENVIRONMENT: >
+          CMAKE_ARGS="-DWITH_PYBIND=ON -DCMAKE_VERBOSE_MAKEFILE=ON"
+          CMAKE_BUILD_PARALLEL_LEVEL=4
       with:
         output-dir: dist
 

--- a/.github/workflows/publish_to_pypi_win.yaml
+++ b/.github/workflows/publish_to_pypi_win.yaml
@@ -71,6 +71,7 @@ jobs:
       env:
         CIBW_BUILD: "${{ matrix.python }}-*"
         CIBW_ARCHS: "${{ matrix.cibw_arch }}"
+        CIBW_BEFORE_BUILD: "pip install pybind11[global]"
         CIBW_ENVIRONMENT: >
           CMAKE_ARGS="-DWITH_PYBIND=ON -DCMAKE_VERBOSE_MAKEFILE=ON"
           CMAKE_BUILD_PARALLEL_LEVEL=4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,8 @@ include(CheckSymbolExists)
 check_symbol_exists(timerfd_create sys/timerfd.h HAVE_TIMERFD)
 check_symbol_exists(getopt_long getopt.h HAVE_GETOPT)
 if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-	add_compile_options(-Ofast)
+	add_compile_options(-O3)
+	add_compile_options(-ffast-math)
 
 	# On Clang -Ofast enables -ffast-math which in turn enables -ffinite-math-only.
 	# This option causes all calls to functions checking for infinity or NaN to raise

--- a/cmake/FindFilesystem.cmake
+++ b/cmake/FindFilesystem.cmake
@@ -27,7 +27,11 @@ endif()
 set(FILESYSTEM_LIBRARIES ${FILESYSTEM_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Filesystem REQUIRED_VARS FILESYSTEM_LIBRARIES)
+if(NOT MSVC)
+	find_package_handle_standard_args(Filesystem REQUIRED_VARS FILESYSTEM_LIBRARIES)
+else()
+	find_package_handle_standard_args(Filesystem DEFAULT_MSG)
+endif()
 
 mark_as_advanced(FILESYSTEM_LIBRARY)
 

--- a/cmake/FindFilesystem.cmake
+++ b/cmake/FindFilesystem.cmake
@@ -1,11 +1,41 @@
-set(FILESYSTEM_LIBRARY stdc++fs)
+# Try to determine whether std::filesystem needs linking
+include(CheckCXXSourceCompiles)
+
+check_cxx_source_compiles("
+	#include <filesystem>
+	int main() {
+		std::filesystem::path p{\".\"};
+		return 0;
+	}
+" HAS_NATIVE_FILESYSTEM)
+
+# Determine link library, if needed
+if(HAS_NATIVE_FILESYSTEM)
+	if(MSVC)
+		# MSVC has native support and doesn't require linking
+		set(FILESYSTEM_LIBRARY "")
+	else()
+		# GCC < 9 or Clang may need explicit -lstdc++fs
+		set(FILESYSTEM_LIBRARY stdc++fs)
+	endif()
+else()
+	# Not supported natively, suggest using ghc_filesystem
+	message(WARNING "std::filesystem not supported, consider enabling FETCH_FILESYSTEM")
+	set(FILESYSTEM_LIBRARY "")
+endif()
 
 set(FILESYSTEM_LIBRARIES ${FILESYSTEM_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Filesystem REQUIRED_VARS FILESYSTEM_LIBRARY)
+find_package_handle_standard_args(Filesystem REQUIRED_VARS FILESYSTEM_LIBRARIES)
 
 mark_as_advanced(FILESYSTEM_LIBRARY)
 
 add_library(filesystem INTERFACE)
-target_link_libraries(filesystem INTERFACE ${FILESYSTEM_LIBRARY})
+
+if(FILESYSTEM_LIBRARY)
+	target_link_libraries(filesystem INTERFACE ${FILESYSTEM_LIBRARY})
+endif()
+
+# Export as standard alias if used via find_package(Filesystem)
+add_library(Filesystem::filesystem ALIAS filesystem)

--- a/dpsim/include/dpsim/DataLoggerInterface.h
+++ b/dpsim/include/dpsim/DataLoggerInterface.h
@@ -28,6 +28,8 @@ public:
 
   DataLoggerInterface() : mAttributes(){};
 
+  virtual ~DataLoggerInterface() = default;
+
   // Start the logger. After starting the number of columns should not be changed.
   virtual void start() = 0;
   // Stops the logger. Afterwards it should not be used anymore.

--- a/dpsim/src/CMakeLists.txt
+++ b/dpsim/src/CMakeLists.txt
@@ -89,7 +89,7 @@ endif()
 if(WITH_OPENMP)
 	list(APPEND DPSIM_SOURCES OpenMPLevelScheduler.cpp)
 	list(APPEND DPSIM_CXX_FLAGS ${OpenMP_CXX_FLAGS})
-	list(APPEND DPSIM_LIBRARIES ${OpenMP_CXX_FLAGS})
+	list(APPEND DPSIM_LIBRARIES OpenMP::OpenMP_CXX)
 endif()
 
 add_library(dpsim ${DPSIM_SOURCES})

--- a/dpsim/src/pybind/Attributes.cpp
+++ b/dpsim/src/pybind/Attributes.cpp
@@ -33,7 +33,9 @@ void addAttributes(py::module_ m) {
              CPS::AttributeBase>(m, "AttributeReal")
       .def("get", &CPS::Attribute<CPS::Real>::get)
       .def("set", &CPS::Attribute<CPS::Real>::set)
-      .def("derive_scaled", &CPS::Attribute<CPS::Real>::deriveScaled);
+      .def("derive_scaled",
+           py::overload_cast<CPS::Real>(
+               &CPS::Attribute<CPS::Real>::template deriveScaled<CPS::Real>));
 
   py::class_<CPS::AttributeStatic<CPS::Real>,
              CPS::AttributePointer<CPS::AttributeStatic<CPS::Real>>,
@@ -48,11 +50,22 @@ void addAttributes(py::module_ m) {
              CPS::AttributeBase>(m, "AttributeComplex")
       .def("get", &CPS::Attribute<CPS::Complex>::get)
       .def("set", &CPS::Attribute<CPS::Complex>::set)
-      .def("derive_real", &CPS::Attribute<CPS::Complex>::deriveReal)
-      .def("derive_imag", &CPS::Attribute<CPS::Complex>::deriveImag)
-      .def("derive_mag", &CPS::Attribute<CPS::Complex>::deriveMag)
-      .def("derive_phase", &CPS::Attribute<CPS::Complex>::derivePhase)
-      .def("derive_scaled", &CPS::Attribute<CPS::Complex>::deriveScaled);
+      .def("derive_real",
+           py::overload_cast<>(
+               &CPS::Attribute<CPS::Complex>::template deriveReal<>))
+      .def("derive_imag",
+           py::overload_cast<>(
+               &CPS::Attribute<CPS::Complex>::template deriveImag<>))
+      .def("derive_mag",
+           py::overload_cast<>(
+               &CPS::Attribute<CPS::Complex>::template deriveMag<>))
+      .def("derive_phase",
+           py::overload_cast<>(
+               &CPS::Attribute<CPS::Complex>::template derivePhase<>))
+      .def("derive_scaled",
+           py::overload_cast<CPS::Complex>(
+               &CPS::Attribute<CPS::Complex>::template deriveScaled<
+                   CPS::Complex>));
 
   py::class_<CPS::AttributeStatic<CPS::Complex>,
              CPS::AttributePointer<CPS::AttributeStatic<CPS::Complex>>,

--- a/dpsim/src/pybind/Attributes.cpp
+++ b/dpsim/src/pybind/Attributes.cpp
@@ -21,104 +21,125 @@ using namespace pybind11::literals;
 
 void addAttributes(py::module_ m) {
 
-  py::class_<CPS::AttributeBase, CPS::AttributePointer<CPS::AttributeBase>>(
-      m, "Attribute")
-      .def("__str__", &CPS::AttributeBase::toString)
-      .def("__repr__", &CPS::AttributeBase::toString);
+  auto attribute =
+      py::class_<CPS::AttributeBase, CPS::AttributePointer<CPS::AttributeBase>>(
+          m, "Attribute")
+          .def("__str__", &CPS::AttributeBase::toString)
+          .def("__repr__", &CPS::AttributeBase::toString);
 
   // Class bindings for the most common attribute types. Allows for the usage of the `get` and `set` methods in Python.
 
-  py::class_<CPS::Attribute<CPS::Real>,
-             CPS::AttributePointer<CPS::Attribute<CPS::Real>>,
-             CPS::AttributeBase>(m, "AttributeReal")
-      .def("get", &CPS::Attribute<CPS::Real>::get)
-      .def("set", &CPS::Attribute<CPS::Real>::set)
-      .def("derive_scaled",
-           py::overload_cast<CPS::Real>(
-               &CPS::Attribute<CPS::Real>::template deriveScaled<CPS::Real>));
+  auto attribute_real =
+      py::class_<CPS::Attribute<CPS::Real>,
+                 CPS::AttributePointer<CPS::Attribute<CPS::Real>>,
+                 CPS::AttributeBase>(m, "AttributeReal")
+          .def("get", &CPS::Attribute<CPS::Real>::get)
+          .def("set", &CPS::Attribute<CPS::Real>::set)
+          .def("derive_scaled",
+               py::overload_cast<CPS::Real>(
+                   &CPS::Attribute<CPS::Real>::template deriveScaled<
+                       CPS::Real>));
 
-  py::class_<CPS::AttributeStatic<CPS::Real>,
-             CPS::AttributePointer<CPS::AttributeStatic<CPS::Real>>,
-             CPS::Attribute<CPS::Real>>(m, "AttributeRealStat");
-  py::class_<CPS::AttributeDynamic<CPS::Real>,
-             CPS::AttributePointer<CPS::AttributeDynamic<CPS::Real>>,
-             CPS::Attribute<CPS::Real>>(m, "AttributeRealDyn")
-      .def("set_reference", &CPS::AttributeDynamic<CPS::Real>::setReference);
+  auto attribute_real_static =
+      py::class_<CPS::AttributeStatic<CPS::Real>,
+                 CPS::AttributePointer<CPS::AttributeStatic<CPS::Real>>,
+                 CPS::Attribute<CPS::Real>>(m, "AttributeRealStat");
+  auto attribute_real_dynamic =
+      py::class_<CPS::AttributeDynamic<CPS::Real>,
+                 CPS::AttributePointer<CPS::AttributeDynamic<CPS::Real>>,
+                 CPS::Attribute<CPS::Real>>(m, "AttributeRealDyn")
+          .def("set_reference",
+               &CPS::AttributeDynamic<CPS::Real>::setReference);
 
-  py::class_<CPS::Attribute<CPS::Complex>,
-             CPS::AttributePointer<CPS::Attribute<CPS::Complex>>,
-             CPS::AttributeBase>(m, "AttributeComplex")
-      .def("get", &CPS::Attribute<CPS::Complex>::get)
-      .def("set", &CPS::Attribute<CPS::Complex>::set)
-      .def("derive_real",
-           py::overload_cast<>(
-               &CPS::Attribute<CPS::Complex>::template deriveReal<>))
-      .def("derive_imag",
-           py::overload_cast<>(
-               &CPS::Attribute<CPS::Complex>::template deriveImag<>))
-      .def("derive_mag",
-           py::overload_cast<>(
-               &CPS::Attribute<CPS::Complex>::template deriveMag<>))
-      .def("derive_phase",
-           py::overload_cast<>(
-               &CPS::Attribute<CPS::Complex>::template derivePhase<>))
-      .def("derive_scaled",
-           py::overload_cast<CPS::Complex>(
-               &CPS::Attribute<CPS::Complex>::template deriveScaled<
-                   CPS::Complex>));
+  auto attribute_complex =
+      py::class_<CPS::Attribute<CPS::Complex>,
+                 CPS::AttributePointer<CPS::Attribute<CPS::Complex>>,
+                 CPS::AttributeBase>(m, "AttributeComplex")
+          .def("get", &CPS::Attribute<CPS::Complex>::get)
+          .def("set", &CPS::Attribute<CPS::Complex>::set)
+          .def("derive_real",
+               py::overload_cast<>(
+                   &CPS::Attribute<CPS::Complex>::template deriveReal<>))
+          .def("derive_imag",
+               py::overload_cast<>(
+                   &CPS::Attribute<CPS::Complex>::template deriveImag<>))
+          .def("derive_mag",
+               py::overload_cast<>(
+                   &CPS::Attribute<CPS::Complex>::template deriveMag<>))
+          .def("derive_phase",
+               py::overload_cast<>(
+                   &CPS::Attribute<CPS::Complex>::template derivePhase<>))
+          .def("derive_scaled",
+               py::overload_cast<CPS::Complex>(
+                   &CPS::Attribute<CPS::Complex>::template deriveScaled<
+                       CPS::Complex>));
 
-  py::class_<CPS::AttributeStatic<CPS::Complex>,
-             CPS::AttributePointer<CPS::AttributeStatic<CPS::Complex>>,
-             CPS::Attribute<CPS::Complex>>(m, "AttributeComplexStat");
-  py::class_<CPS::AttributeDynamic<CPS::Complex>,
-             CPS::AttributePointer<CPS::AttributeDynamic<CPS::Complex>>,
-             CPS::Attribute<CPS::Complex>>(m, "AttributeComplexDyn")
-      .def("set_reference", &CPS::AttributeDynamic<CPS::Complex>::setReference);
+  auto attribute_complex_static =
+      py::class_<CPS::AttributeStatic<CPS::Complex>,
+                 CPS::AttributePointer<CPS::AttributeStatic<CPS::Complex>>,
+                 CPS::Attribute<CPS::Complex>>(m, "AttributeComplexStat");
+  auto attribute_complex_dynamic =
+      py::class_<CPS::AttributeDynamic<CPS::Complex>,
+                 CPS::AttributePointer<CPS::AttributeDynamic<CPS::Complex>>,
+                 CPS::Attribute<CPS::Complex>>(m, "AttributeComplexDyn")
+          .def("set_reference",
+               &CPS::AttributeDynamic<CPS::Complex>::setReference);
 
-  py::class_<CPS::Attribute<CPS::Matrix>,
-             CPS::AttributePointer<CPS::Attribute<CPS::Matrix>>,
-             CPS::AttributeBase>(m, "AttributeMatrix")
-      .def("get", &CPS::Attribute<CPS::Matrix>::get)
-      .def("set", &CPS::Attribute<CPS::Matrix>::set)
-      .def("derive_coeff",
-           &CPS::Attribute<CPS::Matrix>::deriveCoeff<CPS::Real>);
+  auto attribute_matrix =
+      py::class_<CPS::Attribute<CPS::Matrix>,
+                 CPS::AttributePointer<CPS::Attribute<CPS::Matrix>>,
+                 CPS::AttributeBase>(m, "AttributeMatrix")
+          .def("get", &CPS::Attribute<CPS::Matrix>::get)
+          .def("set", &CPS::Attribute<CPS::Matrix>::set)
+          .def("derive_coeff",
+               &CPS::Attribute<CPS::Matrix>::deriveCoeff<CPS::Real>);
 
-  py::class_<CPS::AttributeStatic<CPS::Matrix>,
-             CPS::AttributePointer<CPS::AttributeStatic<CPS::Matrix>>,
-             CPS::Attribute<CPS::Matrix>>(m, "AttributeMatrixStat");
-  py::class_<CPS::AttributeDynamic<CPS::Matrix>,
-             CPS::AttributePointer<CPS::AttributeDynamic<CPS::Matrix>>,
-             CPS::Attribute<CPS::Matrix>>(m, "AttributeMatrixDyn")
-      .def("set_reference", &CPS::AttributeDynamic<CPS::Matrix>::setReference);
+  auto attribute_matrix_static =
+      py::class_<CPS::AttributeStatic<CPS::Matrix>,
+                 CPS::AttributePointer<CPS::AttributeStatic<CPS::Matrix>>,
+                 CPS::Attribute<CPS::Matrix>>(m, "AttributeMatrixStat");
+  auto attribute_matrix_dynamic =
+      py::class_<CPS::AttributeDynamic<CPS::Matrix>,
+                 CPS::AttributePointer<CPS::AttributeDynamic<CPS::Matrix>>,
+                 CPS::Attribute<CPS::Matrix>>(m, "AttributeMatrixDyn")
+          .def("set_reference",
+               &CPS::AttributeDynamic<CPS::Matrix>::setReference);
 
-  py::class_<CPS::Attribute<CPS::MatrixComp>,
-             CPS::AttributePointer<CPS::Attribute<CPS::MatrixComp>>,
-             CPS::AttributeBase>(m, "AttributeMatrixComp")
-      .def("get", &CPS::Attribute<CPS::MatrixComp>::get)
-      .def("set", &CPS::Attribute<CPS::MatrixComp>::set)
-      .def("derive_coeff",
-           &CPS::Attribute<CPS::MatrixComp>::deriveCoeff<CPS::Complex>);
+  auto attribute_matrix_complex =
+      py::class_<CPS::Attribute<CPS::MatrixComp>,
+                 CPS::AttributePointer<CPS::Attribute<CPS::MatrixComp>>,
+                 CPS::AttributeBase>(m, "AttributeMatrixComp")
+          .def("get", &CPS::Attribute<CPS::MatrixComp>::get)
+          .def("set", &CPS::Attribute<CPS::MatrixComp>::set)
+          .def("derive_coeff",
+               &CPS::Attribute<CPS::MatrixComp>::deriveCoeff<CPS::Complex>);
 
-  py::class_<CPS::AttributeStatic<CPS::MatrixComp>,
-             CPS::AttributePointer<CPS::AttributeStatic<CPS::MatrixComp>>,
-             CPS::Attribute<CPS::MatrixComp>>(m, "AttributeMatrixCompStat");
-  py::class_<CPS::AttributeDynamic<CPS::MatrixComp>,
-             CPS::AttributePointer<CPS::AttributeDynamic<CPS::MatrixComp>>,
-             CPS::Attribute<CPS::MatrixComp>>(m, "AttributeMatrixCompDyn")
-      .def("set_reference",
-           &CPS::AttributeDynamic<CPS::MatrixComp>::setReference);
+  auto attribute_matrix_complex_static =
+      py::class_<CPS::AttributeStatic<CPS::MatrixComp>,
+                 CPS::AttributePointer<CPS::AttributeStatic<CPS::MatrixComp>>,
+                 CPS::Attribute<CPS::MatrixComp>>(m, "AttributeMatrixCompStat");
+  auto attribute_matrix_complex_dynamic =
+      py::class_<CPS::AttributeDynamic<CPS::MatrixComp>,
+                 CPS::AttributePointer<CPS::AttributeDynamic<CPS::MatrixComp>>,
+                 CPS::Attribute<CPS::MatrixComp>>(m, "AttributeMatrixCompDyn")
+          .def("set_reference",
+               &CPS::AttributeDynamic<CPS::MatrixComp>::setReference);
 
-  py::class_<CPS::Attribute<CPS::String>,
-             CPS::AttributePointer<CPS::Attribute<CPS::String>>,
-             CPS::AttributeBase>(m, "AttributeString")
-      .def("get", &CPS::Attribute<CPS::String>::get)
-      .def("set", &CPS::Attribute<CPS::String>::set);
+  auto attribute_string =
+      py::class_<CPS::Attribute<CPS::String>,
+                 CPS::AttributePointer<CPS::Attribute<CPS::String>>,
+                 CPS::AttributeBase>(m, "AttributeString")
+          .def("get", &CPS::Attribute<CPS::String>::get)
+          .def("set", &CPS::Attribute<CPS::String>::set);
 
-  py::class_<CPS::AttributeStatic<CPS::String>,
-             CPS::AttributePointer<CPS::AttributeStatic<CPS::String>>,
-             CPS::Attribute<CPS::String>>(m, "AttributeStringStat");
-  py::class_<CPS::AttributeDynamic<CPS::String>,
-             CPS::AttributePointer<CPS::AttributeDynamic<CPS::String>>,
-             CPS::Attribute<CPS::String>>(m, "AttributeStringDyn")
-      .def("set_reference", &CPS::AttributeDynamic<CPS::String>::setReference);
+  auto attribute_string_static =
+      py::class_<CPS::AttributeStatic<CPS::String>,
+                 CPS::AttributePointer<CPS::AttributeStatic<CPS::String>>,
+                 CPS::Attribute<CPS::String>>(m, "AttributeStringStat");
+  auto attribute_string_dynamic =
+      py::class_<CPS::AttributeDynamic<CPS::String>,
+                 CPS::AttributePointer<CPS::AttributeDynamic<CPS::String>>,
+                 CPS::Attribute<CPS::String>>(m, "AttributeStringDyn")
+          .def("set_reference",
+               &CPS::AttributeDynamic<CPS::String>::setReference);
 }

--- a/dpsim/src/pybind/DPComponents.cpp
+++ b/dpsim/src/pybind/DPComponents.cpp
@@ -70,12 +70,14 @@ void addDPPh1Components(py::module_ mDPPh1) {
       .def(py::init<std::string>())
       .def(py::init<std::string, CPS::Logger::Level>())
       .def("set_parameters",
-           static_cast<void (Base::*)(CPS::Complex, CPS::Real)>(
-               &Base::setParameters),
+           static_cast<void (CPS::Base::Ph1::VoltageSource::*)(CPS::Complex,
+                                                               CPS::Real)>(
+               &CPS::Base::Ph1::VoltageSource::setParameters),
            py::arg("voltageRef"), py::arg("srcFreq") = -1)
       .def("set_parameters",
-           static_cast<void (Derived::*)(CPS::Complex, CPS::Real, CPS::Real)>(
-               &Derived::setParameters),
+           static_cast<void (CPS::DP::Ph1::VoltageSourceNorton::*)(
+               CPS::Complex, CPS::Real, CPS::Real)>(
+               &CPS::DP::Ph1::VoltageSourceNorton::setParameters),
            py::arg("voltageRef"), py::arg("srcFreq") = -1,
            py::arg("resistance") = 1e9)
       .def("connect", &CPS::DP::Ph1::VoltageSourceNorton::connect);

--- a/dpsim/src/pybind/DPComponents.cpp
+++ b/dpsim/src/pybind/DPComponents.cpp
@@ -70,9 +70,14 @@ void addDPPh1Components(py::module_ mDPPh1) {
       .def(py::init<std::string>())
       .def(py::init<std::string, CPS::Logger::Level>())
       .def("set_parameters",
-           py::overload_cast<CPS::Complex, CPS::Real>(
-               &CPS::DP::Ph1::VoltageSourceNorton::setParameters),
-           "V_ref"_a, "f_src"_a = -1)
+           static_cast<void (Base::*)(CPS::Complex, CPS::Real)>(
+               &Base::setParameters),
+           py::arg("voltageRef"), py::arg("srcFreq") = -1)
+      .def("set_parameters",
+           static_cast<void (Derived::*)(CPS::Complex, CPS::Real, CPS::Real)>(
+               &Derived::setParameters),
+           py::arg("voltageRef"), py::arg("srcFreq") = -1,
+           py::arg("resistance") = 1e9)
       .def("connect", &CPS::DP::Ph1::VoltageSourceNorton::connect);
 
   py::class_<CPS::DP::Ph1::CurrentSource,


### PR DESCRIPTION
This is an initial test to build windows wheels, following the idea in #368

This PR does:
- Create a Pybind compilation test for windows
- Create a CI workflow to publish python c313 artifacts for windows

Additionally, to make this possible:
- Fixes some of the bindings due to sonarcloud errors
- Changes CMakefiles to allow the multi-platform (and multi-compiler) use in the cmake dependencies
- Fixes some missing destructors 