### PR TITLE
docs: add CONTRIBUTING.md and a notebook output compliance check

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -1,0 +1,31 @@
+name: Compliance checks
+
+on:
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  no-merge-commits:
+    name: No merge commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fail if branch contains merge commits
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          MERGES=$(git log --merges "$BASE".."$HEAD" --oneline)
+          if [ -n "$MERGES" ]; then
+            echo "Error: merge commits found in this branch:"
+            echo "$MERGES"
+            echo ""
+            echo "Please rebase your branch instead of merging the target branch:"
+            echo ""
+            echo "  git fetch upstream"
+            echo "  git rebase upstream/master"
+            echo "  git push --force-with-lease"
+            exit 1
+          fi

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -1,31 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+# SPDX-License-Identifier: MPL-2.0
+
 name: Compliance checks
 
 on:
   pull_request:
-    branches: [master, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  no-merge-commits:
-    name: No merge commits
+  clean-notebook-outputs:
+    name: Notebooks changed by this pull request have no saved outputs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Fail if branch contains merge commits
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Fail if a notebook changed by this pull request has saved outputs
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          BASE=${{ github.event.pull_request.base.sha }}
-          HEAD=${{ github.event.pull_request.head.sha }}
-          MERGES=$(git log --merges "$BASE".."$HEAD" --oneline)
-          if [ -n "$MERGES" ]; then
-            echo "Error: merge commits found in this branch:"
-            echo "$MERGES"
+          # NUL-separated, because this repository has paths containing spaces.
+          mapfile -d '' NOTEBOOKS < <(git diff -z --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" -- '*.ipynb')
+          if [ "${#NOTEBOOKS[@]}" -eq 0 ]; then
+            exit 0
+          fi
+          pip install nbconvert
+          python -m nbconvert --ClearOutputPreprocessor.enabled=True --inplace "${NOTEBOOKS[@]}"
+          if ! git diff --quiet -- "${NOTEBOOKS[@]}"; then
+            echo "Error: the following notebooks have saved outputs committed:"
+            git diff --name-only -- "${NOTEBOOKS[@]}"
             echo ""
-            echo "Please rebase your branch instead of merging the target branch:"
+            echo "Strip outputs before committing:"
             echo ""
-            echo "  git fetch upstream"
-            echo "  git rebase upstream/master"
-            echo "  git push --force-with-lease"
+            echo "  jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace <notebook.ipynb>"
+            echo ""
+            echo "Or install the pre-commit hooks, see the Quick start section of CONTRIBUTING.md."
             exit 1
           fi

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -22,10 +22,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.x'
-
       - name: Fail if a notebook changed by this pull request has saved outputs
         shell: bash
         env:
@@ -37,16 +33,31 @@ jobs:
           if [ "${#NOTEBOOKS[@]}" -eq 0 ]; then
             exit 0
           fi
-          pip install nbconvert
-          python -m nbconvert --ClearOutputPreprocessor.enabled=True --inplace "${NOTEBOOKS[@]}"
-          if ! git diff --quiet -- "${NOTEBOOKS[@]}"; then
-            echo "Error: the following notebooks have saved outputs committed:"
-            git diff --name-only -- "${NOTEBOOKS[@]}"
-            echo ""
-            echo "Strip outputs before committing:"
-            echo ""
-            echo "  jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace <notebook.ipynb>"
-            echo ""
-            echo "Or install the pre-commit hooks, see the Quick start section of CONTRIBUTING.md."
-            exit 1
-          fi
+          # Assert the rule instead of stripping and diffing, so that key order does not read as an output.
+          python3 - "${NOTEBOOKS[@]}" <<'PY'
+          import json
+          import sys
+
+          offenders = []
+          for path in sys.argv[1:]:
+              with open(path, encoding="utf-8") as notebook:
+                  cells = json.load(notebook).get("cells", [])
+              for cell in cells:
+                  if cell.get("cell_type") != "code":
+                      continue
+                  if cell.get("outputs") or cell.get("execution_count") is not None:
+                      offenders.append(path)
+                      break
+
+          if offenders:
+              print("Error: the following notebooks have saved outputs committed:")
+              for path in offenders:
+                  print(f"  {path}")
+              print("")
+              print("Strip outputs before committing:")
+              print("")
+              print("  jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace <notebook.ipynb>")
+              print("")
+              print("Or install the pre-commit hooks, see the Quick start section of CONTRIBUTING.md.")
+              sys.exit(1)
+          PY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,22 @@ repos:
         args: [-r, "~MD013,~MD033,~MD024,~MD002"]
         files: ^docs/hugo/content/.*\.md$
         types: [markdown]
+
+  - repo: local
+    hooks:
+      - id: no-merge-commits
+        name: no merge commits (use rebase)
+        language: system
+        entry: >-
+          bash -c '[ ! -f .git/MERGE_HEAD ] || {
+          echo "";
+          echo "Error: merge commits are not allowed in DPsim.";
+          echo "Please rebase your branch onto the target branch instead:";
+          echo "";
+          echo "  git rebase origin/main";
+          echo "  git push --force-with-lease";
+          echo "";
+          exit 1; }'
+        stages: [pre-commit]
+        always_run: true
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,19 +59,9 @@ repos:
 
   - repo: local
     hooks:
-      - id: no-merge-commits
-        name: no merge commits (use rebase)
-        language: system
-        entry: >-
-          bash -c '[ ! -f .git/MERGE_HEAD ] || {
-          echo "";
-          echo "Error: merge commits are not allowed in DPsim.";
-          echo "Please rebase your branch onto the target branch instead:";
-          echo "";
-          echo "  git rebase origin/main";
-          echo "  git push --force-with-lease";
-          echo "";
-          exit 1; }'
-        stages: [pre-commit]
-        always_run: true
-        pass_filenames: false
+      - id: clear-notebook-outputs
+        name: clear notebook outputs
+        language: python
+        additional_dependencies: ["nbconvert"]
+        entry: python -m nbconvert --ClearOutputPreprocessor.enabled=True --inplace
+        files: \.ipynb$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,6 @@ repos:
       - id: clear-notebook-outputs
         name: clear notebook outputs
         language: python
-        additional_dependencies: ["nbconvert"]
+        additional_dependencies: ["nbconvert==7.17.1"]
         entry: python -m nbconvert --ClearOutputPreprocessor.enabled=True --inplace
         files: \.ipynb$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+SPDX-License-Identifier: MPL-2.0
+-->
+
 # Contributing to DPsim
 
 Thanks for your interest in contributing! Below are the essentials to get a pull request merged. For full detail see the [Contributing guide](https://dpsim.fein-aachen.org/docs/contributing/).
@@ -5,7 +10,7 @@ Thanks for your interest in contributing! Below are the essentials to get a pull
 ## Quick start
 
 1. Fork the repository and clone your fork.
-1. Run `pre-commit install` to activate automated checks (formatting, linear history guard).
+1. Run `pre-commit install` to activate automated checks (formatting, notebook output stripping).
 1. Create a branch with a descriptive prefix (`feature/`, `fix/`, `docs/`).
 1. Make your changes and commit using the conventional commit style (`feat:`, `fix:`, `docs:`, ...) with a sign-off:
 
@@ -25,11 +30,12 @@ Thanks for your interest in contributing! Below are the essentials to get a pull
 
 ## Key requirements
 
-- **Linear history**: merge commits in a feature branch are blocked by CI; rebase instead.
+- **Linear history**: never merge the target branch into your feature branch; rebase instead.
 - **Sign-off**: every commit must include `Signed-off-by` via `git commit -s` ([DCO](https://developercertificate.org/)).
 - **Formatting**: clang-format 17 for C++, black for Python, markdownlint for Markdown; all enforced by pre-commit.
 - **SPDX headers**: new files must include a license header (see [the contributing guide](https://dpsim.fein-aachen.org/docs/contributing/)).
 - **No `std::cout` in C++**: use `SPDLOG_LOGGER_*` macros.
+- **No saved notebook outputs**: strip outputs from `.ipynb` files before committing; pre-commit and CI both enforce this.
 - **Contributions in forks only**: do not push feature branches to the main repository.
 
 ## License

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to DPsim
+
+Thanks for your interest in contributing! Below are the essentials to get a pull request merged. For full detail see the [Contributing guide](https://dpsim.fein-aachen.org/docs/contributing/).
+
+## Quick start
+
+1. Fork the repository and clone your fork.
+1. Run `pre-commit install` to activate automated checks (formatting, linear history guard).
+1. Create a branch with a descriptive prefix (`feature/`, `fix/`, `docs/`).
+1. Make your changes and commit using the conventional commit style (`feat:`, `fix:`, `docs:`, ...) with a sign-off:
+
+   ```shell
+   git commit -s -m "fix: correct node voltage initialization in DiakopticsSolver"
+   ```
+
+1. Keep your branch up to date by rebasing; do not merge the target branch into your branch:
+
+   ```shell
+   git fetch upstream
+   git rebase upstream/master
+   git push --force-with-lease
+   ```
+
+1. Open a pull request against `sogno-platform/dpsim:master`.
+
+## Key requirements
+
+- **Linear history**: merge commits in a feature branch are blocked by CI; rebase instead.
+- **Sign-off**: every commit must include `Signed-off-by` via `git commit -s` ([DCO](https://developercertificate.org/)).
+- **Formatting**: clang-format 17 for C++, black for Python, markdownlint for Markdown; all enforced by pre-commit.
+- **SPDX headers**: new files must include a license header (see [the contributing guide](https://dpsim.fein-aachen.org/docs/contributing/)).
+- **No `std::cout` in C++**: use `SPDLOG_LOGGER_*` macros.
+- **Contributions in forks only**: do not push feature branches to the main repository.
+
+## License
+
+By contributing you agree your work is released under the [Mozilla Public License 2.0](https://mozilla.org/MPL/2.0/).

--- a/docs/hugo/content/en/docs/Contributing/_index.md
+++ b/docs/hugo/content/en/docs/Contributing/_index.md
@@ -17,6 +17,27 @@ in touch through [GitHub Discussions](https://github.com/sogno-platform/dpsim/di
 These pages cover the process. For how the code is organised and the conventions it follows, see
 the [developer guide]({{< ref "/docs/Developer Guide" >}}).
 
+## Quick start
+
+1. Fork the repository and clone your fork.
+1. Run `pre-commit install` to activate the automated checks (formatting, notebook output stripping).
+1. Create a branch with a descriptive prefix (`feature/`, `fix/`, `docs/`).
+1. Commit with a sign-off, using the conventional commit style:
+
+    ```bash
+    git commit -s -m "fix: correct node voltage initialization in DiakopticsSolver"
+    ```
+
+1. Keep your branch up to date by rebasing; do not merge the target branch into your branch:
+
+    ```bash
+    git fetch upstream
+    git rebase upstream/master
+    git push --force-with-lease
+    ```
+
+1. Open a pull request from your fork against `sogno-platform/dpsim:master`.
+
 ## Pull Requests
 
 There are no strict formal requirements besides the following:
@@ -47,9 +68,31 @@ There are no strict formal requirements besides the following:
     Keep the SPDX tags on adjacent lines with no blank line between them, as the tooling
     reads them as a block.
 
+1. **Linear History (no merge commits)**
+
+    DPsim maintains a linear git history.
+    Never merge the target branch into your feature branch; rebase instead:
+
+    ```bash
+    git rebase upstream/master
+    git push --force-with-lease
+    ```
+
+1. **No Saved Notebook Outputs**
+
+    Jupyter notebooks must be committed without saved cell outputs (images, plots, printed text).
+    Saved outputs bloat diffs and can break the notebook test collector, which re-executes notebooks and re-extracts their outputs.
+    Strip outputs before committing:
+
+    ```bash
+    jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace <notebook.ipynb>
+    ```
+
+    A `pre-commit` hook does this automatically once you have run `pre-commit install`; CI also rejects a pull request that changes a notebook still carrying saved outputs.
+
 ## Creating New Releases (info for maintainers)
 
-DPsim currently uses to [Semantic Versioning](https://semver.org/). The periodic creation of
+DPsim currently uses [Semantic Versioning](https://semver.org/). The periodic creation of
 new versions can help to mark significant changes and to analyze new portions of code using tools like SonarCloud.
 
 A new version of DPsim has to be indicated as follows:

--- a/examples/Notebooks/Components/DP_Ph3_AvVoltSourceInverterStateSpace.ipynb
+++ b/examples/Notebooks/Components/DP_Ph3_AvVoltSourceInverterStateSpace.ipynb
@@ -672,6 +672,7 @@
   {
    "cell_type": "markdown",
    "id": "70ae246d",
+   "metadata": {},
    "source": [
     "## Negative-sequence current control\n",
     "\n",
@@ -682,12 +683,14 @@
     "injected current has to drop while the positive-sequence component is left\n",
     "alone. Both runs share the same fault and power flow and differ only in the\n",
     "flag, so pre-fault they must agree."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "97c94b9c",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "alpha = np.exp(2j * np.pi / 3)\n",
     "\n",
@@ -753,10 +756,7 @@
     "    f\"({positive_drift * 100:.2f}% drift).\"\n",
     ")\n",
     "print(\"Negative-sequence current control checks passed.\")"
-   ],
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Adds CONTRIBUTING.md at the repository root, where GitHub surfaces it when opening a pull request, and brings the Contribution and Development Guidelines pages in line with it.

A compliance workflow fails a pull request that changes a notebook still carrying saved outputs, scoped to the range the pull request touches and also available as a pre-commit hook. Linear history stays documented as a policy, since merge commits are a matter for the repository settings.

This is the base of a stack: #607 adds conventional commits on top, #608 adds release-please.
