### PR TITLE
Diakoptics development: KLU-based subnet solving with localized syste…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(COVERAGE "Enable code coverage reporting" OFF)
 
 if(COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	message(STATUS "Enabling code coverage")
-	add_compile_options(--coverage -O0 -g)
+	add_compile_options(--coverage -O0 -g -fprofile-update=atomic)
 	add_link_options(--coverage)
 endif()
 

--- a/dpsim/examples/cxx/CIM/EMT_IEEE_39bus_CIM.cpp
+++ b/dpsim/examples/cxx/CIM/EMT_IEEE_39bus_CIM.cpp
@@ -1,0 +1,374 @@
+/* Author: Christoph Wirtz <christoph.wirtz@fgh-ma.de>
+ * SPDX-FileCopyrightText: 2026 FGH e.V.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <iostream>
+#include <list>
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::DP;
+
+void EMT_IEEE_39Bus_3ph(Real timeStep, Real finalTime) {
+
+  // Simulation parameters
+  String simName = "IEEE-39bus";
+
+  // Find CIM files
+  std::list<fs::path> filenames;
+  filenames = Utils::findFiles({"Rootnet_FULL_NE_29J10h_SV.xml",
+                                "Rootnet_FULL_NE_29J10h_EQ.xml",
+                                "Rootnet_FULL_NE_29J10h_TP.xml"},
+                               "build/_deps/cim-data-src/IEEE-39", "CIMPATH");
+
+  // ----- DYNAMIC SIMULATION -----
+  Logger::setLogDir("logs/" + simName);
+
+  CPS::CIM::Reader reader2(simName, Logger::Level::debug, Logger::Level::off);
+  SystemTopology sys =
+      reader2.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
+                      CPS::GeneratorType::IdealVoltageSource);
+
+  // Replace lines with resistors for comparability:
+  auto r16_17 = CPS::EMT::Ph3::Resistor::make("resistor-16-17");
+  r16_17->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp16_17 = sys.component<CPS::EMT::Ph3::PiLine>("L-16-17");
+  r16_17->connect({comp16_17->node(0), comp16_17->node(1)});
+
+  auto r15_16 = CPS::EMT::Ph3::Resistor::make("resistor-15-16");
+  r15_16->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp15_16 = sys.component<CPS::EMT::Ph3::PiLine>("L-15-16");
+  r15_16->connect({comp15_16->node(0), comp15_16->node(1)});
+
+  auto r01_39 = CPS::EMT::Ph3::Resistor::make("resistor-01-39");
+  r01_39->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp01_39 = sys.component<CPS::EMT::Ph3::PiLine>("L-01-39");
+  r01_39->connect({comp01_39->node(0), comp01_39->node(1)});
+
+  auto r03_04 = CPS::EMT::Ph3::Resistor::make("resistor-03-04");
+  r03_04->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp03_04 = sys.component<CPS::EMT::Ph3::PiLine>("L-03-04");
+  r03_04->connect({comp03_04->node(0), comp03_04->node(1)});
+
+  auto switch05_g = CPS::EMT::Ph3::Switch::make("switch-05-ground");
+  switch05_g->setParameters(CPS::Math::singlePhaseParameterToThreePhase(9999),
+                            CPS::Math::singlePhaseParameterToThreePhase(0.1),
+                            false);
+  auto comp05_06 = sys.component<CPS::EMT::Ph3::PiLine>("L-05-06");
+  switch05_g->connect({comp05_06->node(0), CPS::EMT::SimNode::GND});
+
+  sys.removeComponent("L-16-17");
+  sys.removeComponent("L-15-16");
+  sys.removeComponent("L-01-39");
+  sys.removeComponent("L-03-04");
+  sys.addComponent(r16_17);
+  sys.addComponent(r15_16);
+  sys.addComponent(r01_39);
+  sys.addComponent(r03_04);
+  sys.addComponent(switch05_g);
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  for (auto node : sys.mNodes) {
+    logger->logAttribute(node->name() + ".V", node->attribute("v"));
+  }
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  Simulation sim(simName, Logger::Level::off);
+  // Events
+  Real startTimeFault = 0.1;
+  auto sw1 = SwitchEvent3Ph::make(startTimeFault, switch05_g, true);
+  sim.addEvent(sw1);
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSteadyStateInit(false);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addLogger(logger);
+  sim.run();
+
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = end - start;
+  std::cout << "IEEE-39: Zeit: " << std::fixed << std::setprecision(2)
+            << elapsed.count() << " Sekunden\n";
+}
+
+void EMT_IEEE_39Bus_3ph_openMP(Real timeStep, Real finalTime) {
+
+  // Simulation parameters
+  String simName = "IEEE-39bus_openMP";
+
+  // Find CIM files
+  std::list<fs::path> filenames;
+
+  filenames = Utils::findFiles({"Rootnet_FULL_NE_29J10h_SV.xml",
+                                "Rootnet_FULL_NE_29J10h_EQ.xml",
+                                "Rootnet_FULL_NE_29J10h_TP.xml"},
+                               "build/_deps/cim-data-src/IEEE-39", "CIMPATH");
+
+  // ----- DYNAMIC SIMULATION -----
+  Logger::setLogDir("logs/" + simName);
+
+  CPS::CIM::Reader reader2(simName, Logger::Level::debug, Logger::Level::off);
+  SystemTopology sys =
+      reader2.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
+                      CPS::GeneratorType::IdealVoltageSource);
+
+  // Replace lines with resistors for comparability:
+  auto r16_17 = CPS::EMT::Ph3::Resistor::make("resistor-16-17");
+  r16_17->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp16_17 = sys.component<CPS::EMT::Ph3::PiLine>("L-16-17");
+  r16_17->connect({comp16_17->node(0), comp16_17->node(1)});
+
+  auto r15_16 = CPS::EMT::Ph3::Resistor::make("resistor-15-16");
+  r15_16->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp15_16 = sys.component<CPS::EMT::Ph3::PiLine>("L-15-16");
+  r15_16->connect({comp15_16->node(0), comp15_16->node(1)});
+
+  auto r01_39 = CPS::EMT::Ph3::Resistor::make("resistor-01-39");
+  r01_39->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp01_39 = sys.component<CPS::EMT::Ph3::PiLine>("L-01-39");
+  r01_39->connect({comp01_39->node(0), comp01_39->node(1)});
+
+  auto r03_04 = CPS::EMT::Ph3::Resistor::make("resistor-03-04");
+  r03_04->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp03_04 = sys.component<CPS::EMT::Ph3::PiLine>("L-03-04");
+  r03_04->connect({comp03_04->node(0), comp03_04->node(1)});
+
+  auto switch05_g = CPS::EMT::Ph3::Switch::make("switch-05-ground");
+  switch05_g->setParameters(CPS::Math::singlePhaseParameterToThreePhase(9999),
+                            CPS::Math::singlePhaseParameterToThreePhase(0.1),
+                            false);
+  auto comp05_06 = sys.component<CPS::EMT::Ph3::PiLine>("L-05-06");
+  switch05_g->connect({comp05_06->node(0), CPS::EMT::SimNode::GND});
+
+  sys.removeComponent("L-16-17");
+  sys.removeComponent("L-15-16");
+  sys.removeComponent("L-01-39");
+  sys.removeComponent("L-03-04");
+  sys.addComponent(r16_17);
+  sys.addComponent(r15_16);
+  sys.addComponent(r01_39);
+  sys.addComponent(r03_04);
+  sys.addComponent(switch05_g);
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  for (auto node : sys.mNodes) {
+    logger->logAttribute(node->name() + ".V", node->attribute("v"));
+  }
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  Int threads = 2;
+  Simulation sim(simName, Logger::Level::off);
+  // Events
+  Real startTimeFault = 0.1;
+  auto sw1 = SwitchEvent3Ph::make(startTimeFault, switch05_g, true);
+  sim.addEvent(sw1);
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSteadyStateInit(false);
+  sim.doSystemMatrixRecomputation(true);
+  sim.setScheduler(std::make_shared<OpenMPLevelScheduler>(threads));
+  sim.addLogger(logger);
+  sim.run();
+
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = end - start;
+  std::cout << "IEEE-39 openMP: Zeit: " << std::fixed << std::setprecision(2)
+            << elapsed.count() << " Sekunden\n";
+}
+
+void EMT_IEEE_39Bus_3ph_Diakoptics(Real timeStep, Real finalTime) {
+  // Simulation parameters
+  String simName = "IEEE-39bus_diakoptics";
+
+  // Find CIM files
+  std::list<fs::path> filenames;
+  filenames = Utils::findFiles({"Rootnet_FULL_NE_29J10h_SV.xml",
+                                "Rootnet_FULL_NE_29J10h_EQ.xml",
+                                "Rootnet_FULL_NE_29J10h_TP.xml"},
+                               "build/_deps/cim-data-src/IEEE-39", "CIMPATH");
+
+  // ----- DYNAMIC SIMULATION -----
+  Logger::setLogDir("logs/" + simName);
+
+  CPS::CIM::Reader reader2(simName, Logger::Level::debug, Logger::Level::off);
+  SystemTopology sys =
+      reader2.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
+                      CPS::GeneratorType::IdealVoltageSource);
+
+  // Replace lines with tear component to create 2 subsystems
+  auto r16_17 = CPS::EMT::Ph3::Resistor::make("resistor-16-17");
+  r16_17->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp16_17 = sys.component<CPS::EMT::Ph3::PiLine>("L-16-17");
+  r16_17->connect({comp16_17->node(0), comp16_17->node(1)});
+
+  auto r15_16 = CPS::EMT::Ph3::Resistor::make("resistor-15-16");
+  r15_16->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp15_16 = sys.component<CPS::EMT::Ph3::PiLine>("L-15-16");
+  r15_16->connect({comp15_16->node(0), comp15_16->node(1)});
+
+  auto r01_39 = CPS::EMT::Ph3::Resistor::make("resistor-01-39");
+  r01_39->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp01_39 = sys.component<CPS::EMT::Ph3::PiLine>("L-01-39");
+  r01_39->connect({comp01_39->node(0), comp01_39->node(1)});
+
+  auto r03_04 = CPS::EMT::Ph3::Resistor::make("resistor-03-04");
+  r03_04->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp03_04 = sys.component<CPS::EMT::Ph3::PiLine>("L-03-04");
+  r03_04->connect({comp03_04->node(0), comp03_04->node(1)});
+
+  auto switch05_g = CPS::EMT::Ph3::Switch::make("switch-05-ground");
+  switch05_g->setParameters(CPS::Math::singlePhaseParameterToThreePhase(9999),
+                            CPS::Math::singlePhaseParameterToThreePhase(0.1),
+                            false);
+  auto comp05_06 = sys.component<CPS::EMT::Ph3::PiLine>("L-05-06");
+  switch05_g->connect({comp05_06->node(0), CPS::EMT::SimNode::GND});
+
+  sys.removeComponent("L-16-17");
+  sys.removeComponent("L-15-16");
+  sys.removeComponent("L-01-39");
+  sys.removeComponent("L-03-04");
+  sys.addTearComponent(r16_17);
+  sys.addTearComponent(r15_16);
+  sys.addTearComponent(r01_39);
+  sys.addTearComponent(r03_04);
+  sys.addComponent(switch05_g);
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  for (auto node : sys.mNodes) {
+    logger->logAttribute(node->name() + ".V", node->attribute("v"));
+  }
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  Simulation sim(simName, Logger::Level::off);
+  // Events
+  Real startTimeFault = 0.1;
+  auto sw1 = SwitchEvent3Ph::make(startTimeFault, switch05_g, true);
+  sim.addEvent(sw1);
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTearingComponents(sys.mTearComponents);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSteadyStateInit(false);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addLogger(logger);
+  sim.run();
+
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = end - start;
+  std::cout << "IEEE-39 diakoptics: Zeit: " << std::fixed
+            << std::setprecision(2) << elapsed.count() << " Sekunden\n";
+}
+
+void EMT_IEEE_39Bus_3ph_Diakoptics_openMP(Real timeStep, Real finalTime) {
+  // Simulation parameters
+  String simName = "IEEE-39bus_diakoptics_openMP";
+
+  // Find CIM files
+  std::list<fs::path> filenames;
+  filenames = Utils::findFiles({"Rootnet_FULL_NE_29J10h_SV.xml",
+                                "Rootnet_FULL_NE_29J10h_EQ.xml",
+                                "Rootnet_FULL_NE_29J10h_TP.xml"},
+                               "build/_deps/cim-data-src/IEEE-39", "CIMPATH");
+
+  // ----- DYNAMIC SIMULATION -----
+  Logger::setLogDir("logs/" + simName);
+
+  CPS::CIM::Reader reader2(simName, Logger::Level::debug, Logger::Level::off);
+  SystemTopology sys =
+      reader2.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
+                      CPS::GeneratorType::IdealVoltageSource);
+
+  // Replace lines with tear component to create 2 subsystems
+  auto r16_17 = CPS::EMT::Ph3::Resistor::make("resistor-16-17");
+  r16_17->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp16_17 = sys.component<CPS::EMT::Ph3::PiLine>("L-16-17");
+  r16_17->connect({comp16_17->node(0), comp16_17->node(1)});
+
+  auto r15_16 = CPS::EMT::Ph3::Resistor::make("resistor-15-16");
+  r15_16->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp15_16 = sys.component<CPS::EMT::Ph3::PiLine>("L-15-16");
+  r15_16->connect({comp15_16->node(0), comp15_16->node(1)});
+
+  auto r01_39 = CPS::EMT::Ph3::Resistor::make("resistor-01-39");
+  r01_39->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp01_39 = sys.component<CPS::EMT::Ph3::PiLine>("L-01-39");
+  r01_39->connect({comp01_39->node(0), comp01_39->node(1)});
+
+  auto r03_04 = CPS::EMT::Ph3::Resistor::make("resistor-03-04");
+  r03_04->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+  auto comp03_04 = sys.component<CPS::EMT::Ph3::PiLine>("L-03-04");
+  r03_04->connect({comp03_04->node(0), comp03_04->node(1)});
+
+  auto switch05_g = CPS::EMT::Ph3::Switch::make("switch-05-ground");
+  switch05_g->setParameters(CPS::Math::singlePhaseParameterToThreePhase(9999),
+                            CPS::Math::singlePhaseParameterToThreePhase(0.1),
+                            false);
+  auto comp05_06 = sys.component<CPS::EMT::Ph3::PiLine>("L-05-06");
+  switch05_g->connect({comp05_06->node(0), CPS::EMT::SimNode::GND});
+
+  sys.removeComponent("L-16-17");
+  sys.removeComponent("L-15-16");
+  sys.removeComponent("L-01-39");
+  sys.removeComponent("L-03-04");
+  sys.addTearComponent(r16_17);
+  sys.addTearComponent(r15_16);
+  sys.addTearComponent(r01_39);
+  sys.addTearComponent(r03_04);
+  sys.addComponent(switch05_g);
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  for (auto node : sys.mNodes) {
+    logger->logAttribute(node->name() + ".V", node->attribute("v"));
+  }
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  Simulation sim(simName, Logger::Level::off);
+  // Events
+  Real startTimeFault = 0.1;
+  auto sw1 = SwitchEvent3Ph::make(startTimeFault, switch05_g, true);
+  sim.addEvent(sw1);
+  Int threads = 2;
+  if (threads > 0)
+    sim.setScheduler(std::make_shared<OpenMPLevelScheduler>(threads));
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTearingComponents(sys.mTearComponents);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSteadyStateInit(false);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addLogger(logger);
+  sim.run();
+
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = end - start;
+  std::cout << "IEEE-39 diakoptics_openMP: Zeit: " << std::fixed
+            << std::setprecision(2) << elapsed.count() << " Sekunden\n";
+}
+
+int main(int argc, char *argv[]) {
+
+  Real timeStep = 10e-6;
+  Real finalTime = 1.0;
+
+  EMT_IEEE_39Bus_3ph(timeStep, finalTime);
+  EMT_IEEE_39Bus_3ph_openMP(timeStep, finalTime);
+  EMT_IEEE_39Bus_3ph_Diakoptics(timeStep, finalTime);
+  EMT_IEEE_39Bus_3ph_Diakoptics_openMP(timeStep, finalTime);
+  return 0;
+}

--- a/dpsim/examples/cxx/CIM/EMT_IEEE_39bus_Multi_CIM.cpp
+++ b/dpsim/examples/cxx/CIM/EMT_IEEE_39bus_Multi_CIM.cpp
@@ -1,0 +1,441 @@
+/* Author: Christoph Wirtz <christoph.wirtz@fgh-ma.de>
+ * SPDX-FileCopyrightText: 2026 FGH e.V.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <iostream>
+#include <list>
+#include <string>
+#include <vector>
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::DP;
+
+void EMT_IEEE_39Bus_3ph_Multi(Real timeStep, Real finalTime) {
+
+  // Simulation parameters
+  String simName = "IEEE-39bus_multi";
+  int numGrids = 4;
+
+  // Find CIM files
+  std::list<fs::path> filenames;
+  filenames = Utils::findFiles({"Rootnet_FULL_NE_29J10h_SV.xml",
+                                "Rootnet_FULL_NE_29J10h_EQ.xml",
+                                "Rootnet_FULL_NE_29J10h_TP.xml"},
+                               "build/_deps/cim-data-src/IEEE-39", "CIMPATH");
+
+  // ----- DYNAMIC SIMULATION -----
+  Logger::setLogDir("logs/" + simName);
+
+  // Load numGrids copies of IEEE-39 and merge them into one system
+  SystemTopology sys(60);
+  std::vector<CPS::EMT::SimNode::Ptr> couplingNodes;
+  std::shared_ptr<CPS::EMT::Ph3::Switch> switch05_g_area0;
+  std::shared_ptr<CPS::EMT::Ph3::Switch> switch05_g_area1;
+
+  for (int i = 0; i < numGrids; ++i) {
+    CPS::CIM::Reader reader(simName + "_area" + std::to_string(i),
+                            Logger::Level::debug, Logger::Level::off);
+    SystemTopology area =
+        reader.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
+                       CPS::GeneratorType::IdealVoltageSource);
+
+    couplingNodes.push_back(
+        area.component<CPS::EMT::Ph3::PiLine>("L-01-39")->node(0));
+
+    if (i == 0) {
+      switch05_g_area0 = CPS::EMT::Ph3::Switch::make("switch-05-ground-area0");
+      switch05_g_area0->setParameters(
+          CPS::Math::singlePhaseParameterToThreePhase(9999),
+          CPS::Math::singlePhaseParameterToThreePhase(0.1), false);
+      switch05_g_area0->connect(
+          {area.component<CPS::EMT::Ph3::PiLine>("L-05-06")->node(0),
+           CPS::EMT::SimNode::GND});
+      area.addComponent(switch05_g_area0);
+    }
+
+    // Second fault in a different area, fired at the same time, so two subnets
+    // recompute concurrently (exercises the parallel diakoptics Schur rebuild).
+    if (i == 1) {
+      switch05_g_area1 = CPS::EMT::Ph3::Switch::make("switch-05-ground-area1");
+      switch05_g_area1->setParameters(
+          CPS::Math::singlePhaseParameterToThreePhase(9999),
+          CPS::Math::singlePhaseParameterToThreePhase(0.1), false);
+      switch05_g_area1->connect(
+          {area.component<CPS::EMT::Ph3::PiLine>("L-05-06")->node(0),
+           CPS::EMT::SimNode::GND});
+      area.addComponent(switch05_g_area1);
+    }
+
+    sys.addNodes(area.mNodes);
+    sys.addComponents(area.mComponents);
+  }
+
+  // Couple the grids in a ring with resistors
+  for (int i = 0; i < numGrids; ++i) {
+    int j = (i + 1) % numGrids;
+    auto coupler = CPS::EMT::Ph3::Resistor::make("couple-" + std::to_string(i) +
+                                                 "-" + std::to_string(j));
+    coupler->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+    coupler->connect({couplingNodes[i], couplingNodes[j]});
+    sys.addComponent(coupler);
+  }
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  for (UInt i = 0; i < couplingNodes.size(); ++i)
+    logger->logAttribute("area" + std::to_string(i) + ".V",
+                         couplingNodes[i]->attribute("v"));
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  Simulation sim(simName, Logger::Level::off);
+  // Events
+  Real startTimeFault = 0.005;
+  auto sw1 = SwitchEvent3Ph::make(startTimeFault, switch05_g_area0, true);
+  sim.addEvent(sw1);
+  auto sw2 = SwitchEvent3Ph::make(startTimeFault, switch05_g_area1, true);
+  sim.addEvent(sw2);
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSteadyStateInit(false);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addLogger(logger);
+  sim.run();
+
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = end - start;
+  std::cout << "IEEE-39 multi: Zeit: " << std::fixed << std::setprecision(2)
+            << elapsed.count() << " Sekunden\n";
+
+  sim.logStepTimes(simName + "_step_times");
+}
+
+void EMT_IEEE_39Bus_3ph_Multi_openMP(Real timeStep, Real finalTime) {
+
+  // Simulation parameters
+  String simName = "IEEE-39bus_multi_openMP";
+  int numGrids = 4;
+
+  // Find CIM files
+  std::list<fs::path> filenames;
+  filenames = Utils::findFiles({"Rootnet_FULL_NE_29J10h_SV.xml",
+                                "Rootnet_FULL_NE_29J10h_EQ.xml",
+                                "Rootnet_FULL_NE_29J10h_TP.xml"},
+                               "build/_deps/cim-data-src/IEEE-39", "CIMPATH");
+
+  // ----- DYNAMIC SIMULATION -----
+  Logger::setLogDir("logs/" + simName);
+
+  // Load numGrids copies of IEEE-39 and merge them into one system
+  SystemTopology sys(60);
+  std::vector<CPS::EMT::SimNode::Ptr> couplingNodes;
+  std::shared_ptr<CPS::EMT::Ph3::Switch> switch05_g_area0;
+  std::shared_ptr<CPS::EMT::Ph3::Switch> switch05_g_area1;
+
+  for (int i = 0; i < numGrids; ++i) {
+    CPS::CIM::Reader reader(simName + "_area" + std::to_string(i),
+                            Logger::Level::debug, Logger::Level::off);
+    SystemTopology area =
+        reader.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
+                       CPS::GeneratorType::IdealVoltageSource);
+
+    couplingNodes.push_back(
+        area.component<CPS::EMT::Ph3::PiLine>("L-01-39")->node(0));
+
+    if (i == 0) {
+      switch05_g_area0 = CPS::EMT::Ph3::Switch::make("switch-05-ground-area0");
+      switch05_g_area0->setParameters(
+          CPS::Math::singlePhaseParameterToThreePhase(9999),
+          CPS::Math::singlePhaseParameterToThreePhase(0.1), false);
+      switch05_g_area0->connect(
+          {area.component<CPS::EMT::Ph3::PiLine>("L-05-06")->node(0),
+           CPS::EMT::SimNode::GND});
+      area.addComponent(switch05_g_area0);
+    }
+
+    // Second fault in a different area, fired at the same time, so two subnets
+    // recompute concurrently (exercises the parallel diakoptics Schur rebuild).
+    if (i == 1) {
+      switch05_g_area1 = CPS::EMT::Ph3::Switch::make("switch-05-ground-area1");
+      switch05_g_area1->setParameters(
+          CPS::Math::singlePhaseParameterToThreePhase(9999),
+          CPS::Math::singlePhaseParameterToThreePhase(0.1), false);
+      switch05_g_area1->connect(
+          {area.component<CPS::EMT::Ph3::PiLine>("L-05-06")->node(0),
+           CPS::EMT::SimNode::GND});
+      area.addComponent(switch05_g_area1);
+    }
+
+    sys.addNodes(area.mNodes);
+    sys.addComponents(area.mComponents);
+  }
+
+  // Couple the grids in a ring with resistors
+  for (int i = 0; i < numGrids; ++i) {
+    int j = (i + 1) % numGrids;
+    auto coupler = CPS::EMT::Ph3::Resistor::make("couple-" + std::to_string(i) +
+                                                 "-" + std::to_string(j));
+    coupler->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+    coupler->connect({couplingNodes[i], couplingNodes[j]});
+    sys.addComponent(coupler);
+  }
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  for (UInt i = 0; i < couplingNodes.size(); ++i)
+    logger->logAttribute("area" + std::to_string(i) + ".V",
+                         couplingNodes[i]->attribute("v"));
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  Int threads = numGrids;
+  Simulation sim(simName, Logger::Level::off);
+  // Events
+  Real startTimeFault = 0.005;
+  auto sw1 = SwitchEvent3Ph::make(startTimeFault, switch05_g_area0, true);
+  sim.addEvent(sw1);
+  auto sw2 = SwitchEvent3Ph::make(startTimeFault, switch05_g_area1, true);
+  sim.addEvent(sw2);
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSteadyStateInit(false);
+  sim.doSystemMatrixRecomputation(true);
+  sim.setScheduler(std::make_shared<OpenMPLevelScheduler>(threads));
+  sim.addLogger(logger);
+  sim.run();
+
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = end - start;
+  std::cout << "IEEE-39 multi openMP: Zeit: " << std::fixed
+            << std::setprecision(2) << elapsed.count() << " Sekunden\n";
+
+  sim.logStepTimes(simName + "_step_times");
+}
+
+void EMT_IEEE_39Bus_3ph_Multi_Diakoptics(Real timeStep, Real finalTime) {
+
+  // Simulation parameters
+  String simName = "IEEE-39bus_multi_diakoptics";
+  int numGrids = 4;
+
+  // Find CIM files
+  std::list<fs::path> filenames;
+  filenames = Utils::findFiles({"Rootnet_FULL_NE_29J10h_SV.xml",
+                                "Rootnet_FULL_NE_29J10h_EQ.xml",
+                                "Rootnet_FULL_NE_29J10h_TP.xml"},
+                               "build/_deps/cim-data-src/IEEE-39", "CIMPATH");
+
+  // ----- DYNAMIC SIMULATION -----
+  Logger::setLogDir("logs/" + simName);
+
+  // Load numGrids copies of IEEE-39 and merge them into one system
+  SystemTopology sys(60);
+  std::vector<CPS::EMT::SimNode::Ptr> couplingNodes;
+  std::shared_ptr<CPS::EMT::Ph3::Switch> switch05_g_area0;
+  std::shared_ptr<CPS::EMT::Ph3::Switch> switch05_g_area1;
+
+  for (int i = 0; i < numGrids; ++i) {
+    CPS::CIM::Reader reader(simName + "_area" + std::to_string(i),
+                            Logger::Level::debug, Logger::Level::off);
+    SystemTopology area =
+        reader.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
+                       CPS::GeneratorType::IdealVoltageSource);
+
+    couplingNodes.push_back(
+        area.component<CPS::EMT::Ph3::PiLine>("L-01-39")->node(0));
+
+    if (i == 0) {
+      switch05_g_area0 = CPS::EMT::Ph3::Switch::make("switch-05-ground-area0");
+      switch05_g_area0->setParameters(
+          CPS::Math::singlePhaseParameterToThreePhase(9999),
+          CPS::Math::singlePhaseParameterToThreePhase(0.1), false);
+      switch05_g_area0->connect(
+          {area.component<CPS::EMT::Ph3::PiLine>("L-05-06")->node(0),
+           CPS::EMT::SimNode::GND});
+      area.addComponent(switch05_g_area0);
+    }
+
+    // Second fault in a different area, fired at the same time, so two subnets
+    // recompute concurrently (exercises the parallel diakoptics Schur rebuild).
+    if (i == 1) {
+      switch05_g_area1 = CPS::EMT::Ph3::Switch::make("switch-05-ground-area1");
+      switch05_g_area1->setParameters(
+          CPS::Math::singlePhaseParameterToThreePhase(9999),
+          CPS::Math::singlePhaseParameterToThreePhase(0.1), false);
+      switch05_g_area1->connect(
+          {area.component<CPS::EMT::Ph3::PiLine>("L-05-06")->node(0),
+           CPS::EMT::SimNode::GND});
+      area.addComponent(switch05_g_area1);
+    }
+
+    sys.addNodes(area.mNodes);
+    sys.addComponents(area.mComponents);
+  }
+
+  // Couple the grids in a ring with tear components to create numGrids subsystems
+  for (int i = 0; i < numGrids; ++i) {
+    int j = (i + 1) % numGrids;
+    auto coupler = CPS::EMT::Ph3::Resistor::make("couple-" + std::to_string(i) +
+                                                 "-" + std::to_string(j));
+    coupler->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+    coupler->connect({couplingNodes[i], couplingNodes[j]});
+    sys.addTearComponent(coupler);
+  }
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  for (UInt i = 0; i < couplingNodes.size(); ++i)
+    logger->logAttribute("area" + std::to_string(i) + ".V",
+                         couplingNodes[i]->attribute("v"));
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  Simulation sim(simName, Logger::Level::off);
+  // Events
+  Real startTimeFault = 0.005;
+  auto sw1 = SwitchEvent3Ph::make(startTimeFault, switch05_g_area0, true);
+  sim.addEvent(sw1);
+  auto sw2 = SwitchEvent3Ph::make(startTimeFault, switch05_g_area1, true);
+  sim.addEvent(sw2);
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTearingComponents(sys.mTearComponents);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSteadyStateInit(false);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addLogger(logger);
+  sim.run();
+
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = end - start;
+  std::cout << "IEEE-39 multi diakoptics: Zeit: " << std::fixed
+            << std::setprecision(2) << elapsed.count() << " Sekunden\n";
+
+  sim.logStepTimes(simName + "_step_times");
+}
+
+void EMT_IEEE_39Bus_3ph_Multi_Diakoptics_openMP(Real timeStep, Real finalTime) {
+
+  // Simulation parameters
+  String simName = "IEEE-39bus_multi_diakoptics_openMP";
+  int numGrids = 4;
+
+  // Find CIM files
+  std::list<fs::path> filenames;
+  filenames = Utils::findFiles({"Rootnet_FULL_NE_29J10h_SV.xml",
+                                "Rootnet_FULL_NE_29J10h_EQ.xml",
+                                "Rootnet_FULL_NE_29J10h_TP.xml"},
+                               "build/_deps/cim-data-src/IEEE-39", "CIMPATH");
+
+  // ----- DYNAMIC SIMULATION -----
+  Logger::setLogDir("logs/" + simName);
+
+  // Load numGrids copies of IEEE-39 and merge them into one system
+  SystemTopology sys(60);
+  std::vector<CPS::EMT::SimNode::Ptr> couplingNodes;
+  std::shared_ptr<CPS::EMT::Ph3::Switch> switch05_g_area0;
+  std::shared_ptr<CPS::EMT::Ph3::Switch> switch05_g_area1;
+
+  for (int i = 0; i < numGrids; ++i) {
+    CPS::CIM::Reader reader(simName + "_area" + std::to_string(i),
+                            Logger::Level::debug, Logger::Level::off);
+    SystemTopology area =
+        reader.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
+                       CPS::GeneratorType::IdealVoltageSource);
+
+    couplingNodes.push_back(
+        area.component<CPS::EMT::Ph3::PiLine>("L-01-39")->node(0));
+
+    if (i == 0) {
+      switch05_g_area0 = CPS::EMT::Ph3::Switch::make("switch-05-ground-area0");
+      switch05_g_area0->setParameters(
+          CPS::Math::singlePhaseParameterToThreePhase(9999),
+          CPS::Math::singlePhaseParameterToThreePhase(0.1), false);
+      switch05_g_area0->connect(
+          {area.component<CPS::EMT::Ph3::PiLine>("L-05-06")->node(0),
+           CPS::EMT::SimNode::GND});
+      area.addComponent(switch05_g_area0);
+    }
+
+    // Second fault in a different area, fired at the same time, so two subnets
+    // recompute concurrently (exercises the parallel diakoptics Schur rebuild).
+    if (i == 1) {
+      switch05_g_area1 = CPS::EMT::Ph3::Switch::make("switch-05-ground-area1");
+      switch05_g_area1->setParameters(
+          CPS::Math::singlePhaseParameterToThreePhase(9999),
+          CPS::Math::singlePhaseParameterToThreePhase(0.1), false);
+      switch05_g_area1->connect(
+          {area.component<CPS::EMT::Ph3::PiLine>("L-05-06")->node(0),
+           CPS::EMT::SimNode::GND});
+      area.addComponent(switch05_g_area1);
+    }
+
+    sys.addNodes(area.mNodes);
+    sys.addComponents(area.mComponents);
+  }
+
+  // Couple the grids in a ring with tear components to create numGrids subsystems
+  for (int i = 0; i < numGrids; ++i) {
+    int j = (i + 1) % numGrids;
+    auto coupler = CPS::EMT::Ph3::Resistor::make("couple-" + std::to_string(i) +
+                                                 "-" + std::to_string(j));
+    coupler->setParameters(CPS::Math::singlePhaseParameterToThreePhase(1));
+    coupler->connect({couplingNodes[i], couplingNodes[j]});
+    sys.addTearComponent(coupler);
+  }
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  for (UInt i = 0; i < couplingNodes.size(); ++i)
+    logger->logAttribute("area" + std::to_string(i) + ".V",
+                         couplingNodes[i]->attribute("v"));
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  Simulation sim(simName, Logger::Level::off);
+  // Events
+  Real startTimeFault = 0.005;
+  auto sw1 = SwitchEvent3Ph::make(startTimeFault, switch05_g_area0, true);
+  sim.addEvent(sw1);
+  auto sw2 = SwitchEvent3Ph::make(startTimeFault, switch05_g_area1, true);
+  sim.addEvent(sw2);
+  Int threads = numGrids;
+  if (threads > 0)
+    sim.setScheduler(std::make_shared<OpenMPLevelScheduler>(threads));
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTearingComponents(sys.mTearComponents);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSteadyStateInit(false);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addLogger(logger);
+  sim.run();
+
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = end - start;
+  std::cout << "IEEE-39 multi diakoptics_openMP: Zeit: " << std::fixed
+            << std::setprecision(2) << elapsed.count() << " Sekunden\n";
+
+  sim.logStepTimes(simName + "_step_times");
+}
+
+int main(int argc, char *argv[]) {
+
+  Real timeStep = 10e-6;
+  Real finalTime = 0.02;
+
+  EMT_IEEE_39Bus_3ph_Multi(timeStep, finalTime);
+  EMT_IEEE_39Bus_3ph_Multi_openMP(timeStep, finalTime);
+  EMT_IEEE_39Bus_3ph_Multi_Diakoptics(timeStep, finalTime);
+  EMT_IEEE_39Bus_3ph_Multi_Diakoptics_openMP(timeStep, finalTime);
+  return 0;
+}

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -34,6 +34,7 @@ set(CIRCUIT_SOURCES
 	Circuits/EMT_VSI.cpp
 	Circuits/EMT_PiLine.cpp
 	Circuits/EMT_DecouplingLine_Ph3.cpp
+	Circuits/EMT_Diakoptics.cpp
 	Circuits/EMT_Ph3_R3C1L1CS1_RC_vs_SSN.cpp
 	Circuits/EMT_Ph3_RLC1VS1_RC_vs_SSN.cpp
 	Circuits/EMT_Ph1_General2TerminalSSN.cpp
@@ -220,6 +221,10 @@ if(WITH_CIM)
 		CIM/EMT_CIGRE_MV_withoutDG.cpp
 		CIM/EMT_CIGRE_MV_withDG.cpp
 		CIM/EMT_CIGRE_MV_withDG_withLoadStep.cpp
+
+		# IEEE 39 examples
+		CIM/EMT_IEEE_39bus_CIM.cpp
+		CIM/EMT_IEEE_39bus_Multi_CIM.cpp
 	)
 
 	list(APPEND TEST_SOURCES
@@ -228,6 +233,7 @@ if(WITH_CIM)
 		CIM/EMT_WSCC-9bus_IdealCS.cpp
 		CIM/EMT_WSCC-9bus_IdealVS.cpp
 		CIM/SP_WSCC9bus_SGReducedOrderVBR.cpp
+		CIM/EMT_IEEE_39bus_Multi_CIM.cpp
 	)
 
 	if(WITH_RT)

--- a/dpsim/examples/cxx/Circuits/EMT_Diakoptics.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_Diakoptics.cpp
@@ -1,0 +1,311 @@
+/* Author: Christoph Wirtz <christoph.wirtz@fgh-ma.de>
+ * SPDX-FileCopyrightText: 2026 FGH e.V.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::EMT;
+using namespace CPS::EMT::Ph1;
+
+void EMT_VS_CS_R4() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "EMT_VS_CS_R4";
+  Logger::setLogDir("logs/" + simName);
+
+  // Nodes
+  auto n1 = SimNode::make("n1");
+  auto n2 = SimNode::make("n2");
+  auto n3 = SimNode::make("n3");
+
+  // Components
+  auto vs = VoltageSource::make("vs");
+  vs->setParameters(10);
+  auto r1 = Resistor::make("r_1");
+  r1->setParameters(1);
+  auto r2 = Resistor::make("r_2", Logger::Level::debug);
+  r2->setParameters(1);
+  auto r3 = Resistor::make("r_3");
+  r3->setParameters(10);
+  auto r4 = Resistor::make("r_4");
+  r4->setParameters(5);
+  auto cs = CurrentSource::make("cs");
+  cs->setParameters(1);
+
+  // Topology
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  r1->connect(SimNode::List{n1, n2});
+  r2->connect(SimNode::List{n2, SimNode::GND});
+  r3->connect(SimNode::List{n2, n3});
+  r4->connect(SimNode::List{n3, SimNode::GND});
+  cs->connect(SimNode::List{SimNode::GND, n3});
+
+  // Define system topology
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2, n3},
+                            SystemComponentList{vs, r1, r2, r3, r4, cs});
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v1", n1->attribute("v"));
+  logger->logAttribute("v2", n2->attribute("v"));
+  logger->logAttribute("v3", n3->attribute("v"));
+  logger->logAttribute("i12", r1->attribute("i_intf"));
+  logger->logAttribute("i23", r3->attribute("i_intf"));
+
+  Simulation sim(simName);
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTearingComponents(sys.mTearComponents);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.addLogger(logger);
+
+  sim.run();
+}
+
+void EMT_VS_CS_R4_Diakoptics() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "EMT_VS_CS_R4_Diakoptics";
+  Logger::setLogDir("logs/" + simName);
+
+  // Nodes
+  auto n1 = SimNode::make("n1");
+  auto n2 = SimNode::make("n2");
+  auto n3 = SimNode::make("n3");
+
+  // Components
+  auto vs = VoltageSource::make("vs");
+  vs->setParameters(10);
+  auto r1 = Resistor::make("r_1");
+  r1->setParameters(1);
+  auto r2 = Resistor::make("r_2", Logger::Level::debug);
+  r2->setParameters(1);
+  auto r3 = Resistor::make("r_3");
+  r3->setParameters(10);
+  auto r4 = Resistor::make("r_4");
+  r4->setParameters(5);
+  auto cs = CurrentSource::make("cs");
+  cs->setParameters(1);
+
+  // Topology
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  r1->connect(SimNode::List{n1, n2});
+  r2->connect(SimNode::List{n2, SimNode::GND});
+  r3->connect(SimNode::List{n2, n3});
+  r4->connect(SimNode::List{n3, SimNode::GND});
+  cs->connect(SimNode::List{SimNode::GND, n3});
+
+  // Define system topology
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2, n3},
+                            SystemComponentList{vs, r1, r2, r4, cs});
+  sys.addTearComponent(r3);
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v1", n1->attribute("v"));
+  logger->logAttribute("v2", n2->attribute("v"));
+  logger->logAttribute("v3", n3->attribute("v"));
+  logger->logAttribute("i12", r1->attribute("i_intf"));
+  logger->logAttribute("i23", r3->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTearingComponents(sys.mTearComponents);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.addLogger(logger);
+
+  sim.run();
+}
+
+void EMT_VS_R2L3() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "EMT_VS_R2L3";
+  Logger::setLogDir("logs/" + simName);
+
+  // Nodes
+  auto n1 = SimNode::make("n1");
+  auto n2 = SimNode::make("n2");
+  auto n3 = SimNode::make("n3");
+  auto n4 = SimNode::make("n4");
+
+  // Components
+  auto vs = VoltageSource::make("vs");
+  vs->setParameters(10);
+  auto r1 = Resistor::make("r_1");
+  r1->setParameters(1);
+  auto l1 = Inductor::make("l_1");
+  l1->setParameters(0.02);
+  auto l2 = Inductor::make("l_2");
+  l2->setParameters(0.1);
+  auto l3 = Inductor::make("l_3");
+  l3->setParameters(0.05);
+  auto r2 = Resistor::make("r_2");
+  r2->setParameters(2);
+
+  // Topology
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  r1->connect(SimNode::List{n1, n2});
+  l1->connect(SimNode::List{n2, n3});
+  l2->connect(SimNode::List{n3, SimNode::GND});
+  l3->connect(SimNode::List{n3, n4});
+  r2->connect(SimNode::List{n4, SimNode::GND});
+
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2, n3, n4},
+                            SystemComponentList{vs, r1, l1, l2, l3, r2});
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v1", n1->attribute("v"));
+  logger->logAttribute("v2", n2->attribute("v"));
+  logger->logAttribute("v3", n3->attribute("v"));
+  logger->logAttribute("v4", n4->attribute("v"));
+  logger->logAttribute("i12", r1->attribute("i_intf"));
+  logger->logAttribute("i34", l3->attribute("i_intf"));
+
+  Simulation sim(simName);
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.addLogger(logger);
+
+  sim.run();
+}
+
+void EMT_VS_R2L3_Diakoptics() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "EMT_VS_R2L3_Diakoptics";
+  Logger::setLogDir("logs/" + simName);
+
+  // Nodes
+  auto n1 = SimNode::make("n1");
+  auto n2 = SimNode::make("n2");
+  auto n3 = SimNode::make("n3");
+  auto n4 = SimNode::make("n4");
+
+  // Components
+  auto vs = VoltageSource::make("vs");
+  vs->setParameters(10);
+  auto r1 = Resistor::make("r_1");
+  r1->setParameters(1);
+  auto l1 = Inductor::make("l_1");
+  l1->setParameters(0.02);
+  auto l2 = Inductor::make("l_2");
+  l2->setParameters(0.1);
+  auto l3 = Inductor::make("l_3");
+  l3->setParameters(0.05);
+  auto r2 = Resistor::make("r_2");
+  r2->setParameters(2);
+
+  // Topology
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  r1->connect(SimNode::List{n1, n2});
+  l1->connect(SimNode::List{n2, n3});
+  l2->connect(SimNode::List{n3, SimNode::GND});
+  l3->connect(SimNode::List{n3, n4});
+  r2->connect(SimNode::List{n4, SimNode::GND});
+
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2, n3, n4},
+                            SystemComponentList{vs, r1, l2, l3, r2});
+  sys.addTearComponent(l1);
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v1", n1->attribute("v"));
+  logger->logAttribute("v2", n2->attribute("v"));
+  logger->logAttribute("v3", n3->attribute("v"));
+  logger->logAttribute("v4", n4->attribute("v"));
+  logger->logAttribute("i12", r1->attribute("i_intf"));
+  logger->logAttribute("i34", l3->attribute("i_intf"));
+
+  Simulation sim(simName);
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTearingComponents(sys.mTearComponents);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.addLogger(logger);
+
+  sim.run();
+}
+
+void EMT_VS_CS_R4_Sw_Diakoptics() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.3;
+  String simName = "EMT_VS_CS_R4_Sw_Diakoptics";
+  Logger::setLogDir("logs/" + simName);
+
+  // Nodes
+  auto n1 = SimNode::make("n1");
+  auto n2 = SimNode::make("n2");
+  auto n3 = SimNode::make("n3");
+
+  // Components
+  auto vs = VoltageSource::make("vs");
+  vs->setParameters(10);
+  auto r1 = Resistor::make("r_1");
+  r1->setParameters(1);
+  auto r2 = Resistor::make("r_2", Logger::Level::debug);
+  r2->setParameters(1);
+  auto r3 = Resistor::make("r_3");
+  r3->setParameters(10);
+  auto r4 = Resistor::make("r_4");
+  r4->setParameters(5);
+  auto sw3 = Switch::make("s_3");
+  sw3->setParameters(999, 0.01, false);
+  auto cs = CurrentSource::make("cs");
+  cs->setParameters(1);
+
+  // Topology
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  r1->connect(SimNode::List{n1, n2});
+  r2->connect(SimNode::List{n2, SimNode::GND});
+  r3->connect(SimNode::List{n2, n3});
+  sw3->connect(SimNode::List{n3, SimNode::GND});
+  r4->connect(SimNode::List{n3, SimNode::GND});
+  cs->connect(SimNode::List{SimNode::GND, n3});
+
+  // Define system topology
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2, n3},
+                            SystemComponentList{vs, r2, r3, sw3, r4, cs});
+  sys.addTearComponent(r1);
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v1", n1->attribute("v"));
+  logger->logAttribute("v2", n2->attribute("v"));
+  logger->logAttribute("v3", n3->attribute("v"));
+  logger->logAttribute("i12", r1->attribute("i_intf"));
+  logger->logAttribute("i23", r3->attribute("i_intf"));
+
+  auto swEvent1 = SwitchEvent::make(0.2, sw3, true);
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setDomain(CPS::Domain::EMT);
+  sim.setSystem(sys);
+  sim.setTearingComponents(sys.mTearComponents);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.addLogger(logger);
+  sim.addEvent(swEvent1);
+  sim.doSystemMatrixRecomputation(true);
+  Int threads = 3;
+  if (threads > 0)
+    sim.setScheduler(std::make_shared<OpenMPLevelScheduler>(threads));
+  sim.run();
+}
+
+int main(int argc, char *argv[]) {
+  EMT_VS_CS_R4();
+  EMT_VS_CS_R4_Diakoptics();
+  EMT_VS_R2L3();
+  EMT_VS_R2L3_Diakoptics();
+  EMT_VS_CS_R4_Sw_Diakoptics();
+}

--- a/dpsim/include/dpsim/DiakopticsSolver.h
+++ b/dpsim/include/dpsim/DiakopticsSolver.h
@@ -11,9 +11,12 @@
 #include <dpsim-models/AttributeList.h>
 #include <dpsim-models/SimSignalComp.h>
 #include <dpsim-models/Solver/MNAInterface.h>
+#include <dpsim-models/Solver/MNAVariableCompInterface.h>
 #include <dpsim/DataLogger.h>
+#include <dpsim/DirectLinearSolver.h>
 #include <dpsim/Solver.h>
 
+#include <atomic>
 #include <unordered_map>
 
 namespace DPsim {
@@ -35,15 +38,23 @@ private:
     UInt mVirtualNodeNum;
     /// Offset of block in system matrix
     UInt sysOff;
-    /// Factorization of the subnet's block
-    CPS::LUFactorized luFactorization;
+    /// Sparse direct linear solver (KLU) for the subnet's block
+    std::shared_ptr<DirectLinearSolver> directLinearSolver;
+    /// Subnet system matrix holding the current variable-element values
+    SparseMatrix systemMatrix;
+    /// Index pairs of varying matrix entries within this subnet
+    std::vector<std::pair<UInt, UInt>> listVariableEntries;
+    /// Tear-topology columns coupled to this subnet (restrict Schur recompute)
+    std::vector<UInt> tearColumns;
     /// List of all right side vector contributions
     std::vector<const Matrix *> rightVectorStamps;
     /// Left-side vector of the subnet AFTER complete step
     CPS::Attribute<Matrix>::Ptr leftVector;
+    // #### MNA specific attributes related to system recomputation
+    /// List of components that indicate system matrix recomputation
+    CPS::MNAVariableCompInterface::List mVariableComps;
   };
 
-  ///
   Real mSystemFrequency;
   /// System list
   CPS::SystemTopology mSystem;
@@ -63,15 +74,19 @@ private:
   Matrix mLeftSideVector;
   /// Complete matrix in block form
   Matrix mSystemMatrix;
-  /// Inverse of the complete system matrix (only used for initialization)
-  Matrix mSystemInverse;
+  /// Y_block^-1 * C (block-diagonal solve of the tear topology)
+  Matrix mSystemInverseTearTopology;
   /// Topology of the network removal
   Matrix mTearTopology;
   /// Impedance of the removed network
   CPS::SparseMatrixRow mTearImpedance;
-  /// (Factorization of the) impedance matrix for the removed network, including
-  /// the influence of other subnets
+  /// LU factorization of the tear-impedance Schur complement
   CPS::LUFactorized mTotalTearImpedance;
+  /// Tear-impedance Schur complement Z_tear + C^T * Y_block^-1 * C (un-factorized)
+  Matrix mTearSchur;
+  /// Set by a subnet recompute to request a Schur/LU rebuild in PreSolveTask.
+  /// Written concurrently by parallel SubnetSolveTasks, so it must be atomic.
+  std::atomic<bool> mTearSchurNeedsRebuild{false};
   /// Currents through the removed network
   Matrix mTearCurrents;
   /// Voltages across the removed network
@@ -125,6 +140,9 @@ public:
     }
 
     void execute(Real time, Int timeStepCount);
+    void recomputeSubnetMatrix(Real time);
+    /// Check whether status of variable MNA elements has changed
+    Bool hasVariableComponentChanged();
 
   private:
     DiakopticsSolver<VarType> &mSolver;

--- a/dpsim/src/DiakopticsSolver.cpp
+++ b/dpsim/src/DiakopticsSolver.cpp
@@ -13,6 +13,7 @@
 #include <dpsim-models/MathUtils.h>
 #include <dpsim-models/Solver/MNATearInterface.h>
 #include <dpsim/Definitions.h>
+#include <dpsim/KLUAdapter.h>
 
 using namespace CPS;
 using namespace DPsim;
@@ -80,6 +81,11 @@ void DiakopticsSolver<VarType>::initSubnets(
       auto sigComp = std::dynamic_pointer_cast<CPS::SimSignalComp>(comp);
       if (sigComp)
         mSimSignalComps.push_back(sigComp);
+
+      auto mnaVarComp =
+          std::dynamic_pointer_cast<CPS::MNAVariableCompInterface>(comp);
+      if (mnaVarComp)
+        mSubnets[i].mVariableComps.push_back(mnaVarComp);
     }
   }
 
@@ -217,7 +223,6 @@ template <> void DiakopticsSolver<Complex>::setLogColumns() {
 template <typename VarType> void DiakopticsSolver<VarType>::createMatrices() {
   UInt totalSize = mSubnets.back().sysOff + mSubnets.back().sysSize;
   mSystemMatrix = Matrix::Zero(totalSize, totalSize);
-  mSystemInverse = Matrix::Zero(totalSize, totalSize);
 
   mRightSideVector = Matrix::Zero(totalSize, 1);
   mLeftSideVector = Matrix::Zero(totalSize, 1);
@@ -294,22 +299,24 @@ template <typename VarType> void DiakopticsSolver<VarType>::initComponents() {
 
 template <typename VarType> void DiakopticsSolver<VarType>::initMatrices() {
   for (auto &net : mSubnets) {
-    // We can't directly pass the block reference to mnaApplySystemMatrixStamp,
-    // because it expects a concrete Matrix. It can't be changed to accept some common
-    // base class like DenseBase because that would make it a template function (as
-    // Eigen uses CRTP for polymorphism), which is impossible for virtual functions.
-    CPS::SparseMatrixRow partSys =
-        CPS::SparseMatrixRow(net.sysSize, net.sysSize);
+    // mnaApplySystemMatrixStamp needs a concrete Matrix, not a block reference
+    // (it is virtual, so it cannot be templated to accept a block expression).
+    net.systemMatrix = SparseMatrix(net.sysSize, net.sysSize);
     for (auto comp : net.components) {
-      comp->mnaApplySystemMatrixStamp(partSys);
+      comp->mnaApplySystemMatrixStamp(net.systemMatrix);
     }
     auto block =
         mSystemMatrix.block(net.sysOff, net.sysOff, net.sysSize, net.sysSize);
-    block = partSys;
+    block = net.systemMatrix;
     SPDLOG_LOGGER_INFO(mSLog, "Block: \n{}", block);
-    net.luFactorization = Eigen::PartialPivLU<Matrix>(partSys);
-    SPDLOG_LOGGER_INFO(mSLog, "Factorization: \n{}",
-                       net.luFactorization.matrixLU());
+    net.listVariableEntries.clear();
+    for (auto varElem : net.mVariableComps)
+      for (auto varEntry : varElem->mVariableSystemMatrixEntries)
+        net.listVariableEntries.push_back(varEntry);
+    net.directLinearSolver = std::make_shared<KLUAdapter>(mSLog);
+    net.directLinearSolver->preprocessing(net.systemMatrix,
+                                          net.listVariableEntries);
+    net.directLinearSolver->factorize(net.systemMatrix);
   }
   SPDLOG_LOGGER_INFO(mSLog, "Complete system matrix: \n{}", mSystemMatrix);
 
@@ -320,13 +327,25 @@ template <typename VarType> void DiakopticsSolver<VarType>::initMatrices() {
   SPDLOG_LOGGER_INFO(mSLog, "Topology matrix: \n{}", mTearTopology);
   SPDLOG_LOGGER_INFO(mSLog, "Removed impedance matrix: \n{}", mTearImpedance);
   // TODO this can be sped up as well by using the block diagonal form of Yinv
+  mSystemInverseTearTopology =
+      Matrix::Zero(mTearTopology.rows(), mTearTopology.cols());
   for (auto &net : mSubnets) {
-    mSystemInverse.block(net.sysOff, net.sysOff, net.sysSize, net.sysSize) =
-        net.luFactorization.inverse();
+    Matrix tearTopoBlock =
+        mTearTopology.block(net.sysOff, 0, net.sysSize, mTearTopology.cols());
+    mSystemInverseTearTopology.block(net.sysOff, 0, net.sysSize,
+                                     mTearTopology.cols()) =
+        net.directLinearSolver->solve(tearTopoBlock);
+
+    // Cache tear columns coupled to this subnet (used by recomputeSubnetMatrix)
+    net.tearColumns.clear();
+    for (UInt col = 0; col < static_cast<UInt>(mTearTopology.cols()); ++col) {
+      if (!tearTopoBlock.col(col).isZero())
+        net.tearColumns.push_back(col);
+    }
   }
-  mTotalTearImpedance = Eigen::PartialPivLU<Matrix>(
-      mTearImpedance +
-      mTearTopology.transpose() * mSystemInverse * mTearTopology);
+  mTearSchur =
+      mTearImpedance + mTearTopology.transpose() * mSystemInverseTearTopology;
+  mTotalTearImpedance = Eigen::PartialPivLU<Matrix>(mTearSchur);
   SPDLOG_LOGGER_INFO(mSLog,
                      "Total removed impedance matrix LU decomposition: \n{}",
                      mTotalTearImpedance.matrixLU());
@@ -510,6 +529,54 @@ template <typename VarType> Task::List DiakopticsSolver<VarType>::getTasks() {
 }
 
 template <typename VarType>
+void DiakopticsSolver<VarType>::SubnetSolveTask::recomputeSubnetMatrix(
+    Real time) {
+
+  mSubnet.systemMatrix.setZero();
+  for (auto comp : mSubnet.components) {
+    comp->mnaApplySystemMatrixStamp(mSubnet.systemMatrix);
+  }
+  mSubnet.directLinearSolver->partialRefactorize(mSubnet.systemMatrix,
+                                                 mSubnet.listVariableEntries);
+
+  // A change in this subnet only affects its own tear columns: re-solve and
+  // update this subnet's block of Y^-1 C. The shared Schur complement
+  // and its factorization are rebuilt once in PreSolveTask after all
+  // subnet solves
+  const auto &cols = mSubnet.tearColumns;
+  const UInt nJ = static_cast<UInt>(cols.size());
+  if (nJ == 0)
+    return;
+
+  Matrix tearTopoBlock(mSubnet.sysSize, nJ);
+  for (UInt c = 0; c < nJ; ++c)
+    tearTopoBlock.col(c) = mSolver.mTearTopology.block(mSubnet.sysOff, cols[c],
+                                                       mSubnet.sysSize, 1);
+
+  Matrix invTopoBlock = mSubnet.directLinearSolver->solve(tearTopoBlock);
+
+  for (UInt c = 0; c < nJ; ++c)
+    mSolver.mSystemInverseTearTopology.block(
+        mSubnet.sysOff, cols[c], mSubnet.sysSize, 1) = invTopoBlock.col(c);
+
+  mSolver.mTearSchurNeedsRebuild = true;
+}
+
+template <typename VarType>
+Bool DiakopticsSolver<VarType>::SubnetSolveTask::hasVariableComponentChanged() {
+  bool changed = false;
+  for (auto varElem : mSubnet.mVariableComps) {
+    if (varElem->hasParameterChanged()) {
+      auto idObj = std::dynamic_pointer_cast<IdentifiedObject>(varElem);
+      // if we return true here directly, not all functions are called
+      // and some internal bools lead to further recalculation at t+1
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+template <typename VarType>
 void DiakopticsSolver<VarType>::SubnetSolveTask::execute(Real time,
                                                          Int timeStepCount) {
   auto rBlock =
@@ -521,13 +588,28 @@ void DiakopticsSolver<VarType>::SubnetSolveTask::execute(Real time,
 
   auto lBlock = (**mSolver.mOrigLeftSideVector)
                     .block(mSubnet.sysOff, 0, mSubnet.sysSize, 1);
+
+  if (hasVariableComponentChanged()) {
+    recomputeSubnetMatrix(time);
+  }
   // Solve Y' * v' = I
-  lBlock = mSubnet.luFactorization.solve(rBlock);
+  Matrix rhs = rBlock;
+  lBlock = mSubnet.directLinearSolver->solve(rhs);
 }
 
 template <typename VarType>
 void DiakopticsSolver<VarType>::PreSolveTask::execute(Real time,
                                                       Int timeStepCount) {
+  // Rebuild tear Schur complement and factorization once if any subnet
+  // recomputed. Runs single-threaded after SubnetSolveTasks
+  if (mSolver.mTearSchurNeedsRebuild.exchange(false)) {
+    mSolver.mTearSchur =
+        mSolver.mTearImpedance +
+        mSolver.mTearTopology.transpose() * mSolver.mSystemInverseTearTopology;
+    mSolver.mTotalTearImpedance =
+        Eigen::PartialPivLU<Matrix>(mSolver.mTearSchur);
+  }
+
   mSolver.mTearVoltages.setZero();
   for (auto comp : mSolver.mTearComponents) {
     auto tComp = std::dynamic_pointer_cast<MNATearInterface>(comp);
@@ -553,7 +635,8 @@ void DiakopticsSolver<VarType>::SolveTask::execute(Real time,
                     .block(mSubnet.sysOff, 0, mSubnet.sysSize, 1);
   // Solve Y' * x = C * i
   // v = v' + x
-  lBlock += mSubnet.luFactorization.solve(rBlock);
+  Matrix rhs = rBlock;
+  lBlock += mSubnet.directLinearSolver->solve(rhs);
   **mSubnet.leftVector = lBlock;
 }
 

--- a/examples/Notebooks/Performance/EMT_IEEE_39bus_Multi_Diakoptics.ipynb
+++ b/examples/Notebooks/Performance/EMT_IEEE_39bus_Multi_Diakoptics.ipynb
@@ -1,0 +1,284 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# EMT IEEE-39 Bus Multi-Area Diakoptics Runtime Measurement\n",
+    "\n",
+    "Loads four copies of the IEEE-39 bus system, merges them into one system and couples them in a ring. The `EMT_IEEE_39bus_Multi_CIM` example runs four variants and reports total time and the per-step solve times:\n",
+    "\n",
+    "- monolithic (single MNA system matrix)\n",
+    "- monolithic + OpenMP level scheduler\n",
+    "- diakoptics (ring couplers as tear components -> four subsystems)\n",
+    "- diakoptics + OpenMP level scheduler\n",
+    "\n",
+    "The coupling node voltages of the monolithic and diakoptics runs are compared to confirm both solvers agree and per-step solve times are analysed to compare the system-matrix recomputation triggered by the fault switch at t = 0.005 s."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "650eb188",
+   "metadata": {},
+   "source": [
+    "## Background: Why diakoptics, and what changed with KLU\n",
+    "\n",
+    "**Original Idea:** A large network is torn into subnetworks; the coupling is a small dense Schur complement. On a topology change (switch/fault) only the affected subnetwork block must be refactorized instead of the whole system matrix — a benefit even without parallelization (https://doi.org/10.1049/icp.2025.4299).\n",
+    "\n",
+    "**DPsim:** DPsim's KLU adapter now already supports partial refactorization, which the monolithic KLU solver uses. This also lets the monolithic solver refactorize cheaply at a switch.\n",
+    "\n",
+    "**Measurements:** The dense columns use `Eigen::PartialPivLU` (pre-KLU path), the KLU columns use KLU on both solvers:\n",
+    "\n",
+    "| Stage | MNA before (dense) | Diakoptics before (dense) | MNA + KLU | Diakoptics + KLU |\n",
+    "|-------|----------------------|-----------------------------|-------------|--------------------|\n",
+    "| **Switch step [ms]** | 161.0 | 11.7 | **3.6** | 12.0 |\n",
+    "| **Avg step [ms]**    | 5.81  | 2.04 | 4.28 | **1.71** |\n",
+    "\n",
+    "So while diakoptics improved the switch step by ~13.8x (for the given example), switching to KLU improved the switching step even more significantly (45× speedup). As the diakoptics approach speeds up non-switching step times compared to monolithic KLU, it's still interesting as for most simulations switching /recomputation happens rarely.\n",
+    "\n",
+    "\n",
+    "*(Numbers are multiple tests on one machine; absolute values drift with load, but ratios and effects are stable.\n",
+    "All other data is recomputed live from this run.)*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-1",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "- Domain: EMT, three-phase (ABC)\n",
+    "- Linear solver: KLU, system matrix recomputation enabled\n",
+    "- Grid: 4 copies of IEEE-39, coupled in a ring\n",
+    "- Subsystems (diakoptics): 4 (ring couplers are used as tear components)\n",
+    "- Timestep: 10 us, final time: 0.02 s -> 2000 steps\n",
+    "- Fault: ground switch at bus N05 of area 0 closes at t = 0.005 s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-2",
+   "metadata": {},
+   "source": [
+    "## Run\n",
+    "\n",
+    "Prints the total time of each variant and writes per-step solve times to `logs/<variant>/<variant>_step_times.log`.\n",
+    "Run takes approx. 60s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T17:47:29.872164Z",
+     "iopub.status.busy": "2026-06-19T17:47:29.871864Z",
+     "iopub.status.idle": "2026-06-19T17:48:37.377361Z",
+     "shell.execute_reply": "2026-06-19T17:48:37.375907Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Locate the repository top and build directory (supports in-source and out-of-source builds)\n",
+    "top = Path(\n",
+    "    subprocess.run(\n",
+    "        [\"git\", \"rev-parse\", \"--show-toplevel\"],\n",
+    "        capture_output=True,\n",
+    "        text=True,\n",
+    "        check=True,\n",
+    "    ).stdout.strip()\n",
+    ")\n",
+    "build = next(\n",
+    "    b\n",
+    "    for b in (top / \"build\", top.parent / \"build\", top.parent.parent / \"build\")\n",
+    "    if (b / \"_deps/cim-data-src/IEEE-39\").is_dir()\n",
+    ")\n",
+    "env = {**os.environ, \"CIMPATH\": str(build / \"_deps/cim-data-src/IEEE-39\")}\n",
+    "\n",
+    "# Locate the executable (supports multi-config subdirs and the .exe suffix)\n",
+    "exe = next(\n",
+    "    p\n",
+    "    for p in (build / \"dpsim/examples/cxx\").rglob(\"EMT_IEEE_39bus_Multi_CIM*\")\n",
+    "    if p.is_file() and p.suffix in (\"\", \".exe\")\n",
+    ")\n",
+    "\n",
+    "result = subprocess.run([str(exe)], env=env, capture_output=True, text=True)\n",
+    "print(result.stdout)\n",
+    "if result.returncode != 0:\n",
+    "    print(result.stderr)\n",
+    "    raise SystemExit(f\"{exe.name} exited with code {result.returncode}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-4",
+   "metadata": {},
+   "source": [
+    "## Validate results\n",
+    "\n",
+    "Overlay the coupling node voltages of the monolithic and diakoptics runs. They must match."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import villas.dataprocessing.readtools as rt\n",
+    "import villas.dataprocessing.plottools as pt\n",
+    "\n",
+    "dt = 10e-6\n",
+    "fault_time = 0.005\n",
+    "fault_step = int(round(fault_time / dt))\n",
+    "\n",
+    "variants = {\n",
+    "    \"monolithic\": \"IEEE-39bus_multi\",\n",
+    "    \"monolithic + OpenMP\": \"IEEE-39bus_multi_openMP\",\n",
+    "    \"diakoptics\": \"IEEE-39bus_multi_diakoptics\",\n",
+    "    \"diakoptics + OpenMP\": \"IEEE-39bus_multi_diakoptics_openMP\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mono = rt.read_timeseries_dpsim(\"logs/IEEE-39bus_multi/IEEE-39bus_multi.csv\")\n",
+    "diakoptics = rt.read_timeseries_dpsim(\n",
+    "    \"logs/IEEE-39bus_multi_diakoptics/IEEE-39bus_multi_diakoptics.csv\"\n",
+    ")\n",
+    "\n",
+    "for i in range(0, 4):\n",
+    "    varname = \"area\" + str(i) + \".V_0\"\n",
+    "    pt.set_timeseries_labels(mono[varname], varname + \" monolithic\")\n",
+    "    pt.set_timeseries_labels(diakoptics[varname], varname + \" diakoptics\")\n",
+    "    pt.plot_timeseries(i + 1, mono[varname])\n",
+    "    pt.plot_timeseries(i + 1, diakoptics[varname], \"--\")\n",
+    "    plt.title(\"IEEE-39 with 4 areas coupled in a ring\")\n",
+    "    plt.xlabel(\"Time [s]\")\n",
+    "    plt.ylabel(\"Voltage [V]\")\n",
+    "    diff = max(abs(mono[varname].values - diakoptics[varname].values))\n",
+    "    print(f\"area{i}.V_0 max|mono - diakoptics| = {diff:.3e} V\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-7",
+   "metadata": {},
+   "source": [
+    "## Critical time: per-step solve times\n",
+    "\n",
+    "The diakoptics solver replaces one large system matrix by several smaller subsystem matrices, so each timestep is cheaper to solve. The cost moves to the switch event at t = 0.005 s, where the (Schur-complement) system matrix has to be recomputed. The table and plot below quantify both effects:\n",
+    "\n",
+    "- `solve time [s]`: sum of all step times (excludes initialisation, includes the switch)\n",
+    "- `avg step [ms]`: average time per timestep\n",
+    "- `switch step [ms]`: cost of the timestep that handles the fault -> matrix recomputation\n",
+    "- `post-fault avg [ms]`: average step time after the fault"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "step_times = {}\n",
+    "rows = []\n",
+    "for label, sim in variants.items():\n",
+    "    v = np.loadtxt(f\"logs/{sim}/{sim}_step_times.log\", skiprows=1)\n",
+    "    step_times[label] = v\n",
+    "    switch_window = v[fault_step - 2 : fault_step + 3]\n",
+    "    rows.append(\n",
+    "        {\n",
+    "            \"variant\": label,\n",
+    "            \"solve time [s]\": v.sum(),\n",
+    "            \"avg step [ms]\": v.mean() * 1e3,\n",
+    "            \"switch step [ms]\": switch_window.max() * 1e3,\n",
+    "            \"post-fault avg [ms]\": v[fault_step + 5 :].mean() * 1e3,\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "table = pd.DataFrame(rows).set_index(\"variant\")\n",
+    "table[\"solve speedup\"] = (\n",
+    "    table.loc[\"monolithic\", \"solve time [s]\"] / table[\"solve time [s]\"]\n",
+    ")\n",
+    "table.round(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T17:48:41.483036Z",
+     "iopub.status.busy": "2026-06-19T17:48:41.482254Z",
+     "iopub.status.idle": "2026-06-19T17:48:42.155910Z",
+     "shell.execute_reply": "2026-06-19T17:48:42.154045Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "t = np.arange(len(next(iter(step_times.values())))) * dt\n",
+    "\n",
+    "plt.figure(figsize=(9, 5))\n",
+    "for label, v in step_times.items():\n",
+    "    plt.plot(t, v * 1e3, label=label, linewidth=0.7)\n",
+    "plt.axvline(fault_time, color=\"k\", linestyle=\":\", linewidth=1, label=\"switch event\")\n",
+    "plt.yscale(\"log\")\n",
+    "plt.xlabel(\"Time [s]\")\n",
+    "plt.ylabel(\"Step time [ms]\")\n",
+    "plt.title(\"Per-step solve time - spike at the switch is the matrix recomputation\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f6c884a-37d4-42a9-bf7d-c3c7f6eb3de8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Diakoptics development: KLU-based subnet solving with localized system-matrix recomputation

Changes (DiakopticsSolver.cpp / h):
- Replaces dense per-subnet factorization (Eigen::PartialPivLU) with the sparse DirectLinearSolver (KLUAdapter) per subnet (Like for the monolithic MNA solver)
- Build the tear coupling from block-diagonal solves (Y_block^-1 * C) - dropped full dense mSystemInverse

Added:
- System-matrix recomputation for switching events: detect variable-component changes (hasVariableComponentChanged) and refactor only the subnetwork (recomputeSubnetMatrix) instead of the whole system
- Partial refactorization (KLU factorization path) of the changed subnet instead full refactorization
- Restrict the Schur-complement update to the tear columns coupled to the changed subnet
- EMT three-phase CIM diakoptics examples: EMT_IEEE_39bus_CIM.cpp, EMT_IEEE_39bus_Multi_CIM.cpp, EMT_Diakoptics.cpp
- Performance notebook EMT_IEEE_39bus_Multi_Diakoptics.ipynb: monolithic vs diakoptics (serial and OpenMP), node-voltage validation, average-step and switch-step timing analysis

Features:
- Topology changes (switch/fault) refactorize only the affected subnetwork block, not the full system matrix
- Uses Sparse KLU now: reuses the same DirectLinearSolver interface as MnaSolverDirect

Closes #431