### PR TITLE
Fix realtime datalogger

### DIFF
--- a/.github/workflows/build_test_linux_rocky_profiling.yaml
+++ b/.github/workflows/build_test_linux_rocky_profiling.yaml
@@ -3,68 +3,64 @@ name: Build & Profile RockyLinux
 on:
   workflow_dispatch:
 
-## Build ##
-
 jobs:
   profiling:
     name: Build with Profiling options
     runs-on: ubuntu-latest
     container: sogno/dpsim:dev-rocky
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-    - name: Create Build Environment
-      run: mkdir build
+      - name: Create Build Environment
+        run: mkdir build
 
-    - name: Cache build directory
-      uses: actions/cache@v4
-      with:
-        path: ${{ github.workspace }}/build
-        key: build-cache-rocky-profiling-${{ github.ref }}
+      - name: Cache build directory
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/build
+          key: build-cache-rocky-profiling-${{ github.ref }}
 
-    - name: Configure CMake
-      shell: bash
-      working-directory: ${{ github.workspace }}/build
-      run: cmake $GITHUB_WORKSPACE -DWITH_PROFILING=ON -DWITH_ASAN=ON -DWITH_CUDA=OFF -DFETCH_SPDLOG=ON
+      - name: Configure CMake
+        shell: bash
+        working-directory: ${{ github.workspace }}/build
+        run: cmake $GITHUB_WORKSPACE -DWITH_PROFILING=ON -DWITH_ASAN=ON -DWITH_CUDA=OFF -DFETCH_SPDLOG=ON
 
-    - name: Build every target
-      shell: bash
-      working-directory: ${{ github.workspace }}/build
-      run: cmake --build . --parallel $(nproc)
+      - name: Build every target
+        shell: bash
+        working-directory: ${{ github.workspace }}/build
+        run: cmake --build . --parallel $(nproc)
 
-
-## Tests ##
   test-examples-1:
-    name: Test Examples 1/4
+    name: Test Examples 1/4 - WSCC_9bus_mult_coupled
     needs: [profiling]
-    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@${{github.ref}}
-    with:
-      path: ./build/dpsim/examples/cxx/WSCC_9bus_mult_decoupled
-      name: WSCC_9bus_mult_decoupled
-
-  test-examples-2:
-    name: Test Examples 2/4
-    needs: [profiling]
-    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@${{github.ref}}
+    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@main
     with:
       path: ./build/dpsim/examples/cxx/WSCC_9bus_mult_coupled
       name: WSCC_9bus_mult_coupled
 
-  test-examples-3:
-    name: Test Examples 3/4
+  test-examples-2:
+    name: Test Examples 2/4 - WSCC_9bus_mult_decoupled
     needs: [profiling]
-    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@${{github.ref}}
+    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@main
+    with:
+      path: ./build/dpsim/examples/cxx/WSCC_9bus_mult_decoupled
+      name: WSCC_9bus_mult_decoupled
+
+  test-examples-3:
+    name: Test Examples 3/4 - EMT_WSCC_9bus_split_decoupled
+    needs: [profiling]
+    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@main
     with:
       path: ./build/dpsim/examples/cxx/EMT_WSCC_9bus_split_decoupled
-      name: WSCC_9bus_split_decoupled
+      name: EMT_WSCC_9bus_split_decoupled
 
   test-examples-4:
-    name: Test Examples 4/4
+    name: Test Examples 4/4 - DP_WSCC_9bus_split_decoupled
     needs: [profiling]
-    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@${{github.ref}}
+    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@main
     with:
       path: ./build/dpsim/examples/cxx/DP_WSCC_9bus_split_decoupled
-      name: WSCC_9bus_split_decoupled
+      name: DP_WSCC_9bus_split_decoupled

--- a/dpsim/include/DPsim.h
+++ b/dpsim/include/DPsim.h
@@ -11,6 +11,7 @@
 #include <dpsim/Utils.h>
 
 #ifndef _MSC_VER
+#include <dpsim/RealTimeDataLogger.h>
 #include <dpsim/RealTimeSimulation.h>
 #endif
 

--- a/dpsim/src/RealTimeDataLogger.cpp
+++ b/dpsim/src/RealTimeDataLogger.cpp
@@ -4,12 +4,14 @@
  * SPDX-FileCopyrightText: 2024 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "dpsim-models/Attribute.h"
-#include <iomanip>
 
-#include <dpsim-models/Logger.h>
-#include <dpsim/RealTimeDataLogger.h>
+#include <iomanip>
 #include <memory>
+
+#include <dpsim/RealTimeDataLogger.h>
+
+#include <dpsim-models/Attribute.h>
+#include <dpsim-models/Logger.h>
 
 using namespace DPsim;
 
@@ -41,6 +43,11 @@ void RealTimeDataLogger::start() {
 }
 
 void RealTimeDataLogger::stop() {
+  auto log = CPS::Logger::get("RealTimeDataLogger", CPS::Logger::Level::off,
+                              CPS::Logger::Level::info);
+  log->info("Stopping real-time data logger. Writing memory to file {}",
+            mFilename.string());
+
   auto mLogFile =
       std::ofstream(mFilename, std::ios_base::out | std::ios_base::trunc);
   if (!mLogFile.is_open()) {
@@ -59,6 +66,8 @@ void RealTimeDataLogger::stop() {
     mLogFile << '\n';
   }
   mLogFile.close();
+  log->info("Finished writing real-time data log to file {}.",
+            mFilename.string());
 }
 
 void RealTimeDataLogger::log(Real time, Int timeStepCount) {
@@ -76,15 +85,21 @@ void RealTimeDataLogger::log(Real time, Int timeStepCount) {
   mAttributeData[mCurrentRow][0] = time;
   mCurrentAttribute = 1;
 
-  for (auto it : mAttributes) {
+  for (auto &it : mAttributes) {
+    auto base = it.second.getPtr(); // std::shared_ptr<CPS::AttributeBase>
+
     if (it.second->getType() == typeid(Real)) {
-      mAttributeData[mCurrentRow][mCurrentAttribute++] =
-          **std::dynamic_pointer_cast<std::shared_ptr<CPS::Attribute<Real>>>(
-              it.second.getPtr());
+      auto attr = std::dynamic_pointer_cast<CPS::Attribute<Real>>(base);
+      if (!attr) { /* skip */
+        continue;
+      }
+      mAttributeData[mCurrentRow][mCurrentAttribute++] = attr->get();
     } else if (it.second->getType() == typeid(Int)) {
-      mAttributeData[mCurrentRow][mCurrentAttribute++] =
-          **std::dynamic_pointer_cast<std::shared_ptr<CPS::Attribute<Int>>>(
-              it.second.getPtr());
+      auto attr = std::dynamic_pointer_cast<CPS::Attribute<Int>>(base);
+      if (!attr) { /* skip */
+        continue;
+      }
+      mAttributeData[mCurrentRow][mCurrentAttribute++] = attr->get();
     }
   }
 }


### PR DESCRIPTION
There is a segmentation fault coming from the way the attributes are accessed for some cases.
    
 Additionally, now the model is added to DPsim.h and a more verbose behaviour is implemented when saving the memory dump.