### PR TITLE
fix std::max behaviour in simulation.cpp for windows build with #define NOMINMAX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ if(WIN32)
 	cmake_policy(SET CMP0074 NEW)
 endif()
 
+# Define NOMINMAX to prevent Windows macros from breaking std::max
+if(WIN32)
+  add_compile_definitions(NOMINMAX)
+endif()
+
 # Allow shadowing of CMake targets
 # As we include dependencies via add_subdirectory()
 # we import their targets into the DPsim CMake tree

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 
 # Define NOMINMAX to prevent Windows macros from breaking std::max
 if(WIN32)
-  add_compile_definitions(NOMINMAX)
+	add_compile_definitions(NOMINMAX)
 endif()
 
 # Allow shadowing of CMake targets


### PR DESCRIPTION
- issue with std::max in simulation.cpp: windows.h seems to be included somewhere and standard C++ behaviour of std::max is broken

- proposed fix:  define NOMINMAX for windows builds 
#ifdef _WIN32
#define NOMINMAX
#endif