### PR TITLE
Feature: auto-generate .pyi stub files for dpsimpy via pybind11-stubgen (#384)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11>=2.10.3"]
+requires = ["setuptools>=42", "wheel", "pybind11>=2.10.3", "pybind11-stubgen>=2.5"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11>=2.10.3", "pybind11-stubgen>=2.5"]
+requires = ["setuptools>=42", "wheel", "pybind11>=2.10.3", "pybind11-stubgen>=2.5", "numpy>=2.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ class CMakeBuild(build_ext):
                 cwd=self.build_temp,
             )
 
-        self._generate_stubs(extdir, targets)
+        if ext.name == targets[0]:
+            self._generate_stubs(extdir, targets)
 
     def _generate_stubs(self, extdir, targets):
         stub_env = os.environ.copy()
@@ -89,10 +90,9 @@ class CMakeBuild(build_ext):
                     env=stub_env,
                 )
                 if result.returncode != 0:
-                    print(
-                        f"warning: stub generation for {module} failed (exit {result.returncode}), skipping"
+                    raise RuntimeError(
+                        f"stub generation for {module} failed (exit {result.returncode})"
                     )
-                    continue
 
                 src = os.path.join(stub_tmp, module)
                 dst = os.path.join(extdir, module)
@@ -107,6 +107,10 @@ class CMakeBuild(build_ext):
                     stub_file = src + ".pyi"
                     if os.path.isfile(stub_file):
                         shutil.copy2(stub_file, extdir)
+                    else:
+                        raise RuntimeError(
+                            f"stub generation for {module} succeeded but {stub_file} not found"
+                        )
 
 
 ext_modules_list = [CMakeExtension("dpsimpy")]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 import os
 import sys
 import platform
+import shutil
 import subprocess
+import tempfile
 
 import pybind11
 from setuptools import setup, Extension
@@ -65,6 +67,46 @@ class CMakeBuild(build_ext):
                 ["cmake", "--build", ".", "--target", target] + build_args,
                 cwd=self.build_temp,
             )
+
+        self._generate_stubs(extdir, targets)
+
+    def _generate_stubs(self, extdir, targets):
+        stub_env = os.environ.copy()
+        stub_env["PYTHONPATH"] = extdir + os.pathsep + stub_env.get("PYTHONPATH", "")
+
+        with tempfile.TemporaryDirectory() as stub_tmp:
+            for module in targets:
+                print(f"generating stubs for {module}")
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "pybind11_stubgen",
+                        module,
+                        "--output-dir",
+                        stub_tmp,
+                    ],
+                    env=stub_env,
+                )
+                if result.returncode != 0:
+                    print(
+                        f"warning: stub generation for {module} failed (exit {result.returncode}), skipping"
+                    )
+                    continue
+
+                src = os.path.join(stub_tmp, module)
+                dst = os.path.join(extdir, module)
+                if os.path.isdir(src):
+                    if os.path.exists(dst):
+                        shutil.rmtree(dst)
+                    shutil.copytree(src, dst)
+                    # PEP 561 marker so type checkers recognise the package as typed
+                    open(os.path.join(dst, "py.typed"), "w").close()
+                else:
+                    # flat .pyi file (no submodules)
+                    stub_file = src + ".pyi"
+                    if os.path.isfile(stub_file):
+                        shutil.copy2(stub_file, extdir)
 
 
 ext_modules_list = [CMakeExtension("dpsimpy")]


### PR DESCRIPTION
Closes #384.

Adds `pybind11-stubgen` to the build deps and hooks stub generation into `CMakeBuild.build_extension()` so `.pyi` stubs and a `py.typed` marker (PEP 561) are produced and bundled into the wheel automatically after each build.