### PR TITLE
fix: TurbineGovernorType1 initialization attributes

### DIFF
--- a/dpsim-models/include/dpsim-models/Signal/TurbineGovernorType1.h
+++ b/dpsim-models/include/dpsim-models/Signal/TurbineGovernorType1.h
@@ -55,12 +55,8 @@ private:
   const Attribute<Real>::Ptr mTm;
 
 public:
-  ///
-  explicit TurbineGovernorType1(const String &name)
-      : SimSignalComp(name, name) {}
-
-  /// Constructor with log level
-  TurbineGovernorType1(const String &name, CPS::Logger::Level logLevel);
+  TurbineGovernorType1(const String &name,
+                       Logger::Level logLevel = Logger::Level::off);
 
   /// Initializes exciter parameters
   void setParameters(Real T3, Real T4, Real T5, Real Tc, Real Ts, Real R,


### PR DESCRIPTION
## Summary
- The `explicit TurbineGovernorType1(const String &name)` constructor called `SimSignalComp(name, name)` directly, bypassing the member-initializer list for `mXg1`, `mXg2`, `mXg3`, and `mTm`
- The Python binding `py::init<std::string>()` resolves to this constructor, so any Python-side `TurbineGovernorType1('name')` call produced an object that segfaulted in `initializeStates()` on `**mXg1 = TmRef`
- Fix: initialize with a default value turning logger off