### PR TITLE
Fix Windows build with std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ include(CheckCXXCompilerFlag)
 if(MSVC)
 	# Silence Visual Studio deprecation warnings
 	add_definitions(-D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
-	add_definitions(-D_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING)
 
 	# Silence Visual Studio error C2220
 	add_definitions(-D_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING)

--- a/dpsim-models/include/dpsim-models/Filesystem.h
+++ b/dpsim-models/include/dpsim-models/Filesystem.h
@@ -9,8 +9,8 @@
 #pragma once
 
 #ifndef USE_GHC_FS
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
+#include <filesystem>
+namespace fs = std::filesystem;
 #else
 #include <ghc/filesystem.hpp>
 namespace fs = ghc::filesystem;


### PR DESCRIPTION
This PR fixes the Windows CI build failure caused by the use of <experimental/filesystem> with newer MSVC versions.

Changes:

- Replaces std::experimental::filesystem with C++17 std::filesystem
- Removes the obsolete MSVC warning suppression for experimental filesystem

Closes #479.