### PR TITLE
Feature: steam turbine governor + base governor and turbine

### DIFF
--- a/docs/hugo/content/en/docs/Models/Synchronous Generator Regulators/images/SteamGovernor.drawio.svg
+++ b/docs/hugo/content/en/docs/Models/Synchronous Generator Regulators/images/SteamGovernor.drawio.svg
@@ -1,0 +1,622 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="508px" height="144px" viewBox="-0.5 -0.5 508 144" content="&lt;mxfile&gt;&lt;diagram id=&quot;tAVxjjhIxe6FjWcWs54s&quot; name=&quot;Page-1&quot;&gt;7Vpbj9o4FP41SN2HQbFDQngs0ItUVTvSrLTt08qbGIgaYpSYAfbXr5PYJHYcMJBA2mnVqvGJ8eX7zs3HGdiz9f5TgjarryTA0QBawX5gzwcQAns0Zv9lkkMhsaFXCJZJGPBOpeAl/A9zocWl2zDAqdSREhLRcCMLfRLH2KeSDCUJ2cndFiSSZ92gJa4JXnwU1aV/hwFdFVLPsUr5ZxwuV2JmYPE3ayQ68yHSFQrIrhDlfewPA3uWEEKLp/V+hqMMPIFLMdDHhrfHhSU4pkY/sDgVryja8t3xldGD2C6Og/cZaqwVk5gJpyu6jlgLsMcFiemMRCTJ+9pW/ofJKd7TPzfID2lGciapr40vFwcS3HylnzBZY5ocWIddCbLAeFXBV8gSHCEavsokIc718jjccYZnErKVQIvrJVt88ROula5nyUOkZJv4mP+qCqo60EgZCCgDUZQsMa0NxB4q2y5FOWd6/ryRAX0M3hferPPXyEqxW76jCbeyfOF8amjInjEtEg4nNi1WI216lP11ZnMcUcTesUc28BLxFyommXbKOKQ0IT+w0GSO0yKMIkWEonAZs6bP8MJMPn3FCQ2Zb3jPX6zDIMimme5WIcUvzASyOXfMEzJZQrZxgINzFpGNifcnUeVvn4DrysomtLhiNLbGaGzrdiK88YXKhvch/VZ5/p4BMXR4a77nuOSNs26jqqBCGSUFdR+loGI1p6xS1gSdrpgY6SWKYileCdYVxTvhXW8CxGm22EWC/MF4+uUdW/80/esf9gwH4/kf7B97LIUgF8x7bdBNwbAN/iYKfbZTo8/V0Aed2+mb3CfKCIOtGrHY9QOM2DXYdBSxnLNJNyr7R+mmSEQX4T7TljY0Ap5XCKhTiBbsGVj2rRrB9p0cvgmHnzUqwSBrltEgb10UDoTWSJrkPEqTxGr6FA7GztlgIPSp7WAwARo45GBQ+Ppp7vftt+33XThUqLK9oZnrB14blq4L3e37fmGdVYsF1uhhJmuw63ubLBBlk1M2a3dksybB8JoyQSMuPSkKAFe1Pjj0lFFM6wJAdbqasdorDUy6quz0njIHyDA746F3JWPu2aFaJMzriLCfrxQHXEuNegx551oSnVoIhepgLdJ4ojoVEMoymmeWzmSZzXoAZ9tN33ObCP2LoynyfyxzuTo50zleoB+3FeY8lS5doNPlO62cbHTJeiN9AdnFvwlUCZwopju5I30GpYp7J27MA8mAAA0gHR22ALj9pN5V0fZIlpT0A2gYim697nHV+onZdQ+Lv+hQ6bbJOqQn5hkr84xGCoHFiNfGG2DpcnPteTrtu6vq8BwNLbuWBbg1M+zuGN1VctcITU9SOQiUaHD1req569n2Ujhg6XK4N8HWuatrY7bUQ1h3d+AANKVszyJNW6N9313fvbM0aAPFHzriAHqPPA00FYFLzsLfmXUthimJpHfHg5HIy2qMbTLGlq99J6sN/CcK/lBXiu/qawsATK5hy6jkRyhNQ19GXsakvIQr792+DyoXdJdewl31/cWdQltDHn5xaFPzENcsst18buCFJdNlyd1vP2YAo499ZP269BYIAM010OO+4zkuR+/zErx4A04PKFmCa5YltOPxdKemHP9fHfUnBXZtzagz2JtK2E+/Ouxib8fSJewKddYsP/Mu/HH5sbz94X8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 396 116 L 406 46" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 30 81 L 59.63 81" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 64.88 81 L 57.88 84.5 L 59.63 81 L 57.88 77.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="0" y="66" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 81px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.292ex" height="1.645ex" role="img" focusable="false" viewBox="0 -716 1455 727" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.025ex;">
+                                        <defs>
+                                            <path id="MJX-39-TEX-N-394" d="M51 0Q46 4 46 7Q46 9 215 357T388 709Q391 716 416 716Q439 716 444 709Q447 705 616 357T786 7Q786 4 781 0H51ZM507 344L384 596L137 92L383 91H630Q630 93 507 344Z"/>
+                                            <path id="MJX-39-TEX-I-1D714" d="M495 384Q495 406 514 424T555 443Q574 443 589 425T604 364Q604 334 592 278T555 155T483 38T377 -11Q297 -11 267 66Q266 68 260 61Q201 -11 125 -11Q15 -11 15 139Q15 230 56 325T123 434Q135 441 147 436Q160 429 160 418Q160 406 140 379T94 306T62 208Q61 202 61 187Q61 124 85 100T143 76Q201 76 245 129L253 137V156Q258 297 317 297Q348 297 348 261Q348 243 338 213T318 158L308 135Q309 133 310 129T318 115T334 97T358 83T393 76Q456 76 501 148T546 274Q546 305 533 325T508 357T495 384Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mi">
+                                                    <use data-c="394" xlink:href="#MJX-39-TEX-N-394"/>
+                                                </g>
+                                                <g data-mml-node="mi" transform="translate(833,0)">
+                                                    <use data-c="1D714" xlink:href="#MJX-39-TEX-I-1D714"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="15" y="85" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\De...
+                </text>
+            </switch>
+        </g>
+        <path d="M 146 81 L 179.63 81" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 184.88 81 L 177.88 84.5 L 179.63 81 L 177.88 77.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="66" y="56" width="80" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="76" y="71" width="60" height="25" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 84px; margin-left: 77px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="12.034ex" height="5.195ex" role="img" focusable="false" viewBox="0 -1460 5319 2296" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.891ex;">
+                                        <defs>
+                                            <path id="MJX-40-TEX-I-1D43E" d="M285 628Q285 635 228 637Q205 637 198 638T191 647Q191 649 193 661Q199 681 203 682Q205 683 214 683H219Q260 681 355 681Q389 681 418 681T463 682T483 682Q500 682 500 674Q500 669 497 660Q496 658 496 654T495 648T493 644T490 641T486 639T479 638T470 637T456 637Q416 636 405 634T387 623L306 305Q307 305 490 449T678 597Q692 611 692 620Q692 635 667 637Q651 637 651 648Q651 650 654 662T659 677Q662 682 676 682Q680 682 711 681T791 680Q814 680 839 681T869 682Q889 682 889 672Q889 650 881 642Q878 637 862 637Q787 632 726 586Q710 576 656 534T556 455L509 418L518 396Q527 374 546 329T581 244Q656 67 661 61Q663 59 666 57Q680 47 717 46H738Q744 38 744 37T741 19Q737 6 731 0H720Q680 3 625 3Q503 3 488 0H478Q472 6 472 9T474 27Q478 40 480 43T491 46H494Q544 46 544 71Q544 75 517 141T485 216L427 354L359 301L291 248L268 155Q245 63 245 58Q245 51 253 49T303 46H334Q340 37 340 35Q340 19 333 5Q328 0 317 0Q314 0 280 1T180 2Q118 2 85 2T49 1Q31 1 31 11Q31 13 34 25Q38 41 42 43T65 46Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Z"/>
+                                            <path id="MJX-40-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"/>
+                                            <path id="MJX-40-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-40-TEX-N-2B" d="M56 237T56 250T70 270H369V420L370 570Q380 583 389 583Q402 583 409 568V270H707Q722 262 722 250T707 230H409V-68Q401 -82 391 -82H389H387Q375 -82 369 -68V230H70Q56 237 56 250Z"/>
+                                            <path id="MJX-40-TEX-I-1D460" d="M131 289Q131 321 147 354T203 415T300 442Q362 442 390 415T419 355Q419 323 402 308T364 292Q351 292 340 300T328 326Q328 342 337 354T354 372T367 378Q368 378 368 379Q368 382 361 388T336 399T297 405Q249 405 227 379T204 326Q204 301 223 291T278 274T330 259Q396 230 396 163Q396 135 385 107T352 51T289 7T195 -10Q118 -10 86 19T53 87Q53 126 74 143T118 160Q133 160 146 151T160 120Q160 94 142 76T111 58Q109 57 108 57T107 55Q108 52 115 47T146 34T201 27Q237 27 263 38T301 66T318 97T323 122Q323 150 302 164T254 181T195 196T148 231Q131 256 131 289Z"/>
+                                            <path id="MJX-40-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                            <path id="MJX-40-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+                                            <path id="MJX-40-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mrow" transform="translate(220,710)">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D43E" xlink:href="#MJX-40-TEX-I-1D43E"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(889,0)">
+                                                            <use data-c="28" xlink:href="#MJX-40-TEX-N-28"/>
+                                                        </g>
+                                                        <g data-mml-node="mn" transform="translate(1278,0)">
+                                                            <use data-c="31" xlink:href="#MJX-40-TEX-N-31"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(2000.2,0)">
+                                                            <use data-c="2B" xlink:href="#MJX-40-TEX-N-2B"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(3000.4,0)">
+                                                            <use data-c="1D460" xlink:href="#MJX-40-TEX-I-1D460"/>
+                                                        </g>
+                                                        <g data-mml-node="msub" transform="translate(3469.4,0)">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D447" xlink:href="#MJX-40-TEX-I-1D447"/>
+                                                            </g>
+                                                            <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                                <g data-mml-node="mn">
+                                                                    <use data-c="32" xlink:href="#MJX-40-TEX-N-32"/>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(4490,0)">
+                                                            <use data-c="29" xlink:href="#MJX-40-TEX-N-29"/>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="mrow" transform="translate(1053.5,-686)">
+                                                        <g data-mml-node="mn">
+                                                            <use data-c="31" xlink:href="#MJX-40-TEX-N-31"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(722.2,0)">
+                                                            <use data-c="2B" xlink:href="#MJX-40-TEX-N-2B"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1722.4,0)">
+                                                            <use data-c="1D460" xlink:href="#MJX-40-TEX-I-1D460"/>
+                                                        </g>
+                                                        <g data-mml-node="msub" transform="translate(2191.4,0)">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D447" xlink:href="#MJX-40-TEX-I-1D447"/>
+                                                            </g>
+                                                            <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                                <g data-mml-node="mn">
+                                                                    <use data-c="31" xlink:href="#MJX-40-TEX-N-31"/>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="5079" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="106" y="87" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{K(...
+                </text>
+            </switch>
+        </g>
+        <path d="M 206 81 L 234.63 81" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 239.88 81 L 232.88 84.5 L 234.63 81 L 232.88 77.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="196" cy="81" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 276 81 L 306.63 81" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 311.88 81 L 304.88 84.5 L 306.63 81 L 304.88 77.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="241" y="56" width="35" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="228.5" y="74.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 84px; margin-left: 230px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.304ex" height="4.963ex" role="img" focusable="false" viewBox="0 -1342 1460.6 2193.6" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.927ex;">
+                                        <defs>
+                                            <path id="MJX-41-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-41-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                            <path id="MJX-41-TEX-N-33" d="M127 463Q100 463 85 480T69 524Q69 579 117 622T233 665Q268 665 277 664Q351 652 390 611T430 522Q430 470 396 421T302 350L299 348Q299 347 308 345T337 336T375 315Q457 262 457 175Q457 96 395 37T238 -22Q158 -22 100 21T42 130Q42 158 60 175T105 193Q133 193 151 175T169 130Q169 119 166 110T159 94T148 82T136 74T126 70T118 67L114 66Q165 21 238 21Q293 21 321 74Q338 107 338 175V195Q338 290 274 322Q259 328 213 329L171 330L168 332Q166 335 166 348Q166 366 174 366Q202 366 232 371Q266 376 294 413T322 525V533Q322 590 287 612Q265 626 240 626Q208 626 181 615T143 592T132 580H135Q138 579 143 578T153 573T165 566T175 555T183 540T186 520Q186 498 172 481T127 463Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(480.3,676)">
+                                                        <use data-c="31" xlink:href="#MJX-41-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="msub" transform="translate(220,-686)">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D447" xlink:href="#MJX-41-TEX-I-1D447"/>
+                                                        </g>
+                                                        <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                            <g data-mml-node="mn">
+                                                                <use data-c="33" xlink:href="#MJX-41-TEX-N-33"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="1220.6" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="259" y="87" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <path d="M 346 80.76 L 375.63 80.34" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 380.88 80.27 L 373.93 83.87 L 375.63 80.34 L 373.83 76.87 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="313" y="56" width="33" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 331 68.81 L 341 68.81" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 317 93.8 L 327 93.8" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 326.5 93.5 L 331.5 68.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="314.5" y="56" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 61px; margin-left: 316px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="6.553ex" height="3.047ex" role="img" focusable="false" viewBox="0 -1008 2896.2 1346.8" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.767ex;">
+                                        <defs>
+                                            <path id="MJX-42-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-42-TEX-N-2D9" d="M190 609Q190 637 208 653T252 669Q275 667 292 652T309 609Q309 579 292 564T250 549Q225 549 208 564T190 609Z"/>
+                                            <path id="MJX-42-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-42-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-42-TEX-I-1D462" d="M21 287Q21 295 30 318T55 370T99 420T158 442Q204 442 227 417T250 358Q250 340 216 246T182 105Q182 62 196 45T238 27T291 44T328 78L339 95Q341 99 377 247Q407 367 413 387T427 416Q444 431 463 431Q480 431 488 421T496 402L420 84Q419 79 419 68Q419 43 426 35T447 26Q469 29 482 57T512 145Q514 153 532 153Q551 153 551 144Q550 139 549 130T540 98T523 55T498 17T462 -8Q454 -10 438 -10Q372 -10 347 46Q345 45 336 36T318 21T296 6T267 -6T233 -11Q189 -11 155 7Q103 38 103 113Q103 170 138 262T173 379Q173 380 173 381Q173 390 173 393T169 400T158 404H154Q131 404 112 385T82 344T65 302T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-42-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mover">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D443" xlink:href="#MJX-42-TEX-I-1D443"/>
+                                                            </g>
+                                                            <g data-mml-node="mo" transform="translate(486,239) translate(-250 0)">
+                                                                <use data-c="2D9" xlink:href="#MJX-42-TEX-N-2D9"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-150) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-42-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-42-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D462" xlink:href="#MJX-42-TEX-I-1D462"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1728,0)">
+                                                            <use data-c="1D45D" xlink:href="#MJX-42-TEX-I-1D45D"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="330" y="63" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$\dot{P...
+                </text>
+            </switch>
+        </g>
+        <rect x="315" y="95" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 100px; margin-left: 316px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="9.296ex" height="3.436ex" role="img" focusable="false" viewBox="0 -1008 4108.9 1518.6" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.155ex;">
+                                        <defs>
+                                            <path id="MJX-43-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-43-TEX-N-2D9" d="M190 609Q190 637 208 653T252 669Q275 667 292 652T309 609Q309 579 292 564T250 549Q225 549 208 564T190 609Z"/>
+                                            <path id="MJX-43-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-43-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-43-TEX-I-1D451" d="M366 683Q367 683 438 688T511 694Q523 694 523 686Q523 679 450 384T375 83T374 68Q374 26 402 26Q411 27 422 35Q443 55 463 131Q469 151 473 152Q475 153 483 153H487H491Q506 153 506 145Q506 140 503 129Q490 79 473 48T445 8T417 -8Q409 -10 393 -10Q359 -10 336 5T306 36L300 51Q299 52 296 50Q294 48 292 46Q233 -10 172 -10Q117 -10 75 30T33 157Q33 205 53 255T101 341Q148 398 195 420T280 442Q336 442 364 400Q369 394 369 396Q370 400 396 505T424 616Q424 629 417 632T378 637H357Q351 643 351 645T353 664Q358 683 366 683ZM352 326Q329 405 277 405Q242 405 210 374T160 293Q131 214 119 129Q119 126 119 118T118 106Q118 61 136 44T179 26Q233 26 290 98L298 109L352 326Z"/>
+                                            <path id="MJX-43-TEX-I-1D45C" d="M201 -11Q126 -11 80 38T34 156Q34 221 64 279T146 380Q222 441 301 441Q333 441 341 440Q354 437 367 433T402 417T438 387T464 338T476 268Q476 161 390 75T201 -11ZM121 120Q121 70 147 48T206 26Q250 26 289 58T351 142Q360 163 374 216T388 308Q388 352 370 375Q346 405 306 405Q243 405 195 347Q158 303 140 230T121 120Z"/>
+                                            <path id="MJX-43-TEX-I-1D464" d="M580 385Q580 406 599 424T641 443Q659 443 674 425T690 368Q690 339 671 253Q656 197 644 161T609 80T554 12T482 -11Q438 -11 404 5T355 48Q354 47 352 44Q311 -11 252 -11Q226 -11 202 -5T155 14T118 53T104 116Q104 170 138 262T173 379Q173 380 173 381Q173 390 173 393T169 400T158 404H154Q131 404 112 385T82 344T65 302T57 280Q55 278 41 278H27Q21 284 21 287Q21 293 29 315T52 366T96 418T161 441Q204 441 227 416T250 358Q250 340 217 250T184 111Q184 65 205 46T258 26Q301 26 334 87L339 96V119Q339 122 339 128T340 136T341 143T342 152T345 165T348 182T354 206T362 238T373 281Q402 395 406 404Q419 431 449 431Q468 431 475 421T483 402Q483 389 454 274T422 142Q420 131 420 107V100Q420 85 423 71T442 42T487 26Q558 26 600 148Q609 171 620 213T632 273Q632 306 619 325T593 357T580 385Z"/>
+                                            <path id="MJX-43-TEX-I-1D45B" d="M21 287Q22 293 24 303T36 341T56 388T89 425T135 442Q171 442 195 424T225 390T231 369Q231 367 232 367L243 378Q304 442 382 442Q436 442 469 415T503 336T465 179T427 52Q427 26 444 26Q450 26 453 27Q482 32 505 65T540 145Q542 153 560 153Q580 153 580 145Q580 144 576 130Q568 101 554 73T508 17T439 -10Q392 -10 371 17T350 73Q350 92 386 193T423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 180T152 343Q153 348 153 366Q153 405 129 405Q91 405 66 305Q60 285 60 284Q58 278 41 278H27Q21 284 21 287Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mover">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D443" xlink:href="#MJX-43-TEX-I-1D443"/>
+                                                            </g>
+                                                            <g data-mml-node="mo" transform="translate(486,239) translate(-250 0)">
+                                                                <use data-c="2D9" xlink:href="#MJX-43-TEX-N-2D9"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-321.8) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-43-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-43-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D451" xlink:href="#MJX-43-TEX-I-1D451"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1676,0)">
+                                                            <use data-c="1D45C" xlink:href="#MJX-43-TEX-I-1D45C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2161,0)">
+                                                            <use data-c="1D464" xlink:href="#MJX-43-TEX-I-1D464"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2877,0)">
+                                                            <use data-c="1D45B" xlink:href="#MJX-43-TEX-I-1D45B"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="330" y="102" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$\dot{P...
+                </text>
+            </switch>
+        </g>
+        <rect x="382" y="55" width="35" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 417 80 L 426.5 80 Q 436 80 445.82 79.88 L 455.63 79.76" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 460.88 79.7 L 453.93 83.28 L 455.63 79.76 L 453.84 76.28 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="369.5" y="72" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 81px; margin-left: 371px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.127ex" height="4.611ex" role="img" focusable="false" viewBox="0 -1342 940 2038" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.575ex;">
+                                        <defs>
+                                            <path id="MJX-44-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-44-TEX-I-1D460" d="M131 289Q131 321 147 354T203 415T300 442Q362 442 390 415T419 355Q419 323 402 308T364 292Q351 292 340 300T328 326Q328 342 337 354T354 372T367 378Q368 378 368 379Q368 382 361 388T336 399T297 405Q249 405 227 379T204 326Q204 301 223 291T278 274T330 259Q396 230 396 163Q396 135 385 107T352 51T289 7T195 -10Q118 -10 86 19T53 87Q53 126 74 143T118 160Q133 160 146 151T160 120Q160 94 142 76T111 58Q109 57 108 57T107 55Q108 52 115 47T146 34T201 27Q237 27 263 38T301 66T318 97T323 122Q323 150 302 164T254 181T195 196T148 231Q131 256 131 289Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(220,676)">
+                                                        <use data-c="31" xlink:href="#MJX-44-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="mi" transform="translate(235.5,-686)">
+                                                        <use data-c="1D460" xlink:href="#MJX-44-TEX-I-1D460"/>
+                                                    </g>
+                                                    <rect width="700" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="400" y="85" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <path d="M 385 116 L 396 116" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 406 46 L 417 46" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="397.5" y="34" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 39px; margin-left: 399px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="8.543ex" height="2.312ex" role="img" focusable="false" viewBox="0 -683 3776 1021.8" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.767ex;">
+                                        <defs>
+                                            <path id="MJX-45-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-45-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-45-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-45-TEX-I-1D44E" d="M33 157Q33 258 109 349T280 441Q331 441 370 392Q386 422 416 422Q429 422 439 414T449 394Q449 381 412 234T374 68Q374 43 381 35T402 26Q411 27 422 35Q443 55 463 131Q469 151 473 152Q475 153 483 153H487Q506 153 506 144Q506 138 501 117T481 63T449 13Q436 0 417 -8Q409 -10 393 -10Q359 -10 336 5T306 36L300 51Q299 52 296 50Q294 48 292 46Q233 -10 172 -10Q117 -10 75 30T33 157ZM351 328Q351 334 346 350T323 385T277 405Q242 405 210 374T160 293Q131 214 119 129Q119 126 119 118T118 106Q118 61 136 44T179 26Q217 26 254 59T298 110Q300 114 325 217T351 328Z"/>
+                                            <path id="MJX-45-TEX-I-1D465" d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D443" xlink:href="#MJX-45-TEX-I-1D443"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-150) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-45-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-45-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D45A" xlink:href="#MJX-45-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2034,0)">
+                                                            <use data-c="1D44E" xlink:href="#MJX-45-TEX-I-1D44E"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2563,0)">
+                                                            <use data-c="1D465" xlink:href="#MJX-45-TEX-I-1D465"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="413" y="41" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$P_{m,m...
+                </text>
+            </switch>
+        </g>
+        <rect x="372" y="116" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 121px; margin-left: 373px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="8.2ex" height="2.628ex" role="img" focusable="false" viewBox="0 -683 3624.2 1161.5" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.083ex;">
+                                        <defs>
+                                            <path id="MJX-46-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-46-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-46-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-46-TEX-I-1D456" d="M184 600Q184 624 203 642T247 661Q265 661 277 649T290 619Q290 596 270 577T226 557Q211 557 198 567T184 600ZM21 287Q21 295 30 318T54 369T98 420T158 442Q197 442 223 419T250 357Q250 340 236 301T196 196T154 83Q149 61 149 51Q149 26 166 26Q175 26 185 29T208 43T235 78T260 137Q263 149 265 151T282 153Q302 153 302 143Q302 135 293 112T268 61T223 11T161 -11Q129 -11 102 10T74 74Q74 91 79 106T122 220Q160 321 166 341T173 380Q173 404 156 404H154Q124 404 99 371T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-46-TEX-I-1D45B" d="M21 287Q22 293 24 303T36 341T56 388T89 425T135 442Q171 442 195 424T225 390T231 369Q231 367 232 367L243 378Q304 442 382 442Q436 442 469 415T503 336T465 179T427 52Q427 26 444 26Q450 26 453 27Q482 32 505 65T540 145Q542 153 560 153Q580 153 580 145Q580 144 576 130Q568 101 554 73T508 17T439 -10Q392 -10 371 17T350 73Q350 92 386 193T423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 180T152 343Q153 348 153 366Q153 405 129 405Q91 405 66 305Q60 285 60 284Q58 278 41 278H27Q21 284 21 287Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D443" xlink:href="#MJX-46-TEX-I-1D443"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-289.7) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-46-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-46-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D45A" xlink:href="#MJX-46-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2034,0)">
+                                                            <use data-c="1D456" xlink:href="#MJX-46-TEX-I-1D456"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2379,0)">
+                                                            <use data-c="1D45B" xlink:href="#MJX-46-TEX-I-1D45B"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="387" y="123" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$P_{m,m...
+                </text>
+            </switch>
+        </g>
+        <rect x="462" y="64.5" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 80px; margin-left: 463px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.865ex" height="1.667ex" role="img" focusable="false" viewBox="0 -442 1266.2 737" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.667ex;">
+                                        <defs>
+                                            <path id="MJX-47-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-47-TEX-I-1D454" d="M311 43Q296 30 267 15T206 0Q143 0 105 45T66 160Q66 265 143 353T314 442Q361 442 401 394L404 398Q406 401 409 404T418 412T431 419T447 422Q461 422 470 413T480 394Q480 379 423 152T363 -80Q345 -134 286 -169T151 -205Q10 -205 10 -137Q10 -111 28 -91T74 -71Q89 -71 102 -80T116 -111Q116 -121 114 -130T107 -144T99 -154T92 -162L90 -164H91Q101 -167 151 -167Q189 -167 211 -155Q234 -144 254 -122T282 -75Q288 -56 298 -13Q311 35 311 43ZM384 328L380 339Q377 350 375 354T369 368T359 382T346 393T328 402T306 405Q262 405 221 352Q191 313 171 233T151 117Q151 38 213 38Q269 38 323 108L331 118L384 328Z"/>
+                                            <path id="MJX-47-TEX-I-1D463" d="M173 380Q173 405 154 405Q130 405 104 376T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Q21 294 29 316T53 368T97 419T160 441Q202 441 225 417T249 361Q249 344 246 335Q246 329 231 291T200 202T182 113Q182 86 187 69Q200 26 250 26Q287 26 319 60T369 139T398 222T409 277Q409 300 401 317T383 343T365 361T357 383Q357 405 376 424T417 443Q436 443 451 425T467 367Q467 340 455 284T418 159T347 40T241 -11Q177 -11 139 22Q102 54 102 117Q102 148 110 181T151 298Q173 362 173 380Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-47-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D454" xlink:href="#MJX-47-TEX-I-1D454"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(477,0)">
+                                                            <use data-c="1D463" xlink:href="#MJX-47-TEX-I-1D463"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="477" y="83" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+        <path d="M 436 80 L 436 135 L 196 135 L 196 97.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 196 92.12 L 199.5 99.12 L 196 97.37 L 192.5 99.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 196 34 L 196 64.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 196 69.88 L 192.5 62.88 L 196 64.63 L 199.5 62.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="181" y="4" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 19px; margin-left: 182px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.673ex" height="1.667ex" role="img" focusable="false" viewBox="0 -442 1623.3 737" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.667ex;">
+                                        <defs>
+                                            <path id="MJX-48-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-48-TEX-I-1D45F" d="M21 287Q22 290 23 295T28 317T38 348T53 381T73 411T99 433T132 442Q161 442 183 430T214 408T225 388Q227 382 228 382T236 389Q284 441 347 441H350Q398 441 422 400Q430 381 430 363Q430 333 417 315T391 292T366 288Q346 288 334 299T322 328Q322 376 378 392Q356 405 342 405Q286 405 239 331Q229 315 224 298T190 165Q156 25 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 114 189T154 366Q154 405 128 405Q107 405 92 377T68 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-48-TEX-I-1D452" d="M39 168Q39 225 58 272T107 350T174 402T244 433T307 442H310Q355 442 388 420T421 355Q421 265 310 237Q261 224 176 223Q139 223 138 221Q138 219 132 186T125 128Q125 81 146 54T209 26T302 45T394 111Q403 121 406 121Q410 121 419 112T429 98T420 82T390 55T344 24T281 -1T205 -11Q126 -11 83 42T39 168ZM373 353Q367 405 305 405Q272 405 244 391T199 357T170 316T154 280T149 261Q149 260 169 260Q282 260 327 284T373 353Z"/>
+                                            <path id="MJX-48-TEX-I-1D453" d="M118 -162Q120 -162 124 -164T135 -167T147 -168Q160 -168 171 -155T187 -126Q197 -99 221 27T267 267T289 382V385H242Q195 385 192 387Q188 390 188 397L195 425Q197 430 203 430T250 431Q298 431 298 432Q298 434 307 482T319 540Q356 705 465 705Q502 703 526 683T550 630Q550 594 529 578T487 561Q443 561 443 603Q443 622 454 636T478 657L487 662Q471 668 457 668Q445 668 434 658T419 630Q412 601 403 552T387 469T380 433Q380 431 435 431Q480 431 487 430T498 424Q499 420 496 407T491 391Q489 386 482 386T428 385H372L349 263Q301 15 282 -47Q255 -132 212 -173Q175 -205 139 -205Q107 -205 81 -186T55 -132Q55 -95 76 -78T118 -61Q162 -61 162 -103Q162 -122 151 -136T127 -157L118 -162Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-48-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45F" xlink:href="#MJX-48-TEX-I-1D45F"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(451,0)">
+                                                            <use data-c="1D452" xlink:href="#MJX-48-TEX-I-1D452"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(917,0)">
+                                                            <use data-c="1D453" xlink:href="#MJX-48-TEX-I-1D453"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="196" y="23" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+        <rect x="151" y="55" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 70px; margin-left: 152px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="1.138ex" height="1.439ex" role="img" focusable="false" viewBox="0 -442 503 636" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.439ex;">
+                                        <defs>
+                                            <path id="MJX-49-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mi">
+                                                    <use data-c="1D45D" xlink:href="#MJX-49-TEX-I-1D45D"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="166" y="74" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p$$
+                </text>
+            </switch>
+        </g>
+        <rect x="190" y="88" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 103px; margin-left: 191px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="1.76ex" height="1.505ex" role="img" focusable="false" viewBox="0 -583 778 665" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.186ex;">
+                                        <defs>
+                                            <path id="MJX-50-TEX-N-2212" d="M84 237T84 250T98 270H679Q694 262 694 250T679 230H98Q84 237 84 250Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mo">
+                                                    <use data-c="2212" xlink:href="#MJX-50-TEX-N-2212"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="205" y="107" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$-$$
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/docs/hugo/content/en/docs/Models/Synchronous Generator Regulators/images/SteamGovernor_split.drawio.svg
+++ b/docs/hugo/content/en/docs/Models/Synchronous Generator Regulators/images/SteamGovernor_split.drawio.svg
@@ -1,0 +1,764 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="708px" height="150px" viewBox="-0.5 -0.5 708 150" content="&lt;mxfile&gt;&lt;diagram id=&quot;tAVxjjhIxe6FjWcWs54s&quot; name=&quot;Page-1&quot;&gt;7Vxdc5s4FP01fnQGSXw+1nbbfdnZzGZntn3aoUa2mWLjwUrs7K9fARIgIWzZFoRN2sk0cMFC3HN0da6unAmab09fs3C/+T2NcDKBVnSaoMUEQoBsj/7KLa+lBUG/NKyzOGI31Yan+F/MjBazPscRPgg3kjRNSLwXjct0t8NLItjCLEuP4m2rNBGfug/XuGV4WoZJ2/p3HJFNafUdq7b/huP1hj8ZWOzKNuQ3syYOmzBKj6WpuAd9nqB5lqakPNqe5jjJncf9Ujb0peNq1bEM74jWBywGxUuYPLO3Yz0jr/x18S76lHuNnu3SHTXONmSb0DNAD1fpjszTJM2Ke5FV/KN2gk/kj324jEkOcm5p9411F0eCu1lPv+J0i0n2Sm841k7mPt40/MttGU5CEr+IIIUM63XVXPWExzSmPYEW4yV0nPIjjJWuD8UmDulztsTsU02nyg25UkNAaoiE2RqTVkP0oPHatanATI0fDBTw2fmPM1/ghIT0Gj2kTa5DdkFGNwdKhPRAsvQn5qAyyFdxkkimMInXO3q6pIBiap+94IzEdJh8Yhe2cRTlj5kdNzHBT5QN+TOPNChQW5Y+7yIcXSJH3iY+naUHuzpFyBL9jrwHhkSDQUjBIG5TkUVA5wwUga0xkijTn9hpeyh1+qAkHosyLgt4BYfYoy3NgaQ9QnRfmvfm7EsnCQ3MXTRovH942JfRehWfcmKYIIUtDUXktQgBFYSABggBLHQvI+h7Z6/f2BApTr7nJ5TV7HRxal5cXAy1TSZx1ghMct6KSbw355wlhowLbDJAnmre5uzhfWqGE6d7QrrLH0DhDxbZV1m4nHgzMPEW9Ndf/9D/UHG8GHWM75IKBpDyq0hfDXRfEftdxVAHvomh7gwS/PnwbA5ZYNlvNmY13nrwMevBy2MW9TRmdWbDW8R0p19GIp1BICsv+8GXWtFWz3LQVbRlTkAHfeU/o4fMc0U3O8GDfxtiwL/YlEHA/J4A+/8lrMB35FmPet65EcTAak2httyYQRjPJK5RSqiieaRyJlc22wmcP+/Hrm2S8AdOZuHy57qwyw+nnGPLWJ6paQ7JcKkmOpXeMZLaqNR6J3xRetz9AlAG0Bbhc8GA8GmsVQwt3KANJD4rHNJTsgXA/an6KSbfGseNRJ2e1Xl6fnJVml6BJYh+vqRoTvR3qDFfnhSg1vxC59/wtXHbPr/hcOY5gfQc25UALFu8db4BlkqbK/Ppw9hDVY95NMX7jRPpvuRdp3NGIuagLc0HN1cfLpUxzIk4YKlU3IdA61KJRxstOQ3rr1YEQJdoe+RCbRuexh78htZp0HHliMjF7xBKDXQtA9eYxb+0tYwZkqQkD4GDIAY7ENvniK1fxg6WAf8jKPkfWQMWYgHQqcTWs9IyCQ+HeCl6XvRJXYerS2/fJ40a3bV1uKaW56tnY5naOpT41VObrENcvZnt3szBs8A13ZJuvz/RAF6bbO3MUeTXtXUgABSFIG0eGa8DVd1Rx7wMrz5A0LPFsoXj6akEMxFPlTUV/n/vXgeyDldlq/35vWsVe/re/W4Hot8dezivo+CuCHvLSl2vG3GAShUA5L9ZOIeqpEP2+Fvu6pq6Ev2UO/1629jF3THSjV0AIhWfPNN8UuurKXDEmdANeisGV286pkLGtNqVyx3gqdjpBG122kbY2SXG6pXuYstYvtw9LY4g2zzWuDB2wdbjGjjFT1qT8wddAofXbUlRpq/3zXFikmtdiElyqhx9iZOLw0kITSNb3J0CSd04gXfrtgp5plI0ZSgPnjpdTzKW2sLrijNnmWk9eI5ATpi/2Tl60pNHnMW0w3nwuGtd5v1R1pemHAq+Hdy4cNNSV4Nx1u2Bs9eVqNScNa3WRGEGx0UlObe7J/oB79bwdwvWSFXgGhXWXK+OFWvFUNfHWg4boFesdXLUc6XnTsDeIzYaY9okNhr58eBZGXDEopSjzMpUi1ZGsjKkylQVWZkqF4NukqdcPzJ6tM6PPnJ2BlwxO3OGzc6Qxnc8hue2/DVHJbd5fDbPbVXGqtxbR99jdvi1yFBCJu8rGZbIto5YumZZvdclTb4aPpKCJ9LIhIdfd2x9W1U1wfW1hdpWCTJlEPjzI497BOVhj9xBh73OTvdzullaOzG57X00yptXLKrqJniApqR33phnSnvT0/qPxZS3139yB33+Dw==&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 596 112 L 606 42" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="11" y="67.5" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 83px; margin-left: 12px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.292ex" height="1.645ex" role="img" focusable="false" viewBox="0 -716 1455 727" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.025ex;">
+                                        <defs>
+                                            <path id="MJX-48-TEX-N-394" d="M51 0Q46 4 46 7Q46 9 215 357T388 709Q391 716 416 716Q439 716 444 709Q447 705 616 357T786 7Q786 4 781 0H51ZM507 344L384 596L137 92L383 91H630Q630 93 507 344Z"/>
+                                            <path id="MJX-48-TEX-I-1D714" d="M495 384Q495 406 514 424T555 443Q574 443 589 425T604 364Q604 334 592 278T555 155T483 38T377 -11Q297 -11 267 66Q266 68 260 61Q201 -11 125 -11Q15 -11 15 139Q15 230 56 325T123 434Q135 441 147 436Q160 429 160 418Q160 406 140 379T94 306T62 208Q61 202 61 187Q61 124 85 100T143 76Q201 76 245 129L253 137V156Q258 297 317 297Q348 297 348 261Q348 243 338 213T318 158L308 135Q309 133 310 129T318 115T334 97T358 83T393 76Q456 76 501 148T546 274Q546 305 533 325T508 357T495 384Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mi">
+                                                    <use data-c="394" xlink:href="#MJX-48-TEX-N-394"/>
+                                                </g>
+                                                <g data-mml-node="mi" transform="translate(833,0)">
+                                                    <use data-c="1D714" xlink:href="#MJX-48-TEX-I-1D714"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="26" y="86" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\De...
+                </text>
+            </switch>
+        </g>
+        <path d="M 406 77 L 434.63 77" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 439.88 77 L 432.88 80.5 L 434.63 77 L 432.88 73.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="396" cy="77" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 476 77 L 506.63 77" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 511.88 77 L 504.88 80.5 L 506.63 77 L 504.88 73.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="441" y="52" width="35" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="428.5" y="68.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 78px; margin-left: 430px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.304ex" height="4.963ex" role="img" focusable="false" viewBox="0 -1342 1460.6 2193.6" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.927ex;">
+                                        <defs>
+                                            <path id="MJX-49-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-49-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                            <path id="MJX-49-TEX-N-33" d="M127 463Q100 463 85 480T69 524Q69 579 117 622T233 665Q268 665 277 664Q351 652 390 611T430 522Q430 470 396 421T302 350L299 348Q299 347 308 345T337 336T375 315Q457 262 457 175Q457 96 395 37T238 -22Q158 -22 100 21T42 130Q42 158 60 175T105 193Q133 193 151 175T169 130Q169 119 166 110T159 94T148 82T136 74T126 70T118 67L114 66Q165 21 238 21Q293 21 321 74Q338 107 338 175V195Q338 290 274 322Q259 328 213 329L171 330L168 332Q166 335 166 348Q166 366 174 366Q202 366 232 371Q266 376 294 413T322 525V533Q322 590 287 612Q265 626 240 626Q208 626 181 615T143 592T132 580H135Q138 579 143 578T153 573T165 566T175 555T183 540T186 520Q186 498 172 481T127 463Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(480.3,676)">
+                                                        <use data-c="31" xlink:href="#MJX-49-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="msub" transform="translate(220,-686)">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D447" xlink:href="#MJX-49-TEX-I-1D447"/>
+                                                        </g>
+                                                        <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                            <g data-mml-node="mn">
+                                                                <use data-c="33" xlink:href="#MJX-49-TEX-N-33"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="1220.6" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="459" y="81" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <path d="M 546 76.76 L 575.63 76.34" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 580.88 76.27 L 573.93 79.87 L 575.63 76.34 L 573.83 72.87 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="513" y="52" width="33" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 531 64.81 L 541 64.81" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 517 89.8 L 527 89.8" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 526.5 89.5 L 531.5 64.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="514.5" y="52" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 57px; margin-left: 516px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="6.553ex" height="3.047ex" role="img" focusable="false" viewBox="0 -1008 2896.2 1346.8" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.767ex;">
+                                        <defs>
+                                            <path id="MJX-50-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-50-TEX-N-2D9" d="M190 609Q190 637 208 653T252 669Q275 667 292 652T309 609Q309 579 292 564T250 549Q225 549 208 564T190 609Z"/>
+                                            <path id="MJX-50-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-50-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-50-TEX-I-1D462" d="M21 287Q21 295 30 318T55 370T99 420T158 442Q204 442 227 417T250 358Q250 340 216 246T182 105Q182 62 196 45T238 27T291 44T328 78L339 95Q341 99 377 247Q407 367 413 387T427 416Q444 431 463 431Q480 431 488 421T496 402L420 84Q419 79 419 68Q419 43 426 35T447 26Q469 29 482 57T512 145Q514 153 532 153Q551 153 551 144Q550 139 549 130T540 98T523 55T498 17T462 -8Q454 -10 438 -10Q372 -10 347 46Q345 45 336 36T318 21T296 6T267 -6T233 -11Q189 -11 155 7Q103 38 103 113Q103 170 138 262T173 379Q173 380 173 381Q173 390 173 393T169 400T158 404H154Q131 404 112 385T82 344T65 302T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-50-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mover">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D443" xlink:href="#MJX-50-TEX-I-1D443"/>
+                                                            </g>
+                                                            <g data-mml-node="mo" transform="translate(486,239) translate(-250 0)">
+                                                                <use data-c="2D9" xlink:href="#MJX-50-TEX-N-2D9"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-150) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-50-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-50-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D462" xlink:href="#MJX-50-TEX-I-1D462"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1728,0)">
+                                                            <use data-c="1D45D" xlink:href="#MJX-50-TEX-I-1D45D"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="530" y="59" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$\dot{P...
+                </text>
+            </switch>
+        </g>
+        <rect x="515" y="91" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 96px; margin-left: 516px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="9.296ex" height="3.436ex" role="img" focusable="false" viewBox="0 -1008 4108.9 1518.6" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.155ex;">
+                                        <defs>
+                                            <path id="MJX-51-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-51-TEX-N-2D9" d="M190 609Q190 637 208 653T252 669Q275 667 292 652T309 609Q309 579 292 564T250 549Q225 549 208 564T190 609Z"/>
+                                            <path id="MJX-51-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-51-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-51-TEX-I-1D451" d="M366 683Q367 683 438 688T511 694Q523 694 523 686Q523 679 450 384T375 83T374 68Q374 26 402 26Q411 27 422 35Q443 55 463 131Q469 151 473 152Q475 153 483 153H487H491Q506 153 506 145Q506 140 503 129Q490 79 473 48T445 8T417 -8Q409 -10 393 -10Q359 -10 336 5T306 36L300 51Q299 52 296 50Q294 48 292 46Q233 -10 172 -10Q117 -10 75 30T33 157Q33 205 53 255T101 341Q148 398 195 420T280 442Q336 442 364 400Q369 394 369 396Q370 400 396 505T424 616Q424 629 417 632T378 637H357Q351 643 351 645T353 664Q358 683 366 683ZM352 326Q329 405 277 405Q242 405 210 374T160 293Q131 214 119 129Q119 126 119 118T118 106Q118 61 136 44T179 26Q233 26 290 98L298 109L352 326Z"/>
+                                            <path id="MJX-51-TEX-I-1D45C" d="M201 -11Q126 -11 80 38T34 156Q34 221 64 279T146 380Q222 441 301 441Q333 441 341 440Q354 437 367 433T402 417T438 387T464 338T476 268Q476 161 390 75T201 -11ZM121 120Q121 70 147 48T206 26Q250 26 289 58T351 142Q360 163 374 216T388 308Q388 352 370 375Q346 405 306 405Q243 405 195 347Q158 303 140 230T121 120Z"/>
+                                            <path id="MJX-51-TEX-I-1D464" d="M580 385Q580 406 599 424T641 443Q659 443 674 425T690 368Q690 339 671 253Q656 197 644 161T609 80T554 12T482 -11Q438 -11 404 5T355 48Q354 47 352 44Q311 -11 252 -11Q226 -11 202 -5T155 14T118 53T104 116Q104 170 138 262T173 379Q173 380 173 381Q173 390 173 393T169 400T158 404H154Q131 404 112 385T82 344T65 302T57 280Q55 278 41 278H27Q21 284 21 287Q21 293 29 315T52 366T96 418T161 441Q204 441 227 416T250 358Q250 340 217 250T184 111Q184 65 205 46T258 26Q301 26 334 87L339 96V119Q339 122 339 128T340 136T341 143T342 152T345 165T348 182T354 206T362 238T373 281Q402 395 406 404Q419 431 449 431Q468 431 475 421T483 402Q483 389 454 274T422 142Q420 131 420 107V100Q420 85 423 71T442 42T487 26Q558 26 600 148Q609 171 620 213T632 273Q632 306 619 325T593 357T580 385Z"/>
+                                            <path id="MJX-51-TEX-I-1D45B" d="M21 287Q22 293 24 303T36 341T56 388T89 425T135 442Q171 442 195 424T225 390T231 369Q231 367 232 367L243 378Q304 442 382 442Q436 442 469 415T503 336T465 179T427 52Q427 26 444 26Q450 26 453 27Q482 32 505 65T540 145Q542 153 560 153Q580 153 580 145Q580 144 576 130Q568 101 554 73T508 17T439 -10Q392 -10 371 17T350 73Q350 92 386 193T423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 180T152 343Q153 348 153 366Q153 405 129 405Q91 405 66 305Q60 285 60 284Q58 278 41 278H27Q21 284 21 287Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mover">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D443" xlink:href="#MJX-51-TEX-I-1D443"/>
+                                                            </g>
+                                                            <g data-mml-node="mo" transform="translate(486,239) translate(-250 0)">
+                                                                <use data-c="2D9" xlink:href="#MJX-51-TEX-N-2D9"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-321.8) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-51-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-51-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D451" xlink:href="#MJX-51-TEX-I-1D451"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1676,0)">
+                                                            <use data-c="1D45C" xlink:href="#MJX-51-TEX-I-1D45C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2161,0)">
+                                                            <use data-c="1D464" xlink:href="#MJX-51-TEX-I-1D464"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2877,0)">
+                                                            <use data-c="1D45B" xlink:href="#MJX-51-TEX-I-1D45B"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="530" y="98" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$\dot{P...
+                </text>
+            </switch>
+        </g>
+        <rect x="582" y="51" width="35" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 617 76 L 626.5 76 Q 636 76 645.82 75.88 L 655.63 75.76" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 660.88 75.7 L 653.93 79.28 L 655.63 75.76 L 653.84 72.28 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="569.5" y="68.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 78px; margin-left: 571px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.127ex" height="4.611ex" role="img" focusable="false" viewBox="0 -1342 940 2038" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.575ex;">
+                                        <defs>
+                                            <path id="MJX-52-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-52-TEX-I-1D460" d="M131 289Q131 321 147 354T203 415T300 442Q362 442 390 415T419 355Q419 323 402 308T364 292Q351 292 340 300T328 326Q328 342 337 354T354 372T367 378Q368 378 368 379Q368 382 361 388T336 399T297 405Q249 405 227 379T204 326Q204 301 223 291T278 274T330 259Q396 230 396 163Q396 135 385 107T352 51T289 7T195 -10Q118 -10 86 19T53 87Q53 126 74 143T118 160Q133 160 146 151T160 120Q160 94 142 76T111 58Q109 57 108 57T107 55Q108 52 115 47T146 34T201 27Q237 27 263 38T301 66T318 97T323 122Q323 150 302 164T254 181T195 196T148 231Q131 256 131 289Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(220,676)">
+                                                        <use data-c="31" xlink:href="#MJX-52-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="mi" transform="translate(235.5,-686)">
+                                                        <use data-c="1D460" xlink:href="#MJX-52-TEX-I-1D460"/>
+                                                    </g>
+                                                    <rect width="700" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="600" y="81" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <path d="M 585 112 L 596 112" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 606 42 L 617 42" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="597.5" y="30" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 35px; margin-left: 599px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="8.543ex" height="2.312ex" role="img" focusable="false" viewBox="0 -683 3776 1021.8" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.767ex;">
+                                        <defs>
+                                            <path id="MJX-53-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-53-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-53-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-53-TEX-I-1D44E" d="M33 157Q33 258 109 349T280 441Q331 441 370 392Q386 422 416 422Q429 422 439 414T449 394Q449 381 412 234T374 68Q374 43 381 35T402 26Q411 27 422 35Q443 55 463 131Q469 151 473 152Q475 153 483 153H487Q506 153 506 144Q506 138 501 117T481 63T449 13Q436 0 417 -8Q409 -10 393 -10Q359 -10 336 5T306 36L300 51Q299 52 296 50Q294 48 292 46Q233 -10 172 -10Q117 -10 75 30T33 157ZM351 328Q351 334 346 350T323 385T277 405Q242 405 210 374T160 293Q131 214 119 129Q119 126 119 118T118 106Q118 61 136 44T179 26Q217 26 254 59T298 110Q300 114 325 217T351 328Z"/>
+                                            <path id="MJX-53-TEX-I-1D465" d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D443" xlink:href="#MJX-53-TEX-I-1D443"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-150) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-53-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-53-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D45A" xlink:href="#MJX-53-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2034,0)">
+                                                            <use data-c="1D44E" xlink:href="#MJX-53-TEX-I-1D44E"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2563,0)">
+                                                            <use data-c="1D465" xlink:href="#MJX-53-TEX-I-1D465"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="613" y="37" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$P_{m,m...
+                </text>
+            </switch>
+        </g>
+        <rect x="572" y="112" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 117px; margin-left: 573px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="8.2ex" height="2.628ex" role="img" focusable="false" viewBox="0 -683 3624.2 1161.5" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.083ex;">
+                                        <defs>
+                                            <path id="MJX-54-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-54-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-54-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-54-TEX-I-1D456" d="M184 600Q184 624 203 642T247 661Q265 661 277 649T290 619Q290 596 270 577T226 557Q211 557 198 567T184 600ZM21 287Q21 295 30 318T54 369T98 420T158 442Q197 442 223 419T250 357Q250 340 236 301T196 196T154 83Q149 61 149 51Q149 26 166 26Q175 26 185 29T208 43T235 78T260 137Q263 149 265 151T282 153Q302 153 302 143Q302 135 293 112T268 61T223 11T161 -11Q129 -11 102 10T74 74Q74 91 79 106T122 220Q160 321 166 341T173 380Q173 404 156 404H154Q124 404 99 371T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-54-TEX-I-1D45B" d="M21 287Q22 293 24 303T36 341T56 388T89 425T135 442Q171 442 195 424T225 390T231 369Q231 367 232 367L243 378Q304 442 382 442Q436 442 469 415T503 336T465 179T427 52Q427 26 444 26Q450 26 453 27Q482 32 505 65T540 145Q542 153 560 153Q580 153 580 145Q580 144 576 130Q568 101 554 73T508 17T439 -10Q392 -10 371 17T350 73Q350 92 386 193T423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 180T152 343Q153 348 153 366Q153 405 129 405Q91 405 66 305Q60 285 60 284Q58 278 41 278H27Q21 284 21 287Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D443" xlink:href="#MJX-54-TEX-I-1D443"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-289.7) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-54-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-54-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D45A" xlink:href="#MJX-54-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2034,0)">
+                                                            <use data-c="1D456" xlink:href="#MJX-54-TEX-I-1D456"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2379,0)">
+                                                            <use data-c="1D45B" xlink:href="#MJX-54-TEX-I-1D45B"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="587" y="119" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$P_{m,m...
+                </text>
+            </switch>
+        </g>
+        <rect x="662" y="60.5" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 76px; margin-left: 663px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.865ex" height="1.667ex" role="img" focusable="false" viewBox="0 -442 1266.2 737" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.667ex;">
+                                        <defs>
+                                            <path id="MJX-55-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-55-TEX-I-1D454" d="M311 43Q296 30 267 15T206 0Q143 0 105 45T66 160Q66 265 143 353T314 442Q361 442 401 394L404 398Q406 401 409 404T418 412T431 419T447 422Q461 422 470 413T480 394Q480 379 423 152T363 -80Q345 -134 286 -169T151 -205Q10 -205 10 -137Q10 -111 28 -91T74 -71Q89 -71 102 -80T116 -111Q116 -121 114 -130T107 -144T99 -154T92 -162L90 -164H91Q101 -167 151 -167Q189 -167 211 -155Q234 -144 254 -122T282 -75Q288 -56 298 -13Q311 35 311 43ZM384 328L380 339Q377 350 375 354T369 368T359 382T346 393T328 402T306 405Q262 405 221 352Q191 313 171 233T151 117Q151 38 213 38Q269 38 323 108L331 118L384 328Z"/>
+                                            <path id="MJX-55-TEX-I-1D463" d="M173 380Q173 405 154 405Q130 405 104 376T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Q21 294 29 316T53 368T97 419T160 441Q202 441 225 417T249 361Q249 344 246 335Q246 329 231 291T200 202T182 113Q182 86 187 69Q200 26 250 26Q287 26 319 60T369 139T398 222T409 277Q409 300 401 317T383 343T365 361T357 383Q357 405 376 424T417 443Q436 443 451 425T467 367Q467 340 455 284T418 159T347 40T241 -11Q177 -11 139 22Q102 54 102 117Q102 148 110 181T151 298Q173 362 173 380Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-55-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D454" xlink:href="#MJX-55-TEX-I-1D454"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(477,0)">
+                                                            <use data-c="1D463" xlink:href="#MJX-55-TEX-I-1D463"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="677" y="79" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+        <path d="M 636 76 L 636 131 L 396 131 L 396 93.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 396 88.12 L 399.5 95.12 L 396 93.37 L 392.5 95.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 396 30 L 396 60.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 396 65.88 L 392.5 58.88 L 396 60.63 L 399.5 58.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="381" y="0" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 15px; margin-left: 382px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.673ex" height="1.667ex" role="img" focusable="false" viewBox="0 -442 1623.3 737" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.667ex;">
+                                        <defs>
+                                            <path id="MJX-56-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-56-TEX-I-1D45F" d="M21 287Q22 290 23 295T28 317T38 348T53 381T73 411T99 433T132 442Q161 442 183 430T214 408T225 388Q227 382 228 382T236 389Q284 441 347 441H350Q398 441 422 400Q430 381 430 363Q430 333 417 315T391 292T366 288Q346 288 334 299T322 328Q322 376 378 392Q356 405 342 405Q286 405 239 331Q229 315 224 298T190 165Q156 25 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 114 189T154 366Q154 405 128 405Q107 405 92 377T68 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-56-TEX-I-1D452" d="M39 168Q39 225 58 272T107 350T174 402T244 433T307 442H310Q355 442 388 420T421 355Q421 265 310 237Q261 224 176 223Q139 223 138 221Q138 219 132 186T125 128Q125 81 146 54T209 26T302 45T394 111Q403 121 406 121Q410 121 419 112T429 98T420 82T390 55T344 24T281 -1T205 -11Q126 -11 83 42T39 168ZM373 353Q367 405 305 405Q272 405 244 391T199 357T170 316T154 280T149 261Q149 260 169 260Q282 260 327 284T373 353Z"/>
+                                            <path id="MJX-56-TEX-I-1D453" d="M118 -162Q120 -162 124 -164T135 -167T147 -168Q160 -168 171 -155T187 -126Q197 -99 221 27T267 267T289 382V385H242Q195 385 192 387Q188 390 188 397L195 425Q197 430 203 430T250 431Q298 431 298 432Q298 434 307 482T319 540Q356 705 465 705Q502 703 526 683T550 630Q550 594 529 578T487 561Q443 561 443 603Q443 622 454 636T478 657L487 662Q471 668 457 668Q445 668 434 658T419 630Q412 601 403 552T387 469T380 433Q380 431 435 431Q480 431 487 430T498 424Q499 420 496 407T491 391Q489 386 482 386T428 385H372L349 263Q301 15 282 -47Q255 -132 212 -173Q175 -205 139 -205Q107 -205 81 -186T55 -132Q55 -95 76 -78T118 -61Q162 -61 162 -103Q162 -122 151 -136T127 -157L118 -162Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-56-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45F" xlink:href="#MJX-56-TEX-I-1D45F"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(451,0)">
+                                                            <use data-c="1D452" xlink:href="#MJX-56-TEX-I-1D452"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(917,0)">
+                                                            <use data-c="1D453" xlink:href="#MJX-56-TEX-I-1D453"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="396" y="19" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+        <rect x="356" y="48.5" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 64px; margin-left: 357px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="1.138ex" height="1.439ex" role="img" focusable="false" viewBox="0 -442 503 636" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.439ex;">
+                                        <defs>
+                                            <path id="MJX-57-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mi">
+                                                    <use data-c="1D45D" xlink:href="#MJX-57-TEX-I-1D45D"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="371" y="67" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p$$
+                </text>
+            </switch>
+        </g>
+        <rect x="390" y="84" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 99px; margin-left: 391px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="1.76ex" height="1.505ex" role="img" focusable="false" viewBox="0 -583 778 665" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.186ex;">
+                                        <defs>
+                                            <path id="MJX-58-TEX-N-2212" d="M84 237T84 250T98 270H679Q694 262 694 250T679 230H98Q84 237 84 250Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mo">
+                                                    <use data-c="2212" xlink:href="#MJX-58-TEX-N-2212"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="405" y="103" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$-$$
+                </text>
+            </switch>
+        </g>
+        <path d="M 292 77.5 L 314.63 77.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 319.88 77.5 L 312.88 81 L 314.63 77.5 L 312.88 74 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="282" cy="77.5" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 171 127.5 L 189.13 127.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 194.38 127.5 L 187.38 131 L 189.13 127.5 L 187.38 124 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="112" y="107.5" width="59" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="115" y="118.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 128px; margin-left: 116px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="8.379ex" height="4.952ex" role="img" focusable="false" viewBox="0 -1353 3703.6 2189" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.891ex;">
+                                        <defs>
+                                            <path id="MJX-59-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                            <path id="MJX-59-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-59-TEX-N-2212" d="M84 237T84 250T98 270H679Q694 262 694 250T679 230H98Q84 237 84 250Z"/>
+                                            <path id="MJX-59-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mrow" transform="translate(220,676)">
+                                                        <g data-mml-node="msub">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D447" xlink:href="#MJX-59-TEX-I-1D447"/>
+                                                            </g>
+                                                            <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                                <g data-mml-node="mn">
+                                                                    <use data-c="31" xlink:href="#MJX-59-TEX-N-31"/>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(1242.8,0)">
+                                                            <use data-c="2212" xlink:href="#MJX-59-TEX-N-2212"/>
+                                                        </g>
+                                                        <g data-mml-node="msub" transform="translate(2243,0)">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D447" xlink:href="#MJX-59-TEX-I-1D447"/>
+                                                            </g>
+                                                            <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                                <g data-mml-node="mn">
+                                                                    <use data-c="32" xlink:href="#MJX-59-TEX-N-32"/>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="msub" transform="translate(1341.5,-686)">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D447" xlink:href="#MJX-59-TEX-I-1D447"/>
+                                                        </g>
+                                                        <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                            <g data-mml-node="mn">
+                                                                <use data-c="31" xlink:href="#MJX-59-TEX-N-31"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="3463.6" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="145" y="131" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{T_...
+                </text>
+            </switch>
+        </g>
+        <path d="M 192 27.5 L 282 27.5 L 282 61.13" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 282 66.38 L 278.5 59.38 L 282 61.13 L 285.5 59.38 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 252 127.5 L 282 127.5 L 282 93.87" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 282 88.62 L 285.5 95.62 L 282 93.87 L 278.5 95.62 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 92 27.5 L 183.63 27.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 188.88 27.5 L 181.88 31 L 183.63 27.5 L 181.88 24 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 92 127.5 L 105.63 127.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 110.88 127.5 L 103.88 131 L 105.63 127.5 L 103.88 124 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 92 127.5 L 92 27.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="190" y="7.5" width="30" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="175" y="18.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 28px; margin-left: 176px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.304ex" height="4.952ex" role="img" focusable="false" viewBox="0 -1353 1460.6 2189" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.891ex;">
+                                        <defs>
+                                            <path id="MJX-60-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                            <path id="MJX-60-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+                                            <path id="MJX-60-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="msub" transform="translate(220,676)">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D447" xlink:href="#MJX-60-TEX-I-1D447"/>
+                                                        </g>
+                                                        <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                            <g data-mml-node="mn">
+                                                                <use data-c="32" xlink:href="#MJX-60-TEX-N-32"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="msub" transform="translate(220,-686)">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D447" xlink:href="#MJX-60-TEX-I-1D447"/>
+                                                        </g>
+                                                        <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                            <g data-mml-node="mn">
+                                                                <use data-c="31" xlink:href="#MJX-60-TEX-N-31"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="1220.6" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="205" y="31" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{T_...
+                </text>
+            </switch>
+        </g>
+        <rect x="196" y="107.5" width="69" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="195.5" y="118.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 128px; margin-left: 197px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="8.262ex" height="4.928ex" role="img" focusable="false" viewBox="0 -1342 3652 2178" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.891ex;">
+                                        <defs>
+                                            <path id="MJX-61-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-61-TEX-N-2B" d="M56 237T56 250T70 270H369V420L370 570Q380 583 389 583Q402 583 409 568V270H707Q722 262 722 250T707 230H409V-68Q401 -82 391 -82H389H387Q375 -82 369 -68V230H70Q56 237 56 250Z"/>
+                                            <path id="MJX-61-TEX-I-1D460" d="M131 289Q131 321 147 354T203 415T300 442Q362 442 390 415T419 355Q419 323 402 308T364 292Q351 292 340 300T328 326Q328 342 337 354T354 372T367 378Q368 378 368 379Q368 382 361 388T336 399T297 405Q249 405 227 379T204 326Q204 301 223 291T278 274T330 259Q396 230 396 163Q396 135 385 107T352 51T289 7T195 -10Q118 -10 86 19T53 87Q53 126 74 143T118 160Q133 160 146 151T160 120Q160 94 142 76T111 58Q109 57 108 57T107 55Q108 52 115 47T146 34T201 27Q237 27 263 38T301 66T318 97T323 122Q323 150 302 164T254 181T195 196T148 231Q131 256 131 289Z"/>
+                                            <path id="MJX-61-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(1576,676)">
+                                                        <use data-c="31" xlink:href="#MJX-61-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="mrow" transform="translate(220,-686)">
+                                                        <g data-mml-node="mn">
+                                                            <use data-c="31" xlink:href="#MJX-61-TEX-N-31"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(722.2,0)">
+                                                            <use data-c="2B" xlink:href="#MJX-61-TEX-N-2B"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1722.4,0)">
+                                                            <use data-c="1D460" xlink:href="#MJX-61-TEX-I-1D460"/>
+                                                        </g>
+                                                        <g data-mml-node="msub" transform="translate(2191.4,0)">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D447" xlink:href="#MJX-61-TEX-I-1D447"/>
+                                                            </g>
+                                                            <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                                <g data-mml-node="mn">
+                                                                    <use data-c="31" xlink:href="#MJX-61-TEX-N-31"/>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="3412" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="226" y="131" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <path d="M 356 77.32 L 379.63 77.07" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 384.88 77.01 L 377.92 80.59 L 379.63 77.07 L 377.85 73.59 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="321" y="52.5" width="35" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="308.5" y="66.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 76px; margin-left: 310px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.713ex" height="4.636ex" role="img" focusable="false" viewBox="0 -1342 1199 2049" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.6ex;">
+                                        <defs>
+                                            <path id="MJX-62-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-62-TEX-I-1D445" d="M230 637Q203 637 198 638T193 649Q193 676 204 682Q206 683 378 683Q550 682 564 680Q620 672 658 652T712 606T733 563T739 529Q739 484 710 445T643 385T576 351T538 338L545 333Q612 295 612 223Q612 212 607 162T602 80V71Q602 53 603 43T614 25T640 16Q668 16 686 38T712 85Q717 99 720 102T735 105Q755 105 755 93Q755 75 731 36Q693 -21 641 -21H632Q571 -21 531 4T487 82Q487 109 502 166T517 239Q517 290 474 313Q459 320 449 321T378 323H309L277 193Q244 61 244 59Q244 55 245 54T252 50T269 48T302 46H333Q339 38 339 37T336 19Q332 6 326 0H311Q275 2 180 2Q146 2 117 2T71 2T50 1Q33 1 33 10Q33 12 36 24Q41 43 46 45Q50 46 61 46H67Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628Q287 635 230 637ZM630 554Q630 586 609 608T523 636Q521 636 500 636T462 637H440Q393 637 386 627Q385 624 352 494T319 361Q319 360 388 360Q466 361 492 367Q556 377 592 426Q608 449 619 486T630 554Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(349.5,676)">
+                                                        <use data-c="31" xlink:href="#MJX-62-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="mi" transform="translate(220,-686)">
+                                                        <use data-c="1D445" xlink:href="#MJX-62-TEX-I-1D445"/>
+                                                    </g>
+                                                    <rect width="959" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="339" y="79" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <path d="M 43 81.25 L 92 81.75" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/docs/hugo/content/en/docs/Models/Synchronous Generator Regulators/images/SteamGovernor_windup.drawio.svg
+++ b/docs/hugo/content/en/docs/Models/Synchronous Generator Regulators/images/SteamGovernor_windup.drawio.svg
@@ -1,0 +1,1015 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="708px" height="183px" viewBox="-0.5 -0.5 708 183" content="&lt;mxfile&gt;&lt;diagram id=&quot;tAVxjjhIxe6FjWcWs54s&quot; name=&quot;Page-1&quot;&gt;7Vxbb6M4FP41eVkpFba5hMdJOzMrrVZbbVfamacRE2iKhoSI0DbdX78m2AQfDDFgCNNMNZqCocac71y+c2wzI7ebw+fE2z39GftBNMOGf5iRuxnGyCQ2/ZW1vOUtGLOGdRL67KZTw0P4X8AaDdb6HPrBXrgxjeMoDXdi4yreboNVKrR5SRK/irc9xpH41J23DioNDysvqrb+G/rpU966sIxT++9BuH7iT0YGu7Lx+M2si/2T58evedPxHvJxRm6TOE7zo83hNogy4XG55B19qrlaDCwJtqnSHxhO/icvXvTM3o6NLH3jrxts/Q+Z1OjZNt7SxuVTuonoGaKHj/E2vY2jODneS4zjD21Pg0P6185bhWkGctZSHRsbbuAL4mYj/RzEmyBN3ugNrychcxk/leTL25Ig8tLwRQTJY1ivi+6KJ9zHIR0JNrheInxj5X/E9NJeIN7Cu9nHz8kqYH9ZFizsDFc6Q5XOUi9ZB2mlM3pQev1T0xE7OY7YlcBoZv+s27sgSj16jR7SLtceuwBRzgATod2nSfwj4OAy6B/DKAJNXhSut/R0RYENaPvyJUjSkJrLB3ZhE/p+9pjl61OYBg9UK7JnvlLnQNuS+HnrB/45Jcn6DA6NasKuzglXai55YnPJlzSJSDSJt8mURkCnAQrXVLAoqvEP7LRqUrUyyJWPeRvmMnMdYo82FA1K2VJUX5qPpvGlo4g66Do1KL2/t9/lXvsxPGSKoUMpTGCMxKkoBJYoBNahEMZ52YhGcEY+GsRRRCQuDz6msoFY9a62lzyQRB7MVz0m3mrmLNHMuaO//vlG/yPH47tJe626IKgBqYUD4whZVKCyJaqLFhqgaggrPuUozvKeQpOhtJnh2+fd1HGKvO9BtPRWP9bHdvhwiiIjm44mM0PAzLjZnYlDSIOZFSauBh6lodtf8InwuQA9Z6HII/Tgt1CIqV2oea1kpkLEDSTKfQG6UCbhCDd3pI+AI0PmKq8CLQyEzIXeGi1CmjvSiBZSIekntFaRt9+HKxEw0TdRdJK3L9kJ9RHs9Cu783hydyjfeXc2Ky4Te06vJwI5MYFjNJ1ukFuA2thqiFNYvLfSbbvshr36eB3TaDMscDs9yAfQXfucqrJVM0JRv9rmhwhZPfRIe4JYDKfCRnYZA0mCx6mTj1qpt0hCRTW0HDU2qKMqgZCMTRzl/96ljmAdTpXF6ZF7XQo1f+9yN11R7pY5ntSJ28vDBocw/VI6/nqK6/TsFMmzEx7ITwSgHP5LbKAtARC8uYwVIF4JuIA7x7IiDpT4JQt+cxuoH3EkZj9Uza8gxd2rwAPrE5Hpk3Z6IOdXc2QBAumCYpVGqs/fdErl13kxYVOUFmTaablV7TS1aGcdGTuVYI+116wOOz8eYVaFLV2YOmEbsCg7L2asi8qCjFQMVZZFuN2srTR97RfjxCTXOOOTYKrsfwqjs+YkuKaJFT3mCLAby3W6ThXDSCXpSlMePLfqnqQttcXtipaNmmncOJagnDh7syb1pCf3QRLSAWfOo1dd5v2p7AKEHAq+6dp6dNYeTWftAXS2XelWrrO62ZpIzPC0VAnmdn28H3K6ur8uWPPscrpYc746Vawlpq6ONXQbaFCsVXLUpimZWsDeIzYKNq0TG4X8ePSsDFnixKMlzcpkRSstWRmRZaqSrEyWi2E7ylKu7wk9WmdH15ydIVvMzqxxszOisBhufN2GK+Ckus39s37dlmWs0kVf9D2W+19FhiNkRmVB8qiKbKqQpTZl9UFLmrwaPpEJT6KQCY9fd6ws+5QFuIEWfiJTeeXn39ds96SydUC6gH04s1eomDfyZlA76VBorBUjMGTRBeSJ/OXYOJ/FKGY80Q3WRcezzpzh+LipUgNR2LVQweec1zbNqtdG5mIsL80fP+Q8ZsX0JVKpX71gA5c97jymqWOmoWPY7+442mohX+grKqF5SW+CYKh2AJzKyyodGPNBRxq9iKViTYN4EQn3Y5PMo3iRYbheL8dRcIHLcD1LZUfYEKrQG3W5GRFoRqZzY7iWZdIsCWGHLzgawqiG2T/WT7ng1gi5cpGhlKtvZbeZvp/XuUtFBWIAoybWDQG9qAYGAh2EpC+daoyvFLNiR3Cxyt24IR0hM852pROxvnlg228DTBdDYhCYk1PRG6WfrkZoLCrJvtXUsU58z68CY+WY/c9djukX6gzrgjtwix2kFZDu+c7NjXeYOjxjb9zELoKYYaI4ladl7yaqq3SeUAt/bbetogZcLB4PMduqxrbm9dl8lVqL6kRRCSnKIm0mQNqnQiwpEbJim8hB6MtyQL3CIY3xUWcYUyldXrKEh61KBHHdMYt4tkIGqV7Ea7f0d7wiXsFnxCLQRecEKtVbt2MVD8MvScBZeY0GZbfLrpvVZTBPNyGUK/uLYURSzgYIQBkWfXWiLMvHf5aNif38sQ39sWOM+YUwFoKnVdFDsKLnykTCl/cLIcrWIRLZzEGmhn9khPn7aupcecAEFDli0ccxjDFXA9gqhfyO5OHcJowuHFvmLlpTCVu2PfKyE4KQATiQGipTCchJFINM250bcOKRR0Vt+zbs2k8anJbFTthlaHAN8wWAUro+cLg4Vvdtg+ILYzv2hbH1yxWggSAaSHX5uBY0HFmWl3/hw/pIMfjtmrDAFviYFI9aoyBRV/3bXY38K9PlREZahkPgapMbuPfBNgcMCfT09K3yPISfvvhOPv4P&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 419.5 115.5 L 429.5 45.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="0" y="70.5" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 86px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.292ex" height="1.645ex" role="img" focusable="false" viewBox="0 -716 1455 727" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.025ex;">
+                                        <defs>
+                                            <path id="MJX-2822-TEX-N-394" d="M51 0Q46 4 46 7Q46 9 215 357T388 709Q391 716 416 716Q439 716 444 709Q447 705 616 357T786 7Q786 4 781 0H51ZM507 344L384 596L137 92L383 91H630Q630 93 507 344Z"/>
+                                            <path id="MJX-2822-TEX-I-1D714" d="M495 384Q495 406 514 424T555 443Q574 443 589 425T604 364Q604 334 592 278T555 155T483 38T377 -11Q297 -11 267 66Q266 68 260 61Q201 -11 125 -11Q15 -11 15 139Q15 230 56 325T123 434Q135 441 147 436Q160 429 160 418Q160 406 140 379T94 306T62 208Q61 202 61 187Q61 124 85 100T143 76Q201 76 245 129L253 137V156Q258 297 317 297Q348 297 348 261Q348 243 338 213T318 158L308 135Q309 133 310 129T318 115T334 97T358 83T393 76Q456 76 501 148T546 274Q546 305 533 325T508 357T495 384Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mi">
+                                                    <use data-c="394" xlink:href="#MJX-2822-TEX-N-394"/>
+                                                </g>
+                                                <g data-mml-node="mi" transform="translate(833,0)">
+                                                    <use data-c="1D714" xlink:href="#MJX-2822-TEX-I-1D714"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="15" y="89" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\De...
+                </text>
+            </switch>
+        </g>
+        <path d="M 372 81 L 400.63 81" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 405.88 81 L 398.88 84.5 L 400.63 81 L 398.88 77.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="362" cy="81" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="407" y="56" width="35" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="394.5" y="72" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 81px; margin-left: 396px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.304ex" height="4.963ex" role="img" focusable="false" viewBox="0 -1342 1460.6 2193.6" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.927ex;">
+                                        <defs>
+                                            <path id="MJX-2823-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-2823-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                            <path id="MJX-2823-TEX-N-33" d="M127 463Q100 463 85 480T69 524Q69 579 117 622T233 665Q268 665 277 664Q351 652 390 611T430 522Q430 470 396 421T302 350L299 348Q299 347 308 345T337 336T375 315Q457 262 457 175Q457 96 395 37T238 -22Q158 -22 100 21T42 130Q42 158 60 175T105 193Q133 193 151 175T169 130Q169 119 166 110T159 94T148 82T136 74T126 70T118 67L114 66Q165 21 238 21Q293 21 321 74Q338 107 338 175V195Q338 290 274 322Q259 328 213 329L171 330L168 332Q166 335 166 348Q166 366 174 366Q202 366 232 371Q266 376 294 413T322 525V533Q322 590 287 612Q265 626 240 626Q208 626 181 615T143 592T132 580H135Q138 579 143 578T153 573T165 566T175 555T183 540T186 520Q186 498 172 481T127 463Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(480.3,676)">
+                                                        <use data-c="31" xlink:href="#MJX-2823-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="msub" transform="translate(220,-686)">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D447" xlink:href="#MJX-2823-TEX-I-1D447"/>
+                                                        </g>
+                                                        <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                            <g data-mml-node="mn">
+                                                                <use data-c="33" xlink:href="#MJX-2823-TEX-N-33"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="1220.6" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="425" y="85" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <rect x="417" y="34" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 39px; margin-left: 418px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="6.553ex" height="3.047ex" role="img" focusable="false" viewBox="0 -1008 2896.2 1346.8" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.767ex;">
+                                        <defs>
+                                            <path id="MJX-2824-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-2824-TEX-N-2D9" d="M190 609Q190 637 208 653T252 669Q275 667 292 652T309 609Q309 579 292 564T250 549Q225 549 208 564T190 609Z"/>
+                                            <path id="MJX-2824-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-2824-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-2824-TEX-I-1D462" d="M21 287Q21 295 30 318T55 370T99 420T158 442Q204 442 227 417T250 358Q250 340 216 246T182 105Q182 62 196 45T238 27T291 44T328 78L339 95Q341 99 377 247Q407 367 413 387T427 416Q444 431 463 431Q480 431 488 421T496 402L420 84Q419 79 419 68Q419 43 426 35T447 26Q469 29 482 57T512 145Q514 153 532 153Q551 153 551 144Q550 139 549 130T540 98T523 55T498 17T462 -8Q454 -10 438 -10Q372 -10 347 46Q345 45 336 36T318 21T296 6T267 -6T233 -11Q189 -11 155 7Q103 38 103 113Q103 170 138 262T173 379Q173 380 173 381Q173 390 173 393T169 400T158 404H154Q131 404 112 385T82 344T65 302T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-2824-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mover">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D443" xlink:href="#MJX-2824-TEX-I-1D443"/>
+                                                            </g>
+                                                            <g data-mml-node="mo" transform="translate(486,239) translate(-250 0)">
+                                                                <use data-c="2D9" xlink:href="#MJX-2824-TEX-N-2D9"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-150) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-2824-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-2824-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D462" xlink:href="#MJX-2824-TEX-I-1D462"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1728,0)">
+                                                            <use data-c="1D45D" xlink:href="#MJX-2824-TEX-I-1D45D"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="432" y="41" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$\dot{P...
+                </text>
+            </switch>
+        </g>
+        <rect x="397" y="112.5" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 117px; margin-left: 398px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="9.296ex" height="3.436ex" role="img" focusable="false" viewBox="0 -1008 4108.9 1518.6" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.155ex;">
+                                        <defs>
+                                            <path id="MJX-2825-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-2825-TEX-N-2D9" d="M190 609Q190 637 208 653T252 669Q275 667 292 652T309 609Q309 579 292 564T250 549Q225 549 208 564T190 609Z"/>
+                                            <path id="MJX-2825-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-2825-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-2825-TEX-I-1D451" d="M366 683Q367 683 438 688T511 694Q523 694 523 686Q523 679 450 384T375 83T374 68Q374 26 402 26Q411 27 422 35Q443 55 463 131Q469 151 473 152Q475 153 483 153H487H491Q506 153 506 145Q506 140 503 129Q490 79 473 48T445 8T417 -8Q409 -10 393 -10Q359 -10 336 5T306 36L300 51Q299 52 296 50Q294 48 292 46Q233 -10 172 -10Q117 -10 75 30T33 157Q33 205 53 255T101 341Q148 398 195 420T280 442Q336 442 364 400Q369 394 369 396Q370 400 396 505T424 616Q424 629 417 632T378 637H357Q351 643 351 645T353 664Q358 683 366 683ZM352 326Q329 405 277 405Q242 405 210 374T160 293Q131 214 119 129Q119 126 119 118T118 106Q118 61 136 44T179 26Q233 26 290 98L298 109L352 326Z"/>
+                                            <path id="MJX-2825-TEX-I-1D45C" d="M201 -11Q126 -11 80 38T34 156Q34 221 64 279T146 380Q222 441 301 441Q333 441 341 440Q354 437 367 433T402 417T438 387T464 338T476 268Q476 161 390 75T201 -11ZM121 120Q121 70 147 48T206 26Q250 26 289 58T351 142Q360 163 374 216T388 308Q388 352 370 375Q346 405 306 405Q243 405 195 347Q158 303 140 230T121 120Z"/>
+                                            <path id="MJX-2825-TEX-I-1D464" d="M580 385Q580 406 599 424T641 443Q659 443 674 425T690 368Q690 339 671 253Q656 197 644 161T609 80T554 12T482 -11Q438 -11 404 5T355 48Q354 47 352 44Q311 -11 252 -11Q226 -11 202 -5T155 14T118 53T104 116Q104 170 138 262T173 379Q173 380 173 381Q173 390 173 393T169 400T158 404H154Q131 404 112 385T82 344T65 302T57 280Q55 278 41 278H27Q21 284 21 287Q21 293 29 315T52 366T96 418T161 441Q204 441 227 416T250 358Q250 340 217 250T184 111Q184 65 205 46T258 26Q301 26 334 87L339 96V119Q339 122 339 128T340 136T341 143T342 152T345 165T348 182T354 206T362 238T373 281Q402 395 406 404Q419 431 449 431Q468 431 475 421T483 402Q483 389 454 274T422 142Q420 131 420 107V100Q420 85 423 71T442 42T487 26Q558 26 600 148Q609 171 620 213T632 273Q632 306 619 325T593 357T580 385Z"/>
+                                            <path id="MJX-2825-TEX-I-1D45B" d="M21 287Q22 293 24 303T36 341T56 388T89 425T135 442Q171 442 195 424T225 390T231 369Q231 367 232 367L243 378Q304 442 382 442Q436 442 469 415T503 336T465 179T427 52Q427 26 444 26Q450 26 453 27Q482 32 505 65T540 145Q542 153 560 153Q580 153 580 145Q580 144 576 130Q568 101 554 73T508 17T439 -10Q392 -10 371 17T350 73Q350 92 386 193T423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 180T152 343Q153 348 153 366Q153 405 129 405Q91 405 66 305Q60 285 60 284Q58 278 41 278H27Q21 284 21 287Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mover">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D443" xlink:href="#MJX-2825-TEX-I-1D443"/>
+                                                            </g>
+                                                            <g data-mml-node="mo" transform="translate(486,239) translate(-250 0)">
+                                                                <use data-c="2D9" xlink:href="#MJX-2825-TEX-N-2D9"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-321.8) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-2825-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-2825-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D451" xlink:href="#MJX-2825-TEX-I-1D451"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1676,0)">
+                                                            <use data-c="1D45C" xlink:href="#MJX-2825-TEX-I-1D45C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2161,0)">
+                                                            <use data-c="1D464" xlink:href="#MJX-2825-TEX-I-1D464"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2877,0)">
+                                                            <use data-c="1D45B" xlink:href="#MJX-2825-TEX-I-1D45B"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="412" y="120" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$\dot{P...
+                </text>
+            </switch>
+        </g>
+        <path d="M 408 115 L 419 115" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 429 46 L 440 46" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 647 81 L 647 174 L 362 174 L 362 97.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 362 92.12 L 365.5 99.12 L 362 97.37 L 358.5 99.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 362 34 L 362 64.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 362 69.88 L 358.5 62.88 L 362 64.63 L 365.5 62.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="347" y="4" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 19px; margin-left: 348px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.673ex" height="1.667ex" role="img" focusable="false" viewBox="0 -442 1623.3 737" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.667ex;">
+                                        <defs>
+                                            <path id="MJX-2826-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-2826-TEX-I-1D45F" d="M21 287Q22 290 23 295T28 317T38 348T53 381T73 411T99 433T132 442Q161 442 183 430T214 408T225 388Q227 382 228 382T236 389Q284 441 347 441H350Q398 441 422 400Q430 381 430 363Q430 333 417 315T391 292T366 288Q346 288 334 299T322 328Q322 376 378 392Q356 405 342 405Q286 405 239 331Q229 315 224 298T190 165Q156 25 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 114 189T154 366Q154 405 128 405Q107 405 92 377T68 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-2826-TEX-I-1D452" d="M39 168Q39 225 58 272T107 350T174 402T244 433T307 442H310Q355 442 388 420T421 355Q421 265 310 237Q261 224 176 223Q139 223 138 221Q138 219 132 186T125 128Q125 81 146 54T209 26T302 45T394 111Q403 121 406 121Q410 121 419 112T429 98T420 82T390 55T344 24T281 -1T205 -11Q126 -11 83 42T39 168ZM373 353Q367 405 305 405Q272 405 244 391T199 357T170 316T154 280T149 261Q149 260 169 260Q282 260 327 284T373 353Z"/>
+                                            <path id="MJX-2826-TEX-I-1D453" d="M118 -162Q120 -162 124 -164T135 -167T147 -168Q160 -168 171 -155T187 -126Q197 -99 221 27T267 267T289 382V385H242Q195 385 192 387Q188 390 188 397L195 425Q197 430 203 430T250 431Q298 431 298 432Q298 434 307 482T319 540Q356 705 465 705Q502 703 526 683T550 630Q550 594 529 578T487 561Q443 561 443 603Q443 622 454 636T478 657L487 662Q471 668 457 668Q445 668 434 658T419 630Q412 601 403 552T387 469T380 433Q380 431 435 431Q480 431 487 430T498 424Q499 420 496 407T491 391Q489 386 482 386T428 385H372L349 263Q301 15 282 -47Q255 -132 212 -173Q175 -205 139 -205Q107 -205 81 -186T55 -132Q55 -95 76 -78T118 -61Q162 -61 162 -103Q162 -122 151 -136T127 -157L118 -162Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-2826-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45F" xlink:href="#MJX-2826-TEX-I-1D45F"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(451,0)">
+                                                            <use data-c="1D452" xlink:href="#MJX-2826-TEX-I-1D452"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(917,0)">
+                                                            <use data-c="1D453" xlink:href="#MJX-2826-TEX-I-1D453"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="362" y="23" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+        <rect x="322" y="52.5" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 67px; margin-left: 323px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="1.138ex" height="1.439ex" role="img" focusable="false" viewBox="0 -442 503 636" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.439ex;">
+                                        <defs>
+                                            <path id="MJX-2827-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mi">
+                                                    <use data-c="1D45D" xlink:href="#MJX-2827-TEX-I-1D45D"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="337" y="71" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p$$
+                </text>
+            </switch>
+        </g>
+        <rect x="356" y="88" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 103px; margin-left: 357px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="1.76ex" height="1.505ex" role="img" focusable="false" viewBox="0 -583 778 665" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.186ex;">
+                                        <defs>
+                                            <path id="MJX-2828-TEX-N-2212" d="M84 237T84 250T98 270H679Q694 262 694 250T679 230H98Q84 237 84 250Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mo">
+                                                    <use data-c="2212" xlink:href="#MJX-2828-TEX-N-2212"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="371" y="107" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$-$$
+                </text>
+            </switch>
+        </g>
+        <path d="M 258 81.5 L 280.63 81.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 285.88 81.5 L 278.88 85 L 280.63 81.5 L 278.88 78 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="248" cy="81.5" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 137 131.5 L 155.63 131.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 160.88 131.5 L 153.88 135 L 155.63 131.5 L 153.88 128 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="78" y="111.5" width="59" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="81" y="122.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 131px; margin-left: 82px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="8.379ex" height="4.952ex" role="img" focusable="false" viewBox="0 -1353 3703.6 2189" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.891ex;">
+                                        <defs>
+                                            <path id="MJX-2829-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                            <path id="MJX-2829-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-2829-TEX-N-2212" d="M84 237T84 250T98 270H679Q694 262 694 250T679 230H98Q84 237 84 250Z"/>
+                                            <path id="MJX-2829-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mrow" transform="translate(220,676)">
+                                                        <g data-mml-node="msub">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D447" xlink:href="#MJX-2829-TEX-I-1D447"/>
+                                                            </g>
+                                                            <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                                <g data-mml-node="mn">
+                                                                    <use data-c="31" xlink:href="#MJX-2829-TEX-N-31"/>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(1242.8,0)">
+                                                            <use data-c="2212" xlink:href="#MJX-2829-TEX-N-2212"/>
+                                                        </g>
+                                                        <g data-mml-node="msub" transform="translate(2243,0)">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D447" xlink:href="#MJX-2829-TEX-I-1D447"/>
+                                                            </g>
+                                                            <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                                <g data-mml-node="mn">
+                                                                    <use data-c="32" xlink:href="#MJX-2829-TEX-N-32"/>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="msub" transform="translate(1341.5,-686)">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D447" xlink:href="#MJX-2829-TEX-I-1D447"/>
+                                                        </g>
+                                                        <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                            <g data-mml-node="mn">
+                                                                <use data-c="31" xlink:href="#MJX-2829-TEX-N-31"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="3463.6" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="111" y="135" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{T_...
+                </text>
+            </switch>
+        </g>
+        <path d="M 158 31.5 L 248 31.5 L 248 65.13" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 248 70.38 L 244.5 63.38 L 248 65.13 L 251.5 63.38 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 218 131.5 L 248 131.5 L 248 97.87" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 248 92.62 L 251.5 99.62 L 248 97.87 L 244.5 99.62 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 58 31.5 L 149.63 31.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 154.88 31.5 L 147.88 35 L 149.63 31.5 L 147.88 28 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 58 131.5 L 71.63 131.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 76.88 131.5 L 69.88 135 L 71.63 131.5 L 69.88 128 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 58 131.5 L 58 31.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="156" y="11.5" width="30" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="141" y="22.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 31px; margin-left: 142px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.304ex" height="4.952ex" role="img" focusable="false" viewBox="0 -1353 1460.6 2189" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.891ex;">
+                                        <defs>
+                                            <path id="MJX-2830-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                            <path id="MJX-2830-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+                                            <path id="MJX-2830-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="msub" transform="translate(220,676)">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D447" xlink:href="#MJX-2830-TEX-I-1D447"/>
+                                                        </g>
+                                                        <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                            <g data-mml-node="mn">
+                                                                <use data-c="32" xlink:href="#MJX-2830-TEX-N-32"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="msub" transform="translate(220,-686)">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D447" xlink:href="#MJX-2830-TEX-I-1D447"/>
+                                                        </g>
+                                                        <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                            <g data-mml-node="mn">
+                                                                <use data-c="31" xlink:href="#MJX-2830-TEX-N-31"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="1220.6" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="171" y="35" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{T_...
+                </text>
+            </switch>
+        </g>
+        <rect x="162" y="111.5" width="69" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="166.5" y="122.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 131px; margin-left: 168px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="8.262ex" height="4.928ex" role="img" focusable="false" viewBox="0 -1342 3652 2178" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.891ex;">
+                                        <defs>
+                                            <path id="MJX-2831-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-2831-TEX-N-2B" d="M56 237T56 250T70 270H369V420L370 570Q380 583 389 583Q402 583 409 568V270H707Q722 262 722 250T707 230H409V-68Q401 -82 391 -82H389H387Q375 -82 369 -68V230H70Q56 237 56 250Z"/>
+                                            <path id="MJX-2831-TEX-I-1D460" d="M131 289Q131 321 147 354T203 415T300 442Q362 442 390 415T419 355Q419 323 402 308T364 292Q351 292 340 300T328 326Q328 342 337 354T354 372T367 378Q368 378 368 379Q368 382 361 388T336 399T297 405Q249 405 227 379T204 326Q204 301 223 291T278 274T330 259Q396 230 396 163Q396 135 385 107T352 51T289 7T195 -10Q118 -10 86 19T53 87Q53 126 74 143T118 160Q133 160 146 151T160 120Q160 94 142 76T111 58Q109 57 108 57T107 55Q108 52 115 47T146 34T201 27Q237 27 263 38T301 66T318 97T323 122Q323 150 302 164T254 181T195 196T148 231Q131 256 131 289Z"/>
+                                            <path id="MJX-2831-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(1576,676)">
+                                                        <use data-c="31" xlink:href="#MJX-2831-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="mrow" transform="translate(220,-686)">
+                                                        <g data-mml-node="mn">
+                                                            <use data-c="31" xlink:href="#MJX-2831-TEX-N-31"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(722.2,0)">
+                                                            <use data-c="2B" xlink:href="#MJX-2831-TEX-N-2B"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1722.4,0)">
+                                                            <use data-c="1D460" xlink:href="#MJX-2831-TEX-I-1D460"/>
+                                                        </g>
+                                                        <g data-mml-node="msub" transform="translate(2191.4,0)">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D447" xlink:href="#MJX-2831-TEX-I-1D447"/>
+                                                            </g>
+                                                            <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                                <g data-mml-node="mn">
+                                                                    <use data-c="31" xlink:href="#MJX-2831-TEX-N-31"/>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="3412" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="197" y="135" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <path d="M 322 81.32 L 345.63 81.07" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 350.88 81.01 L 343.92 84.59 L 345.63 81.07 L 343.85 77.59 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="287" y="56.5" width="35" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="274.5" y="70.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 80px; margin-left: 276px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.713ex" height="4.636ex" role="img" focusable="false" viewBox="0 -1342 1199 2049" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.6ex;">
+                                        <defs>
+                                            <path id="MJX-2832-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-2832-TEX-I-1D445" d="M230 637Q203 637 198 638T193 649Q193 676 204 682Q206 683 378 683Q550 682 564 680Q620 672 658 652T712 606T733 563T739 529Q739 484 710 445T643 385T576 351T538 338L545 333Q612 295 612 223Q612 212 607 162T602 80V71Q602 53 603 43T614 25T640 16Q668 16 686 38T712 85Q717 99 720 102T735 105Q755 105 755 93Q755 75 731 36Q693 -21 641 -21H632Q571 -21 531 4T487 82Q487 109 502 166T517 239Q517 290 474 313Q459 320 449 321T378 323H309L277 193Q244 61 244 59Q244 55 245 54T252 50T269 48T302 46H333Q339 38 339 37T336 19Q332 6 326 0H311Q275 2 180 2Q146 2 117 2T71 2T50 1Q33 1 33 10Q33 12 36 24Q41 43 46 45Q50 46 61 46H67Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628Q287 635 230 637ZM630 554Q630 586 609 608T523 636Q521 636 500 636T462 637H440Q393 637 386 627Q385 624 352 494T319 361Q319 360 388 360Q466 361 492 367Q556 377 592 426Q608 449 619 486T630 554Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(349.5,676)">
+                                                        <use data-c="31" xlink:href="#MJX-2832-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="mi" transform="translate(220,-686)">
+                                                        <use data-c="1D445" xlink:href="#MJX-2832-TEX-I-1D445"/>
+                                                    </g>
+                                                    <rect width="959" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="305" y="83" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <path d="M 30 85.5 L 58 85.75" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 487 81.5 L 518.63 81.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 523.88 81.5 L 516.88 85 L 518.63 81.5 L 516.88 78 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="477" cy="81.5" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 442 81 L 460.63 81.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 465.88 81.48 L 458.81 84.84 L 460.63 81.37 L 458.95 77.84 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 560 81.5 L 590.63 81.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 595.88 81.5 L 588.88 85 L 590.63 81.5 L 588.88 78 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="525" y="56.5" width="35" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 630 81.39 L 670.63 81.14" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 675.88 81.1 L 668.9 84.65 L 670.63 81.14 L 668.86 77.65 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="597" y="56.5" width="33" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 615 69.31 L 625 69.31" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 601 94.3 L 611 94.3" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 610.5 94 L 615.5 69" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="512.5" y="72" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 81px; margin-left: 513px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.127ex" height="4.611ex" role="img" focusable="false" viewBox="0 -1342 940 2038" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.575ex;">
+                                        <defs>
+                                            <path id="MJX-2833-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-2833-TEX-I-1D460" d="M131 289Q131 321 147 354T203 415T300 442Q362 442 390 415T419 355Q419 323 402 308T364 292Q351 292 340 300T328 326Q328 342 337 354T354 372T367 378Q368 378 368 379Q368 382 361 388T336 399T297 405Q249 405 227 379T204 326Q204 301 223 291T278 274T330 259Q396 230 396 163Q396 135 385 107T352 51T289 7T195 -10Q118 -10 86 19T53 87Q53 126 74 143T118 160Q133 160 146 151T160 120Q160 94 142 76T111 58Q109 57 108 57T107 55Q108 52 115 47T146 34T201 27Q237 27 263 38T301 66T318 97T323 122Q323 150 302 164T254 181T195 196T148 231Q131 256 131 289Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(220,676)">
+                                                        <use data-c="31" xlink:href="#MJX-2833-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="mi" transform="translate(235.5,-686)">
+                                                        <use data-c="1D460" xlink:href="#MJX-2833-TEX-I-1D460"/>
+                                                    </g>
+                                                    <rect width="700" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="542" y="85" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <rect x="598.5" y="57.5" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 62px; margin-left: 600px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="8.543ex" height="2.312ex" role="img" focusable="false" viewBox="0 -683 3776 1021.8" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.767ex;">
+                                        <defs>
+                                            <path id="MJX-2834-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-2834-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-2834-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-2834-TEX-I-1D44E" d="M33 157Q33 258 109 349T280 441Q331 441 370 392Q386 422 416 422Q429 422 439 414T449 394Q449 381 412 234T374 68Q374 43 381 35T402 26Q411 27 422 35Q443 55 463 131Q469 151 473 152Q475 153 483 153H487Q506 153 506 144Q506 138 501 117T481 63T449 13Q436 0 417 -8Q409 -10 393 -10Q359 -10 336 5T306 36L300 51Q299 52 296 50Q294 48 292 46Q233 -10 172 -10Q117 -10 75 30T33 157ZM351 328Q351 334 346 350T323 385T277 405Q242 405 210 374T160 293Q131 214 119 129Q119 126 119 118T118 106Q118 61 136 44T179 26Q217 26 254 59T298 110Q300 114 325 217T351 328Z"/>
+                                            <path id="MJX-2834-TEX-I-1D465" d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D443" xlink:href="#MJX-2834-TEX-I-1D443"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-150) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-2834-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-2834-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D45A" xlink:href="#MJX-2834-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2034,0)">
+                                                            <use data-c="1D44E" xlink:href="#MJX-2834-TEX-I-1D44E"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2563,0)">
+                                                            <use data-c="1D465" xlink:href="#MJX-2834-TEX-I-1D465"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="614" y="65" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$P_{m,m...
+                </text>
+            </switch>
+        </g>
+        <rect x="598" y="96" width="30" height="10" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 101px; margin-left: 599px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 7px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="8.2ex" height="2.628ex" role="img" focusable="false" viewBox="0 -683 3624.2 1161.5" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.083ex;">
+                                        <defs>
+                                            <path id="MJX-2835-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                            <path id="MJX-2835-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-2835-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+                                            <path id="MJX-2835-TEX-I-1D456" d="M184 600Q184 624 203 642T247 661Q265 661 277 649T290 619Q290 596 270 577T226 557Q211 557 198 567T184 600ZM21 287Q21 295 30 318T54 369T98 420T158 442Q197 442 223 419T250 357Q250 340 236 301T196 196T154 83Q149 61 149 51Q149 26 166 26Q175 26 185 29T208 43T235 78T260 137Q263 149 265 151T282 153Q302 153 302 143Q302 135 293 112T268 61T223 11T161 -11Q129 -11 102 10T74 74Q74 91 79 106T122 220Q160 321 166 341T173 380Q173 404 156 404H154Q124 404 99 371T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Z"/>
+                                            <path id="MJX-2835-TEX-I-1D45B" d="M21 287Q22 293 24 303T36 341T56 388T89 425T135 442Q171 442 195 424T225 390T231 369Q231 367 232 367L243 378Q304 442 382 442Q436 442 469 415T503 336T465 179T427 52Q427 26 444 26Q450 26 453 27Q482 32 505 65T540 145Q542 153 560 153Q580 153 580 145Q580 144 576 130Q568 101 554 73T508 17T439 -10Q392 -10 371 17T350 73Q350 92 386 193T423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 180T152 343Q153 348 153 366Q153 405 129 405Q91 405 66 305Q60 285 60 284Q58 278 41 278H27Q21 284 21 287Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D443" xlink:href="#MJX-2835-TEX-I-1D443"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(675,-289.7) scale(0.973)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-2835-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(878,0)">
+                                                            <use data-c="2C" xlink:href="#MJX-2835-TEX-N-2C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1156,0)">
+                                                            <use data-c="1D45A" xlink:href="#MJX-2835-TEX-I-1D45A"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2034,0)">
+                                                            <use data-c="1D456" xlink:href="#MJX-2835-TEX-I-1D456"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(2379,0)">
+                                                            <use data-c="1D45B" xlink:href="#MJX-2835-TEX-I-1D45B"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="613" y="103" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="7px" text-anchor="middle">
+                    $$P_{m,m...
+                </text>
+            </switch>
+        </g>
+        <path d="M 562.5 143.5 L 531.37 143.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 526.12 143.5 L 533.12 140 L 531.37 143.5 L 533.12 147 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="572.5" cy="143.5" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 572.5 81 L 572.5 127.13" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 572.5 132.38 L 569 125.38 L 572.5 127.13 L 576 125.38 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 647 144 L 588.87 143.55" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 583.62 143.51 L 590.64 140.06 L 588.87 143.55 L 590.59 147.06 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="572.5" y="140.5" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 156px; margin-left: 573px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="1.76ex" height="1.505ex" role="img" focusable="false" viewBox="0 -583 778 665" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.186ex;">
+                                        <defs>
+                                            <path id="MJX-2836-TEX-N-2212" d="M84 237T84 250T98 270H679Q694 262 694 250T679 230H98Q84 237 84 250Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mo">
+                                                    <use data-c="2212" xlink:href="#MJX-2836-TEX-N-2212"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="587" y="159" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$-$$
+                </text>
+            </switch>
+        </g>
+        <rect x="497" y="130.5" width="28" height="26" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="481" y="134.5" width="60" height="18" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 144px; margin-left: 482px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.488ex" height="1.902ex" role="img" focusable="false" viewBox="0 -683 1541.5 840.8" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.357ex;">
+                                        <defs>
+                                            <path id="MJX-2837-TEX-I-1D43E" d="M285 628Q285 635 228 637Q205 637 198 638T191 647Q191 649 193 661Q199 681 203 682Q205 683 214 683H219Q260 681 355 681Q389 681 418 681T463 682T483 682Q500 682 500 674Q500 669 497 660Q496 658 496 654T495 648T493 644T490 641T486 639T479 638T470 637T456 637Q416 636 405 634T387 623L306 305Q307 305 490 449T678 597Q692 611 692 620Q692 635 667 637Q651 637 651 648Q651 650 654 662T659 677Q662 682 676 682Q680 682 711 681T791 680Q814 680 839 681T869 682Q889 682 889 672Q889 650 881 642Q878 637 862 637Q787 632 726 586Q710 576 656 534T556 455L509 418L518 396Q527 374 546 329T581 244Q656 67 661 61Q663 59 666 57Q680 47 717 46H738Q744 38 744 37T741 19Q737 6 731 0H720Q680 3 625 3Q503 3 488 0H478Q472 6 472 9T474 27Q478 40 480 43T491 46H494Q544 46 544 71Q544 75 517 141T485 216L427 354L359 301L291 248L268 155Q245 63 245 58Q245 51 253 49T303 46H334Q340 37 340 35Q340 19 333 5Q328 0 317 0Q314 0 280 1T180 2Q118 2 85 2T49 1Q31 1 31 11Q31 13 34 25Q38 41 42 43T65 46Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Z"/>
+                                            <path id="MJX-2837-TEX-I-1D44F" d="M73 647Q73 657 77 670T89 683Q90 683 161 688T234 694Q246 694 246 685T212 542Q204 508 195 472T180 418L176 399Q176 396 182 402Q231 442 283 442Q345 442 383 396T422 280Q422 169 343 79T173 -11Q123 -11 82 27T40 150V159Q40 180 48 217T97 414Q147 611 147 623T109 637Q104 637 101 637H96Q86 637 83 637T76 640T73 647ZM336 325V331Q336 405 275 405Q258 405 240 397T207 376T181 352T163 330L157 322L136 236Q114 150 114 114Q114 66 138 42Q154 26 178 26Q211 26 245 58Q270 81 285 114T318 219Q336 291 336 325Z"/>
+                                            <path id="MJX-2837-TEX-I-1D450" d="M34 159Q34 268 120 355T306 442Q362 442 394 418T427 355Q427 326 408 306T360 285Q341 285 330 295T319 325T330 359T352 380T366 386H367Q367 388 361 392T340 400T306 404Q276 404 249 390Q228 381 206 359Q162 315 142 235T121 119Q121 73 147 50Q169 26 205 26H209Q321 26 394 111Q403 121 406 121Q410 121 419 112T429 98T420 83T391 55T346 25T282 0T202 -11Q127 -11 81 37T34 159Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D43E" xlink:href="#MJX-2837-TEX-I-1D43E"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(882,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D44F" xlink:href="#MJX-2837-TEX-I-1D44F"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(429,0)">
+                                                            <use data-c="1D450" xlink:href="#MJX-2837-TEX-I-1D450"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="511" y="147" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$K_{bc}$$
+                </text>
+            </switch>
+        </g>
+        <path d="M 497 143.5 L 477 144 L 477 97.87" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 477 92.62 L 480.5 99.62 L 477 97.87 L 473.5 99.62 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="227" y="122.5" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 137px; margin-left: 228px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.126ex" height="1.439ex" role="img" focusable="false" viewBox="0 -442 939.6 636" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.439ex;">
+                                        <defs>
+                                            <path id="MJX-2838-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-2838-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-2838-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mn">
+                                                            <use data-c="31" xlink:href="#MJX-2838-TEX-N-31"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="242" y="141" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+        <rect x="487" y="51.5" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 67px; margin-left: 488px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.865ex" height="2.403ex" role="img" focusable="false" viewBox="0 -767 1266.2 1062" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.667ex;">
+                                        <defs>
+                                            <path id="MJX-2839-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-2839-TEX-N-2D9" d="M190 609Q190 637 208 653T252 669Q275 667 292 652T309 609Q309 579 292 564T250 549Q225 549 208 564T190 609Z"/>
+                                            <path id="MJX-2839-TEX-I-1D454" d="M311 43Q296 30 267 15T206 0Q143 0 105 45T66 160Q66 265 143 353T314 442Q361 442 401 394L404 398Q406 401 409 404T418 412T431 419T447 422Q461 422 470 413T480 394Q480 379 423 152T363 -80Q345 -134 286 -169T151 -205Q10 -205 10 -137Q10 -111 28 -91T74 -71Q89 -71 102 -80T116 -111Q116 -121 114 -130T107 -144T99 -154T92 -162L90 -164H91Q101 -167 151 -167Q189 -167 211 -155Q234 -144 254 -122T282 -75Q288 -56 298 -13Q311 35 311 43ZM384 328L380 339Q377 350 375 354T369 368T359 382T346 393T328 402T306 405Q262 405 221 352Q191 313 171 233T151 117Q151 38 213 38Q269 38 323 108L331 118L384 328Z"/>
+                                            <path id="MJX-2839-TEX-I-1D463" d="M173 380Q173 405 154 405Q130 405 104 376T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Q21 294 29 316T53 368T97 419T160 441Q202 441 225 417T249 361Q249 344 246 335Q246 329 231 291T200 202T182 113Q182 86 187 69Q200 26 250 26Q287 26 319 60T369 139T398 222T409 277Q409 300 401 317T383 343T365 361T357 383Q357 405 376 424T417 443Q436 443 451 425T467 367Q467 340 455 284T418 159T347 40T241 -11Q177 -11 139 22Q102 54 102 117Q102 148 110 181T151 298Q173 362 173 380Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mover">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D45D" xlink:href="#MJX-2839-TEX-I-1D45D"/>
+                                                            </g>
+                                                            <g data-mml-node="mo" transform="translate(334.8,-2) translate(-250 0)">
+                                                                <use data-c="2D9" xlink:href="#MJX-2839-TEX-N-2D9"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D454" xlink:href="#MJX-2839-TEX-I-1D454"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(477,0)">
+                                                            <use data-c="1D463" xlink:href="#MJX-2839-TEX-I-1D463"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="502" y="70" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\do...
+                </text>
+            </switch>
+        </g>
+        <rect x="560" y="56" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 71px; margin-left: 561px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.865ex" height="2.565ex" role="img" focusable="false" viewBox="0 -741.8 1266.2 1133.8" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.887ex;">
+                                        <defs>
+                                            <path id="MJX-2840-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-2840-TEX-N-2217" d="M229 286Q216 420 216 436Q216 454 240 464Q241 464 245 464T251 465Q263 464 273 456T283 436Q283 419 277 356T270 286L328 328Q384 369 389 372T399 375Q412 375 423 365T435 338Q435 325 425 315Q420 312 357 282T289 250L355 219L425 184Q434 175 434 161Q434 146 425 136T401 125Q393 125 383 131T328 171L270 213Q283 79 283 63Q283 53 276 44T250 35Q231 35 224 44T216 63Q216 80 222 143T229 213L171 171Q115 130 110 127Q106 124 100 124Q87 124 76 134T64 161Q64 166 64 169T67 175T72 181T81 188T94 195T113 204T138 215T170 230T210 250L74 315Q65 324 65 338Q65 353 74 363T98 374Q106 374 116 368T171 328L229 286Z"/>
+                                            <path id="MJX-2840-TEX-I-1D454" d="M311 43Q296 30 267 15T206 0Q143 0 105 45T66 160Q66 265 143 353T314 442Q361 442 401 394L404 398Q406 401 409 404T418 412T431 419T447 422Q461 422 470 413T480 394Q480 379 423 152T363 -80Q345 -134 286 -169T151 -205Q10 -205 10 -137Q10 -111 28 -91T74 -71Q89 -71 102 -80T116 -111Q116 -121 114 -130T107 -144T99 -154T92 -162L90 -164H91Q101 -167 151 -167Q189 -167 211 -155Q234 -144 254 -122T282 -75Q288 -56 298 -13Q311 35 311 43ZM384 328L380 339Q377 350 375 354T369 368T359 382T346 393T328 402T306 405Q262 405 221 352Q191 313 171 233T151 117Q151 38 213 38Q269 38 323 108L331 118L384 328Z"/>
+                                            <path id="MJX-2840-TEX-I-1D463" d="M173 380Q173 405 154 405Q130 405 104 376T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Q21 294 29 316T53 368T97 419T160 441Q202 441 225 417T249 361Q249 344 246 335Q246 329 231 291T200 202T182 113Q182 86 187 69Q200 26 250 26Q287 26 319 60T369 139T398 222T409 277Q409 300 401 317T383 343T365 361T357 383Q357 405 376 424T417 443Q436 443 451 425T467 367Q467 340 455 284T418 159T347 40T241 -11Q177 -11 139 22Q102 54 102 117Q102 148 110 181T151 298Q173 362 173 380Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msubsup">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-2840-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,413) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mo">
+                                                            <use data-c="2217" xlink:href="#MJX-2840-TEX-N-2217"/>
+                                                        </g>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-247) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D454" xlink:href="#MJX-2840-TEX-I-1D454"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(477,0)">
+                                                            <use data-c="1D463" xlink:href="#MJX-2840-TEX-I-1D463"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="575" y="75" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p^{...
+                </text>
+            </switch>
+        </g>
+        <rect x="677" y="64.5" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 80px; margin-left: 678px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.865ex" height="1.667ex" role="img" focusable="false" viewBox="0 -442 1266.2 737" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.667ex;">
+                                        <defs>
+                                            <path id="MJX-2841-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-2841-TEX-I-1D454" d="M311 43Q296 30 267 15T206 0Q143 0 105 45T66 160Q66 265 143 353T314 442Q361 442 401 394L404 398Q406 401 409 404T418 412T431 419T447 422Q461 422 470 413T480 394Q480 379 423 152T363 -80Q345 -134 286 -169T151 -205Q10 -205 10 -137Q10 -111 28 -91T74 -71Q89 -71 102 -80T116 -111Q116 -121 114 -130T107 -144T99 -154T92 -162L90 -164H91Q101 -167 151 -167Q189 -167 211 -155Q234 -144 254 -122T282 -75Q288 -56 298 -13Q311 35 311 43ZM384 328L380 339Q377 350 375 354T369 368T359 382T346 393T328 402T306 405Q262 405 221 352Q191 313 171 233T151 117Q151 38 213 38Q269 38 323 108L331 118L384 328Z"/>
+                                            <path id="MJX-2841-TEX-I-1D463" d="M173 380Q173 405 154 405Q130 405 104 376T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Q21 294 29 316T53 368T97 419T160 441Q202 441 225 417T249 361Q249 344 246 335Q246 329 231 291T200 202T182 113Q182 86 187 69Q200 26 250 26Q287 26 319 60T369 139T398 222T409 277Q409 300 401 317T383 343T365 361T357 383Q357 405 376 424T417 443Q436 443 451 425T467 367Q467 340 455 284T418 159T347 40T241 -11Q177 -11 139 22Q102 54 102 117Q102 148 110 181T151 298Q173 362 173 380Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-2841-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D454" xlink:href="#MJX-2841-TEX-I-1D454"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(477,0)">
+                                                            <use data-c="1D463" xlink:href="#MJX-2841-TEX-I-1D463"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="692" y="83" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+        <rect x="473" y="82.5" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 97px; margin-left: 474px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="1.76ex" height="1.505ex" role="img" focusable="false" viewBox="0 -583 778 665" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.186ex;">
+                                        <defs>
+                                            <path id="MJX-2842-TEX-N-2212" d="M84 237T84 250T98 270H679Q694 262 694 250T679 230H98Q84 237 84 250Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mo">
+                                                    <use data-c="2212" xlink:href="#MJX-2842-TEX-N-2212"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="488" y="101" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$-$$
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/docs/hugo/content/en/docs/Models/Synchronous Generator Regulators/images/SteamTurbine.drawio.svg
+++ b/docs/hugo/content/en/docs/Models/Synchronous Generator Regulators/images/SteamTurbine.drawio.svg
@@ -1,0 +1,558 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="517px" height="194px" viewBox="-0.5 -0.5 517 194" content="&lt;mxfile&gt;&lt;diagram id=&quot;tAVxjjhIxe6FjWcWs54s&quot; name=&quot;Page-1&quot;&gt;5Vrbjps6FP0aHifCNuby2GTaTqVWpzpzpNN5qlBwElSCEWEmSb++BszFxkwIkJAq8xK8sbfttde+2IOGFtvD59iNNt+oRwIN6t5BQ48ahACbmP2kkiOX2FYuWMe+x0WV4Nn/TbhQ59JX3yM7oWNCaZD4kShc0jAky0SQuXFM92K3FQ3EWSN3TRqC56UbNKX/+16yyaU21iv5E/HXm2JmoPM3W7fozFXsNq5H97ko64M+amgRU5rkT9vDggQpeAUuuaJPLW/LhcUkTLoMsI18xJsbvPLN8YUlx2K3xGOb582Qhuxnvkm2AWsB9ticsdgafY2XXAV0uJXceE14N5vPlKqvDeTr/EzoliTxkXWISeAm/puIvctNuC77VbtkD3yj6k0XqxE2zYAwop+aNV+/adZj3m5AkZBDIm5/l8T0F1nQgMYVPCs/CCSRG/jrkDWXDCbC5PM3Eic+o9QH/mLre146zXy/8RPyHLkZdnvmQEwW09fQI+ny9fcgT3WSw7tg8rcPwDTzMdwFTcQpuq8IXYg2NS4XsiH4g7NJRg5+8qP2/JIiMcO89XjgwGSNY9EI2bJ+1Bu1UWmzGpa1jgK6EitPMrxgc53hoObS/RjNh36nPpu6ZjxdtJ1hzEzbMTEGFjQAskWF+ZK4DslK5aI6Ga7Y5HvRQqSqisxdgsc5TNYlNGCTybaCyXgEJtu4JZJoeLGK3SULJyCNJukPnO/+S+PL4imT3HaIWdEwKdRrzOmzv5EM5kj2QrhhL1NhL4jHiDxonHx3bngABSnF+HCtjFdOP7LnNqyuAKKVCHA6vwUlbW8ID2DACQFRFYInItm/f38kG2QwJAeypr0uF8j6ZJ5/7tteAEsOhuDsirkHdYjBJ8rgsqStqtiX+rvBJa2YnqyB6amlfJWsYEjg5nmzUa8q9BTW45qwLWkar/LlWNxWwngAjrh/rDjD4SabxznD2bcHCNDRhICobhWmLrGwPh0gxTn0/fAmQjK80EZDa2p1sAHSmRvrEkQtseZDHLvHWrco7bBTzCPprUDONfQOXEhV6ab5/1NaEjx9v+N64AGd9o7LVQPwdLiYthoY34egPoNiyu6d/FNdlpz+u7lkLy8afG/Q11p9rj5V18Xn31hchgTQtEYjQaqrJwk6x+VyKlu55vHidIfy4Zz0eeWzAjIvFjIkAxvObEDMkJTp1uVCRtuNSpZ4v9xz4nUadsBXPYkb/U7io5eqWOVIQw/d3SuQtiukjKBf75mgEFkTMxQ0QD8r+N/8/0t5wpiO/GaHEBAEfrRrI2MNbncX5Z+ZrPxDao5R7jKAHCQNp3k8gSoCjnJ473DfNSk+EMsuelV8DAUcF3bQro42fsluMaj14g+YwJBwd2bF1yTnlmQI9rtW6VOQGaozXPnZz/bW090IPoOAI/uM3UxqF/vsx2iriDMDbKI7sMADMGfy4feKH14ZbSVfZgH/HiwAdPkgf038VVVHiX9wD/izbNLwgG4xqEfeZs3qW9o8Z1RfJKOPfwA=&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 30 164 L 59.63 164" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 64.88 164 L 57.88 167.5 L 59.63 164 L 57.88 160.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="0" y="149" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 164px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.865ex" height="1.667ex" role="img" focusable="false" viewBox="0 -442 1266.2 737" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.667ex;">
+                                        <defs>
+                                            <path id="MJX-1327-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-1327-TEX-I-1D454" d="M311 43Q296 30 267 15T206 0Q143 0 105 45T66 160Q66 265 143 353T314 442Q361 442 401 394L404 398Q406 401 409 404T418 412T431 419T447 422Q461 422 470 413T480 394Q480 379 423 152T363 -80Q345 -134 286 -169T151 -205Q10 -205 10 -137Q10 -111 28 -91T74 -71Q89 -71 102 -80T116 -111Q116 -121 114 -130T107 -144T99 -154T92 -162L90 -164H91Q101 -167 151 -167Q189 -167 211 -155Q234 -144 254 -122T282 -75Q288 -56 298 -13Q311 35 311 43ZM384 328L380 339Q377 350 375 354T369 368T359 382T346 393T328 402T306 405Q262 405 221 352Q191 313 171 233T151 117Q151 38 213 38Q269 38 323 108L331 118L384 328Z"/>
+                                            <path id="MJX-1327-TEX-I-1D463" d="M173 380Q173 405 154 405Q130 405 104 376T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Q21 294 29 316T53 368T97 419T160 441Q202 441 225 417T249 361Q249 344 246 335Q246 329 231 291T200 202T182 113Q182 86 187 69Q200 26 250 26Q287 26 319 60T369 139T398 222T409 277Q409 300 401 317T383 343T365 361T357 383Q357 405 376 424T417 443Q436 443 451 425T467 367Q467 340 455 284T418 159T347 40T241 -11Q177 -11 139 22Q102 54 102 117Q102 148 110 181T151 298Q173 362 173 380Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-1327-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D454" xlink:href="#MJX-1327-TEX-I-1D454"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(477,0)">
+                                                            <use data-c="1D463" xlink:href="#MJX-1327-TEX-I-1D463"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="15" y="168" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+        <path d="M 146 164 L 179.63 164" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 184.88 164 L 177.88 167.5 L 179.63 164 L 177.88 160.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="66" y="139" width="80" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="76" y="154" width="60" height="25" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 167px; margin-left: 77px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="10.099ex" height="4.963ex" role="img" focusable="false" viewBox="0 -1342 4463.8 2193.6" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.927ex;">
+                                        <defs>
+                                            <path id="MJX-1328-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-1328-TEX-N-2B" d="M56 237T56 250T70 270H369V420L370 570Q380 583 389 583Q402 583 409 568V270H707Q722 262 722 250T707 230H409V-68Q401 -82 391 -82H389H387Q375 -82 369 -68V230H70Q56 237 56 250Z"/>
+                                            <path id="MJX-1328-TEX-I-1D460" d="M131 289Q131 321 147 354T203 415T300 442Q362 442 390 415T419 355Q419 323 402 308T364 292Q351 292 340 300T328 326Q328 342 337 354T354 372T367 378Q368 378 368 379Q368 382 361 388T336 399T297 405Q249 405 227 379T204 326Q204 301 223 291T278 274T330 259Q396 230 396 163Q396 135 385 107T352 51T289 7T195 -10Q118 -10 86 19T53 87Q53 126 74 143T118 160Q133 160 146 151T160 120Q160 94 142 76T111 58Q109 57 108 57T107 55Q108 52 115 47T146 34T201 27Q237 27 263 38T301 66T318 97T323 122Q323 150 302 164T254 181T195 196T148 231Q131 256 131 289Z"/>
+                                            <path id="MJX-1328-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                            <path id="MJX-1328-TEX-I-1D436" d="M50 252Q50 367 117 473T286 641T490 704Q580 704 633 653Q642 643 648 636T656 626L657 623Q660 623 684 649Q691 655 699 663T715 679T725 690L740 705H746Q760 705 760 698Q760 694 728 561Q692 422 692 421Q690 416 687 415T669 413H653Q647 419 647 422Q647 423 648 429T650 449T651 481Q651 552 619 605T510 659Q484 659 454 652T382 628T299 572T226 479Q194 422 175 346T156 222Q156 108 232 58Q280 24 350 24Q441 24 512 92T606 240Q610 253 612 255T628 257Q648 257 648 248Q648 243 647 239Q618 132 523 55T319 -22Q206 -22 128 53T50 252Z"/>
+                                            <path id="MJX-1328-TEX-I-1D43B" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 219 683Q260 681 355 681Q389 681 418 681T463 682T483 682Q499 682 499 672Q499 670 497 658Q492 641 487 638H485Q483 638 480 638T473 638T464 637T455 637Q416 636 405 634T387 623Q384 619 355 500Q348 474 340 442T328 395L324 380Q324 378 469 378H614L615 381Q615 384 646 504Q674 619 674 627T617 637Q594 637 587 639T580 648Q580 650 582 660Q586 677 588 679T604 682Q609 682 646 681T740 680Q802 680 835 681T871 682Q888 682 888 672Q888 645 876 638H874Q872 638 869 638T862 638T853 637T844 637Q805 636 794 634T776 623Q773 618 704 340T634 58Q634 51 638 51Q646 48 692 46H723Q729 38 729 37T726 19Q722 6 716 0H701Q664 2 567 2Q533 2 504 2T458 2T437 1Q420 1 420 10Q420 15 423 24Q428 43 433 45Q437 46 448 46H454Q481 46 514 49Q520 50 522 50T528 55T534 64T540 82T547 110T558 153Q565 181 569 198Q602 330 602 331T457 332H312L279 197Q245 63 245 58Q245 51 253 49T303 46H334Q340 38 340 37T337 19Q333 6 327 0H312Q275 2 178 2Q144 2 115 2T69 2T48 1Q31 1 31 10Q31 12 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(1981.9,676)">
+                                                        <use data-c="31" xlink:href="#MJX-1328-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="mrow" transform="translate(220,-686)">
+                                                        <g data-mml-node="mn">
+                                                            <use data-c="31" xlink:href="#MJX-1328-TEX-N-31"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(722.2,0)">
+                                                            <use data-c="2B" xlink:href="#MJX-1328-TEX-N-2B"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1722.4,0)">
+                                                            <use data-c="1D460" xlink:href="#MJX-1328-TEX-I-1D460"/>
+                                                        </g>
+                                                        <g data-mml-node="msub" transform="translate(2191.4,0)">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D447" xlink:href="#MJX-1328-TEX-I-1D447"/>
+                                                            </g>
+                                                            <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                                <g data-mml-node="mi">
+                                                                    <use data-c="1D436" xlink:href="#MJX-1328-TEX-I-1D436"/>
+                                                                </g>
+                                                                <g data-mml-node="mi" transform="translate(760,0)">
+                                                                    <use data-c="1D43B" xlink:href="#MJX-1328-TEX-I-1D43B"/>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="4223.8" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="106" y="170" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <path d="M 266 164 L 301.63 164" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 306.88 164 L 299.88 167.5 L 301.63 164 L 299.88 160.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="186" y="139" width="80" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="308" y="139" width="80" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="196" y="149" width="60" height="25" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 162px; margin-left: 197px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="10.097ex" height="4.961ex" role="img" focusable="false" viewBox="0 -1342 4463 2192.8" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.925ex;">
+                                        <defs>
+                                            <path id="MJX-1329-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-1329-TEX-N-2B" d="M56 237T56 250T70 270H369V420L370 570Q380 583 389 583Q402 583 409 568V270H707Q722 262 722 250T707 230H409V-68Q401 -82 391 -82H389H387Q375 -82 369 -68V230H70Q56 237 56 250Z"/>
+                                            <path id="MJX-1329-TEX-I-1D460" d="M131 289Q131 321 147 354T203 415T300 442Q362 442 390 415T419 355Q419 323 402 308T364 292Q351 292 340 300T328 326Q328 342 337 354T354 372T367 378Q368 378 368 379Q368 382 361 388T336 399T297 405Q249 405 227 379T204 326Q204 301 223 291T278 274T330 259Q396 230 396 163Q396 135 385 107T352 51T289 7T195 -10Q118 -10 86 19T53 87Q53 126 74 143T118 160Q133 160 146 151T160 120Q160 94 142 76T111 58Q109 57 108 57T107 55Q108 52 115 47T146 34T201 27Q237 27 263 38T301 66T318 97T323 122Q323 150 302 164T254 181T195 196T148 231Q131 256 131 289Z"/>
+                                            <path id="MJX-1329-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                            <path id="MJX-1329-TEX-I-1D445" d="M230 637Q203 637 198 638T193 649Q193 676 204 682Q206 683 378 683Q550 682 564 680Q620 672 658 652T712 606T733 563T739 529Q739 484 710 445T643 385T576 351T538 338L545 333Q612 295 612 223Q612 212 607 162T602 80V71Q602 53 603 43T614 25T640 16Q668 16 686 38T712 85Q717 99 720 102T735 105Q755 105 755 93Q755 75 731 36Q693 -21 641 -21H632Q571 -21 531 4T487 82Q487 109 502 166T517 239Q517 290 474 313Q459 320 449 321T378 323H309L277 193Q244 61 244 59Q244 55 245 54T252 50T269 48T302 46H333Q339 38 339 37T336 19Q332 6 326 0H311Q275 2 180 2Q146 2 117 2T71 2T50 1Q33 1 33 10Q33 12 36 24Q41 43 46 45Q50 46 61 46H67Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628Q287 635 230 637ZM630 554Q630 586 609 608T523 636Q521 636 500 636T462 637H440Q393 637 386 627Q385 624 352 494T319 361Q319 360 388 360Q466 361 492 367Q556 377 592 426Q608 449 619 486T630 554Z"/>
+                                            <path id="MJX-1329-TEX-I-1D43B" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 219 683Q260 681 355 681Q389 681 418 681T463 682T483 682Q499 682 499 672Q499 670 497 658Q492 641 487 638H485Q483 638 480 638T473 638T464 637T455 637Q416 636 405 634T387 623Q384 619 355 500Q348 474 340 442T328 395L324 380Q324 378 469 378H614L615 381Q615 384 646 504Q674 619 674 627T617 637Q594 637 587 639T580 648Q580 650 582 660Q586 677 588 679T604 682Q609 682 646 681T740 680Q802 680 835 681T871 682Q888 682 888 672Q888 645 876 638H874Q872 638 869 638T862 638T853 637T844 637Q805 636 794 634T776 623Q773 618 704 340T634 58Q634 51 638 51Q646 48 692 46H723Q729 38 729 37T726 19Q722 6 716 0H701Q664 2 567 2Q533 2 504 2T458 2T437 1Q420 1 420 10Q420 15 423 24Q428 43 433 45Q437 46 448 46H454Q481 46 514 49Q520 50 522 50T528 55T534 64T540 82T547 110T558 153Q565 181 569 198Q602 330 602 331T457 332H312L279 197Q245 63 245 58Q245 51 253 49T303 46H334Q340 38 340 37T337 19Q333 6 327 0H312Q275 2 178 2Q144 2 115 2T69 2T48 1Q31 1 31 10Q31 12 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(1981.5,676)">
+                                                        <use data-c="31" xlink:href="#MJX-1329-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="mrow" transform="translate(220,-686)">
+                                                        <g data-mml-node="mn">
+                                                            <use data-c="31" xlink:href="#MJX-1329-TEX-N-31"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(722.2,0)">
+                                                            <use data-c="2B" xlink:href="#MJX-1329-TEX-N-2B"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1722.4,0)">
+                                                            <use data-c="1D460" xlink:href="#MJX-1329-TEX-I-1D460"/>
+                                                        </g>
+                                                        <g data-mml-node="msub" transform="translate(2191.4,0)">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D447" xlink:href="#MJX-1329-TEX-I-1D447"/>
+                                                            </g>
+                                                            <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                                <g data-mml-node="mi">
+                                                                    <use data-c="1D445" xlink:href="#MJX-1329-TEX-I-1D445"/>
+                                                                </g>
+                                                                <g data-mml-node="mi" transform="translate(759,0)">
+                                                                    <use data-c="1D43B" xlink:href="#MJX-1329-TEX-I-1D43B"/>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="4223" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="226" y="165" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <rect x="318" y="151.5" width="60" height="25" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 164px; margin-left: 319px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="9.899ex" height="4.963ex" role="img" focusable="false" viewBox="0 -1342 4375.4 2193.6" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.927ex;">
+                                        <defs>
+                                            <path id="MJX-1330-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+                                            <path id="MJX-1330-TEX-N-2B" d="M56 237T56 250T70 270H369V420L370 570Q380 583 389 583Q402 583 409 568V270H707Q722 262 722 250T707 230H409V-68Q401 -82 391 -82H389H387Q375 -82 369 -68V230H70Q56 237 56 250Z"/>
+                                            <path id="MJX-1330-TEX-I-1D460" d="M131 289Q131 321 147 354T203 415T300 442Q362 442 390 415T419 355Q419 323 402 308T364 292Q351 292 340 300T328 326Q328 342 337 354T354 372T367 378Q368 378 368 379Q368 382 361 388T336 399T297 405Q249 405 227 379T204 326Q204 301 223 291T278 274T330 259Q396 230 396 163Q396 135 385 107T352 51T289 7T195 -10Q118 -10 86 19T53 87Q53 126 74 143T118 160Q133 160 146 151T160 120Q160 94 142 76T111 58Q109 57 108 57T107 55Q108 52 115 47T146 34T201 27Q237 27 263 38T301 66T318 97T323 122Q323 150 302 164T254 181T195 196T148 231Q131 256 131 289Z"/>
+                                            <path id="MJX-1330-TEX-I-1D447" d="M40 437Q21 437 21 445Q21 450 37 501T71 602L88 651Q93 669 101 677H569H659Q691 677 697 676T704 667Q704 661 687 553T668 444Q668 437 649 437Q640 437 637 437T631 442L629 445Q629 451 635 490T641 551Q641 586 628 604T573 629Q568 630 515 631Q469 631 457 630T439 622Q438 621 368 343T298 60Q298 48 386 46Q418 46 427 45T436 36Q436 31 433 22Q429 4 424 1L422 0Q419 0 415 0Q410 0 363 1T228 2Q99 2 64 0H49Q43 6 43 9T45 27Q49 40 55 46H83H94Q174 46 189 55Q190 56 191 56Q196 59 201 76T241 233Q258 301 269 344Q339 619 339 625Q339 630 310 630H279Q212 630 191 624Q146 614 121 583T67 467Q60 445 57 441T43 437H40Z"/>
+                                            <path id="MJX-1330-TEX-I-1D436" d="M50 252Q50 367 117 473T286 641T490 704Q580 704 633 653Q642 643 648 636T656 626L657 623Q660 623 684 649Q691 655 699 663T715 679T725 690L740 705H746Q760 705 760 698Q760 694 728 561Q692 422 692 421Q690 416 687 415T669 413H653Q647 419 647 422Q647 423 648 429T650 449T651 481Q651 552 619 605T510 659Q484 659 454 652T382 628T299 572T226 479Q194 422 175 346T156 222Q156 108 232 58Q280 24 350 24Q441 24 512 92T606 240Q610 253 612 255T628 257Q648 257 648 248Q648 243 647 239Q618 132 523 55T319 -22Q206 -22 128 53T50 252Z"/>
+                                            <path id="MJX-1330-TEX-I-1D442" d="M740 435Q740 320 676 213T511 42T304 -22Q207 -22 138 35T51 201Q50 209 50 244Q50 346 98 438T227 601Q351 704 476 704Q514 704 524 703Q621 689 680 617T740 435ZM637 476Q637 565 591 615T476 665Q396 665 322 605Q242 542 200 428T157 216Q157 126 200 73T314 19Q404 19 485 98T608 313Q637 408 637 476Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="mfrac">
+                                                    <g data-mml-node="mn" transform="translate(1937.7,676)">
+                                                        <use data-c="31" xlink:href="#MJX-1330-TEX-N-31"/>
+                                                    </g>
+                                                    <g data-mml-node="mrow" transform="translate(220,-686)">
+                                                        <g data-mml-node="mn">
+                                                            <use data-c="31" xlink:href="#MJX-1330-TEX-N-31"/>
+                                                        </g>
+                                                        <g data-mml-node="mo" transform="translate(722.2,0)">
+                                                            <use data-c="2B" xlink:href="#MJX-1330-TEX-N-2B"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(1722.4,0)">
+                                                            <use data-c="1D460" xlink:href="#MJX-1330-TEX-I-1D460"/>
+                                                        </g>
+                                                        <g data-mml-node="msub" transform="translate(2191.4,0)">
+                                                            <g data-mml-node="mi">
+                                                                <use data-c="1D447" xlink:href="#MJX-1330-TEX-I-1D447"/>
+                                                            </g>
+                                                            <g data-mml-node="TeXAtom" transform="translate(617,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                                <g data-mml-node="mi">
+                                                                    <use data-c="1D436" xlink:href="#MJX-1330-TEX-I-1D436"/>
+                                                                </g>
+                                                                <g data-mml-node="mi" transform="translate(760,0)">
+                                                                    <use data-c="1D442" xlink:href="#MJX-1330-TEX-I-1D442"/>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                    <rect width="4135.4" height="60" x="120" y="220"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="348" y="168" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$\frac{1}...
+                </text>
+            </switch>
+        </g>
+        <path d="M 164 164 L 164.45 105.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 164.49 100.12 L 167.94 107.14 L 164.45 105.37 L 160.94 107.09 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="147" y="69" width="35" height="30" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="269" y="69" width="35" height="30" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="416" y="69" width="35" height="30" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 166 69 L 166 19 L 269.63 19" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 274.88 19 L 267.88 22.5 L 269.63 19 L 267.88 15.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="136" y="69" width="60" height="25" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 82px; margin-left: 137px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="4.265ex" height="1.878ex" role="img" focusable="false" viewBox="0 -680 1884.9 830" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.339ex;">
+                                        <defs>
+                                            <path id="MJX-1331-TEX-I-1D439" d="M48 1Q31 1 31 11Q31 13 34 25Q38 41 42 43T65 46Q92 46 125 49Q139 52 144 61Q146 66 215 342T285 622Q285 629 281 629Q273 632 228 634H197Q191 640 191 642T193 659Q197 676 203 680H742Q749 676 749 669Q749 664 736 557T722 447Q720 440 702 440H690Q683 445 683 453Q683 454 686 477T689 530Q689 560 682 579T663 610T626 626T575 633T503 634H480Q398 633 393 631Q388 629 386 623Q385 622 352 492L320 363H375Q378 363 398 363T426 364T448 367T472 374T489 386Q502 398 511 419T524 457T529 475Q532 480 548 480H560Q567 475 567 470Q567 467 536 339T502 207Q500 200 482 200H470Q463 206 463 212Q463 215 468 234T473 274Q473 303 453 310T364 317H309L277 190Q245 66 245 60Q245 46 334 46H359Q365 40 365 39T363 19Q359 6 353 0H336Q295 2 185 2Q120 2 86 2T48 1Z"/>
+                                            <path id="MJX-1331-TEX-I-1D43B" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 219 683Q260 681 355 681Q389 681 418 681T463 682T483 682Q499 682 499 672Q499 670 497 658Q492 641 487 638H485Q483 638 480 638T473 638T464 637T455 637Q416 636 405 634T387 623Q384 619 355 500Q348 474 340 442T328 395L324 380Q324 378 469 378H614L615 381Q615 384 646 504Q674 619 674 627T617 637Q594 637 587 639T580 648Q580 650 582 660Q586 677 588 679T604 682Q609 682 646 681T740 680Q802 680 835 681T871 682Q888 682 888 672Q888 645 876 638H874Q872 638 869 638T862 638T853 637T844 637Q805 636 794 634T776 623Q773 618 704 340T634 58Q634 51 638 51Q646 48 692 46H723Q729 38 729 37T726 19Q722 6 716 0H701Q664 2 567 2Q533 2 504 2T458 2T437 1Q420 1 420 10Q420 15 423 24Q428 43 433 45Q437 46 448 46H454Q481 46 514 49Q520 50 522 50T528 55T534 64T540 82T547 110T558 153Q565 181 569 198Q602 330 602 331T457 332H312L279 197Q245 63 245 58Q245 51 253 49T303 46H334Q340 38 340 37T337 19Q333 6 327 0H312Q275 2 178 2Q144 2 115 2T69 2T48 1Q31 1 31 10Q31 12 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"/>
+                                            <path id="MJX-1331-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D439" xlink:href="#MJX-1331-TEX-I-1D439"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(676,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D43B" xlink:href="#MJX-1331-TEX-I-1D43B"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(888,0)">
+                                                            <use data-c="1D443" xlink:href="#MJX-1331-TEX-I-1D443"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="166" y="85" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$F_{HP}$$
+                </text>
+            </switch>
+        </g>
+        <path d="M 286.25 164 L 286.7 105.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 286.74 100.12 L 290.19 107.14 L 286.7 105.37 L 283.19 107.09 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 388 164 L 434 164 L 433.77 105.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 433.75 100.12 L 437.28 107.1 L 433.77 105.37 L 430.28 107.13 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 286.5 68.5 L 286.5 35.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 286.5 30.12 L 290 37.12 L 286.5 35.37 L 283 37.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="256.5" y="71.5" width="60" height="25" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 84px; margin-left: 258px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.65ex" height="1.878ex" role="img" focusable="false" viewBox="0 -680 1613.4 830" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.339ex;">
+                                        <defs>
+                                            <path id="MJX-1332-TEX-I-1D439" d="M48 1Q31 1 31 11Q31 13 34 25Q38 41 42 43T65 46Q92 46 125 49Q139 52 144 61Q146 66 215 342T285 622Q285 629 281 629Q273 632 228 634H197Q191 640 191 642T193 659Q197 676 203 680H742Q749 676 749 669Q749 664 736 557T722 447Q720 440 702 440H690Q683 445 683 453Q683 454 686 477T689 530Q689 560 682 579T663 610T626 626T575 633T503 634H480Q398 633 393 631Q388 629 386 623Q385 622 352 492L320 363H375Q378 363 398 363T426 364T448 367T472 374T489 386Q502 398 511 419T524 457T529 475Q532 480 548 480H560Q567 475 567 470Q567 467 536 339T502 207Q500 200 482 200H470Q463 206 463 212Q463 215 468 234T473 274Q473 303 453 310T364 317H309L277 190Q245 66 245 60Q245 46 334 46H359Q365 40 365 39T363 19Q359 6 353 0H336Q295 2 185 2Q120 2 86 2T48 1Z"/>
+                                            <path id="MJX-1332-TEX-I-1D43C" d="M43 1Q26 1 26 10Q26 12 29 24Q34 43 39 45Q42 46 54 46H60Q120 46 136 53Q137 53 138 54Q143 56 149 77T198 273Q210 318 216 344Q286 624 286 626Q284 630 284 631Q274 637 213 637H193Q184 643 189 662Q193 677 195 680T209 683H213Q285 681 359 681Q481 681 487 683H497Q504 676 504 672T501 655T494 639Q491 637 471 637Q440 637 407 634Q393 631 388 623Q381 609 337 432Q326 385 315 341Q245 65 245 59Q245 52 255 50T307 46H339Q345 38 345 37T342 19Q338 6 332 0H316Q279 2 179 2Q143 2 113 2T65 2T43 1Z"/>
+                                            <path id="MJX-1332-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D439" xlink:href="#MJX-1332-TEX-I-1D439"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(676,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D43C" xlink:href="#MJX-1332-TEX-I-1D43C"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(504,0)">
+                                                            <use data-c="1D443" xlink:href="#MJX-1332-TEX-I-1D443"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="287" y="88" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$F_{IP}$$
+                </text>
+            </switch>
+        </g>
+        <path d="M 433.5 71.5 L 433.5 35.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 433.5 30.12 L 437 37.12 L 433.5 35.37 L 430 37.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="403.5" y="71.5" width="60" height="25" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 84px; margin-left: 405px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.933ex" height="1.878ex" role="img" focusable="false" viewBox="0 -680 1738.6 830" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.339ex;">
+                                        <defs>
+                                            <path id="MJX-1333-TEX-I-1D439" d="M48 1Q31 1 31 11Q31 13 34 25Q38 41 42 43T65 46Q92 46 125 49Q139 52 144 61Q146 66 215 342T285 622Q285 629 281 629Q273 632 228 634H197Q191 640 191 642T193 659Q197 676 203 680H742Q749 676 749 669Q749 664 736 557T722 447Q720 440 702 440H690Q683 445 683 453Q683 454 686 477T689 530Q689 560 682 579T663 610T626 626T575 633T503 634H480Q398 633 393 631Q388 629 386 623Q385 622 352 492L320 363H375Q378 363 398 363T426 364T448 367T472 374T489 386Q502 398 511 419T524 457T529 475Q532 480 548 480H560Q567 475 567 470Q567 467 536 339T502 207Q500 200 482 200H470Q463 206 463 212Q463 215 468 234T473 274Q473 303 453 310T364 317H309L277 190Q245 66 245 60Q245 46 334 46H359Q365 40 365 39T363 19Q359 6 353 0H336Q295 2 185 2Q120 2 86 2T48 1Z"/>
+                                            <path id="MJX-1333-TEX-I-1D43F" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 217 683Q271 680 344 680Q485 680 506 683H518Q524 677 524 674T522 656Q517 641 513 637H475Q406 636 394 628Q387 624 380 600T313 336Q297 271 279 198T252 88L243 52Q243 48 252 48T311 46H328Q360 46 379 47T428 54T478 72T522 106T564 161Q580 191 594 228T611 270Q616 273 628 273H641Q647 264 647 262T627 203T583 83T557 9Q555 4 553 3T537 0T494 -1Q483 -1 418 -1T294 0H116Q32 0 32 10Q32 17 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"/>
+                                            <path id="MJX-1333-TEX-I-1D443" d="M287 628Q287 635 230 637Q206 637 199 638T192 648Q192 649 194 659Q200 679 203 681T397 683Q587 682 600 680Q664 669 707 631T751 530Q751 453 685 389Q616 321 507 303Q500 302 402 301H307L277 182Q247 66 247 59Q247 55 248 54T255 50T272 48T305 46H336Q342 37 342 35Q342 19 335 5Q330 0 319 0Q316 0 282 1T182 2Q120 2 87 2T51 1Q33 1 33 11Q33 13 36 25Q40 41 44 43T67 46Q94 46 127 49Q141 52 146 61Q149 65 218 339T287 628ZM645 554Q645 567 643 575T634 597T609 619T560 635Q553 636 480 637Q463 637 445 637T416 636T404 636Q391 635 386 627Q384 621 367 550T332 412T314 344Q314 342 395 342H407H430Q542 342 590 392Q617 419 631 471T645 554Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D439" xlink:href="#MJX-1333-TEX-I-1D439"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(676,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D43F" xlink:href="#MJX-1333-TEX-I-1D43F"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(681,0)">
+                                                            <use data-c="1D443" xlink:href="#MJX-1333-TEX-I-1D443"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="434" y="88" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$F_{LP}$$
+                </text>
+            </switch>
+        </g>
+        <path d="M 296.5 19 L 417.13 19" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 422.38 19 L 415.38 22.5 L 417.13 19 L 415.38 15.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="286.5" cy="19" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <ellipse cx="433.5" cy="19" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 443.5 18.66 L 479.63 18.95" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 484.88 18.99 L 477.85 22.43 L 479.63 18.95 L 477.91 15.44 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="485.5" y="4" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 19px; margin-left: 487px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.73ex" height="1.439ex" role="img" focusable="false" viewBox="0 -442 1206.8 636" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.439ex;">
+                                        <defs>
+                                            <path id="MJX-1334-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-1334-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-1334-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D45A" xlink:href="#MJX-1334-TEX-I-1D45A"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="501" y="23" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+        <rect x="149.5" y="159" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 174px; margin-left: 151px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="3.052ex" height="1.65ex" role="img" focusable="false" viewBox="0 -442 1349 729.2" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.65ex;">
+                                        <defs>
+                                            <path id="MJX-1335-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-1335-TEX-I-210E" d="M137 683Q138 683 209 688T282 694Q294 694 294 685Q294 674 258 534Q220 386 220 383Q220 381 227 388Q288 442 357 442Q411 442 444 415T478 336Q478 285 440 178T402 50Q403 36 407 31T422 26Q450 26 474 56T513 138Q516 149 519 151T535 153Q555 153 555 145Q555 144 551 130Q535 71 500 33Q466 -10 419 -10H414Q367 -10 346 17T325 74Q325 90 361 192T398 345Q398 404 354 404H349Q266 404 205 306L198 293L164 158Q132 28 127 16Q114 -11 83 -11Q69 -11 59 -2T48 16Q48 30 121 320L195 616Q195 629 188 632T149 637H128Q122 643 122 645T124 664Q129 683 137 683Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-1335-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="210E" xlink:href="#MJX-1335-TEX-I-210E"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(576,0)">
+                                                            <use data-c="1D45D" xlink:href="#MJX-1335-TEX-I-1D45D"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="165" y="178" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+        <rect x="274" y="159" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 174px; margin-left: 275px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.682ex" height="1.65ex" role="img" focusable="false" viewBox="0 -442 1185.6 729.2" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.65ex;">
+                                        <defs>
+                                            <path id="MJX-1336-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-1336-TEX-I-1D456" d="M184 600Q184 624 203 642T247 661Q265 661 277 649T290 619Q290 596 270 577T226 557Q211 557 198 567T184 600ZM21 287Q21 295 30 318T54 369T98 420T158 442Q197 442 223 419T250 357Q250 340 236 301T196 196T154 83Q149 61 149 51Q149 26 166 26Q175 26 185 29T208 43T235 78T260 137Q263 149 265 151T282 153Q302 153 302 143Q302 135 293 112T268 61T223 11T161 -11Q129 -11 102 10T74 74Q74 91 79 106T122 220Q160 321 166 341T173 380Q173 404 156 404H154Q124 404 99 371T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-1336-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D456" xlink:href="#MJX-1336-TEX-I-1D456"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(345,0)">
+                                                            <use data-c="1D45D" xlink:href="#MJX-1336-TEX-I-1D45D"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="289" y="178" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+        <rect x="393.5" y="164" width="30" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 174px; margin-left: 395px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <mjx-container class="MathJax" jax="SVG" display="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="2.607ex" height="1.65ex" role="img" focusable="false" viewBox="0 -442 1152.4 729.2" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.65ex;">
+                                        <defs>
+                                            <path id="MJX-1337-TEX-I-1D45D" d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z"/>
+                                            <path id="MJX-1337-TEX-I-1D459" d="M117 59Q117 26 142 26Q179 26 205 131Q211 151 215 152Q217 153 225 153H229Q238 153 241 153T246 151T248 144Q247 138 245 128T234 90T214 43T183 6T137 -11Q101 -11 70 11T38 85Q38 97 39 102L104 360Q167 615 167 623Q167 626 166 628T162 632T157 634T149 635T141 636T132 637T122 637Q112 637 109 637T101 638T95 641T94 647Q94 649 96 661Q101 680 107 682T179 688Q194 689 213 690T243 693T254 694Q266 694 266 686Q266 675 193 386T118 83Q118 81 118 75T117 65V59Z"/>
+                                        </defs>
+                                        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+                                            <g data-mml-node="math">
+                                                <g data-mml-node="msub">
+                                                    <g data-mml-node="mi">
+                                                        <use data-c="1D45D" xlink:href="#MJX-1337-TEX-I-1D45D"/>
+                                                    </g>
+                                                    <g data-mml-node="TeXAtom" transform="translate(536,-150) scale(0.707)" data-mjx-texclass="ORD">
+                                                        <g data-mml-node="mi">
+                                                            <use data-c="1D459" xlink:href="#MJX-1337-TEX-I-1D459"/>
+                                                        </g>
+                                                        <g data-mml-node="mi" transform="translate(298,0)">
+                                                            <use data-c="1D45D" xlink:href="#MJX-1337-TEX-I-1D45D"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </svg>
+                                </mjx-container>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="409" y="178" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    $$p_{...
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/docs/hugo/content/en/docs/Models/Synchronous Generator Regulators/index.md
+++ b/docs/hugo/content/en/docs/Models/Synchronous Generator Regulators/index.md
@@ -393,6 +393,110 @@ $$
 $$
 Since all variables at $t=k-\Delta t$ are known, $\tau_m(k)$ is computed in the `preStep` of the generator and used to approximate the mechanical equations at time $k+\Delta t$.
 
+# Steam Governor
+
+<center>
+<figure margin=30%>
+    <img src="./images/SteamGovernor.drawio.svg" width=65% alt="Steam Governor">
+    <figcaption></br>Fig. 8: Control diagram of the steam turbine governor </br>
+                Adapted from [6]
+    </figcaption>
+</figure>
+</center>
+</br>
+
+The control diagram of this model is depicted in Fig. 8. This model receives as input the frequency deviation $\Delta\omega = \omega_{ref} - \omega$ from the nominal frequency (normally $50\,\text{Hz}$ or $60\,\text{Hz}$) and produces the valve opening signal $p_{gv}$ for the turbine. $p_{ref}$ is the mechanical power produced at nominal frequency. The governor implements a lead-lag controller $\frac{K(1+sT_2)}{(1+sT_1)}$ where $K=1/R$ and $R$ is the droop coefficient, followed by a PT1 integrator with embedded rate limiters and an anti-windup loop. To avoid unnecessary dead-beat behaviour, complex transfer functions with more than one pole and zero are decomposed via partial fraction expansion into parallel PT1 elements, as shown in Fig. 9.
+
+<center>
+<figure margin=30%>
+    <img src="./images/SteamGovernor_split.drawio.svg" width=90% alt="Steam Governor split">
+    <figcaption></br>Fig. 9: Control diagram of the steam turbine governor after partial-fraction decomposition </br>
+    </figcaption>
+</figure>
+</center>
+</br>
+
+Analogous to the static exciter model, the integrator uses an anti-windup strategy as shown in Fig. 10.
+
+<center>
+<figure margin=30%>
+    <img src="./images/SteamGovernor_windup.drawio.svg" width=90% alt="Steam Governor anti-windup">
+    <figcaption></br>Fig. 10: Control diagram of the steam turbine governor with anti-windup strategy </br>
+    </figcaption>
+</figure>
+</center>
+</br>
+
+The forward-Euler discretised equations are:
+$$
+    \Delta \omega (k-\Delta t) = \omega_{ref} - \omega (k-\Delta t),
+$$
+$$
+    p_{1}(k) = p_{1}(k-\Delta t) + \frac{\Delta t}{T_{1}} \left(\Delta \omega (k-\Delta t) \cdot \frac{T_{1} - T_{2}}{T_{1}} - p_{1}(k-\Delta t)\right),
+$$
+$$
+    p(k-\Delta t) = \frac{1}{R} \left(p_{1}(k-\Delta t) + \Delta \omega(k-\Delta t) \cdot \frac{T_{2}}{T_{1}}\right),
+$$
+$$
+    \dot{p}(k-\Delta t) = \frac{1}{T_{3}}\left(p(k-\Delta t) + p_{ref} - p_{gv}(k-\Delta t)\right) - K_{bc} \left(p_{gv}^{*}(k-\Delta t) - p_{gv}(k-\Delta t)\right),
+$$
+$$
+    p_{gv}^{*}(k) = p_{gv}^{*}(k-\Delta t) + \Delta t \cdot \dot{p}(k-\Delta t),
+$$
+
+and
+
+$$
+p_{gv}(k) = p_{gv}^{*}(k) \quad \text{if} \quad P_{m,\min} \leq p_{gv}^{*}(k) \leq P_{m,\max}, \\
+p_{gv}(k) = P_{m,\max} \quad \text{if} \quad p_{gv}^{*}(k) > P_{m,\max}, \\
+p_{gv}(k) = P_{m,\min} \quad \text{if} \quad p_{gv}^{*}(k) < P_{m,\min}.
+$$
+
+If $T_1 = 0$ the $p_1(k)$ equation is skipped and $p(k)$ is instead:
+$$
+    p(k-\Delta t) = \frac{1}{R} \left(\Delta \omega(k-\Delta t) + \frac{T_{2}}{\Delta t} \left(\Delta \omega(k-\Delta t) - \Delta \omega(k-2\Delta t)\right)\right).
+$$
+
+Assuming the simulation starts in steady state (all derivatives zero, $\Delta\omega(0)=0$), the initial values are:
+$$
+    p_{1}(t=0) = 0, \quad p(t=0) = 0, \quad p_{ref} = p_{gv}^{*}(t=0) = p_{gv}(t=0).
+$$
+
+# Steam Turbine
+
+<center>
+<figure margin=30%>
+    <img src="./images/SteamTurbine.drawio.svg" width=65% alt="Steam Turbine">
+    <figcaption></br>Fig. 11: Control diagram of the steam turbine </br>
+                Adapted from [6]
+    </figcaption>
+</figure>
+</center>
+</br>
+
+The steam turbine receives the valve opening signal $p_{gv}$ from the Steam Governor and outputs mechanical power $p_m$ to the synchronous generator. It is divided into high-pressure (HP), intermediate-pressure (IP), and low-pressure (LP) stages, each modelled as a first-order lag with time constants $T_{CH}$, $T_{RH}$, $T_{CO}$ respectively. Setting a time constant to zero disables that lag element. The total mechanical power is a weighted sum of each stage: $F_{HP} + F_{IP} + F_{LP} = 1$ must hold. The forward-Euler discretised equations are:
+
+$$
+    p_{hp}(k) = p_{hp}(k-\Delta t) + \frac{\Delta t}{T_{CH}} \left(p_{gv}(k-\Delta t) - p_{hp}(k-\Delta t)\right),
+$$
+$$
+    p_{ip}(k) = p_{ip}(k-\Delta t) + \frac{\Delta t}{T_{RH}} \left(p_{hp}(k-\Delta t) - p_{ip}(k-\Delta t)\right),
+$$
+$$
+    p_{lp}(k) = p_{lp}(k-\Delta t) + \frac{\Delta t}{T_{CO}} \left(p_{ip}(k-\Delta t) - p_{lp}(k-\Delta t)\right),
+$$
+$$
+    p_{m}(k) = F_{HP} \cdot p_{hp}(k) + F_{IP} \cdot p_{ip}(k) + F_{LP} \cdot p_{lp}(k).
+$$
+
+Assuming the simulation starts in steady state (all derivatives zero), the initial values are:
+$$
+    p_{hp}(t=0) = p_{gv}(t=0), \quad p_{ip}(t=0) = p_{hp}(t=0), \quad p_{lp}(t=0) = p_{ip}(t=0),
+$$
+$$
+    p_{m}(t=0) = F_{HP} \cdot p_{hp}(t=0) + F_{IP} \cdot p_{ip}(t=0) + F_{LP} \cdot p_{lp}(t=0).
+$$
+
 # References
 
 - [1] “IEEE Recommended Practice for Excitation System Models for Power System Stability Studies,” in IEEE Std 421.5-2016 (Revision of IEEE Std 421.5-2005) , vol., no., pp.1-207, 26 Aug. 2016, doi: 10.1109/IEEESTD.2016.7553421.

--- a/dpsim-models/include/dpsim-models/Base/Base_Governor.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Governor.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/Definitions.h>
+
+namespace CPS {
+namespace Base {
+
+class GovernorParameters {
+public:
+  GovernorParameters() {}
+  virtual ~GovernorParameters() = default;
+};
+
+/// @brief Base model for Governors
+class Governor {
+public:
+  virtual void
+  setParameters(std::shared_ptr<Base::GovernorParameters> parameters) = 0;
+
+  /// Set steady-state initial values (call after setParameters, before first step)
+  virtual void initializeStates(Real PmRef) = 0;
+
+  /// Step the governor and return the valve/gate opening signal Pgv
+  virtual Real step(Real Omega, Real dt) = 0;
+
+  virtual ~Governor() = default;
+};
+
+} // namespace Base
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/Base/Base_ReducedOrderSynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_ReducedOrderSynchronGenerator.h
@@ -9,7 +9,9 @@
 #pragma once
 
 #include <dpsim-models/Base/Base_Exciter.h>
+#include <dpsim-models/Base/Base_Governor.h>
 #include <dpsim-models/Base/Base_PSS.h>
+#include <dpsim-models/Base/Base_Turbine.h>
 #include <dpsim-models/MNASimPowerComp.h>
 #include <dpsim-models/Signal/TurbineGovernorType1.h>
 #include <dpsim-models/Solver/MNAInterface.h>
@@ -86,11 +88,20 @@ public:
   void setInitialValues(Complex initComplexElectricalPower,
                         Real initMechanicalPower, Complex initTerminalVoltage);
 
-  /// Add governor and turbine
+  /// Add governor and turbine (TurbineGovernorType1 legacy API)
   void addGovernor(Real T3, Real T4, Real T5, Real Tc, Real Ts, Real R,
                    Real Pmin, Real Pmax, Real OmRef, Real TmRef);
   void
   addGovernor(std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernor);
+  /// Add a modular governor + turbine pair (new API for SteamTurbineGovernor / SteamTurbine)
+  void
+  addGovernorAndTurbine(std::shared_ptr<Base::Governor> governor,
+                        std::shared_ptr<Base::GovernorParameters> govParams,
+                        std::shared_ptr<Base::Turbine> turbine,
+                        std::shared_ptr<Base::TurbineParameters> turbineParams);
+  /// Add a pre-constructed governor + turbine pair (parameters already set)
+  void addGovernorAndTurbine(std::shared_ptr<Base::Governor> governor,
+                             std::shared_ptr<Base::Turbine> turbine);
   /// Add voltage regulator and exciter
   void addExciter(std::shared_ptr<Base::Exciter> exciter,
                   std::shared_ptr<Base::ExciterParameters> params);
@@ -268,14 +279,20 @@ protected:
   Bool mInitialValuesSet = false;
 
   // #### Controllers ####
-  /// Determines if Turbine and Governor are activated
+  /// Determines if TurbineGovernorType1 is activated
   Bool mHasTurbineGovernor = false;
+  /// Determines if modular Governor + Turbine pair is activated
+  Bool mHasGovernorAndTurbine = false;
   /// Determines if Exciter is activated
   Bool mHasExciter = false;
   /// Determines if PSS is activated
   Bool mHasPSS = false;
-  /// Signal component modelling governor control and steam turbine
+  /// TurbineGovernorType1 (legacy)
   std::shared_ptr<Signal::TurbineGovernorType1> mTurbineGovernor;
+  /// Modular governor (SteamTurbineGovernor / HydroTurbineGovernor)
+  std::shared_ptr<Base::Governor> mGovernor;
+  /// Modular turbine (SteamTurbine / HydroTurbine)
+  std::shared_ptr<Base::Turbine> mTurbine;
   /// Signal component modelling voltage regulator and exciter
   std::shared_ptr<Base::Exciter> mExciter;
   /// Power system stabilizer

--- a/dpsim-models/include/dpsim-models/Base/Base_SynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_SynchronGenerator.h
@@ -10,7 +10,9 @@
 
 #include <dpsim-models/AttributeList.h>
 #include <dpsim-models/Base/Base_Exciter.h>
+#include <dpsim-models/Base/Base_Governor.h>
 #include <dpsim-models/Base/Base_PSS.h>
+#include <dpsim-models/Base/Base_Turbine.h>
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Signal/TurbineGovernor.h>
 #include <dpsim-models/Signal/TurbineGovernorType1.h>
@@ -43,6 +45,16 @@ public:
   // Deprecated scalar convenience — creates TurbineGovernorType1 internally; use object overload instead
   void addGovernor(Real T3, Real T4, Real T5, Real Tc, Real Ts, Real R,
                    Real Tmin, Real Tmax, Real OmRef, Real TmRef);
+
+  /// Add a modular governor + turbine pair (new API for SteamTurbineGovernor / SteamTurbine)
+  void
+  addGovernorAndTurbine(std::shared_ptr<Base::Governor> governor,
+                        std::shared_ptr<Base::GovernorParameters> govParams,
+                        std::shared_ptr<Base::Turbine> turbine,
+                        std::shared_ptr<Base::TurbineParameters> turbineParams);
+  /// Add a pre-constructed governor + turbine pair (parameters already set)
+  void addGovernorAndTurbine(std::shared_ptr<Base::Governor> governor,
+                             std::shared_ptr<Base::Turbine> turbine);
 
   /// Add voltage regulator and exciter
   void addExciter(std::shared_ptr<Base::Exciter> exciter,
@@ -284,6 +296,8 @@ protected:
   Bool mHasTurbineGovernor = false;
   /// Determines if TurbineGovernorType1 is activated
   Bool mHasTurbineGovernorType1 = false;
+  /// Determines if modular Governor + Turbine pair is activated
+  Bool mHasGovernorAndTurbine = false;
   /// Determines if Exciter is activated
   Bool mHasExciter = false;
   /// Determines if PSS is activated
@@ -387,6 +401,10 @@ public:
   std::shared_ptr<Signal::TurbineGovernor> mTurbineGovernor;
   /// Signal component modelling governor control and steam turbine (TurbineGovernorType1)
   std::shared_ptr<Signal::TurbineGovernorType1> mTurbineGovernorType1;
+  /// Modular governor (SteamTurbineGovernor / HydroTurbineGovernor)
+  std::shared_ptr<Base::Governor> mGovernor;
+  /// Modular turbine (SteamTurbine / HydroTurbine)
+  std::shared_ptr<Base::Turbine> mTurbine;
   /// Signal component modelling voltage regulator and exciter
   std::shared_ptr<Base::Exciter> mExciter;
   /// Power system stabilizer

--- a/dpsim-models/include/dpsim-models/Base/Base_Turbine.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Turbine.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/Definitions.h>
+
+namespace CPS {
+namespace Base {
+
+class TurbineParameters {
+public:
+  TurbineParameters() {}
+  virtual ~TurbineParameters() = default;
+};
+
+/// @brief Base model for Turbines
+class Turbine {
+public:
+  virtual void
+  setParameters(std::shared_ptr<Base::TurbineParameters> parameters) = 0;
+
+  /// Set steady-state initial values (call after setParameters, before first step)
+  virtual void initializeStates(Real PmInit) = 0;
+
+  /// Step the turbine with valve/gate opening Pgv and return mechanical power Pm
+  virtual Real step(Real Pgv, Real dt) = 0;
+
+  virtual ~Turbine() = default;
+};
+
+} // namespace Base
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -160,5 +160,7 @@
 #include <dpsim-models/Signal/PSS1A.h>
 #include <dpsim-models/Signal/SignalGenerator.h>
 #include <dpsim-models/Signal/SineWaveGenerator.h>
+#include <dpsim-models/Signal/SteamTurbine.h>
+#include <dpsim-models/Signal/SteamTurbineGovernor.h>
 #include <dpsim-models/Signal/TurbineGovernor.h>
 #include <dpsim-models/Signal/TurbineGovernorType1.h>

--- a/dpsim-models/include/dpsim-models/Factory.h
+++ b/dpsim-models/include/dpsim-models/Factory.h
@@ -4,13 +4,17 @@
 #include <dpsim-models/Logger.h>
 
 #include <dpsim-models/Base/Base_Exciter.h>
+#include <dpsim-models/Base/Base_Governor.h>
 #include <dpsim-models/Base/Base_PSS.h>
 #include <dpsim-models/Base/Base_ReducedOrderSynchronGenerator.h>
+#include <dpsim-models/Base/Base_Turbine.h>
 
 #include <dpsim-models/DP/DP_Ph1_SynchronGenerator4OrderPCM.h>
 #include <dpsim-models/DP/DP_Ph1_SynchronGenerator4OrderTPM.h>
 #include <dpsim-models/DP/DP_Ph1_SynchronGenerator6OrderPCM.h>
 #include <dpsim-models/Signal/PSS1A.h>
+#include <dpsim-models/Signal/SteamTurbine.h>
+#include <dpsim-models/Signal/SteamTurbineGovernor.h>
 
 #include <dpsim-models/Signal/ExciterDC1.h>
 #include <dpsim-models/Signal/ExciterDC1Simp.h>
@@ -166,3 +170,19 @@ void registerPSSs() {
       "PSS1A", new DerivedCreator<CPS::Signal::PSS1A, CPS::Base::PSS>);
 }
 } // namespace PSSFactory
+
+namespace GovernorFactory {
+void registerGovernors() {
+  FactoryRegistration<CPS::Base::Governor> _SteamGovernor(
+      "SteamGovernor", new DerivedCreator<CPS::Signal::SteamTurbineGovernor,
+                                          CPS::Base::Governor>);
+}
+} // namespace GovernorFactory
+
+namespace TurbineFactory {
+void registerTurbines() {
+  FactoryRegistration<CPS::Base::Turbine> _SteamTurbine(
+      "SteamTurbine",
+      new DerivedCreator<CPS::Signal::SteamTurbine, CPS::Base::Turbine>);
+}
+} // namespace TurbineFactory

--- a/dpsim-models/include/dpsim-models/Signal/SteamTurbine.h
+++ b/dpsim-models/include/dpsim-models/Signal/SteamTurbine.h
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/Base/Base_Turbine.h>
+#include <dpsim-models/Logger.h>
+#include <dpsim-models/SimSignalComp.h>
+
+namespace CPS {
+namespace Signal {
+
+class SteamTurbineParameters : public Base::TurbineParameters,
+                               public SharedFactory<SteamTurbineParameters> {
+public:
+  /// Power fraction of the high-pressure stage
+  Real Fhp = 0;
+  /// Power fraction of the intermediate-pressure stage
+  Real Fip = 0;
+  /// Power fraction of the low-pressure stage
+  Real Flp = 0;
+  /// Time constant of main inlet volume and steam chest (s)
+  Real Tch = 0;
+  /// Time constant of reheater (s)
+  Real Trh = 0;
+  /// Time constant of crossover piping and LP inlet volumes (s)
+  Real Tco = 0;
+};
+
+/// Three-stage steam turbine (tandem compound: HP/IP/LP)
+/// Ref.: A. Roehder, B. Fuchs, J. Massman, M. Quester, A. Schnettler,
+///       "Transmission system stability assessment within an integrated grid
+///       development process"
+class SteamTurbine : public SimSignalComp,
+                     public Base::Turbine,
+                     public SharedFactory<SteamTurbine> {
+private:
+  std::shared_ptr<SteamTurbineParameters> mParameters;
+
+  // ### State variables at time k — loggable via .attr() ###
+  /// High-pressure stage power
+  const Attribute<Real>::Ptr mPhp;
+  /// Intermediate-pressure stage power
+  const Attribute<Real>::Ptr mPip;
+  /// Low-pressure stage power
+  const Attribute<Real>::Ptr mPlp;
+  /// Mechanical output power (pu)
+  const Attribute<Real>::Ptr mPm;
+
+  // ### Staging variables for next step ###
+  Real mPhp_next = 0;
+  Real mPip_next = 0;
+  Real mPlp_next = 0;
+
+public:
+  explicit SteamTurbine(const String &name)
+      : SimSignalComp(name, name), mPhp(mAttributes->create<Real>("Php")),
+        mPip(mAttributes->create<Real>("Pip")),
+        mPlp(mAttributes->create<Real>("Plp")),
+        mPm(mAttributes->create<Real>("Pm")) {}
+
+  SteamTurbine(const String &name, CPS::Logger::Level logLevel);
+
+  void setParameters(std::shared_ptr<Base::TurbineParameters> parameters) final;
+  void initializeStates(Real Pminit) final;
+  Real step(Real Pgv, Real dt) final;
+};
+
+} // namespace Signal
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/Signal/SteamTurbineGovernor.h
+++ b/dpsim-models/include/dpsim-models/Signal/SteamTurbineGovernor.h
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/Base/Base_Governor.h>
+#include <dpsim-models/Logger.h>
+#include <dpsim-models/SimSignalComp.h>
+
+namespace CPS {
+namespace Signal {
+
+class SteamGorvernorParameters
+    : public Base::GovernorParameters,
+      public SharedFactory<SteamGorvernorParameters> {
+public:
+  /// Droop — the value 1/K in the controller K(1+sT2)/(1+sT1)
+  Real R = 0;
+  /// T1 related to the lag in the controller K(1+sT2)/(1+sT1)
+  Real T1 = 0;
+  /// T2 related to the lead in the controller K(1+sT2)
+  Real T2 = 0;
+  /// Time constant T3 of the actuator
+  Real T3 = 0;
+
+  /// Maximum rate of change of Pgv (pu/s)
+  Real dPmax = 0;
+  /// Minimum rate of change of Pgv (pu/s)
+  Real dPmin = 0;
+  /// Maximum mechanical power (pu)
+  Real Pmax = 0;
+  /// Minimum mechanical power (pu)
+  Real Pmin = 0;
+
+  /// Speed setpoint (pu); typically 1
+  Real OmRef = 0;
+
+  /// Anti-windup proportional gain
+  Real Kbc = 0;
+};
+
+/// Steam turbine governor
+/// Ref.: A. Roehder, B. Fuchs, J. Massman, M. Quester, A. Schnettler,
+///       "Transmission system stability assessment within an integrated grid
+///       development process"
+class SteamTurbineGovernor : public SimSignalComp,
+                             public Base::Governor,
+                             public SharedFactory<SteamTurbineGovernor> {
+private:
+  std::shared_ptr<SteamGorvernorParameters> mParameters;
+
+  // ### Setpoints ###
+  Real mPref = 0;
+
+  // ### State variables (previous step) ###
+  Real mDelOm_prev = 0;
+  Real mDelOm_2prev = 0;
+  Real mP1_prev = 0;
+
+  // ### State variables (current step) — loggable via .attr() ###
+  /// Delta omega = OmRef - Omega at time k
+  const Attribute<Real>::Ptr mDelOm;
+  /// Intermediate lead-lag state at time k
+  const Attribute<Real>::Ptr mP1;
+  /// Lead-lag output at time k
+  const Attribute<Real>::Ptr mP;
+  /// Gate/valve opening before limiter
+  const Attribute<Real>::Ptr mPgvLim;
+  /// Gate/valve opening (governor output) at time k
+  const Attribute<Real>::Ptr mPgv;
+
+  // ### Auxiliar variables computed in initializeStates ###
+  Real mCa = 0;
+  Real mCb = 0;
+
+  // ### Internal transient ###
+  Real mDerPgv = 0;
+
+public:
+  explicit SteamTurbineGovernor(const String &name)
+      : SimSignalComp(name, name), mDelOm(mAttributes->create<Real>("DelOm")),
+        mP1(mAttributes->create<Real>("P1")),
+        mP(mAttributes->create<Real>("P")),
+        mPgvLim(mAttributes->create<Real>("PgvLim")),
+        mPgv(mAttributes->create<Real>("Pgv")) {}
+
+  SteamTurbineGovernor(const String &name, CPS::Logger::Level logLevel);
+
+  void
+  setParameters(std::shared_ptr<Base::GovernorParameters> parameters) final;
+  void initializeStates(Real Pref) final;
+  Real step(Real Omega, Real dt) final;
+};
+
+} // namespace Signal
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/Signal/SteamTurbineGovernor.h
+++ b/dpsim-models/include/dpsim-models/Signal/SteamTurbineGovernor.h
@@ -10,9 +10,8 @@
 namespace CPS {
 namespace Signal {
 
-class SteamGorvernorParameters
-    : public Base::GovernorParameters,
-      public SharedFactory<SteamGorvernorParameters> {
+class SteamGovernorParameters : public Base::GovernorParameters,
+                                public SharedFactory<SteamGovernorParameters> {
 public:
   /// Droop — the value 1/K in the controller K(1+sT2)/(1+sT1)
   Real R = 0;
@@ -47,7 +46,7 @@ class SteamTurbineGovernor : public SimSignalComp,
                              public Base::Governor,
                              public SharedFactory<SteamTurbineGovernor> {
 private:
-  std::shared_ptr<SteamGorvernorParameters> mParameters;
+  std::shared_ptr<SteamGovernorParameters> mParameters;
 
   // ### Setpoints ###
   Real mPref = 0;

--- a/dpsim-models/src/Base/Base_ReducedOrderSynchronGenerator.cpp
+++ b/dpsim-models/src/Base/Base_ReducedOrderSynchronGenerator.cpp
@@ -355,6 +355,10 @@ void Base::ReducedOrderSynchronGenerator<Real>::initializeFromNodesAndTerminals(
   if (mHasTurbineGovernor) {
     mTurbineGovernor->initializeStates(**mMechTorque);
   }
+  if (mHasGovernorAndTurbine) {
+    mGovernor->initializeStates(**mMechTorque);
+    mTurbine->initializeStates(**mMechTorque);
+  }
   if (mHasPSS) {
     mPSS->initialize(mNomOmega / mBase_OmMech, **mMechTorque, (**mVdq0)(0, 0),
                      (**mVdq0)(1, 0));
@@ -439,6 +443,10 @@ void Base::ReducedOrderSynchronGenerator<
   if (mHasTurbineGovernor) {
     mTurbineGovernor->initializeStates(**mMechTorque);
   }
+  if (mHasGovernorAndTurbine) {
+    mGovernor->initializeStates(**mMechTorque);
+    mTurbine->initializeStates(**mMechTorque);
+  }
   if (mHasPSS) {
     mPSS->initialize(mNomOmega / mBase_OmMech, **mMechTorque, (**mVdq)(0, 0),
                      (**mVdq)(1, 0));
@@ -504,7 +512,11 @@ void Base::ReducedOrderSynchronGenerator<Complex>::mnaCompPreStep(
     mEf_prev = **mEf;
     **mEf = mExciter->step((**mVdq)(0, 0), (**mVdq)(1, 0), mTimeStep, Vpss);
   }
-  if (mHasTurbineGovernor) {
+  if (mHasGovernorAndTurbine) {
+    mMechTorque_prev = **mMechTorque;
+    Real Pgv = mGovernor->step(**mOmMech, mTimeStep);
+    **mMechTorque = mTurbine->step(Pgv, mTimeStep);
+  } else if (mHasTurbineGovernor) {
     mMechTorque_prev = **mMechTorque;
     **mMechTorque = mTurbineGovernor->step(**mOmMech, mTimeStep);
   }
@@ -538,7 +550,11 @@ void Base::ReducedOrderSynchronGenerator<Real>::mnaCompPreStep(
     mEf_prev = **mEf;
     **mEf = mExciter->step((**mVdq0)(0, 0), (**mVdq0)(1, 0), mTimeStep, Vpss);
   }
-  if (mHasTurbineGovernor) {
+  if (mHasGovernorAndTurbine) {
+    mMechTorque_prev = **mMechTorque;
+    Real Pgv = mGovernor->step(**mOmMech, mTimeStep);
+    **mMechTorque = mTurbine->step(Pgv, mTimeStep);
+  } else if (mHasTurbineGovernor) {
     mMechTorque_prev = **mMechTorque;
     **mMechTorque = mTurbineGovernor->step(**mOmMech, mTimeStep);
   }
@@ -690,6 +706,52 @@ void Base::ReducedOrderSynchronGenerator<VarType>::addGovernor(
   }
   mTurbineGovernor = turbineGovernor;
   mHasTurbineGovernor = true;
+}
+
+template <typename VarType>
+void Base::ReducedOrderSynchronGenerator<VarType>::addGovernorAndTurbine(
+    std::shared_ptr<Base::Governor> governor,
+    std::shared_ptr<Base::GovernorParameters> govParams,
+    std::shared_ptr<Base::Turbine> turbine,
+    std::shared_ptr<Base::TurbineParameters> turbineParams) {
+  if (!governor) {
+    SPDLOG_LOGGER_ERROR(this->mSLog,
+                        "addGovernorAndTurbine called with null governor on {}",
+                        *this->mName);
+    return;
+  }
+  if (!turbine) {
+    SPDLOG_LOGGER_ERROR(this->mSLog,
+                        "addGovernorAndTurbine called with null turbine on {}",
+                        *this->mName);
+    return;
+  }
+  governor->setParameters(govParams);
+  turbine->setParameters(turbineParams);
+  mGovernor = governor;
+  mTurbine = turbine;
+  mHasGovernorAndTurbine = true;
+}
+
+template <typename VarType>
+void Base::ReducedOrderSynchronGenerator<VarType>::addGovernorAndTurbine(
+    std::shared_ptr<Base::Governor> governor,
+    std::shared_ptr<Base::Turbine> turbine) {
+  if (!governor) {
+    SPDLOG_LOGGER_ERROR(this->mSLog,
+                        "addGovernorAndTurbine called with null governor on {}",
+                        *this->mName);
+    return;
+  }
+  if (!turbine) {
+    SPDLOG_LOGGER_ERROR(this->mSLog,
+                        "addGovernorAndTurbine called with null turbine on {}",
+                        *this->mName);
+    return;
+  }
+  mGovernor = governor;
+  mTurbine = turbine;
+  mHasGovernorAndTurbine = true;
 }
 
 template <typename VarType>

--- a/dpsim-models/src/Base/Base_SynchronGenerator.cpp
+++ b/dpsim-models/src/Base/Base_SynchronGenerator.cpp
@@ -473,6 +473,46 @@ void Base::SynchronGenerator::addGovernor(Real T3, Real T4, Real T5, Real Tc,
   addGovernor(gov);
 }
 
+void Base::SynchronGenerator::addGovernorAndTurbine(
+    std::shared_ptr<Base::Governor> governor,
+    std::shared_ptr<Base::GovernorParameters> govParams,
+    std::shared_ptr<Base::Turbine> turbine,
+    std::shared_ptr<Base::TurbineParameters> turbineParams) {
+  auto log = CPS::Logger::get("SynchronGenerator", CPS::Logger::Level::off,
+                              CPS::Logger::Level::info);
+  if (!governor) {
+    SPDLOG_LOGGER_ERROR(log, "addGovernorAndTurbine called with null governor");
+    return;
+  }
+  if (!turbine) {
+    SPDLOG_LOGGER_ERROR(log, "addGovernorAndTurbine called with null turbine");
+    return;
+  }
+  governor->setParameters(govParams);
+  turbine->setParameters(turbineParams);
+  mGovernor = governor;
+  mTurbine = turbine;
+  mHasGovernorAndTurbine = true;
+}
+
+void Base::SynchronGenerator::addGovernorAndTurbine(
+    std::shared_ptr<Base::Governor> governor,
+    std::shared_ptr<Base::Turbine> turbine) {
+  auto log = CPS::Logger::get("SynchronGenerator", CPS::Logger::Level::off,
+                              CPS::Logger::Level::info);
+  if (!governor) {
+    SPDLOG_LOGGER_ERROR(log, "addGovernorAndTurbine called with null governor");
+    return;
+  }
+  if (!turbine) {
+    SPDLOG_LOGGER_ERROR(log, "addGovernorAndTurbine called with null turbine");
+    return;
+  }
+  mGovernor = governor;
+  mTurbine = turbine;
+  mHasGovernorAndTurbine = true;
+}
+
 void Base::SynchronGenerator::addPSS(
     std::shared_ptr<Base::PSS> pss,
     std::shared_ptr<Base::PSSParameters> parameters) {

--- a/dpsim-models/src/Base/Base_SynchronGenerator.cpp
+++ b/dpsim-models/src/Base/Base_SynchronGenerator.cpp
@@ -304,6 +304,10 @@ void Base::SynchronGenerator::initPerUnitStates() {
     // to the exciter pu system
     mExciter->initialize(init_vt_abs, (mLmd / mRfd) * init_vfd);
   }
+  if (mHasGovernorAndTurbine) {
+    mGovernor->initializeStates(**mMechTorque);
+    mTurbine->initializeStates(**mMechTorque);
+  }
 }
 
 void Base::SynchronGenerator::calcStateSpaceMatrixDQ() {

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -166,6 +166,8 @@ list(APPEND MODELS_SOURCES
 	Signal/ExciterStatic.cpp
 	Signal/PSS1A.cpp
 	Signal/FIRFilter.cpp
+	Signal/SteamTurbineGovernor.cpp
+	Signal/SteamTurbine.cpp
 	Signal/TurbineGovernor.cpp
 	Signal/TurbineGovernorType1.cpp
 	Signal/PLL.cpp

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorDQTrapez.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorDQTrapez.cpp
@@ -70,7 +70,10 @@ void EMT::Ph3::SynchronGeneratorDQTrapez::stepInPerUnit(Real time) {
   }
 
   // Update of mechanical torque from turbine governor
-  if (mHasTurbineGovernorType1)
+  if (mHasGovernorAndTurbine) {
+    Real Pgv = mGovernor->step(**mOmMech, mTimeStep);
+    **mMechTorque = mTurbine->step(Pgv, mTimeStep);
+  } else if (mHasTurbineGovernorType1)
     **mMechTorque = mTurbineGovernorType1->step(**mOmMech, mTimeStep);
   else if (mHasTurbineGovernor)
     **mMechTorque = mTurbineGovernor->step(

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorVBR.cpp
@@ -285,7 +285,10 @@ void EMT::Ph3::SynchronGeneratorVBR::mnaCompApplyRightSideVectorStamp(
 void EMT::Ph3::SynchronGeneratorVBR::stepInPerUnit() {
 
   // Update of mechanical torque from turbine governor
-  if (mHasTurbineGovernorType1)
+  if (mHasGovernorAndTurbine) {
+    Real Pgv = mGovernor->step(**mOmMech, mTimeStep);
+    **mMechTorque = -mTurbine->step(Pgv, mTimeStep);
+  } else if (mHasTurbineGovernorType1)
     **mMechTorque = -mTurbineGovernorType1->step(**mOmMech, mTimeStep);
   else if (mHasTurbineGovernor)
     **mMechTorque = -mTurbineGovernor->step(

--- a/dpsim-models/src/Signal/SteamTurbine.cpp
+++ b/dpsim-models/src/Signal/SteamTurbine.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/Signal/SteamTurbine.h>
+
+using namespace CPS;
+using namespace CPS::Signal;
+
+Signal::SteamTurbine::SteamTurbine(const String &name,
+                                   CPS::Logger::Level logLevel)
+    : SimSignalComp(name, name, logLevel),
+      mPhp(mAttributes->create<Real>("Php")),
+      mPip(mAttributes->create<Real>("Pip")),
+      mPlp(mAttributes->create<Real>("Plp")),
+      mPm(mAttributes->create<Real>("Pm")) {}
+
+void SteamTurbine::setParameters(
+    std::shared_ptr<Base::TurbineParameters> parameters) {
+  auto params =
+      std::dynamic_pointer_cast<Signal::SteamTurbineParameters>(parameters);
+  if (!params) {
+    SPDLOG_LOGGER_ERROR(
+        mSLog,
+        "Type of parameters class of {} has to be SteamTurbineParameters!",
+        this->name());
+    throw CPS::TypeException();
+  }
+  Real fractionSum = params->Fhp + params->Fip + params->Flp;
+  if (std::abs(fractionSum - 1.0) > 1e-9) {
+    SPDLOG_LOGGER_ERROR(
+        mSLog,
+        "The sum of power fractions Fhp+Fip+Flp of steam turbine {} must equal "
+        "1 (got {:f})",
+        this->name(), fractionSum);
+    throw CPS::InvalidArgumentException();
+  }
+  mParameters = params;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "Steam turbine parameters:"
+                     "\nFhp: {:e}"
+                     "\nFip: {:e}"
+                     "\nFlp: {:e}"
+                     "\nTch: {:e}"
+                     "\nTrh: {:e}"
+                     "\nTco: {:e}",
+                     mParameters->Fhp, mParameters->Fip, mParameters->Flp,
+                     mParameters->Tch, mParameters->Trh, mParameters->Tco);
+  mSLog->flush();
+}
+
+void SteamTurbine::initializeStates(Real Pminit) {
+  if (Pminit < 0 || Pminit > 1) {
+    SPDLOG_LOGGER_ERROR(
+        mSLog,
+        "Initial mechanical power of steam turbine {} must be in [0, 1] pu",
+        this->name());
+    throw CPS::InvalidArgumentException();
+  }
+  **mPhp = Pminit;
+  **mPip = Pminit;
+  **mPlp = Pminit;
+  **mPm = Pminit;
+  mPhp_next = Pminit;
+  mPip_next = Pminit;
+  mPlp_next = Pminit;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "Turbine initial values:"
+                     "\nPhp: {:f}"
+                     "\nPip: {:f}"
+                     "\nPlp: {:f}"
+                     "\nPm: {:f}",
+                     **mPhp, **mPip, **mPlp, **mPm);
+  mSLog->flush();
+}
+
+Real SteamTurbine::step(Real Pgv, Real dt) {
+  // Shift next-step staging into current
+  **mPhp = mPhp_next;
+  **mPip = mPip_next;
+  **mPlp = mPlp_next;
+
+  // High-pressure stage
+  if (mParameters->Tch == 0)
+    **mPhp = Pgv;
+  else
+    mPhp_next = **mPhp + (dt / mParameters->Tch) * (Pgv - **mPhp);
+
+  // Intermediate-pressure stage
+  if (mParameters->Trh == 0)
+    **mPip = **mPhp;
+  else
+    mPip_next = **mPip + (dt / mParameters->Trh) * (**mPhp - **mPip);
+
+  // Low-pressure stage
+  if (mParameters->Tco == 0)
+    **mPlp = **mPip;
+  else
+    mPlp_next = **mPlp + (dt / mParameters->Tco) * (**mPip - **mPlp);
+
+  **mPm = mParameters->Fhp * **mPhp + mParameters->Fip * **mPip +
+          mParameters->Flp * **mPlp;
+
+  return **mPm;
+}

--- a/dpsim-models/src/Signal/SteamTurbineGovernor.cpp
+++ b/dpsim-models/src/Signal/SteamTurbineGovernor.cpp
@@ -25,12 +25,12 @@ void SteamTurbineGovernor::setParameters(
         this->name());
     throw CPS::TypeException();
   }
-  if (params->T3 == 0) {
-    SPDLOG_LOGGER_ERROR(mSLog, "T3 must not be zero for {}", this->name());
+  if (params->T3 <= 0) {
+    SPDLOG_LOGGER_ERROR(mSLog, "T3 must be positive for {}", this->name());
     throw CPS::InvalidArgumentException();
   }
-  if (params->R == 0) {
-    SPDLOG_LOGGER_ERROR(mSLog, "R must not be zero for {}", this->name());
+  if (params->R <= 0) {
+    SPDLOG_LOGGER_ERROR(mSLog, "R must be positive for {}", this->name());
     throw CPS::InvalidArgumentException();
   }
   mParameters = params;

--- a/dpsim-models/src/Signal/SteamTurbineGovernor.cpp
+++ b/dpsim-models/src/Signal/SteamTurbineGovernor.cpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/Signal/SteamTurbineGovernor.h>
+
+using namespace CPS;
+using namespace CPS::Signal;
+
+Signal::SteamTurbineGovernor::SteamTurbineGovernor(const String &name,
+                                                   CPS::Logger::Level logLevel)
+    : SimSignalComp(name, name, logLevel),
+      mDelOm(mAttributes->create<Real>("DelOm")),
+      mP1(mAttributes->create<Real>("P1")), mP(mAttributes->create<Real>("P")),
+      mPgvLim(mAttributes->create<Real>("PgvLim")),
+      mPgv(mAttributes->create<Real>("Pgv")) {}
+
+void SteamTurbineGovernor::setParameters(
+    std::shared_ptr<Base::GovernorParameters> parameters) {
+  auto params =
+      std::dynamic_pointer_cast<Signal::SteamGorvernorParameters>(parameters);
+  if (!params) {
+    SPDLOG_LOGGER_ERROR(
+        mSLog,
+        "Type of parameters class of {} has to be SteamGorvernorParameters!",
+        this->name());
+    throw CPS::TypeException();
+  }
+  if (params->T3 == 0) {
+    SPDLOG_LOGGER_ERROR(mSLog, "T3 must not be zero for {}", this->name());
+    throw CPS::InvalidArgumentException();
+  }
+  if (params->R == 0) {
+    SPDLOG_LOGGER_ERROR(mSLog, "R must not be zero for {}", this->name());
+    throw CPS::InvalidArgumentException();
+  }
+  mParameters = params;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\nSteam Governor parameters:"
+                     "\nOmRef: {:e}"
+                     "\nR: {:e}"
+                     "\nT1: {:e}"
+                     "\nT2: {:e}"
+                     "\nT3: {:e}"
+                     "\ndPmax: {:e}"
+                     "\ndPmin: {:e}"
+                     "\nPmax: {:e}"
+                     "\nPmin: {:e}"
+                     "\nKbc: {:e}\n",
+                     mParameters->OmRef, mParameters->R, mParameters->T1,
+                     mParameters->T2, mParameters->T3, mParameters->dPmax,
+                     mParameters->dPmin, mParameters->Pmax, mParameters->Pmin,
+                     mParameters->Kbc);
+  mSLog->flush();
+}
+
+void SteamTurbineGovernor::initializeStates(Real Pref) {
+  if (Pref < 0 || Pref > 1) {
+    SPDLOG_LOGGER_ERROR(mSLog, "Pref of steam governor {} must be in [0, 1] pu",
+                        this->name());
+    throw CPS::InvalidArgumentException();
+  }
+  mPref = Pref;
+  **mDelOm = 0;
+  mDelOm_prev = 0;
+  mDelOm_2prev = 0;
+  **mP1 = 0;
+  mP1_prev = 0;
+  **mP = 0;
+  mDerPgv = 0;
+  **mPgvLim = Pref;
+  **mPgv = Pref;
+
+  if (mParameters->T1 == 0) {
+    mCa = 0;
+    mCb = 0;
+  } else {
+    mCa = mParameters->T2 / mParameters->T1;
+    mCb = (mParameters->T1 - mParameters->T2) / mParameters->T1;
+  }
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\nSteam Governor initial values:"
+                     "\nPref: {:f}"
+                     "\nDelOm: {:f}"
+                     "\nDerPgv: {:f}"
+                     "\nPgv: {:f}",
+                     mPref, **mDelOm, mDerPgv, **mPgv);
+  mSLog->flush();
+}
+
+Real SteamTurbineGovernor::step(Real Omega, Real dt) {
+  // Shift state variables one step back
+  mDelOm_2prev = mDelOm_prev;
+  mDelOm_prev = **mDelOm;
+  mP1_prev = **mP1;
+
+  // Compute input deviation
+  **mDelOm = mParameters->OmRef - Omega;
+
+  // Lead-lag controller K(1+sT2)/(1+sT1): if T1==0, use filtered-derivative form
+  if (mParameters->T1 == 0) {
+    **mP =
+        (1.0 / mParameters->R) *
+        (mDelOm_prev + (mParameters->T2 / dt) * (mDelOm_prev - mDelOm_2prev));
+  } else {
+    **mP1 = mP1_prev + (dt / mParameters->T1) * (mDelOm_prev * mCb - mP1_prev);
+    **mP = (1.0 / mParameters->R) * (mP1_prev + mDelOm_prev * mCa);
+  }
+
+  // Integrator with rate limiter and anti-windup
+  mDerPgv = (1.0 / mParameters->T3) * (mPref + **mP - **mPgv);
+  if (mDerPgv < mParameters->dPmin)
+    mDerPgv = mParameters->dPmin;
+  if (mDerPgv > mParameters->dPmax)
+    mDerPgv = mParameters->dPmax;
+  mDerPgv = mDerPgv - mParameters->Kbc * (**mPgvLim - **mPgv);
+
+  **mPgvLim = **mPgvLim + dt * mDerPgv;
+
+  // Output limiter
+  if (**mPgvLim < mParameters->Pmin)
+    **mPgv = mParameters->Pmin;
+  else if (**mPgvLim > mParameters->Pmax)
+    **mPgv = mParameters->Pmax;
+  else
+    **mPgv = **mPgvLim;
+
+  return **mPgv;
+}

--- a/dpsim-models/src/Signal/SteamTurbineGovernor.cpp
+++ b/dpsim-models/src/Signal/SteamTurbineGovernor.cpp
@@ -17,11 +17,11 @@ Signal::SteamTurbineGovernor::SteamTurbineGovernor(const String &name,
 void SteamTurbineGovernor::setParameters(
     std::shared_ptr<Base::GovernorParameters> parameters) {
   auto params =
-      std::dynamic_pointer_cast<Signal::SteamGorvernorParameters>(parameters);
+      std::dynamic_pointer_cast<Signal::SteamGovernorParameters>(parameters);
   if (!params) {
     SPDLOG_LOGGER_ERROR(
         mSLog,
-        "Type of parameters class of {} has to be SteamGorvernorParameters!",
+        "Type of parameters class of {} has to be SteamGovernorParameters!",
         this->name());
     throw CPS::TypeException();
   }

--- a/dpsim/examples/cxx/Circuits/SP_ReducedOrderSG_SMIB_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_ReducedOrderSG_SMIB_Fault.cpp
@@ -2,6 +2,8 @@
 #include "../GeneratorFactory.h"
 #include <DPsim.h>
 #include <dpsim-models/Signal/PSS1A.h>
+#include <dpsim-models/Signal/SteamTurbine.h>
+#include <dpsim-models/Signal/SteamTurbineGovernor.h>
 
 using namespace DPsim;
 using namespace CPS;
@@ -24,6 +26,10 @@ const Examples::Components::TurbineGovernor::TurbineGovernorPSAT1
 // Power System Stabilizer
 const Examples::Components::PSS1A::Parameters pss1aParams;
 
+// Steam Governor + Turbine
+const Examples::Components::SteamGovernor::Parameters steamGovParams;
+const Examples::Components::SteamTurbine::Parameters steamTurbineParams;
+
 int main(int argc, char *argv[]) {
 
   // Simulation parameters
@@ -37,6 +43,7 @@ int main(int argc, char *argv[]) {
   bool withExciter = false;
   bool withTurbineGovernor = false;
   bool withPSS = false;
+  bool withSteamGovernor = false;
   std::string SGModel = "4";
   std::string stepSize_str = "";
   std::string inertia_str = "";
@@ -63,6 +70,9 @@ int main(int argc, char *argv[]) {
     }
     if (args.options.find("WithPSS") != args.options.end()) {
       withPSS = args.getOptionBool("WithPSS");
+    }
+    if (args.options.find("WithSteamGovernor") != args.options.end()) {
+      withSteamGovernor = args.getOptionBool("WithSteamGovernor");
     }
     if (args.options.find("FinalTime") != args.options.end()) {
       finalTime = args.getOptionReal("FinalTime");
@@ -203,7 +213,7 @@ int main(int argc, char *argv[]) {
     genSP->addPSS(pssSP, pssParams);
   }
 
-  // Turbine Governor
+  // Turbine Governor (TurbineGovernorType1 legacy)
   std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernorSP = nullptr;
   if (withTurbineGovernor) {
     turbineGovernorSP =
@@ -213,6 +223,35 @@ int main(int argc, char *argv[]) {
         turbineGovernor.Tc, turbineGovernor.Ts, turbineGovernor.R,
         turbineGovernor.Tmin, turbineGovernor.Tmax, turbineGovernor.OmegaRef);
     genSP->addGovernor(turbineGovernorSP);
+  }
+
+  // Steam Governor + Turbine (modular new API)
+  if (withSteamGovernor) {
+    auto govParams = Signal::SteamGorvernorParameters::make();
+    govParams->R = steamGovParams.R;
+    govParams->T1 = steamGovParams.T1;
+    govParams->T2 = steamGovParams.T2;
+    govParams->T3 = steamGovParams.T3;
+    govParams->dPmax = steamGovParams.dPmax;
+    govParams->dPmin = steamGovParams.dPmin;
+    govParams->Pmax = steamGovParams.Pmax;
+    govParams->Pmin = steamGovParams.Pmin;
+    govParams->OmRef = steamGovParams.OmRef;
+    govParams->Kbc = steamGovParams.Kbc;
+
+    auto turbParams = Signal::SteamTurbineParameters::make();
+    turbParams->Fhp = steamTurbineParams.Fhp;
+    turbParams->Fip = steamTurbineParams.Fip;
+    turbParams->Flp = steamTurbineParams.Flp;
+    turbParams->Tch = steamTurbineParams.Tch;
+    turbParams->Trh = steamTurbineParams.Trh;
+    turbParams->Tco = steamTurbineParams.Tco;
+
+    auto steamGov =
+        Signal::SteamTurbineGovernor::make("SynGen_SteamGovernor", logLevel);
+    auto steamTurb =
+        Signal::SteamTurbine::make("SynGen_SteamTurbine", logLevel);
+    genSP->addGovernorAndTurbine(steamGov, govParams, steamTurb, turbParams);
   }
 
   // Grid bus as Slack

--- a/dpsim/examples/cxx/Circuits/SP_ReducedOrderSG_SMIB_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_ReducedOrderSG_SMIB_Fault.cpp
@@ -227,7 +227,7 @@ int main(int argc, char *argv[]) {
 
   // Steam Governor + Turbine (modular new API)
   if (withSteamGovernor) {
-    auto govParams = Signal::SteamGorvernorParameters::make();
+    auto govParams = Signal::SteamGovernorParameters::make();
     govParams->R = steamGovParams.R;
     govParams->T1 = steamGovParams.T1;
     govParams->T2 = steamGovParams.T2;

--- a/dpsim/examples/cxx/Examples.h
+++ b/dpsim/examples/cxx/Examples.h
@@ -161,6 +161,32 @@ struct Parameters {
   Real Tw = 10.0;
 };
 } // namespace PSS1A
+
+namespace SteamGovernor {
+struct Parameters {
+  Real R = 0.04;
+  Real T1 = 0.0;
+  Real T2 = 0.2;
+  Real T3 = 0.1;
+  Real dPmax = 50;
+  Real dPmin = -50;
+  Real Pmax = 1.0;
+  Real Pmin = 0.0;
+  Real OmRef = 1.0;
+  Real Kbc = 0.0;
+};
+} // namespace SteamGovernor
+
+namespace SteamTurbine {
+struct Parameters {
+  Real Fhp = 0.3;
+  Real Fip = 0.3;
+  Real Flp = 0.4;
+  Real Tch = 0.1;
+  Real Trh = 4.0;
+  Real Tco = 0.3;
+};
+} // namespace SteamTurbine
 } // namespace Components
 
 namespace Grids {

--- a/dpsim/src/pybind/BaseComponents.cpp
+++ b/dpsim/src/pybind/BaseComponents.cpp
@@ -7,7 +7,9 @@
  *********************************************************************************/
 
 #include <DPsim.h>
+#include <dpsim-models/Base/Base_Governor.h>
 #include <dpsim-models/Base/Base_PSS.h>
+#include <dpsim-models/Base/Base_Turbine.h>
 #include <dpsim-models/CSVReader.h>
 #include <dpsim-models/IdentifiedObject.h>
 #include <dpsim-models/Signal/PSS1A.h>
@@ -103,7 +105,26 @@ void addBaseComponents(py::module_ mBase) {
             self.addGovernor(T3, T4, T5, Tc, Ts, R, Pmin, Pmax, OmRef, TmRef);
           },
           "T3"_a, "T4"_a, "T5"_a, "Tc"_a, "Ts"_a, "R"_a, "Pmin"_a, "Pmax"_a,
-          "OmRef"_a, "TmRef"_a);
+          "OmRef"_a, "TmRef"_a)
+      .def(
+          "add_governor_and_turbine",
+          [](CPS::Base::ReducedOrderSynchronGenerator<CPS::Complex> &self,
+             std::shared_ptr<CPS::Base::Governor> governor,
+             std::shared_ptr<CPS::Base::GovernorParameters> govParams,
+             std::shared_ptr<CPS::Base::Turbine> turbine,
+             std::shared_ptr<CPS::Base::TurbineParameters> turbineParams) {
+            self.addGovernorAndTurbine(governor, govParams, turbine,
+                                       turbineParams);
+          },
+          "governor"_a, "gov_params"_a, "turbine"_a, "turbine_params"_a)
+      .def(
+          "add_governor_and_turbine",
+          [](CPS::Base::ReducedOrderSynchronGenerator<CPS::Complex> &self,
+             std::shared_ptr<CPS::Base::Governor> governor,
+             std::shared_ptr<CPS::Base::Turbine> turbine) {
+            self.addGovernorAndTurbine(governor, turbine);
+          },
+          "governor"_a, "turbine"_a);
 
   py::class_<
       CPS::Base::ReducedOrderSynchronGenerator<CPS::Real>,
@@ -174,5 +195,24 @@ void addBaseComponents(py::module_ mBase) {
             self.addGovernor(T3, T4, T5, Tc, Ts, R, Pmin, Pmax, OmRef, TmRef);
           },
           "T3"_a, "T4"_a, "T5"_a, "Tc"_a, "Ts"_a, "R"_a, "Pmin"_a, "Pmax"_a,
-          "OmRef"_a, "TmRef"_a);
+          "OmRef"_a, "TmRef"_a)
+      .def(
+          "add_governor_and_turbine",
+          [](CPS::Base::ReducedOrderSynchronGenerator<CPS::Real> &self,
+             std::shared_ptr<CPS::Base::Governor> governor,
+             std::shared_ptr<CPS::Base::GovernorParameters> govParams,
+             std::shared_ptr<CPS::Base::Turbine> turbine,
+             std::shared_ptr<CPS::Base::TurbineParameters> turbineParams) {
+            self.addGovernorAndTurbine(governor, govParams, turbine,
+                                       turbineParams);
+          },
+          "governor"_a, "gov_params"_a, "turbine"_a, "turbine_params"_a)
+      .def(
+          "add_governor_and_turbine",
+          [](CPS::Base::ReducedOrderSynchronGenerator<CPS::Real> &self,
+             std::shared_ptr<CPS::Base::Governor> governor,
+             std::shared_ptr<CPS::Base::Turbine> turbine) {
+            self.addGovernorAndTurbine(governor, turbine);
+          },
+          "governor"_a, "turbine"_a);
 }

--- a/dpsim/src/pybind/SignalComponents.cpp
+++ b/dpsim/src/pybind/SignalComponents.cpp
@@ -7,10 +7,14 @@
  *********************************************************************************/
 
 #include <DPsim.h>
+#include <dpsim-models/Base/Base_Governor.h>
 #include <dpsim-models/Base/Base_PSS.h>
+#include <dpsim-models/Base/Base_Turbine.h>
 #include <dpsim-models/CSVReader.h>
 #include <dpsim-models/IdentifiedObject.h>
 #include <dpsim-models/Signal/PSS1A.h>
+#include <dpsim-models/Signal/SteamTurbine.h>
+#include <dpsim-models/Signal/SteamTurbineGovernor.h>
 #include <dpsim/RealTimeSimulation.h>
 #include <dpsim/Simulation.h>
 #include <dpsim/pybind/SignalComponents.h>
@@ -221,4 +225,69 @@ void addSignalComponents(py::module_ mSignal) {
            "OmRef"_a)
       .def("initialize_states",
            &CPS::Signal::TurbineGovernorType1::initializeStates, "TmRef"_a);
+
+  // Base Governor / Turbine
+  py::class_<CPS::Base::GovernorParameters,
+             std::shared_ptr<CPS::Base::GovernorParameters>>(
+      mSignal, "GovernorParameters");
+  py::class_<CPS::Base::Governor, std::shared_ptr<CPS::Base::Governor>>(
+      mSignal, "Governor");
+
+  py::class_<CPS::Base::TurbineParameters,
+             std::shared_ptr<CPS::Base::TurbineParameters>>(
+      mSignal, "TurbineParameters");
+  py::class_<CPS::Base::Turbine, std::shared_ptr<CPS::Base::Turbine>>(
+      mSignal, "Turbine");
+
+  // SteamTurbineGovernor
+  py::class_<CPS::Signal::SteamGorvernorParameters,
+             std::shared_ptr<CPS::Signal::SteamGorvernorParameters>,
+             CPS::Base::GovernorParameters>(mSignal, "SteamGorvernorParameters",
+                                            py::multiple_inheritance())
+      .def(py::init<>())
+      .def_readwrite("R", &CPS::Signal::SteamGorvernorParameters::R)
+      .def_readwrite("T1", &CPS::Signal::SteamGorvernorParameters::T1)
+      .def_readwrite("T2", &CPS::Signal::SteamGorvernorParameters::T2)
+      .def_readwrite("T3", &CPS::Signal::SteamGorvernorParameters::T3)
+      .def_readwrite("dPmax", &CPS::Signal::SteamGorvernorParameters::dPmax)
+      .def_readwrite("dPmin", &CPS::Signal::SteamGorvernorParameters::dPmin)
+      .def_readwrite("Pmax", &CPS::Signal::SteamGorvernorParameters::Pmax)
+      .def_readwrite("Pmin", &CPS::Signal::SteamGorvernorParameters::Pmin)
+      .def_readwrite("OmRef", &CPS::Signal::SteamGorvernorParameters::OmRef)
+      .def_readwrite("Kbc", &CPS::Signal::SteamGorvernorParameters::Kbc);
+
+  py::class_<CPS::Signal::SteamTurbineGovernor,
+             std::shared_ptr<CPS::Signal::SteamTurbineGovernor>,
+             CPS::SimSignalComp, CPS::Base::Governor>(
+      mSignal, "SteamTurbineGovernor", py::multiple_inheritance())
+      .def(py::init<std::string>())
+      .def(py::init<std::string, CPS::Logger::Level>())
+      .def("set_parameters", &CPS::Signal::SteamTurbineGovernor::setParameters,
+           "parameters"_a)
+      .def("initialize_states",
+           &CPS::Signal::SteamTurbineGovernor::initializeStates, "Pref"_a);
+
+  // SteamTurbine
+  py::class_<CPS::Signal::SteamTurbineParameters,
+             std::shared_ptr<CPS::Signal::SteamTurbineParameters>,
+             CPS::Base::TurbineParameters>(mSignal, "SteamTurbineParameters",
+                                           py::multiple_inheritance())
+      .def(py::init<>())
+      .def_readwrite("Fhp", &CPS::Signal::SteamTurbineParameters::Fhp)
+      .def_readwrite("Fip", &CPS::Signal::SteamTurbineParameters::Fip)
+      .def_readwrite("Flp", &CPS::Signal::SteamTurbineParameters::Flp)
+      .def_readwrite("Tch", &CPS::Signal::SteamTurbineParameters::Tch)
+      .def_readwrite("Trh", &CPS::Signal::SteamTurbineParameters::Trh)
+      .def_readwrite("Tco", &CPS::Signal::SteamTurbineParameters::Tco);
+
+  py::class_<CPS::Signal::SteamTurbine,
+             std::shared_ptr<CPS::Signal::SteamTurbine>, CPS::SimSignalComp,
+             CPS::Base::Turbine>(mSignal, "SteamTurbine",
+                                 py::multiple_inheritance())
+      .def(py::init<std::string>())
+      .def(py::init<std::string, CPS::Logger::Level>())
+      .def("set_parameters", &CPS::Signal::SteamTurbine::setParameters,
+           "parameters"_a)
+      .def("initialize_states", &CPS::Signal::SteamTurbine::initializeStates,
+           "Pminit"_a);
 }

--- a/dpsim/src/pybind/SignalComponents.cpp
+++ b/dpsim/src/pybind/SignalComponents.cpp
@@ -240,21 +240,21 @@ void addSignalComponents(py::module_ mSignal) {
       mSignal, "Turbine");
 
   // SteamTurbineGovernor
-  py::class_<CPS::Signal::SteamGorvernorParameters,
-             std::shared_ptr<CPS::Signal::SteamGorvernorParameters>,
-             CPS::Base::GovernorParameters>(mSignal, "SteamGorvernorParameters",
+  py::class_<CPS::Signal::SteamGovernorParameters,
+             std::shared_ptr<CPS::Signal::SteamGovernorParameters>,
+             CPS::Base::GovernorParameters>(mSignal, "SteamGovernorParameters",
                                             py::multiple_inheritance())
       .def(py::init<>())
-      .def_readwrite("R", &CPS::Signal::SteamGorvernorParameters::R)
-      .def_readwrite("T1", &CPS::Signal::SteamGorvernorParameters::T1)
-      .def_readwrite("T2", &CPS::Signal::SteamGorvernorParameters::T2)
-      .def_readwrite("T3", &CPS::Signal::SteamGorvernorParameters::T3)
-      .def_readwrite("dPmax", &CPS::Signal::SteamGorvernorParameters::dPmax)
-      .def_readwrite("dPmin", &CPS::Signal::SteamGorvernorParameters::dPmin)
-      .def_readwrite("Pmax", &CPS::Signal::SteamGorvernorParameters::Pmax)
-      .def_readwrite("Pmin", &CPS::Signal::SteamGorvernorParameters::Pmin)
-      .def_readwrite("OmRef", &CPS::Signal::SteamGorvernorParameters::OmRef)
-      .def_readwrite("Kbc", &CPS::Signal::SteamGorvernorParameters::Kbc);
+      .def_readwrite("R", &CPS::Signal::SteamGovernorParameters::R)
+      .def_readwrite("T1", &CPS::Signal::SteamGovernorParameters::T1)
+      .def_readwrite("T2", &CPS::Signal::SteamGovernorParameters::T2)
+      .def_readwrite("T3", &CPS::Signal::SteamGovernorParameters::T3)
+      .def_readwrite("dPmax", &CPS::Signal::SteamGovernorParameters::dPmax)
+      .def_readwrite("dPmin", &CPS::Signal::SteamGovernorParameters::dPmin)
+      .def_readwrite("Pmax", &CPS::Signal::SteamGovernorParameters::Pmax)
+      .def_readwrite("Pmin", &CPS::Signal::SteamGovernorParameters::Pmin)
+      .def_readwrite("OmRef", &CPS::Signal::SteamGovernorParameters::OmRef)
+      .def_readwrite("Kbc", &CPS::Signal::SteamGovernorParameters::Kbc);
 
   py::class_<CPS::Signal::SteamTurbineGovernor,
              std::shared_ptr<CPS::Signal::SteamTurbineGovernor>,


### PR DESCRIPTION
## Summary

Adds a steam turbine governor and a three-stage steam turbine (HP/IP/LP) as separate objects, plus the Base::Governor and Base::Turbine interfaces.

- New models: SteamTurbineGovernor (lead-lag + integrator with rate limiter) and SteamTurbine (HP/IP/LP stages)
- addGovernorAndTurbine() on both SG base classes, same pattern as addExciter() (#402) and addPSS() (#486)
- DQTrapez and VBR generators step the new chain when attached, fall back to TurbineGovernorType1 otherwise
- Python bindings for set_parameters(), initialize_states(), and add_governor_and_turbine()
- Docs with block diagrams and equations for both models

## What comes next

Next PR adds the hydro variants using the same base classes.

## Other comments

Continuation of the controllers work from @martinmoraga at ACS.