### PR TITLE
Fix angle conversion in Math::polarDeg

### DIFF
--- a/dpsim-models/src/MathUtils.cpp
+++ b/dpsim-models/src/MathUtils.cpp
@@ -52,7 +52,7 @@ Complex Math::polar(Real abs, Real phase) {
 }
 
 Complex Math::polarDeg(Real abs, Real phase) {
-  return std::polar<Real>(abs, radtoDeg(phase));
+  return std::polar<Real>(abs, degToRad(phase));
 }
 
 void Math::setVectorElement(Matrix &mat, Matrix::Index row, Complex value,


### PR DESCRIPTION
Fix `Math::polarDeg` to convert degrees to radians before calling `std::polar`.