### PR TITLE
fix: correct N0.V filter in DP_CIGRE_MV_withDG_withLoadStep notebook

### DIFF
--- a/examples/Notebooks/Grids/DP_CIGRE_MV_withDG_withLoadStep.ipynb
+++ b/examples/Notebooks/Grids/DP_CIGRE_MV_withDG_withLoadStep.ipynb
@@ -437,7 +437,7 @@
     "plt.figure(figsize=(12, 12))\n",
     "subplot_number = 1\n",
     "for ts_name, ts_obj in ts_dpsim.items():\n",
-    "    if ts_name[-2:] == \".V\" and ts_name[:-2] != \"N0.V\":\n",
+    "    if ts_name[-2:] == \".V\" and ts_name != \"N0.V\":\n",
     "        plt.subplot(4, 3, subplot_number)\n",
     "        subplot_number += 1\n",
     "        plt.plot(\n",


### PR DESCRIPTION
## Summary

- Fixes `ValueError: num must be an integer with 1 <= num <= 12, not 13` in CI after #496 merged