### PR TITLE
Bugfix for 2 minor issues in DiakopticsSolver:

### DIFF
--- a/dpsim/include/dpsim/DiakopticsSolver.h
+++ b/dpsim/include/dpsim/DiakopticsSolver.h
@@ -168,6 +168,9 @@ public:
         : Task(solver.mName + ".PostSolve"), mSolver(solver) {
       for (auto &net : solver.mSubnets) {
         mAttributeDependencies.push_back(net.leftVector);
+        for (UInt node = 0; node < net.mRealNetNodeNum; ++node) {
+          mModifiedAttributes.push_back(net.nodes[node]->attribute("v"));
+        }
       }
       mModifiedAttributes.push_back(Scheduler::external);
     }

--- a/dpsim/src/DiakopticsSolver.cpp
+++ b/dpsim/src/DiakopticsSolver.cpp
@@ -285,6 +285,11 @@ template <typename VarType> void DiakopticsSolver<VarType>::initComponents() {
   // Initialize signal components.
   for (auto comp : mSimSignalComps)
     comp->initialize(mSystem.mSystemOmega, mTimeStep);
+
+  // Initialize nodes
+  for (UInt net = 0; net < mSubnets.size(); ++net)
+    for (auto node : mSubnets[net].nodes)
+      node->initialize();
 }
 
 template <typename VarType> void DiakopticsSolver<VarType>::initMatrices() {


### PR DESCRIPTION
- fix t=0 logging and one-timestep logger lag
- Call node->initialize() for all subnet nodes at the end of initComponents
- Declare each node's v attribute as a modified attribute of PostSolveTask

Closes #504