### PR TITLE
Fix EMT 3Ph Switch behaviour for Matrix Recomputation

### DIFF
--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Switch.h
@@ -16,6 +16,9 @@ namespace Base {
 namespace Ph1 {
 /// Dynamic Phasor Three-Phase Switch
 class Switch {
+protected:
+  Bool mIsClosedPrev = false;
+
 public:
   /// Resistance if switch is open [ohm]
   const Attribute<Real>::Ptr mOpenResistance;

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Switch.h
@@ -15,6 +15,9 @@ namespace Base {
 namespace Ph3 {
 /// Dynamic Phasor Three-Phase Switch
 class Switch {
+protected:
+  Bool mIsClosedPrev = false;
+
 public:
   /// Resistance if switch is open [ohm]
   const CPS::Attribute<Matrix>::Ptr mOpenResistance;
@@ -37,6 +40,9 @@ public:
   }
   void closeSwitch() { **mIsClosed = true; }
   void openSwitch() { **mIsClosed = false; }
+
+  /// Check if switch is closed
+  Bool isClosed() { return **mIsClosed; }
 };
 } // namespace Ph3
 } // namespace Base

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoadSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoadSwitch.h
@@ -17,6 +17,7 @@ namespace Ph1 {
 /// Constant impedance load model consisting of RLC elements
 class RXLoadSwitch : public CompositePowerComp<Complex>,
                      public MNASwitchInterface,
+                     public MNAVariableCompInterface,
                      public SharedFactory<RXLoadSwitch> {
 protected:
   /// Internal RXLoad
@@ -73,6 +74,9 @@ public:
   void mnaCompApplySwitchSystemMatrixStamp(Bool closed,
                                            SparseMatrixRow &systemMatrix,
                                            Int freqIdx) override;
+
+  // #### MNA section for variable component ####
+  Bool hasParameterChanged() override;
 };
 } // namespace Ph1
 } // namespace DP

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Switch.h
@@ -12,8 +12,8 @@
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Logger.h>
 #include <dpsim-models/MNASimPowerComp.h>
-#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAVariableCompInterface.h>
 
 namespace CPS {
 namespace DP {
@@ -25,8 +25,8 @@ namespace Ph1 {
 class Switch : public MNASimPowerComp<Complex>,
                public Base::Ph1::Switch,
                public SharedFactory<Switch>,
-               public MNASwitchInterface {
-protected:
+               public MNASwitchInterface,
+               public MNAVariableCompInterface {
 public:
   /// Defines UID, name, component parameters and logging level
   Switch(String uid, String name, Logger::Level loglevel = Logger::Level::off);
@@ -68,6 +68,9 @@ public:
   void mnaCompApplySwitchSystemMatrixStamp(Bool closed,
                                            SparseMatrixRow &systemMatrix,
                                            Int freqIdx);
+
+  // #### MNA section for variable component ####
+  Bool hasParameterChanged();
 };
 } // namespace Ph1
 } // namespace DP

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_varResSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_varResSwitch.h
@@ -31,7 +31,6 @@ class varResSwitch : public MNASimPowerComp<Complex>,
                      public SharedFactory<varResSwitch> {
 
 protected:
-  Bool mPrevState = false;
   Real mDeltaResClosed = 0;
   Real mDeltaResOpen = 1.5;
   Real mPrevRes; // previous resistance value to multiply with rate of change
@@ -94,6 +93,7 @@ public:
                                            SparseMatrixRow &systemMatrix,
                                            Int freqIdx);
 
+  // #### MNA section for variable component ####
   Bool hasParameterChanged();
 };
 } // namespace Ph1

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesSwitch.h
@@ -12,8 +12,8 @@
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Logger.h>
 #include <dpsim-models/MNASimPowerComp.h>
-#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAVariableCompInterface.h>
 
 namespace CPS {
 namespace DP {
@@ -27,7 +27,10 @@ namespace Ph3 {
 class SeriesSwitch : public MNASimPowerComp<Complex>,
                      public Base::Ph1::Switch,
                      public SharedFactory<SeriesSwitch>,
-                     public MNASwitchInterface {
+                     public MNASwitchInterface,
+                     public MNAVariableCompInterface {
+protected:
+  Bool mPrevState = false;
 
 public:
   /// Defines UID, name and logging level
@@ -68,6 +71,9 @@ public:
                                  Attribute<Matrix>::Ptr &leftVector) override;
   void mnaCompPostStep(Real time, Int timeStepCount,
                        Attribute<Matrix>::Ptr &leftVector) override;
+
+  // #### MNA section for variable component ####
+  Bool hasParameterChanged() override;
 };
 } // namespace Ph3
 } // namespace DP

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_Switch.h
@@ -12,8 +12,8 @@
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Logger.h>
 #include <dpsim-models/MNASimPowerComp.h>
-#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAVariableCompInterface.h>
 
 namespace CPS {
 namespace EMT {
@@ -25,8 +25,8 @@ namespace Ph1 {
 class Switch : public MNASimPowerComp<Real>,
                public Base::Ph1::Switch,
                public SharedFactory<Switch>,
+               public MNAVariableCompInterface,
                public MNASwitchInterface {
-
 public:
   /// Defines UID, name, component parameters and logging level
   Switch(String uid, String name, Logger::Level loglevel = Logger::Level::off);
@@ -69,6 +69,8 @@ public:
                                  AttributeBase::List &attributeDependencies,
                                  AttributeBase::List &modifiedAttributes,
                                  Attribute<Matrix>::Ptr &leftVector) override;
+  // #### MNA section for variable component ####
+  Bool hasParameterChanged() override;
 };
 } // namespace Ph1
 } // namespace EMT

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SeriesSwitch.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SeriesSwitch.h
@@ -10,8 +10,8 @@
 
 #include <dpsim-models/Base/Base_Ph1_Switch.h>
 #include <dpsim-models/MNASimPowerComp.h>
-#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAVariableCompInterface.h>
 
 namespace CPS {
 namespace EMT {
@@ -25,7 +25,10 @@ namespace Ph3 {
 class SeriesSwitch : public MNASimPowerComp<Real>,
                      public Base::Ph1::Switch,
                      public SharedFactory<SeriesSwitch>,
+                     public MNAVariableCompInterface,
                      public MNASwitchInterface {
+protected:
+  Bool mPrevState = false;
 
 public:
   /// Defines UID, name and log level
@@ -68,6 +71,9 @@ public:
                                  AttributeBase::List &attributeDependencies,
                                  AttributeBase::List &modifiedAttributes,
                                  Attribute<Matrix>::Ptr &leftVector) override;
+
+  // #### MNA section for variable component ####
+  Bool hasParameterChanged() override;
 };
 } // namespace Ph3
 } // namespace EMT

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Switch.h
@@ -12,8 +12,8 @@
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Logger.h>
 #include <dpsim-models/MNASimPowerComp.h>
-#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAVariableCompInterface.h>
 
 namespace CPS {
 namespace EMT {
@@ -25,8 +25,8 @@ namespace Ph3 {
 class Switch : public MNASimPowerComp<Real>,
                public Base::Ph3::Switch,
                public SharedFactory<Switch>,
+               public MNAVariableCompInterface,
                public MNASwitchInterface {
-
 public:
   /// Defines UID, name, component parameters and logging level
   Switch(String uid, String name, Logger::Level loglevel = Logger::Level::off);
@@ -69,6 +69,9 @@ public:
                                  AttributeBase::List &attributeDependencies,
                                  AttributeBase::List &modifiedAttributes,
                                  Attribute<Matrix>::Ptr &leftVector) override;
+
+  // #### MNA section for variable component ####
+  Bool hasParameterChanged() override;
 };
 } // namespace Ph3
 } // namespace EMT

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Switch.h
@@ -12,8 +12,8 @@
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Logger.h>
 #include <dpsim-models/MNASimPowerComp.h>
-#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAVariableCompInterface.h>
 
 namespace CPS {
 namespace SP {
@@ -25,6 +25,7 @@ namespace Ph1 {
 class Switch : public MNASimPowerComp<Complex>,
                public Base::Ph1::Switch,
                public SharedFactory<Switch>,
+               public MNAVariableCompInterface,
                public MNASwitchInterface {
 
 public:
@@ -68,6 +69,9 @@ public:
   void mnaCompApplySwitchSystemMatrixStamp(Bool closed,
                                            SparseMatrixRow &systemMatrix,
                                            Int freqIdx) override;
+
+  // #### MNA section for variable component ####
+  Bool hasParameterChanged() override;
 };
 } // namespace Ph1
 } // namespace SP

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_varResSwitch.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_varResSwitch.h
@@ -31,7 +31,6 @@ class varResSwitch : public MNASimPowerComp<Complex>,
                      public SharedFactory<varResSwitch> {
 
 protected:
-  Bool mPrevState = false;
   Real mDeltaResClosed = 0;
   Real mDeltaResOpen = 1.5;
   Real mPrevRes; // previous resistance value to multiply with rate of change
@@ -94,6 +93,7 @@ public:
                                            SparseMatrixRow &systemMatrix,
                                            Int freqIdx);
 
+  // #### MNA section for variable component ####
   Bool hasParameterChanged();
 };
 } // namespace Ph1

--- a/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
@@ -132,3 +132,7 @@ void DP::Ph1::RXLoadSwitch::updateSwitchState(Real time) {
     }
   }
 }
+
+Bool DP::Ph1::RXLoadSwitch::hasParameterChanged() {
+  return mSubSwitch->hasParameterChanged();
+};

--- a/dpsim-models/src/DP/DP_Ph1_Switch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Switch.cpp
@@ -107,3 +107,13 @@ void DP::Ph1::Switch::mnaCompPostStep(Real time, Int timeStepCount,
   mnaCompUpdateVoltage(**leftVector);
   mnaCompUpdateCurrent(**leftVector);
 }
+
+Bool DP::Ph1::Switch::hasParameterChanged() {
+  // Check if state of switch changed
+  if (!(mIsClosedPrev == this->mnaIsClosed())) {
+    mIsClosedPrev = this->mnaIsClosed();
+    return 1; //recompute system matrix
+  } else {
+    return 0; // do not recompute system matrix
+  }
+};

--- a/dpsim-models/src/DP/DP_Ph1_varResSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_varResSwitch.cpp
@@ -103,11 +103,8 @@ void DP::Ph1::varResSwitch::mnaCompUpdateCurrent(const Matrix &leftVector) {
 }
 
 Bool DP::Ph1::varResSwitch::hasParameterChanged() {
-  //Get present state
-  Bool presentState = this->mnaIsClosed();
-
   // Check if state of switch changed from open to closed
-  if (!(mPrevState == presentState)) {
+  if (!(mIsClosedPrev == this->mnaIsClosed())) {
     // Switch is closed : change with 1/mDeltaRes
     if (this->mnaIsClosed() == true) {
       // mClosedResistance= 1./mDeltaRes*mPrevRes;
@@ -117,7 +114,7 @@ Bool DP::Ph1::varResSwitch::hasParameterChanged() {
       if (**mClosedResistance < mInitClosedRes) {
         **mClosedResistance = mInitClosedRes;
         mPrevRes = **mClosedResistance;
-        mPrevState = this->mnaIsClosed();
+        mIsClosedPrev = this->mnaIsClosed();
       }
     }
     // Switch is opened : change with mDeltaRes
@@ -128,7 +125,7 @@ Bool DP::Ph1::varResSwitch::hasParameterChanged() {
       if (**mOpenResistance > mInitOpenRes) {
         **mOpenResistance = mInitOpenRes;
         mPrevRes = **mOpenResistance;
-        mPrevState = this->mnaIsClosed();
+        mIsClosedPrev = this->mnaIsClosed();
       }
     }
     return 1; //recompute system matrix
@@ -142,7 +139,7 @@ void DP::Ph1::varResSwitch::setInitParameters(Real timestep) {
   mDeltaResClosed = 0;
   // mDeltaResOpen = 1.5; // assumption for 1ms step size
   mDeltaResOpen = 0.5 * timestep / 0.001 + 1;
-  mPrevState = **mIsClosed;
+  mIsClosedPrev = **mIsClosed;
   mPrevRes = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
   mInitClosedRes = **mClosedResistance;
   mInitOpenRes = **mOpenResistance;

--- a/dpsim-models/src/DP/DP_Ph3_SeriesSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_SeriesSwitch.cpp
@@ -21,6 +21,9 @@ DP::Ph3::SeriesSwitch::SeriesSwitch(String uid, String name,
 
 void DP::Ph3::SeriesSwitch::initializeFromNodesAndTerminals(Real frequency) {
 
+  mTerminals[0]->setPhaseType(PhaseType::ABC);
+  mTerminals[1]->setPhaseType(PhaseType::ABC);
+
   Real impedance = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
   **mIntfVoltage = initialVoltage(1) - initialVoltage(0);
   **mIntfCurrent = **mIntfVoltage / impedance;
@@ -117,3 +120,13 @@ void DP::Ph3::SeriesSwitch::mnaCompUpdateCurrent(const Matrix &leftVector) {
                       std::abs((**mIntfCurrent)(0, 0)),
                       std::arg((**mIntfCurrent)(0, 0)));
 }
+
+Bool DP::Ph3::SeriesSwitch::hasParameterChanged() {
+  // Check if state of switch changed
+  if (!(mIsClosedPrev == this->mnaIsClosed())) {
+    mIsClosedPrev = this->mnaIsClosed();
+    return 1; //recompute system matrix
+  } else {
+    return 0; // do not recompute system matrix
+  }
+};

--- a/dpsim-models/src/EMT/EMT_Ph1_Switch.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_Switch.cpp
@@ -117,3 +117,13 @@ void EMT::Ph1::Switch::mnaCompUpdateCurrent(const Matrix &leftVector) {
                                ? (**mIntfVoltage)(0, 0) / (**mClosedResistance)
                                : (**mIntfVoltage)(0, 0) / (**mOpenResistance);
 }
+
+Bool EMT::Ph1::Switch::hasParameterChanged() {
+  // Check if state of switch changed
+  if (!(mIsClosedPrev == this->mnaIsClosed())) {
+    mIsClosedPrev = this->mnaIsClosed();
+    return 1; //recompute system matrix
+  } else {
+    return 0; // do not recompute system matrix
+  }
+};

--- a/dpsim-models/src/EMT/EMT_Ph3_SeriesSwitch.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SeriesSwitch.cpp
@@ -128,3 +128,13 @@ void EMT::Ph3::SeriesSwitch::mnaCompUpdateCurrent(const Matrix &leftVector) {
 
   SPDLOG_LOGGER_DEBUG(mSLog, "Current A: {}", (**mIntfCurrent)(0, 0));
 }
+
+Bool EMT::Ph3::SeriesSwitch::hasParameterChanged() {
+  // Check if state of switch changed
+  if (!(mIsClosedPrev == this->mnaIsClosed())) {
+    mIsClosedPrev = this->mnaIsClosed();
+    return 1; //recompute system matrix
+  } else {
+    return 0; // do not recompute system matrix
+  }
+};

--- a/dpsim-models/src/EMT/EMT_Ph3_Switch.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Switch.cpp
@@ -134,3 +134,13 @@ void EMT::Ph3::Switch::mnaCompUpdateCurrent(const Matrix &leftVector) {
 
   **mIntfCurrent = conductance * **mIntfVoltage;
 }
+
+Bool EMT::Ph3::Switch::hasParameterChanged() {
+  // Check if state of switch changed
+  if (!(mIsClosedPrev == this->mnaIsClosed())) {
+    mIsClosedPrev = this->mnaIsClosed();
+    return 1; //recompute system matrix
+  } else {
+    return 0; // do not recompute system matrix
+  }
+};

--- a/dpsim-models/src/SP/SP_Ph1_Switch.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Switch.cpp
@@ -107,3 +107,13 @@ void SP::Ph1::Switch::mnaCompPostStep(Real time, Int timeStepCount,
   mnaCompUpdateVoltage(**leftVector);
   mnaCompUpdateCurrent(**leftVector);
 }
+
+Bool SP::Ph1::Switch::hasParameterChanged() {
+  // Check if state of switch changed
+  if (!(mIsClosedPrev == mnaIsClosed())) {
+    mIsClosedPrev = mnaIsClosed();
+    return 1; //recompute system matrix
+  } else {
+    return 0; // do not recompute system matrix
+  }
+};

--- a/dpsim-models/src/SP/SP_Ph1_varResSwitch.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_varResSwitch.cpp
@@ -103,11 +103,8 @@ void SP::Ph1::varResSwitch::mnaCompUpdateCurrent(const Matrix &leftVector) {
 }
 
 Bool SP::Ph1::varResSwitch::hasParameterChanged() {
-  //Get present state
-  Bool presentState = this->mnaIsClosed();
-
   // Check if state of switch changed from open to closed
-  if (!(mPrevState == presentState)) {
+  if (!(mIsClosedPrev == this->mnaIsClosed())) {
     // Switch is closed : change with 1/mDeltaRes
     if (this->mnaIsClosed() == true) {
       // mClosedResistance= 1./mDeltaRes*mPrevRes;
@@ -117,7 +114,7 @@ Bool SP::Ph1::varResSwitch::hasParameterChanged() {
       if (**mClosedResistance < mInitClosedRes) {
         **mClosedResistance = mInitClosedRes;
         mPrevRes = **mClosedResistance;
-        mPrevState = this->mnaIsClosed();
+        mIsClosedPrev = this->mnaIsClosed();
       }
     }
     // Switch is opened : change with mDeltaRes
@@ -128,7 +125,7 @@ Bool SP::Ph1::varResSwitch::hasParameterChanged() {
       if (**mOpenResistance > mInitOpenRes) {
         **mOpenResistance = mInitOpenRes;
         mPrevRes = **mOpenResistance;
-        mPrevState = this->mnaIsClosed();
+        mIsClosedPrev = this->mnaIsClosed();
       }
     }
     return 1; //recompute system matrix
@@ -142,7 +139,7 @@ void SP::Ph1::varResSwitch::setInitParameters(Real timestep) {
   mDeltaResClosed = 0;
   // mDeltaResOpen = 1.5; // assumption for 1ms step size
   mDeltaResOpen = 0.5 * timestep / 0.001 + 1;
-  mPrevState = **mIsClosed;
+  mIsClosedPrev = **mIsClosed;
   mPrevRes = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
   mInitClosedRes = **mClosedResistance;
   mInitOpenRes = **mOpenResistance;

--- a/dpsim/src/MNASolverDirect.cpp
+++ b/dpsim/src/MNASolverDirect.cpp
@@ -78,12 +78,7 @@ void MnaSolverDirect<VarType>::stampVariableSystemMatrix() {
   // Continue from base matrix
   mVariableSystemMatrix = mBaseSystemMatrix;
 
-  // Now stamp switches into matrix
-  SPDLOG_LOGGER_INFO(mSLog, "Stamping switches");
-  for (auto sw : mMNAIntfSwitches)
-    sw->mnaApplySystemMatrixStamp(mVariableSystemMatrix);
-
-  // Now stamp initial state of variable elements into matrix
+  // Now stamp initial state of variable elements and switches into matrix
   SPDLOG_LOGGER_INFO(mSLog, "Stamping variable elements");
   for (auto varElem : mMNAIntfVariableComps)
     varElem->mnaApplySystemMatrixStamp(mVariableSystemMatrix);
@@ -139,11 +134,7 @@ void MnaSolverDirect<VarType>::recomputeSystemMatrix(Real time) {
   // Start from base matrix
   mVariableSystemMatrix = mBaseSystemMatrix;
 
-  // Now stamp switches into matrix
-  for (auto sw : mMNAIntfSwitches)
-    sw->mnaApplySystemMatrixStamp(mVariableSystemMatrix);
-
-  // Now stamp variable elements into matrix
+  // Now stamp variable elements and switches into matrix
   for (auto comp : mMNAIntfVariableComps)
     comp->mnaApplySystemMatrixStamp(mVariableSystemMatrix);
 


### PR DESCRIPTION
- proposed fix for Issue #415
- Added new Testcase for EMT_Ph3_Switch
- changed EMT/EMT_Ph3_Switch.h to MNAVariableCompInterface
- added Bool EMT::Ph3::Switch::hasParameterChanged() implementation
- new member variable for Switch: protected: Bool mPrevState = false;