### PR TITLE
Disable code coverage in linux-fedora-examples on workflow

### DIFF
--- a/.github/workflows/build_test_linux_fedora.yaml
+++ b/.github/workflows/build_test_linux_fedora.yaml
@@ -67,7 +67,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{ github.workspace }}/build
-      run: cmake -DCIM_VERSION=CGMES_2.4.15_16FEB2016 -DCOVERAGE=ON $GITHUB_WORKSPACE
+      run: cmake -DCIM_VERSION=CGMES_2.4.15_16FEB2016 $GITHUB_WORKSPACE
 
     - name: Build every target
       shell: bash


### PR DESCRIPTION
Currently, errors like #410 are happening. 
To stop blocking the pipeline, we need to investigate a better way. I suggest we can turn off the code coverage compilation from cpp examples (is currently not yet used) meanwhile a solution is found.