### PR TITLE
Refactor: remove duplicate initialize(mFrequencies) calls and migrate SVC to CompositePowerComp (#508)

### DIFF
--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SVC.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <dpsim-models/Base/Base_Ph1_SVC.h>
+#include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/DP/DP_Ph1_Capacitor.h>
 #include <dpsim-models/DP/DP_Ph1_Inductor.h>
 #include <dpsim-models/DP/DP_Ph1_Switch.h>
-#include <dpsim-models/Solver/MNAInterface.h>
 #include <dpsim-models/Solver/MNAVariableCompInterface.h>
 
 namespace CPS {
@@ -26,19 +26,17 @@ namespace Ph1 {
 /// The equivalent DC circuit is a resistance in parallel with a current source.
 /// The resistance is constant for a defined time step and system
 /// frequency and the current source changes for each iteration.
-class SVC : public MNASimPowerComp<Complex>,
+class SVC : public CompositePowerComp<Complex>,
             public Base::Ph1::SVC,
             public MNAVariableCompInterface,
             public SharedFactory<SVC> {
 protected:
-  /// True after createSubComponents() runs; prevents double-construction.
-  /// ### internal components
   /// Internal inductor
   std::shared_ptr<DP::Ph1::Inductor> mSubInductor;
-  std::shared_ptr<DP::Ph1::Switch> mSubInductorProtectionSwitch;
+  std::shared_ptr<DP::Ph1::Switch> mSubInductorSwitch;
   /// Internal capacitor
   std::shared_ptr<DP::Ph1::Capacitor> mSubCapacitor;
-  std::shared_ptr<DP::Ph1::Switch> mSubCapacitorProtectionSwitch;
+  std::shared_ptr<DP::Ph1::Switch> mSubCapacitorSwitch;
 
   Bool mValueChange = false;
   Bool mInductiveMode = false;
@@ -77,38 +75,33 @@ public:
   // #### General ####
   /// Constructs subcomponents; idempotent.
   void createSubComponents() override;
-  /// Initializes states from power flow data
-  void initializeFromNodesAndTerminals(Real frequency) override;
+  /// Initializes states from power flow data (parent-specific part).
+  void initializeParentFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
-  /// Initializes MNA specific variables
-  void mnaCompInitialize(Real omega, Real timeStep,
-                         Attribute<Matrix>::Ptr leftVector) override;
-  //void mnaCompInitializeHarm(Real omega, Real timeStep, std::vector<Attribute<Matrix>::Ptr> leftVectors);
-  /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
-  /// Stamps right side (source) vector
-  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
   /// Update interface voltage from MNA system results
   void mnaCompUpdateVoltage(const Matrix &leftVector) override;
   /// Update interface current from MNA system results
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;
-  /// MNA pre step operations
-  void mnaCompPreStep(Real time, Int timeStepCount) override;
-  /// MNA post step operations
-  void mnaCompPostStep(Real time, Int timeStepCount,
-                       Attribute<Matrix>::Ptr &leftVector) override;
-  /// add MNA pre step dependencies
-  void mnaCompAddPreStepDependencies(
+  /// MNA pre step operations (parent-specific)
+  void mnaParentPreStep(Real time, Int timeStepCount) override;
+  /// MNA post step operations (parent-specific)
+  void mnaParentPostStep(Real time, Int timeStepCount,
+                         Attribute<Matrix>::Ptr &leftVector) override;
+  /// add MNA pre step dependencies (parent-specific)
+  void mnaParentAddPreStepDependencies(
       AttributeBase::List &prevStepDependencies,
       AttributeBase::List &attributeDependencies,
       AttributeBase::List &modifiedAttributes) override;
-  /// add MNA post step dependencies
+  /// add MNA post step dependencies (parent-specific)
   void
-  mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
-                                 AttributeBase::List &attributeDependencies,
-                                 AttributeBase::List &modifiedAttributes,
-                                 Attribute<Matrix>::Ptr &leftVector) override;
+  mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
+                                   AttributeBase::List &attributeDependencies,
+                                   AttributeBase::List &modifiedAttributes,
+                                   Attribute<Matrix>::Ptr &leftVector) override;
+
+  // #### Variable component interface ####
+  Bool hasParameterChanged() override { return mValueChange; }
 
   // #### Tearing methods ####
   Bool ValueChanged();

--- a/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
@@ -41,7 +41,6 @@ void DP::Ph1::PiLine::createSubComponents() {
       std::make_shared<DP::Ph1::Resistor>(**mName + "_res", mLogLevel);
   mSubSeriesResistor->setParameters(**mSeriesRes);
   mSubSeriesResistor->connect({mTerminals[0]->node(), mVirtualNodes[0]});
-  mSubSeriesResistor->initialize(mFrequencies);
   addMNASubComponent(mSubSeriesResistor,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -50,7 +49,6 @@ void DP::Ph1::PiLine::createSubComponents() {
       std::make_shared<DP::Ph1::Inductor>(**mName + "_ind", mLogLevel);
   mSubSeriesInductor->setParameters(**mSeriesInd);
   mSubSeriesInductor->connect({mVirtualNodes[0], mTerminals[1]->node()});
-  mSubSeriesInductor->initialize(mFrequencies);
   addMNASubComponent(mSubSeriesInductor,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -60,7 +58,6 @@ void DP::Ph1::PiLine::createSubComponents() {
   mSubParallelResistor0->setParameters(2. / **mParallelCond);
   mSubParallelResistor0->connect(
       SimNode::List{SimNode::GND, mTerminals[0]->node()});
-  mSubParallelResistor0->initialize(mFrequencies);
   addMNASubComponent(mSubParallelResistor0,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -70,7 +67,6 @@ void DP::Ph1::PiLine::createSubComponents() {
   mSubParallelResistor1->setParameters(2. / **mParallelCond);
   mSubParallelResistor1->connect(
       SimNode::List{SimNode::GND, mTerminals[1]->node()});
-  mSubParallelResistor1->initialize(mFrequencies);
   addMNASubComponent(mSubParallelResistor1,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -81,7 +77,6 @@ void DP::Ph1::PiLine::createSubComponents() {
     mSubParallelCapacitor0->setParameters(**mParallelCap / 2.);
     mSubParallelCapacitor0->connect(
         SimNode::List{SimNode::GND, mTerminals[0]->node()});
-    mSubParallelCapacitor0->initialize(mFrequencies);
     addMNASubComponent(mSubParallelCapacitor0,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -91,7 +86,6 @@ void DP::Ph1::PiLine::createSubComponents() {
     mSubParallelCapacitor1->setParameters(**mParallelCap / 2.);
     mSubParallelCapacitor1->connect(
         SimNode::List{SimNode::GND, mTerminals[1]->node()});
-    mSubParallelCapacitor1->initialize(mFrequencies);
     addMNASubComponent(mSubParallelCapacitor1,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);

--- a/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoadSwitch.cpp
@@ -47,11 +47,9 @@ void DP::Ph1::RXLoadSwitch::initializeParentFromNodesAndTerminals(
   }
 
   mSubRXLoad->connect({virtualNode(0)});
-  mSubRXLoad->initialize(mFrequencies);
   mSubRXLoad->initializeFromNodesAndTerminals(frequency);
 
   mSubSwitch->connect({node(0)});
-  mSubSwitch->initialize(mFrequencies);
   mSubSwitch->initializeFromNodesAndTerminals(frequency);
 
   **mIntfVoltage = **mSubRXLoad->mIntfVoltage;

--- a/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
@@ -37,7 +37,6 @@ void DP::Ph1::RxLine::createSubComponents() {
       std::make_shared<DP::Ph1::Resistor>(**mName + "_res", mLogLevel);
   mSubResistor->setParameters(**mSeriesRes);
   mSubResistor->connect({mTerminals[0]->node(), mVirtualNodes[0]});
-  mSubResistor->initialize(mFrequencies);
   addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
@@ -45,7 +44,6 @@ void DP::Ph1::RxLine::createSubComponents() {
       std::make_shared<DP::Ph1::Inductor>(**mName + "_ind", mLogLevel);
   mSubInductor->setParameters(**mSeriesInd);
   mSubInductor->connect({mVirtualNodes[0], mTerminals[1]->node()});
-  mSubInductor->initialize(mFrequencies);
   addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
@@ -53,7 +51,6 @@ void DP::Ph1::RxLine::createSubComponents() {
       std::make_shared<DP::Ph1::Resistor>(**mName + "_snubber_res", mLogLevel);
   mInitialResistor->setParameters(1e6);
   mInitialResistor->connect({SimNode::GND, mTerminals[1]->node()});
-  mInitialResistor->initialize(mFrequencies);
   addMNASubComponent(mInitialResistor,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);

--- a/dpsim-models/src/DP/DP_Ph1_SVC.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SVC.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::SVC::SVC(String uid, String name, Logger::Level logLevel)
-    : MNASimPowerComp<Complex>(uid, name, true, true, logLevel),
+    : CompositePowerComp<Complex>(uid, name, true, true, logLevel),
       mVpcc(mAttributes->create<Real>("Vpcc", 0)),
       mVmeasPrev(mAttributes->create<Real>("Vmeas", 0)) {
   setTerminalNumber(1);
@@ -31,39 +31,42 @@ void DP::Ph1::SVC::createSubComponents() {
     return;
   mSubCompCreated = true;
 
-  // Inductor/capacitor values depend on omega, which is computed from the
-  // simulation frequency in initializeFromNodesAndTerminals() rather than
-  // mFrequencies here, since the latter is not guaranteed to be populated
-  // yet during this pre-pass. They are created here (existence doesn't
-  // depend on that value) but parametrized there, before their own
-  // initializeFromNodesAndTerminals() runs.
+  // Inductor/capacitor values depend on omega computed from the simulation
+  // frequency in initializeParentFromNodesAndTerminals(). They are created
+  // here (topology) and parametrized there (values).
 
   // Inductor with Switch
   mSubInductor =
       std::make_shared<DP::Ph1::Inductor>(**mName + "_ind", mLogLevel);
   mSubInductor->connect({SimNode::GND, mVirtualNodes[0]});
-  mSubInductor->initialize(mFrequencies);
+  addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
+                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
   mSubInductorSwitch =
       std::make_shared<DP::Ph1::Switch>(**mName + "_Lswitch", mLogLevel);
   mSubInductorSwitch->setParameters(mSwitchROpen, mSwitchRClosed, false);
   mSubInductorSwitch->connect({mVirtualNodes[0], mTerminals[0]->node()});
-  mSubInductorSwitch->initialize(mFrequencies);
+  addMNASubComponent(mSubInductorSwitch,
+                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
+                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
   // Capacitor with Switch
   mSubCapacitor =
       std::make_shared<DP::Ph1::Capacitor>(**mName + "_cap", mLogLevel);
   mSubCapacitor->connect({SimNode::GND, mVirtualNodes[1]});
-  mSubCapacitor->initialize(mFrequencies);
+  addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
+                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
   mSubCapacitorSwitch =
       std::make_shared<DP::Ph1::Switch>(**mName + "_Cswitch", mLogLevel);
   mSubCapacitorSwitch->setParameters(mSwitchROpen, mSwitchRClosed, false);
   mSubCapacitorSwitch->connect({mVirtualNodes[1], mTerminals[0]->node()});
-  mSubCapacitorSwitch->initialize(mFrequencies);
+  addMNASubComponent(mSubCapacitorSwitch,
+                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
+                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 }
 
-void DP::Ph1::SVC::initializeFromNodesAndTerminals(Real frequency) {
+void DP::Ph1::SVC::initializeParentFromNodesAndTerminals(Real frequency) {
   // initial state is both switches are open
   Real omega = 2. * PI * frequency;
   // init L and C with small/high values (both have high impedance)
@@ -105,14 +108,8 @@ void DP::Ph1::SVC::initializeFromNodesAndTerminals(Real frequency) {
       (**mIntfVoltage)(0, 0) - CImpedance * (**mIntfCurrent)(0, 0);
   mVirtualNodes[1]->setInitialVoltage(VCSwitch);
 
-  createSubComponents();
   mSubInductor->setParameters(LInit);
   mSubCapacitor->setParameters(CInit);
-
-  mSubInductor->initializeFromNodesAndTerminals(frequency);
-  mSubInductorSwitch->initializeFromNodesAndTerminals(frequency);
-  mSubCapacitor->initializeFromNodesAndTerminals(frequency);
-  mSubCapacitorSwitch->initializeFromNodesAndTerminals(frequency);
 
   SPDLOG_LOGGER_INFO(mSLog,
                      "\n--- Initialization from powerflow ---"
@@ -128,70 +125,14 @@ void DP::Ph1::SVC::initializeFromNodesAndTerminals(Real frequency) {
 
 // #### MNA functions ####
 
-void DP::Ph1::SVC::mnaCompInitialize(Real omega, Real timeStep,
-                                     Attribute<Matrix>::Ptr leftVector) {
-  updateMatrixNodeIndices();
-
-  SPDLOG_LOGGER_INFO(mSLog, "\nTerminal 0 connected to {:s} = sim node {:d}",
-                     mTerminals[0]->node()->name(),
-                     mTerminals[0]->node()->matrixNodeIndex());
-
-  mSubInductor->mnaInitialize(omega, timeStep, leftVector);
-  mRightVectorStamps.push_back(
-      &mSubInductor->attributeTyped<Matrix>("right_vector")->get());
-
-  mSubInductorSwitch->mnaInitialize(omega, timeStep, leftVector);
-  mRighteVctorStamps.push_back(
-      &mSubInductorSwitch->attributeTyped<Matrix>("right_vector")->get());
-
-  mSubCapacitor->mnaInitialize(omega, timeStep, leftVector);
-  mRightVectorStamps.push_back(
-      &mSubCapacitor->attributeTyped<Matrix>("right_vector")->get());
-
-  mSubCapacitorSwitch->mnaInitialize(omega, timeStep, leftVector);
-  mRightVectorStamps.push_back(
-      &mSubCapacitorSwitch->attributeTyped<Matrix>("right_vector")->get());
-}
-
-void DP::Ph1::SVC::mnaCompApplySystemMatrixStamp(
-    SparseMatrixRow &systemMatrix) {
-  mSubInductor->mnaApplySystemMatrixStamp(systemMatrix);
-  mSubCapacitor->mnaApplySystemMatrixStamp(systemMatrix);
-  mSubCapacitorSwitch->mnaApplySystemMatrixStamp(systemMatrix);
-  mSubInductorSwitch->mnaApplySystemMatrixStamp(systemMatrix);
-}
-
-void DP::Ph1::SVC::mnaCompApplyRightSideVectorStamp(Matrix &rightVector) {
-  mSubInductor->mnaApplyRightSideVectorStamp(rightVector);
-  mSubCapacitor->mnaApplyRightSideVectorStamp(rightVector);
-  mSubCapacitorSwitch->mnaApplyRightSideVectorStamp(rightVector);
-  mSubInductorSwitch->mnaApplyRightSideVectorStamp(rightVector);
-}
-
-void DP::Ph1::SVC::mnaCompAddPreStepDependencies(
+void DP::Ph1::SVC::mnaParentAddPreStepDependencies(
     AttributeBase::List &prevStepDependencies,
     AttributeBase::List &attributeDependencies,
     AttributeBase::List &modifiedAttributes) {
-  // add pre-step dependencies of subcomponents
-  mSubInductor->mnaAddPreStepDependencies(
-      prevStepDependencies, attributeDependencies, modifiedAttributes);
-  mSubInductorSwitch->mnaAddPreStepDependencies(
-      prevStepDependencies, attributeDependencies, modifiedAttributes);
-  mSubCapacitor->mnaAddPreStepDependencies(
-      prevStepDependencies, attributeDependencies, modifiedAttributes);
-  mSubCapacitorSwitch->mnaAddPreStepDependencies(
-      prevStepDependencies, attributeDependencies, modifiedAttributes);
-
-  // add pre-step dependencies of component itself
   modifiedAttributes.push_back(mRightVector);
 }
 
-void DP::Ph1::SVC::mnaCompPreStep(Real time, Int timeStepCount) {
-  mSubInductor->mnaPreStep(time, timeStepCount);
-  mSubInductorSwitch->mnaPreStep(time, timeStepCount);
-  mSubCapacitor->mnaPreStep(time, timeStepCount);
-  mSubCapacitorSwitch->mnaPreStep(time, timeStepCount);
-
+void DP::Ph1::SVC::mnaParentPreStep(Real time, Int timeStepCount) {
   mnaCompApplyRightSideVectorStamp(**mRightVector);
 
   if (time > 0.1 && !mDisconnect) {
@@ -204,39 +145,20 @@ void DP::Ph1::SVC::mnaCompPreStep(Real time, Int timeStepCount) {
   }
 }
 
-void DP::Ph1::SVC::mnaCompAddPostStepDependencies(
+void DP::Ph1::SVC::mnaParentAddPostStepDependencies(
     AttributeBase::List &prevStepDependencies,
     AttributeBase::List &attributeDependencies,
     AttributeBase::List &modifiedAttributes,
     Attribute<Matrix>::Ptr &leftVector) {
-  // add post-step dependencies of subcomponents
-  mSubInductor->mnaAddPostStepDependencies(prevStepDependencies,
-                                           attributeDependencies,
-                                           modifiedAttributes, leftVector);
-  mSubInductorSwitch->mnaAddPostStepDependencies(
-      prevStepDependencies, attributeDependencies, modifiedAttributes,
-      leftVector);
-  mSubCapacitor->mnaAddPostStepDependencies(prevStepDependencies,
-                                            attributeDependencies,
-                                            modifiedAttributes, leftVector);
-  mSubCapacitorSwitch->mnaAddPostStepDependencies(
-      prevStepDependencies, attributeDependencies, modifiedAttributes,
-      leftVector);
-
-  // add post-step dependencies of component itself
   attributeDependencies.push_back(leftVector);
   modifiedAttributes.push_back(mIntfVoltage);
   modifiedAttributes.push_back(mIntfCurrent);
 }
 
-void DP::Ph1::SVC::mnaCompPostStep(Real time, Int timeStepCount) {
-  mSubInductor->mnaPostStep(time, timeStepCount, leftVector);
-  mSubInductorSwitch->mnaPostStep(time, timeStepCount, leftVector);
-  mSubCapacitor->mnaPostStep(time, timeStepCount, leftVector);
-  mSubCapacitorSwitch->mnaPostStep(time, timeStepCount, leftVector);
-
-  mnaCompUpdateVoltage(**mLeftVector);
-  mnaCompUpdateCurrent(**mLeftVector);
+void DP::Ph1::SVC::mnaParentPostStep(Real time, Int timeStepCount,
+                                     Attribute<Matrix>::Ptr &leftVector) {
+  mnaCompUpdateVoltage(**leftVector);
+  mnaCompUpdateCurrent(**leftVector);
 
   mDeltaT = time - mPrevTimeStep;
   mPrevTimeStep = time;
@@ -302,7 +224,6 @@ void DP::Ph1::SVC::updateSusceptance() {
   Real Fac1 = mDeltaT / (2 * mTr);
   Real Fac2 = mDeltaT * mKr / (2 * mTr);
 
-  Complex vintf = (**mIntfVoltage)(0, 0);
   Real V = Math::abs((**mIntfVoltage)(0, 0).real());
 
   // Pt1 with trapez rule for voltage measurement
@@ -313,25 +234,18 @@ void DP::Ph1::SVC::updateSusceptance() {
   Real deltaVPrev = (**mVmeasPrev - mRefVolt) / mNomVolt;
 
   // calc new B with trapezoidal rule
-  //Real B = (1/(1+Fac1)) * (Fac2 * (mDeltaV + deltaVPrev) + (1-Fac1) * mBPrev);
   Real B = (1 / (1 + Fac1)) *
            (Fac2 * (**mDeltaV + deltaVPrev) + (1 - Fac1) * **mBPrev);
-  //SPDLOG_LOGGER_INFO(mSLog, "New B value: percent={}, absolute={}", 100 * B, B * mBN);
 
   // check bounds
   if (B > mBMax) {
     B = mBMax;
-    //SPDLOG_LOGGER_DEBUG(mSLog, "New B value exceeds Bmax");
   } else if (B < mBMin) {
     B = mBMin;
-    //SPDLOG_LOGGER_DEBUG(mSLog, "New B value exceeds Bmin");
   }
 
   // set new B if it has a new value and difference is big enough
   if (B != **mBPrev) {
-    //if (B != mBPrev && mBSetCounter > 0.001){
-    //mValueChange = true;
-    //mBSetCounter = 0;
     Real omega = 2 * M_PI * mFrequencies(0, 0);
 
     if (B > 0) {
@@ -341,7 +255,6 @@ void DP::Ph1::SVC::updateSusceptance() {
       if (Math::abs(1 - inductance / mLPrev) > 0.01) {
         mInductiveMode = true;
         mSubInductor->updateInductance(inductance, mDeltaT);
-        //SPDLOG_LOGGER_DEBUG(mSLog, "Inductive Mode: New Inductance: L = {} [H]", inductance);
         mLPrev = inductance;
 
         mValueChange = true;
@@ -354,7 +267,6 @@ void DP::Ph1::SVC::updateSusceptance() {
       if (Math::abs(1 - capacitance / mCPrev) > 0.01) {
         mInductiveMode = false;
         mSubCapacitor->updateCapacitance(capacitance, mDeltaT);
-        //SPDLOG_LOGGER_DEBUG(mSLog, "Capacitive Mode: New Capacitance: C = {} [F]", capacitance);
         mCPrev = capacitance;
 
         mValueChange = true;

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorIdeal.cpp
@@ -39,7 +39,6 @@ void DP::Ph1::SynchronGeneratorIdeal::createSubComponents() {
   // Alias the sub-source's virtual node to parent VN0 so the transformer row
   // in the system matrix uses the same index.
   mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[0], 0);
-  mSubVoltageSource->initialize(mFrequencies);
   addMNASubComponent(mSubVoltageSource,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp
@@ -168,7 +168,6 @@ void DP::Ph1::SynchronGeneratorTrStab::createSubComponents() {
   // Alias the sub-source's virtual node to parent VN1 so the KCL row in the
   // system matrix uses the same node index as the parent's VN1.
   mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[1], 0);
-  mSubVoltageSource->initialize(mFrequencies);
   addMNASubComponent(mSubVoltageSource,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -177,7 +176,6 @@ void DP::Ph1::SynchronGeneratorTrStab::createSubComponents() {
   mSubInductor = DP::Ph1::Inductor::make(**mName + "_ind", mLogLevel);
   mSubInductor->setParameters(mLpd);
   mSubInductor->connect({mVirtualNodes[0], terminal(0)->node()});
-  mSubInductor->initialize(mFrequencies);
   addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 }

--- a/dpsim-models/src/DP/DP_Ph3_PiLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_PiLine.cpp
@@ -44,7 +44,6 @@ void DP::Ph3::PiLine::createSubComponents() {
       std::make_shared<DP::Ph3::Resistor>(**mName + "_res", mLogLevel);
   mSubSeriesResistor->setParameters(**mSeriesRes);
   mSubSeriesResistor->connect({mTerminals[0]->node(), mVirtualNodes[0]});
-  mSubSeriesResistor->initialize(mFrequencies);
   addMNASubComponent(mSubSeriesResistor,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -53,7 +52,6 @@ void DP::Ph3::PiLine::createSubComponents() {
       std::make_shared<DP::Ph3::Inductor>(**mName + "_ind", mLogLevel);
   mSubSeriesInductor->setParameters(**mSeriesInd);
   mSubSeriesInductor->connect({mVirtualNodes[0], mTerminals[1]->node()});
-  mSubSeriesInductor->initialize(mFrequencies);
   addMNASubComponent(mSubSeriesInductor,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -64,7 +62,6 @@ void DP::Ph3::PiLine::createSubComponents() {
   mSubParallelResistor0->setParameters(2. * (**mParallelCond).inverse());
   mSubParallelResistor0->connect(
       SimNode::List{SimNode::GND, mTerminals[0]->node()});
-  mSubParallelResistor0->initialize(mFrequencies);
   addMNASubComponent(mSubParallelResistor0,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -74,7 +71,6 @@ void DP::Ph3::PiLine::createSubComponents() {
   mSubParallelResistor1->setParameters(2. * (**mParallelCond).inverse());
   mSubParallelResistor1->connect(
       SimNode::List{SimNode::GND, mTerminals[1]->node()});
-  mSubParallelResistor1->initialize(mFrequencies);
   addMNASubComponent(mSubParallelResistor1,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -85,7 +81,6 @@ void DP::Ph3::PiLine::createSubComponents() {
     mSubParallelCapacitor0->setParameters(**mParallelCap / 2.);
     mSubParallelCapacitor0->connect(
         SimNode::List{SimNode::GND, mTerminals[0]->node()});
-    mSubParallelCapacitor0->initialize(mFrequencies);
     addMNASubComponent(mSubParallelCapacitor0,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -95,7 +90,6 @@ void DP::Ph3::PiLine::createSubComponents() {
     mSubParallelCapacitor1->setParameters(**mParallelCap / 2.);
     mSubParallelCapacitor1->connect(
         SimNode::List{SimNode::GND, mTerminals[1]->node()});
-    mSubParallelCapacitor1->initialize(mFrequencies);
     addMNASubComponent(mSubParallelCapacitor1,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);

--- a/dpsim-models/src/EMT/EMT_Ph1_PiLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_PiLine.cpp
@@ -44,7 +44,6 @@ void EMT::Ph1::PiLine::createSubComponents() {
       std::make_shared<EMT::Ph1::Resistor>(**mName + "_res", mLogLevel);
   mSubSeriesResistor->setParameters(**mSeriesRes);
   mSubSeriesResistor->connect({mTerminals[0]->node(), mVirtualNodes[0]});
-  mSubSeriesResistor->initialize(mFrequencies);
   addMNASubComponent(mSubSeriesResistor,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -53,7 +52,6 @@ void EMT::Ph1::PiLine::createSubComponents() {
       std::make_shared<EMT::Ph1::Inductor>(**mName + "_ind", mLogLevel);
   mSubSeriesInductor->setParameters(**mSeriesInd);
   mSubSeriesInductor->connect({mVirtualNodes[0], mTerminals[1]->node()});
-  mSubSeriesInductor->initialize(mFrequencies);
   addMNASubComponent(mSubSeriesInductor,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -64,7 +62,6 @@ void EMT::Ph1::PiLine::createSubComponents() {
   mSubParallelResistor0->setParameters(2. / (**mParallelCond));
   mSubParallelResistor0->connect(
       SimNode::List{SimNode::GND, mTerminals[0]->node()});
-  mSubParallelResistor0->initialize(mFrequencies);
   addMNASubComponent(mSubParallelResistor0,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -74,7 +71,6 @@ void EMT::Ph1::PiLine::createSubComponents() {
   mSubParallelResistor1->setParameters(2. / (**mParallelCond));
   mSubParallelResistor1->connect(
       SimNode::List{SimNode::GND, mTerminals[1]->node()});
-  mSubParallelResistor1->initialize(mFrequencies);
   addMNASubComponent(mSubParallelResistor1,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -85,7 +81,6 @@ void EMT::Ph1::PiLine::createSubComponents() {
     mSubParallelCapacitor0->setParameters(**mParallelCap / 2.);
     mSubParallelCapacitor0->connect(
         SimNode::List{SimNode::GND, mTerminals[0]->node()});
-    mSubParallelCapacitor0->initialize(mFrequencies);
     addMNASubComponent(mSubParallelCapacitor0,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -95,7 +90,6 @@ void EMT::Ph1::PiLine::createSubComponents() {
     mSubParallelCapacitor1->setParameters(**mParallelCap / 2.);
     mSubParallelCapacitor1->connect(
         SimNode::List{SimNode::GND, mTerminals[1]->node()});
-    mSubParallelCapacitor1->initialize(mFrequencies);
     addMNASubComponent(mSubParallelCapacitor1,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);

--- a/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
@@ -49,7 +49,6 @@ void EMT::Ph3::PiLine::createSubComponents() {
       std::make_shared<EMT::Ph3::Resistor>(**mName + "_res", mLogLevel);
   mSubSeriesResistor->setParameters(**mSeriesRes);
   mSubSeriesResistor->connect({mTerminals[0]->node(), mVirtualNodes[0]});
-  mSubSeriesResistor->initialize(mFrequencies);
   addMNASubComponent(mSubSeriesResistor,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -58,7 +57,6 @@ void EMT::Ph3::PiLine::createSubComponents() {
       std::make_shared<EMT::Ph3::Inductor>(**mName + "_ind", mLogLevel);
   mSubSeriesInductor->setParameters(**mSeriesInd);
   mSubSeriesInductor->connect({mVirtualNodes[0], mTerminals[1]->node()});
-  mSubSeriesInductor->initialize(mFrequencies);
   addMNASubComponent(mSubSeriesInductor,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -69,7 +67,6 @@ void EMT::Ph3::PiLine::createSubComponents() {
   mSubParallelResistor0->setParameters(2. * (**mParallelCond).inverse());
   mSubParallelResistor0->connect(
       SimNode::List{SimNode::GND, mTerminals[0]->node()});
-  mSubParallelResistor0->initialize(mFrequencies);
   addMNASubComponent(mSubParallelResistor0,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -79,7 +76,6 @@ void EMT::Ph3::PiLine::createSubComponents() {
   mSubParallelResistor1->setParameters(2. * (**mParallelCond).inverse());
   mSubParallelResistor1->connect(
       SimNode::List{SimNode::GND, mTerminals[1]->node()});
-  mSubParallelResistor1->initialize(mFrequencies);
   addMNASubComponent(mSubParallelResistor1,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -90,7 +86,6 @@ void EMT::Ph3::PiLine::createSubComponents() {
     mSubParallelCapacitor0->setParameters(**mParallelCap / 2.);
     mSubParallelCapacitor0->connect(
         SimNode::List{SimNode::GND, mTerminals[0]->node()});
-    mSubParallelCapacitor0->initialize(mFrequencies);
     addMNASubComponent(mSubParallelCapacitor0,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -100,7 +95,6 @@ void EMT::Ph3::PiLine::createSubComponents() {
     mSubParallelCapacitor1->setParameters(**mParallelCap / 2.);
     mSubParallelCapacitor1->connect(
         SimNode::List{SimNode::GND, mTerminals[1]->node()});
-    mSubParallelCapacitor1->initialize(mFrequencies);
     addMNASubComponent(mSubParallelCapacitor1,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);

--- a/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
@@ -209,12 +209,7 @@ void EMT::Ph3::RXLoad::initializeParentFromNodesAndTerminals(Real frequency) {
                                         mResistance * **mIntfCurrent);
   }
 
-  // Sub-components were just created above; initialize them now so their
-  // post-init current can be read back before this hook returns (the
-  // framework's generic sub-init loop would otherwise run too late for
-  // that).
   if ((**mActivePower)(0, 0) != 0) {
-    mSubResistor->initialize(mFrequencies);
     mSubResistor->initializeFromNodesAndTerminals(frequency);
     if (!mReactanceInSeries) {
       **mIntfCurrent += mSubResistor->intfCurrent();
@@ -222,13 +217,11 @@ void EMT::Ph3::RXLoad::initializeParentFromNodesAndTerminals(Real frequency) {
   }
 
   if (mReactance(0, 0) > 0) {
-    mSubInductor->initialize(mFrequencies);
     mSubInductor->initializeFromNodesAndTerminals(frequency);
     if (!mReactanceInSeries) {
       **mIntfCurrent += mSubInductor->intfCurrent();
     }
   } else if (mReactance(0, 0) < 0) {
-    mSubCapacitor->initialize(mFrequencies);
     mSubCapacitor->initializeFromNodesAndTerminals(frequency);
     if (!mReactanceInSeries) {
       **mIntfCurrent += mSubCapacitor->intfCurrent();

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorIdeal.cpp
@@ -63,8 +63,6 @@ void EMT::Ph3::SynchronGeneratorIdeal::createSubComponents() {
   if (mSourceType == CPS::GeneratorType::IdealCurrentSource)
     mSubComponents[0]->setTerminalAt(terminal(0), 1);
 
-  mSubComponents[0]->initialize(mFrequencies);
-
   if (mSourceType == CPS::GeneratorType::IdealVoltageSource)
     mRefVoltage->setReference(
         mSubComponents[0]->attributeTyped<MatrixComp>("V_ref"));

--- a/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SynchronGeneratorTrStab.cpp
@@ -146,7 +146,6 @@ void EMT::Ph3::SynchronGeneratorTrStab::createSubComponents() {
       EMT::Ph3::VoltageSource::make(**mName + "_src", mLogLevel);
   mSubVoltageSource->connect({SimNode::GND, mVirtualNodes[0]});
   mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[1], 0);
-  mSubVoltageSource->initialize(mFrequencies);
   addMNASubComponent(mSubVoltageSource,
                      MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
@@ -155,7 +154,6 @@ void EMT::Ph3::SynchronGeneratorTrStab::createSubComponents() {
   mSubInductor->setParameters(
       CPS::Math::singlePhaseParameterToThreePhase(mLpd));
   mSubInductor->connect({mVirtualNodes[0], terminal(0)->node()});
-  mSubInductor->initialize(mFrequencies);
   addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 }

--- a/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
@@ -184,7 +184,6 @@ void SP::Ph1::PiLine::createSubComponents() {
       std::make_shared<SP::Ph1::Resistor>(**mName + "_res", mLogLevel);
   mSubSeriesResistor->setParameters(**mSeriesRes);
   mSubSeriesResistor->connect({mTerminals[0]->node(), mVirtualNodes[0]});
-  mSubSeriesResistor->initialize(mFrequencies);
   addMNASubComponent(mSubSeriesResistor, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
@@ -192,7 +191,6 @@ void SP::Ph1::PiLine::createSubComponents() {
       std::make_shared<SP::Ph1::Inductor>(**mName + "_ind", mLogLevel);
   mSubSeriesInductor->setParameters(**mSeriesInd);
   mSubSeriesInductor->connect({mVirtualNodes[0], mTerminals[1]->node()});
-  mSubSeriesInductor->initialize(mFrequencies);
   addMNASubComponent(mSubSeriesInductor, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
@@ -203,7 +201,6 @@ void SP::Ph1::PiLine::createSubComponents() {
     mSubParallelResistor0->setParameters(2. / **mParallelCond);
     mSubParallelResistor0->connect(
         SimNode::List{SimNode::GND, mTerminals[0]->node()});
-    mSubParallelResistor0->initialize(mFrequencies);
     addMNASubComponent(mSubParallelResistor0, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
@@ -212,7 +209,6 @@ void SP::Ph1::PiLine::createSubComponents() {
     mSubParallelResistor1->setParameters(2. / **mParallelCond);
     mSubParallelResistor1->connect(
         SimNode::List{SimNode::GND, mTerminals[1]->node()});
-    mSubParallelResistor1->initialize(mFrequencies);
     addMNASubComponent(mSubParallelResistor1, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
   }
@@ -223,7 +219,6 @@ void SP::Ph1::PiLine::createSubComponents() {
     mSubParallelCapacitor0->setParameters(**mParallelCap / 2.);
     mSubParallelCapacitor0->connect(
         SimNode::List{SimNode::GND, mTerminals[0]->node()});
-    mSubParallelCapacitor0->initialize(mFrequencies);
     addMNASubComponent(mSubParallelCapacitor0, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
 
@@ -232,7 +227,6 @@ void SP::Ph1::PiLine::createSubComponents() {
     mSubParallelCapacitor1->setParameters(**mParallelCap / 2.);
     mSubParallelCapacitor1->connect(
         SimNode::List{SimNode::GND, mTerminals[1]->node()});
-    mSubParallelCapacitor1->initialize(mFrequencies);
     addMNASubComponent(mSubParallelCapacitor1, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
   }

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGeneratorTrStab.cpp
@@ -169,7 +169,6 @@ void SP::Ph1::SynchronGeneratorTrStab::createSubComponents() {
   mSubVoltageSource = SP::Ph1::VoltageSource::make(**mName + "_src", mLogLevel);
   mSubVoltageSource->connect({SimNode::GND, mVirtualNodes[0]});
   mSubVoltageSource->setVirtualNodeAt(mVirtualNodes[1], 0);
-  mSubVoltageSource->initialize(mFrequencies);
   addMNASubComponent(mSubVoltageSource,
                      MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -177,7 +176,6 @@ void SP::Ph1::SynchronGeneratorTrStab::createSubComponents() {
   mSubInductor = SP::Ph1::Inductor::make(**mName + "_ind", mLogLevel);
   mSubInductor->setParameters(mLpd);
   mSubInductor->connect({mVirtualNodes[0], terminal(0)->node()});
-  mSubInductor->initialize(mFrequencies);
   addMNASubComponent(mSubInductor, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 }


### PR DESCRIPTION
## Summary

- Remove duplicate `->initialize(mFrequencies)` calls from `createSubComponents()` and `initializeParentFromNodesAndTerminals()` in 13 composite component files; `CompositePowerComp::initializeFromNodesAndTerminals()` already calls this for every registered sub-component, making the earlier calls redundant
- Migrate `DP_Ph1_SVC` from the old `MNASimPowerComp` pattern to `CompositePowerComp`, matching the pattern introduced by #496; adds the missing `hasParameterChanged()` override required by `MNAVariableCompInterface` and fixes pre-existing signature mismatches

Closes #508.