### PR TITLE
Uses dpsim manylinux container and skips rc versions in PyPI

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -46,6 +46,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.23.2
       env:
         CIBW_BUILD: "${{ matrix.python }}-${{ matrix.platform }}"
+        CIBW_MANYLINUX_X86_64_IMAGE: sogno/dpsim:manylinux
       with:
         output-dir: dist
 
@@ -80,5 +81,5 @@ jobs:
         skip-existing: true
 
     - name: Publish distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+      if: startsWith(github.ref, 'refs/tags') && !contains(github.ref, '-rc')
       uses: pypa/gh-action-pypi-publish@v1.13.0


### PR DESCRIPTION
Resolves #441 

Fixes not using the manylinux container with the deps of dpsim for building. 

Skips RC versions in PyPI but publishes in TestPyPI.