### PR TITLE
Fix: Bumped CI to node 24 actions

### DIFF
--- a/.github/workflows/build_nix.yaml
+++ b/.github/workflows/build_nix.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -24,7 +24,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Setup Nix cache
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v17
         with:
           name: dpsim
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/.github/workflows/build_test_linux_fedora.yaml
+++ b/.github/workflows/build_test_linux_fedora.yaml
@@ -15,7 +15,7 @@ jobs:
     container: sogno/dpsim:dev
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -23,7 +23,7 @@ jobs:
       run: mkdir build
 
     - name: Setup build directory cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/build
         key: build-fedora-dir-cache-${{ github.ref }}
@@ -39,7 +39,7 @@ jobs:
       run: cmake --build . --target dpsimpy --target tests --target dpsimpyvillas --parallel $(nproc)
 
     - name: Archive build directory
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         path: ${{ github.workspace }}/build
         name: build-fedora-examples-cache-${{ github.sha }}
@@ -51,7 +51,7 @@ jobs:
     container: sogno/dpsim:dev
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -59,7 +59,7 @@ jobs:
       run: mkdir build
 
     - name: Setup build directory cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/build
         key: build-fedora-dir-example-cache-${{ github.ref }}
@@ -75,7 +75,7 @@ jobs:
       run: cmake --build . --parallel $(nproc)
 
     - name: Archive build directory
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         path: ${{ github.workspace }}/build
         name: build-cache-examples-cpp-${{ github.sha }}
@@ -89,10 +89,10 @@ jobs:
     container: sogno/dpsim:dev
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Restore build archive
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
        name: build-fedora-examples-cache-${{ github.sha }}
        path: ${{ github.workspace }}/build
@@ -125,7 +125,7 @@ jobs:
         pytest -n auto --cov --cov-branch --cov-report=xml examples/Notebooks/
 
     - name: Archive notebook outputs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-output-${{ github.sha }}
         path: outputs/
@@ -140,7 +140,7 @@ jobs:
         lcov --list coverage.cleaned.info
 
     - name: Upload coverage artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-fedora--${{ github.sha }}
         path: |
@@ -151,7 +151,7 @@ jobs:
 
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: sogno-platform/dpsim
@@ -162,13 +162,13 @@ jobs:
     needs: [test-jupyter-notebooks]
     steps:
     - name: Download new notebook results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
        name: pytest-output-${{ github.sha }}
        path: ${{ github.workspace }}/notebooks-new
 
     - name: Download master notebook results
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/notebooks-master
         key: notebook-output-cache-master-${{ github.sha }}
@@ -176,7 +176,7 @@ jobs:
           notebook-output-cache-master-
 
     - name: Download previous commit notebook results
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/notebooks-previous
         key: notebook-output-cache-commit-${{ github.ref }}-${{ github.sha }}
@@ -213,7 +213,7 @@ jobs:
     needs: [linux-fedora-examples]
     steps:
     - name: Restore build archive
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
        name: build-cache-examples-cpp-${{ github.sha }}
        path: ${{ github.workspace }}/build
@@ -241,7 +241,7 @@ jobs:
     container: sogno/dpsim:dev
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run cppcheck
       working-directory: ${{ github.workspace }}
@@ -301,7 +301,7 @@ jobs:
       continue-on-error: true
 
     - name: Archive cppcheck output
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.cppcheck.outcome == 'failure' }}
       with:
         name: cppcheck-output

--- a/.github/workflows/build_test_linux_fedora_minimal.yaml
+++ b/.github/workflows/build_test_linux_fedora_minimal.yaml
@@ -15,7 +15,7 @@ jobs:
     container: sogno/dpsim:dev-minimal
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -23,7 +23,7 @@ jobs:
       run: mkdir build
 
     - name: Cache build directory
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/build
         key: build-cache-fedora-minimal-${{ github.ref }}

--- a/.github/workflows/build_test_linux_rocky.yaml
+++ b/.github/workflows/build_test_linux_rocky.yaml
@@ -15,7 +15,7 @@ jobs:
     container: sogno/dpsim:dev-rocky
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -23,7 +23,7 @@ jobs:
       run: mkdir build
 
     - name: Cache build directory
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/build
         key: build-cache-rocky-${{ github.ref }}
@@ -44,7 +44,7 @@ jobs:
     container: sogno/dpsim:dev-rocky
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -52,7 +52,7 @@ jobs:
       run: mkdir build
 
     - name: Cache build directory
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/build
         key: build-cache-rocky-clang-${{ github.ref }}

--- a/.github/workflows/build_test_linux_rocky_profiling.yaml
+++ b/.github/workflows/build_test_linux_rocky_profiling.yaml
@@ -10,7 +10,7 @@ jobs:
     container: sogno/dpsim:dev-rocky
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -18,7 +18,7 @@ jobs:
         run: mkdir build
 
       - name: Cache build directory
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/build
           key: build-cache-rocky-profiling-${{ github.ref }}

--- a/.github/workflows/build_test_windows.yaml
+++ b/.github/workflows/build_test_windows.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Create build folder
       run: |
@@ -22,7 +22,7 @@ jobs:
         mkdir build
 
     - name: Setup build directory cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/build
         key: build-windows-cache-${{ github.ref }}
@@ -41,7 +41,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Create build folder
       run: |
@@ -49,7 +49,7 @@ jobs:
         mkdir build
 
     - name: Setup build directory cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/build
         key: build-windows-bindings-cache-${{ github.ref }}

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -8,17 +8,17 @@ jobs:
     runs-on: sogno-platform-dpsim-runner
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev_rocky
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
          file: packaging/Docker/Dockerfile.dev-rocky
          push: true
@@ -29,17 +29,17 @@ jobs:
     runs-on: sogno-platform-dpsim-runner
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_release
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
          file: packaging/Docker/Dockerfile
          push: true
@@ -49,17 +49,17 @@ jobs:
     runs-on: sogno-platform-dpsim-runner
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
          file: packaging/Docker/Dockerfile.dev
          push: true
@@ -69,17 +69,17 @@ jobs:
     runs-on: sogno-platform-dpsim-runner
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
          file: packaging/Docker/Dockerfile.dev-minimal
          push: true
@@ -89,17 +89,17 @@ jobs:
     runs-on: sogno-platform-dpsim-runner
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_dev
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
          file: packaging/Docker/Dockerfile.manylinux
          push: true
@@ -110,17 +110,17 @@ jobs:
     runs-on: sogno-platform-dpsim-runner
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
 
       - name: Build and push
         id: docker_build_release
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
          file: .binder/Dockerfile
          push: true

--- a/.github/workflows/documentation-fein.yaml
+++ b/.github/workflows/documentation-fein.yaml
@@ -9,21 +9,21 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v3
+      uses: peaceiris/actions-hugo@v3.2.1
       with:
         hugo-version: '0.108.0'
         extended: true
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -34,7 +34,7 @@ jobs:
     - run: cd docs/hugo && hugo --minify --baseURL "https://dpsim.fein-aachen.org"
 
     - name: Deploy dpsim-simulator / FEIN
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@v4.1.0
       with:
         deploy_key: ${{ secrets.HUGO_ACTIONS_DEPLOY_KEY }}
         external_repository: dpsim-simulator/dpsim-simulator.github.io

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -13,7 +13,7 @@ jobs:
     container: sogno/dpsim:dev
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Create Build Environment
       run: mkdir build
@@ -35,7 +35,7 @@ jobs:
         cp -r build/docs/doxygen/html/. reference/doxygen
 
     - name: Archive reference directory
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         path: ${{ github.workspace }}/reference
         name: reference-cache
@@ -51,21 +51,21 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v3
+      uses: peaceiris/actions-hugo@v3.2.1
       with:
         hugo-version: '0.108.0'
         extended: true
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -76,7 +76,7 @@ jobs:
     - run: cd docs/hugo && hugo --minify
 
     - name: Restore reference archive
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
        name: reference-cache
        path: ${{ github.workspace }}/reference
@@ -87,7 +87,7 @@ jobs:
         cp -r docs/hugo/public/. public
 
     - name: Deploy page
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./public

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -9,6 +9,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.x'
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -15,7 +15,7 @@ jobs:
     container: sogno/dpsim:dev
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -24,7 +24,7 @@ jobs:
       run: python3 -m build --sdist --outdir dist/
 
     - name: Archive Python source distribution
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dist-source
         path: dist/
@@ -38,7 +38,7 @@ jobs:
         python: [cp39, cp310, cp311, cp312, cp313]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -51,7 +51,7 @@ jobs:
         output-dir: dist
 
     - name: Upload wheel as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dist-wheels-${{ matrix.python }}-${{ matrix.platform }}
         path: dist/
@@ -68,14 +68,14 @@ jobs:
 
     steps:
     - name: Download wheels from build jobs
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: dist-*
         merge-multiple: true
         path: dist/
 
     - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@v1.13.0
+      uses: pypa/gh-action-pypi-publish@v1.14.0
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
@@ -92,11 +92,11 @@ jobs:
 
     steps:
     - name: Download wheels from build jobs
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: dist-*
         merge-multiple: true
         path: dist/
 
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.13.0
+      uses: pypa/gh-action-pypi-publish@v1.14.0

--- a/.github/workflows/run_and_profile_example.yaml
+++ b/.github/workflows/run_and_profile_example.yaml
@@ -19,7 +19,7 @@ jobs:
     container: sogno/dpsim:dev-rocky
     steps:
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/build
           key: build-cache-rocky-profiling-${{ github.sha }}
@@ -45,7 +45,7 @@ jobs:
           gprof "$BINARY_PATH" | gprof2dot -s | dot -Tpng -o profiling.png || true
 
       - name: Archive profiler output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: profiler-output-${{ inputs.name }}
           path: |

--- a/.github/workflows/run_villas_example.yaml
+++ b/.github/workflows/run_villas_example.yaml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore build archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-cache-examples-cpp-${{ github.sha }}
           path: ${{ github.workspace }}/build

--- a/.github/workflows/sonar_cloud.yaml
+++ b/.github/workflows/sonar_cloud.yaml
@@ -16,30 +16,30 @@ jobs:
 
     steps:
       - name: Fetch repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
-      - name: Setup Node 20
-        uses: actions/setup-node@v4
+      - name: Setup Node 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install sonar-scanner and build-wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v6
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v8.1.0
 
       - name: Create Build Folder
         run: mkdir build
 
       - name: Setup build directory cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/build
           key: wrapper-dir-cache-${{ github.ref }}
 
       - name: Setup sonar cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .scannerwork
@@ -55,10 +55,11 @@ jobs:
         run: build-wrapper-linux-x86-64 --out-dir "${{ env.BUILD_WRAPPER_OUT_DIR }}" cmake --build build/ -j "$(nproc)"
 
       - name: Run sonar-scanner
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@v8.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
         with:
           args: >
             --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json


### PR DESCRIPTION
## Summary

GitHub is removing the Node 20 runner runtime in fall 2026 (Node 24 becomes the forced default in June 2026). Every action pinned to a node20 or older runtime will break at that point. This PR proactively upgrades all 14 workflows to Node 24-compatible versions and fixes the SonarCloud workflow, which was additionally broken by a deprecated action API.

The changes here are expected to close #475 and #468.

## Changes by category

**SonarCloud (functional fix):**
- `sonarqube-scan-action` v6 → **v8.1.0** — first release shipping node24; earlier v7.x still emitted node20 warnings
- `install-build-wrapper` bumped to the same version
- Added `SONAR_HOST_URL: https://sonarcloud.io` — required by v7+; the old action defaulted it silently

**GitHub first-party actions (node24 runtime):**
- `actions/checkout` v3/v4 → **v6**
- `actions/setup-node` v4 → **v6** · explicit `node-version` bumped 20/22 → 24
- `actions/setup-python` v3 → **v6** · added explicit `python-version: '3.x'` (default changed in v6)
- `actions/cache` v4 → **v5**
- `actions/upload-artifact` v4 → **v7**
- `actions/download-artifact` v4 → **v8**

**Third-party actions (node24 runtime):**
- `peaceiris/actions-hugo` @v3 → **@v3.2.1** (v3.1.0 introduced node24)
- `peaceiris/actions-gh-pages` @v4 → **@v4.1.0**
- `docker/login-action` v3 → **v4**
- `docker/build-push-action` v5 → **v7**
- `cachix/cachix-action` v14 → **v17**
- `codecov/codecov-action` v5 → **v6**
- `pypa/gh-action-pypi-publish` v1.13.0 → **v1.14.0**

## Not changed

`pypa/cibuildwheel` stays at **v2.23.2** as v3 is a major-version bump with breaking changes to the wheel-build configuration (default manylinux image, dropped Python 3.6–3.8, changed build frontend). It uses a composite/Python runtime so it emits no Node warnings. A separate PR should change it in case this is needed, but is not critical at the moment.
