### PR TITLE
Adapt sonar to avoid deprecated checks for secrets

### DIFF
--- a/.github/workflows/sonar_cloud.yaml
+++ b/.github/workflows/sonar_cloud.yaml
@@ -1,65 +1,44 @@
 name: Sonar Cloud Analysis
+
 on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
 
 jobs:
   sonarcloud:
     name: Prepare and run Sonar Scan
     runs-on: ubuntu-latest
     container: sogno/dpsim:dev
-    outputs:
-      skip: ${{ steps.check_token.outputs.skip }} # Output to indicate if the job was skipped
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
+
     steps:
-      - name: Check for SONAR_TOKEN
-        id: check_token
-        run: |
-          if [ -z "${{ secrets.SONAR_TOKEN }}" ]; then
-            echo "SONAR_TOKEN is not set. Skipping the job."
-            echo "::set-output name=skip::true"
-          else
-            echo "::set-output name=skip::false"
-          fi
-
-      - name: Skip Job if Token is Missing
-        if: steps.check_token.outputs.skip == 'true'
-        run: |
-          echo "Skipping the SonarCloud analysis due to missing SONAR_TOKEN."
-          exit 0
-
       - name: Fetch repository
-        if: steps.check_token.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node 20
-        if: steps.check_token.outputs.skip != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Install sonar-scanner and build-wrapper
-        if: steps.check_token.outputs.skip != 'true'
         uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v6
 
       - name: Create Build Folder
-        if: steps.check_token.outputs.skip != 'true'
         run: mkdir build
 
       - name: Setup build directory cache
-        if: steps.check_token.outputs.skip != 'true'
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/build
           key: wrapper-dir-cache-${{ github.ref }}
 
       - name: Setup sonar cache
-        if: steps.check_token.outputs.skip != 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -68,19 +47,14 @@ jobs:
           key: sonar-cache-${{ github.ref }}
 
       - name: Configure CMake
-        if: steps.check_token.outputs.skip != 'true'
         shell: bash
         working-directory: ${{ github.workspace }}/build
-        run: |
-          cmake -DCIM_VERSION=CGMES_2.4.15_16FEB2016 $GITHUB_WORKSPACE
+        run: cmake -DCIM_VERSION=CGMES_2.4.15_16FEB2016 "$GITHUB_WORKSPACE"
 
       - name: Run build-wrapper
-        if: steps.check_token.outputs.skip != 'true'
-        run: |
-          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ -j $(nproc)
+        run: build-wrapper-linux-x86-64 --out-dir "${{ env.BUILD_WRAPPER_OUT_DIR }}" cmake --build build/ -j "$(nproc)"
 
       - name: Run sonar-scanner
-        if: steps.check_token.outputs.skip != 'true'
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
At the moment, checking for secret existence (in old ways) in PRs from forks leads to not running the sonar checks for them.