### PR TITLE
Fix module dpsimvillas

### DIFF
--- a/.github/workflows/build_test_linux_rocky_profiling.yaml
+++ b/.github/workflows/build_test_linux_rocky_profiling.yaml
@@ -3,68 +3,64 @@ name: Build & Profile RockyLinux
 on:
   workflow_dispatch:
 
-## Build ##
-
 jobs:
   profiling:
     name: Build with Profiling options
     runs-on: ubuntu-latest
     container: sogno/dpsim:dev-rocky
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-    - name: Create Build Environment
-      run: mkdir build
+      - name: Create Build Environment
+        run: mkdir build
 
-    - name: Cache build directory
-      uses: actions/cache@v4
-      with:
-        path: ${{ github.workspace }}/build
-        key: build-cache-rocky-profiling-${{ github.ref }}
+      - name: Cache build directory
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/build
+          key: build-cache-rocky-profiling-${{ github.ref }}
 
-    - name: Configure CMake
-      shell: bash
-      working-directory: ${{ github.workspace }}/build
-      run: cmake $GITHUB_WORKSPACE -DWITH_PROFILING=ON -DWITH_ASAN=ON -DWITH_CUDA=OFF -DFETCH_SPDLOG=ON
+      - name: Configure CMake
+        shell: bash
+        working-directory: ${{ github.workspace }}/build
+        run: cmake $GITHUB_WORKSPACE -DWITH_PROFILING=ON -DWITH_ASAN=ON -DWITH_CUDA=OFF -DFETCH_SPDLOG=ON
 
-    - name: Build every target
-      shell: bash
-      working-directory: ${{ github.workspace }}/build
-      run: cmake --build . --parallel $(nproc)
+      - name: Build every target
+        shell: bash
+        working-directory: ${{ github.workspace }}/build
+        run: cmake --build . --parallel $(nproc)
 
-
-## Tests ##
   test-examples-1:
-    name: Test Examples 1/4
+    name: Test Examples 1/4 - WSCC_9bus_mult_coupled
     needs: [profiling]
-    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@${{github.ref}}
-    with:
-      path: ./build/dpsim/examples/cxx/WSCC_9bus_mult_decoupled
-      name: WSCC_9bus_mult_decoupled
-
-  test-examples-2:
-    name: Test Examples 2/4
-    needs: [profiling]
-    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@${{github.ref}}
+    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@main
     with:
       path: ./build/dpsim/examples/cxx/WSCC_9bus_mult_coupled
       name: WSCC_9bus_mult_coupled
 
-  test-examples-3:
-    name: Test Examples 3/4
+  test-examples-2:
+    name: Test Examples 2/4 - WSCC_9bus_mult_decoupled
     needs: [profiling]
-    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@${{github.ref}}
+    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@main
+    with:
+      path: ./build/dpsim/examples/cxx/WSCC_9bus_mult_decoupled
+      name: WSCC_9bus_mult_decoupled
+
+  test-examples-3:
+    name: Test Examples 3/4 - EMT_WSCC_9bus_split_decoupled
+    needs: [profiling]
+    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@main
     with:
       path: ./build/dpsim/examples/cxx/EMT_WSCC_9bus_split_decoupled
-      name: WSCC_9bus_split_decoupled
+      name: EMT_WSCC_9bus_split_decoupled
 
   test-examples-4:
-    name: Test Examples 4/4
+    name: Test Examples 4/4 - DP_WSCC_9bus_split_decoupled
     needs: [profiling]
-    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@${{github.ref}}
+    uses: sogno-platform/dpsim/.github/workflows/run_and_profile_example.yaml@main
     with:
       path: ./build/dpsim/examples/cxx/DP_WSCC_9bus_split_decoupled
-      name: WSCC_9bus_split_decoupled
+      name: DP_WSCC_9bus_split_decoupled

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,14 +280,13 @@ if(WITH_PYBIND)
 endif()
 
 add_subdirectory(dpsim-models)
+if(WITH_VILLAS)
+	add_subdirectory(dpsim-villas)
+endif()
 add_subdirectory(dpsim)
 
 if(DPSIM_BUILD_DOC)
 	add_subdirectory(docs)
-endif()
-
-if(WITH_VILLAS)
-	add_subdirectory(dpsim-villas)
 endif()
 
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")

--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -92,6 +92,7 @@
 #include <dpsim-models/EMT/EMT_Ph3_AvVoltSourceInverterStateSpace.h>
 #include <dpsim-models/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.h>
 #include <dpsim-models/EMT/EMT_Ph3_Capacitor.h>
+#include <dpsim-models/EMT/EMT_Ph3_ControlledCurrentSource.h>
 #include <dpsim-models/EMT/EMT_Ph3_ControlledVoltageSource.h>
 #include <dpsim-models/EMT/EMT_Ph3_CurrentSource.h>
 #include <dpsim-models/EMT/EMT_Ph3_Inductor.h>

--- a/dpsim-villas/CMakeLists.txt
+++ b/dpsim-villas/CMakeLists.txt
@@ -1,3 +1,13 @@
+configure_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/include/dpsim-villas/Config.h.in
+	${CMAKE_CURRENT_BINARY_DIR}/include/dpsim-villas/Config.h
+)
+
+set(DPSIM_VILLAS_INCLUDE_DIRS
+	${CMAKE_CURRENT_SOURCE_DIR}/include
+	${CMAKE_CURRENT_BINARY_DIR}/include
+)
+
 if(WITH_PYBIND)
 	pybind11_add_module(dpsimpyvillas src/pybind-dpsim-villas.cpp)
 	set_target_properties(dpsimpyvillas
@@ -17,17 +27,27 @@ endif()
 
 add_subdirectory(src)
 
+target_include_directories(dpsim-villas PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}/include
+	${CMAKE_CURRENT_BINARY_DIR}/include
+)
+
 if(DPSIM_BUILD_EXAMPLES)
 	add_subdirectory(examples)
 endif()
 
 file(GLOB_RECURSE HEADER_FILES include/*.h)
+set(GENERATED_HEADER ${CMAKE_CURRENT_BINARY_DIR}/include/dpsim-villas/Config.h)
 
 target_sources(dpsim-villas PUBLIC
 	FILE_SET public_headers
 	TYPE HEADERS
-	BASE_DIRS include
-	FILES "${HEADER_FILES}"
+	BASE_DIRS
+		${CMAKE_CURRENT_SOURCE_DIR}/include
+		${CMAKE_CURRENT_BINARY_DIR}/include
+	FILES
+		${HEADER_FILES}
+		${GENERATED_HEADER}
 )
 
 install(TARGETS dpsim-villas

--- a/dpsim-villas/examples/cxx/Fpga9BusHil.cpp
+++ b/dpsim-villas/examples/cxx/Fpga9BusHil.cpp
@@ -7,20 +7,11 @@
 #include <filesystem>
 #include <fstream>
 
-#include "../examples/cxx/Examples.h"
 #include <DPsim.h>
-#include <dpsim-models/Attribute.h>
-#include <dpsim-models/DP/DP_Ph1_CurrentSource.h>
-#include <dpsim-models/EMT/EMT_Ph3_RXLoad.h>
-#include <dpsim-models/EMT/EMT_Ph3_SynchronGeneratorVBR.h>
-#include <dpsim-models/SimNode.h>
-#include <dpsim-villas/InterfaceVillas.h>
-#include <dpsim-villas/InterfaceVillasQueueless.h>
-#include <dpsim/Definitions.h>
-#include <dpsim/Event.h>
-#include <dpsim/RealTimeDataLogger.h>
-#include <dpsim/Utils.h>
-#include <memory>
+
+#include <dpsim-villas/Interfaces.h>
+
+#include "../examples/cxx/Examples.h"
 
 using namespace DPsim;
 using namespace CPS::EMT;
@@ -135,16 +126,16 @@ hilTopology(CommandLineArgs &args, std::shared_ptr<Interface> intf,
   sys.initWithPowerflow(systemPF, CPS::Domain::EMT);
 
   sys.component<CPS::EMT::Ph3::RXLoad>("LOAD5")->setParameters(
-      Matrix({{125e6, 0, 0}, {0, 125e6, 0}, {0, 0, 125e6}}),
-      Matrix({{90e6, 0, 0}, {0, 90e6, 0}, {0, 0, 90e6}}), 230e3, true);
+      CPS::Math::singlePhaseParameterToThreePhase(125e6),
+      CPS::Math::singlePhaseParameterToThreePhase(90e6), 230e3, true);
 
   sys.component<CPS::EMT::Ph3::RXLoad>("LOAD8")->setParameters(
-      Matrix({{100e6, 0, 0}, {0, 100e6, 0}, {0, 0, 100e6}}),
-      Matrix({{30e6, 0, 0}, {0, 30e6, 0}, {0, 0, 30e6}}), 230e3, true);
+      CPS::Math::singlePhaseParameterToThreePhase(100e6),
+      CPS::Math::singlePhaseParameterToThreePhase(30e6), 230e3, true);
 
   sys.component<CPS::EMT::Ph3::RXLoad>("LOAD6")->setParameters(
-      Matrix({{90e6, 0, 0}, {0, 90e6, 0}, {0, 0, 90e6}}),
-      Matrix({{30e6, 0, 0}, {0, 30e6, 0}, {0, 0, 30e6}}), 230e3, true);
+      CPS::Math::singlePhaseParameterToThreePhase(90e6),
+      CPS::Math::singlePhaseParameterToThreePhase(30e6), 230e3, true);
 
   auto gen1 = sys.component<CPS::EMT::Ph3::SynchronGeneratorVBR>("GEN1");
   gen1->addGovernor(govKundur.Ta_t, govKundur.Tb, govKundur.Tc, govKundur.Fa,

--- a/dpsim-villas/examples/cxx/FpgaCosim3PhInfiniteBus.cpp
+++ b/dpsim-villas/examples/cxx/FpgaCosim3PhInfiniteBus.cpp
@@ -6,24 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dpsim-models/Logger.h>
 #include <filesystem>
 #include <fstream>
 
 #include <DPsim.h>
-#include <dpsim-models/Attribute.h>
-#include <dpsim-models/EMT/EMT_Ph3_ControlledCurrentSource.h>
-#include <dpsim-models/EMT/EMT_Ph3_ControlledVoltageSource.h>
-#include <dpsim-models/EMT/EMT_Ph3_Inductor.h>
-#include <dpsim-models/EMT/EMT_Ph3_NetworkInjection.h>
-#include <dpsim-models/EMT/EMT_Ph3_Resistor.h>
-#include <dpsim-models/SimNode.h>
-#include <dpsim-villas/InterfaceVillas.h>
-#include <dpsim-villas/InterfaceVillasQueueless.h>
-#include <dpsim/Event.h>
-#include <dpsim/RealTimeDataLogger.h>
-#include <dpsim/Utils.h>
-#include <memory>
+
+#include <dpsim-villas/Interfaces.h>
 
 using namespace DPsim;
 using namespace CPS::EMT;
@@ -153,16 +141,15 @@ SystemTopology buildTopology(CommandLineArgs &args,
       50);
 
   auto r = Ph3::Resistor::make("R");
-  r->setParameters(Matrix{{10.4275, 0, 0}, {0, 10.4275, 0}, {0, 0, 10.4275}});
+  r->setParameters(CPS::Math::singlePhaseParameterToThreePhase(10.4275));
 
   auto l = Ph3::Inductor::make("L");
-  l->setParameters(
-      Matrix{{0.325101, 0, 0}, {0, 0.325101, 0}, {0, 0, 0.325101}});
+  l->setParameters(CPS::Math::singlePhaseParameterToThreePhase(0.325101));
   auto r2 = Ph3::Resistor::make("R2");
-  r2->setParameters(Matrix{{5.29e6, 0, 0}, {0, 5.29e6, 0}, {0, 0, 5.29e6}});
+  r2->setParameters(CPS::Math::singlePhaseParameterToThreePhase(5.29e6));
 
   auto cs = Ph3::ControlledCurrentSource::make("cs");
-  cs->setParameters(Matrix{{0.0}, {0.0}, {0.0}});
+  cs->setParameters(CPS::Math::singlePhaseParameterToThreePhase(0.0));
 
   // Topology
   vs->connect({SimNode::GND, bus1});

--- a/dpsim-villas/examples/cxx/FpgaCosimulation.cpp
+++ b/dpsim-villas/examples/cxx/FpgaCosimulation.cpp
@@ -6,20 +6,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dpsim-models/Logger.h>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 
 #include <DPsim.h>
-#include <dpsim-models/Attribute.h>
-#include <dpsim-models/EMT/EMT_Ph3_ControlledVoltageSource.h>
-#include <dpsim-models/SimNode.h>
-#include <dpsim-villas/InterfaceVillas.h>
-#include <dpsim-villas/InterfaceVillasQueueless.h>
-#include <dpsim/Event.h>
-#include <dpsim/RealTimeDataLogger.h>
-#include <dpsim/Utils.h>
-#include <memory>
+
+#include <dpsim-villas/Interfaces.h>
 
 using namespace DPsim;
 using namespace CPS::EMT;
@@ -141,13 +134,13 @@ SystemTopology buildTopology(CommandLineArgs &args,
 
   // Components
   auto vs = Ph3::ControlledVoltageSource::make("vs");
-  auto voltageRef = Matrix({{230e3}, {230e3}, {230e3}});
+  auto voltageRef = CPS::Math::singlePhaseParameterToThreePhase(230e3);
   vs->setParameters(voltageRef);
 
   auto load = Ph3::RXLoad::make("load");
-  auto active = Matrix({{125e6, 0, 0}, {0, 125e6, 0}, {0, 0, 125e6}});
+  auto active = CPS::Math::singlePhaseParameterToThreePhase(125e6);
   // auto reactive = Matrix::Zero(3, 3);
-  auto reactive = Matrix({{50e6, 0, 0}, {0, 50e6, 0}, {0, 0, 50e6}});
+  auto reactive = CPS::Math::singlePhaseParameterToThreePhase(50e6);
   load->setParameters(active, reactive, 230e3, true);
 
   // Topology

--- a/dpsim-villas/include/dpsim-villas/Config.h.in
+++ b/dpsim-villas/include/dpsim-villas/Config.h.in
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#ifndef DPSIM_VILLAS_CONFIG_H
+#define DPSIM_VILLAS_CONFIG_H
+
+#define DPSIM_VILLAS_VERSION "@PROJECT_VERSION@"
+
+// Features
+#cmakedefine WITH_RT
+#cmakedefine WITH_VILLAS
+#cmakedefine WITH_CIM
+#cmakedefine WITH_PYBIND
+#cmakedefine WITH_SUNDIALS
+#cmakedefine WITH_OPENMP
+#cmakedefine WITH_CUDA
+#cmakedefine WITH_CUDA_SPARSE
+#cmakedefine WITH_MAGMA
+#cmakedefine WITH_KLU
+#cmakedefine WITH_MNASOLVERPLUGIN
+#cmakedefine WITH_JSON
+#cmakedefine CGMES_BUILD
+
+#cmakedefine HAVE_GETOPT
+#cmakedefine HAVE_TIMERFD
+
+#endif

--- a/dpsim-villas/include/dpsim-villas/Interfaces.h
+++ b/dpsim-villas/include/dpsim-villas/Interfaces.h
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-villas/Config.h>
+
+#include <dpsim-villas/InterfaceVillas.h>
+#include <dpsim-villas/InterfaceVillasQueueless.h>

--- a/dpsim/include/DPsim.h
+++ b/dpsim/include/DPsim.h
@@ -11,6 +11,7 @@
 #include <dpsim/Utils.h>
 
 #ifndef _MSC_VER
+#include <dpsim/RealTimeDataLogger.h>
 #include <dpsim/RealTimeSimulation.h>
 #endif
 

--- a/dpsim/src/RealTimeDataLogger.cpp
+++ b/dpsim/src/RealTimeDataLogger.cpp
@@ -4,12 +4,14 @@
  * SPDX-FileCopyrightText: 2024 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "dpsim-models/Attribute.h"
-#include <iomanip>
 
-#include <dpsim-models/Logger.h>
-#include <dpsim/RealTimeDataLogger.h>
+#include <iomanip>
 #include <memory>
+
+#include <dpsim/RealTimeDataLogger.h>
+
+#include <dpsim-models/Attribute.h>
+#include <dpsim-models/Logger.h>
 
 using namespace DPsim;
 
@@ -41,6 +43,11 @@ void RealTimeDataLogger::start() {
 }
 
 void RealTimeDataLogger::stop() {
+  auto log = CPS::Logger::get("RealTimeDataLogger", CPS::Logger::Level::off,
+                              CPS::Logger::Level::info);
+  log->info("Stopping real-time data logger. Writing memory to file {}",
+            mFilename.string());
+
   auto mLogFile =
       std::ofstream(mFilename, std::ios_base::out | std::ios_base::trunc);
   if (!mLogFile.is_open()) {
@@ -59,6 +66,8 @@ void RealTimeDataLogger::stop() {
     mLogFile << '\n';
   }
   mLogFile.close();
+  log->info("Finished writing real-time data log to file {}.",
+            mFilename.string());
 }
 
 void RealTimeDataLogger::log(Real time, Int timeStepCount) {
@@ -76,15 +85,21 @@ void RealTimeDataLogger::log(Real time, Int timeStepCount) {
   mAttributeData[mCurrentRow][0] = time;
   mCurrentAttribute = 1;
 
-  for (auto it : mAttributes) {
+  for (auto &it : mAttributes) {
+    auto base = it.second.getPtr(); // std::shared_ptr<CPS::AttributeBase>
+
     if (it.second->getType() == typeid(Real)) {
-      mAttributeData[mCurrentRow][mCurrentAttribute++] =
-          **std::dynamic_pointer_cast<std::shared_ptr<CPS::Attribute<Real>>>(
-              it.second.getPtr());
+      auto attr = std::dynamic_pointer_cast<CPS::Attribute<Real>>(base);
+      if (!attr) { /* skip */
+        continue;
+      }
+      mAttributeData[mCurrentRow][mCurrentAttribute++] = attr->get();
     } else if (it.second->getType() == typeid(Int)) {
-      mAttributeData[mCurrentRow][mCurrentAttribute++] =
-          **std::dynamic_pointer_cast<std::shared_ptr<CPS::Attribute<Int>>>(
-              it.second.getPtr());
+      auto attr = std::dynamic_pointer_cast<CPS::Attribute<Int>>(base);
+      if (!attr) { /* skip */
+        continue;
+      }
+      mAttributeData[mCurrentRow][mCurrentAttribute++] = attr->get();
     }
   }
 }


### PR DESCRIPTION
This PR does a cleanup on the module structure and fixes the examples.

1. Create a Config.h to expose options and allow future granular control for the compilation of modules, models and examples in dpsim-villas
2. Creates a single point to include the interfaces in dpsim-villas
3. Add a missing component required by the examples with cosimulation to DPsim.h
4. Fixes the errors in Eigen by initializing using the method to create 3 phase parameters
5. Cleans the imports in the examples