### PR TITLE
DP/SFA SSN: base classes and single-phase serial RLC component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,6 +28,8 @@
 /dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator6bOrderVBR.h @martinmoraga
 /dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGeneratorTrStab.h @gnakti
 /dpsim-models/include/dpsim-models/DP/DP_Ph1_varResSwitch.h @gnakti
+/dpsim-models/include/dpsim-models/DP/DP_Ph1_TwoTerminalVTypeSSNComp.h @leonardocarreras
+/dpsim-models/include/dpsim-models/DP/DP_Ph1_SSN_Full_Serial_RLC.h @leonardocarreras
 /dpsim-models/include/dpsim-models/EMT/EMT_SSNComp.h @georgii-tishenin
 /dpsim-models/include/dpsim-models/EMT/EMT_VTypeSSNComp.h @georgii-tishenin
 /dpsim-models/include/dpsim-models/EMT/EMT_VTypeVariableSSNComp.h @georgii-tishenin
@@ -57,6 +59,8 @@
 /dpsim-models/src/DP/DP_Ph1_SynchronGenerator6bOrderVBR.cpp @martinmoraga
 /dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp @gnakti
 /dpsim-models/src/DP/DP_Ph1_varResSwitch.cpp @gnakti
+/dpsim-models/src/DP/DP_Ph1_TwoTerminalVTypeSSNComp.cpp @leonardocarreras
+/dpsim-models/src/DP/DP_Ph1_SSN_Full_Serial_RLC.cpp @leonardocarreras
 /dpsim-models/src/EMT/EMT_SSNComp.cpp @georgii-tishenin
 /dpsim-models/src/EMT/EMT_VTypeSSNComp.cpp @georgii-tishenin
 /dpsim-models/src/EMT/EMT_VTypeVariableSSNComp.cpp @georgii-tishenin

--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -56,9 +56,11 @@
 #ifdef WITH_VILLAS
 #include <dpsim-models/DP/DP_Ph1_ProfileVoltageSource.h>
 #endif
+#include <dpsim-models/DP/DP_ITypeSSNComp.h>
 #include <dpsim-models/DP/DP_Ph1_ControlledCurrentSource.h>
 #include <dpsim-models/DP/DP_Ph1_ControlledVoltageSource.h>
 #include <dpsim-models/DP/DP_Ph1_RxLine.h>
+#include <dpsim-models/DP/DP_Ph1_SSN_Full_Serial_RLC.h>
 #include <dpsim-models/DP/DP_Ph1_SVC.h>
 #include <dpsim-models/DP/DP_Ph1_Switch.h>
 #include <dpsim-models/DP/DP_Ph1_SynchronGenerator3OrderVBR.h>
@@ -72,10 +74,13 @@
 #include <dpsim-models/DP/DP_Ph1_SynchronGeneratorIdeal.h>
 #include <dpsim-models/DP/DP_Ph1_SynchronGeneratorTrStab.h>
 #include <dpsim-models/DP/DP_Ph1_Transformer.h>
+#include <dpsim-models/DP/DP_Ph1_TwoTerminalVTypeSSNComp.h>
 #include <dpsim-models/DP/DP_Ph1_VoltageSource.h>
 #include <dpsim-models/DP/DP_Ph1_VoltageSourceNorton.h>
 #include <dpsim-models/DP/DP_Ph1_VoltageSourceRamp.h>
 #include <dpsim-models/DP/DP_Ph1_varResSwitch.h>
+#include <dpsim-models/DP/DP_SSNComp.h>
+#include <dpsim-models/DP/DP_VTypeSSNComp.h>
 
 #include <dpsim-models/DP/DP_Ph3_Capacitor.h>
 #include <dpsim-models/DP/DP_Ph3_Inductor.h>

--- a/dpsim-models/include/dpsim-models/DP/DP_ITypeSSNComp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_ITypeSSNComp.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_SSNComp.h>
+
+namespace CPS {
+namespace DP {
+
+/// \brief Abstract base for DP I-type SSN components (input current, output voltage).
+class ITypeSSNComp : public SSNComp {
+protected:
+  ITypeSSNComp(String uid, String name, Int inputSize, Int outputSize,
+               Logger::Level logLevel = Logger::Level::off);
+
+  Attribute<MatrixComp>::Ptr inputAttribute() const override final;
+  Attribute<MatrixComp>::Ptr outputAttribute() const override final;
+
+  /// Reconstruct the initial input current from node/terminal phasors.
+  virtual MatrixComp buildInitialInputFromNodes(Real frequency) = 0;
+
+public:
+  void initializeFromNodesAndTerminals(Real frequency) override;
+
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
+
+  void mnaCompPostStep(Real time, Int timeStepCount,
+                       Attribute<Matrix>::Ptr &leftVector) override final;
+};
+
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SSN_Full_Serial_RLC.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SSN_Full_Serial_RLC.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_Ph1_TwoTerminalVTypeSSNComp.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph1 {
+namespace SSN {
+
+/// \brief Series RLC one-port as a DP V-type SSN component.
+///
+/// States x = [v_C; i_L], input = port voltage, output = inductor current.
+class Full_Serial_RLC final : public TwoTerminalVTypeSSNComp,
+                              public SharedFactory<Full_Serial_RLC> {
+public:
+  using SharedFactory<Full_Serial_RLC>::make;
+
+  Full_Serial_RLC(String uid, String name,
+                  Logger::Level logLevel = Logger::Level::off);
+  Full_Serial_RLC(String name, Logger::Level logLevel = Logger::Level::off)
+      : Full_Serial_RLC(name, name, logLevel) {}
+
+  SimPowerComp<Complex>::Ptr clone(String name) override;
+
+  void setParameters(Real resistance, Real inductance, Real capacitance);
+
+private:
+  Real mResistance = 0.;
+  Real mInductance = 0.;
+  Real mCapacitance = 0.;
+};
+
+} // namespace SSN
+} // namespace Ph1
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_TwoTerminalVTypeSSNComp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_TwoTerminalVTypeSSNComp.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_VTypeSSNComp.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph1 {
+
+/// \brief Single-phase, two-terminal V-type SSN stamping layer.
+///
+/// Provides the concrete MNA stamps (Norton admittance, history current, node
+/// voltage read) shared by single-phase two-terminal V-type SSN components.
+class TwoTerminalVTypeSSNComp : public VTypeSSNComp {
+protected:
+  TwoTerminalVTypeSSNComp(String uid, String name,
+                          Logger::Level logLevel = Logger::Level::off);
+
+  MatrixComp buildInitialInputFromNodes(Real frequency) override final;
+
+public:
+  void
+  mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override final;
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override final;
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override final;
+};
+
+} // namespace Ph1
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_SSNComp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_SSNComp.h
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Solver/MNAInterface.h>
+
+namespace CPS {
+namespace DP {
+
+/// \brief Abstract base class for DP/SFA state-space nodal (SSN) components.
+///
+/// DP counterpart of EMT::SSNComp. The SFA carrier shift uses the real-augmented
+/// form A_aug = [[A, w I], [-w I, A]]; see the .cpp for how it folds back to the
+/// complex envelope model. Single carrier only. Input/output meaning is fixed by
+/// derived V-type / I-type classes.
+class SSNComp : public MNASimPowerComp<Complex> {
+private:
+  const Int mInputSize;
+  const Int mOutputSize;
+
+protected:
+  Real mTimeStep;
+
+  /// Continuous-time real physical model (user-provided).
+  Matrix mA;
+  Matrix mB;
+  Matrix mC;
+  Matrix mD;
+
+  /// Complex envelope discrete operators (folded from the augmented model).
+  MatrixComp mDiscreteA;
+  MatrixComp mDiscreteB;
+
+  /// Complex Norton matrix W = C dB + D.
+  MatrixComp mW;
+  /// Complex history term.
+  MatrixComp mYHist;
+
+  /// Complex envelope state X.
+  const Attribute<MatrixComp>::Ptr mX;
+
+  SSNComp(String uid, String name, Int inputSize, Int outputSize,
+          Logger::Level logLevel = Logger::Level::off);
+
+  /// Build A_aug = [[A, w I], [-w I, A]].
+  Matrix buildAugmentedA(Real omega) const;
+  /// Build B_aug = blkdiag(B, B).
+  Matrix buildAugmentedB() const;
+
+  /// Discretize the augmented model and fold it into complex dA, dB, W.
+  virtual void recomputeDiscreteModel(Real omega);
+
+  virtual MatrixComp calculateHistoryVector() const;
+
+  /// Steady-state envelope state X_ss = (j w I - A)^-1 B u.
+  virtual MatrixComp calculateSteadyStateStateFromInput(const MatrixComp &u,
+                                                        Real omega) const;
+  virtual MatrixComp
+  calculateSteadyStateOutputFromInput(const MatrixComp &x,
+                                      const MatrixComp &u) const;
+
+  virtual void updateState(const MatrixComp &uOld, const MatrixComp &uNew);
+
+  /// Hook for variable/time-varying SSN components.
+  virtual void updateStateSpaceModel();
+
+  virtual Attribute<MatrixComp>::Ptr inputAttribute() const = 0;
+  virtual Attribute<MatrixComp>::Ptr outputAttribute() const = 0;
+
+public:
+  /// Get number of internal state variables of the SSN model.
+  UInt getStateCount() const;
+
+  /// Get the complex discrete state-transition operator of the envelope model.
+  const MatrixComp &getDiscreteA() const;
+  /// Get the complex discrete input operator of the envelope model.
+  const MatrixComp &getDiscreteB() const;
+  /// Get the continuous-time output matrix of the SSN model.
+  const Matrix &getC() const;
+
+  void setParameters(const Matrix &A, const Matrix &B, const Matrix &C,
+                     const Matrix &D);
+
+  void mnaCompInitialize(Real omega, Real timeStep,
+                         Attribute<Matrix>::Ptr leftVector) override final;
+
+  void mnaCompAddPreStepDependencies(
+      AttributeBase::List &prevStepDependencies,
+      AttributeBase::List &attributeDependencies,
+      AttributeBase::List &modifiedAttributes) override final;
+
+  void mnaCompPreStep(Real time, Int timeStepCount) override final;
+
+  void mnaCompAddPostStepDependencies(
+      AttributeBase::List &prevStepDependencies,
+      AttributeBase::List &attributeDependencies,
+      AttributeBase::List &modifiedAttributes,
+      Attribute<Matrix>::Ptr &leftVector) override final;
+};
+
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_VTypeSSNComp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_VTypeSSNComp.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_SSNComp.h>
+
+namespace CPS {
+namespace DP {
+
+/// \brief Abstract base for DP V-type SSN components (input voltage, output current).
+class VTypeSSNComp : public SSNComp {
+protected:
+  VTypeSSNComp(String uid, String name, Int inputSize, Int outputSize,
+               Logger::Level logLevel = Logger::Level::off);
+
+  Attribute<MatrixComp>::Ptr inputAttribute() const override final;
+  Attribute<MatrixComp>::Ptr outputAttribute() const override final;
+
+  /// Reconstruct the initial input voltage from node/terminal phasors.
+  virtual MatrixComp buildInitialInputFromNodes(Real frequency) = 0;
+
+public:
+  void initializeFromNodesAndTerminals(Real frequency) override;
+
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override final;
+
+  void mnaCompPostStep(Real time, Int timeStepCount,
+                       Attribute<Matrix>::Ptr &leftVector) override final;
+};
+
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -52,6 +52,8 @@ list(APPEND MODELS_SOURCES
 	DP/DP_Ph1_varResSwitch.cpp
 	DP/DP_Ph1_DPDQInterface.cpp
 
+	DP/DP_SSNComp.cpp
+
 	DP/DP_Ph3_VoltageSource.cpp
 	DP/DP_Ph3_Capacitor.cpp
 	DP/DP_Ph3_Inductor.cpp

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -53,6 +53,8 @@ list(APPEND MODELS_SOURCES
 	DP/DP_Ph1_DPDQInterface.cpp
 
 	DP/DP_SSNComp.cpp
+	DP/DP_VTypeSSNComp.cpp
+	DP/DP_ITypeSSNComp.cpp
 
 	DP/DP_Ph3_VoltageSource.cpp
 	DP/DP_Ph3_Capacitor.cpp

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -55,6 +55,8 @@ list(APPEND MODELS_SOURCES
 	DP/DP_SSNComp.cpp
 	DP/DP_VTypeSSNComp.cpp
 	DP/DP_ITypeSSNComp.cpp
+	DP/DP_Ph1_TwoTerminalVTypeSSNComp.cpp
+	DP/DP_Ph1_SSN_Full_Serial_RLC.cpp
 
 	DP/DP_Ph3_VoltageSource.cpp
 	DP/DP_Ph3_Capacitor.cpp

--- a/dpsim-models/src/DP/DP_ITypeSSNComp.cpp
+++ b/dpsim-models/src/DP/DP_ITypeSSNComp.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_ITypeSSNComp.h>
+
+using namespace CPS;
+
+DP::ITypeSSNComp::ITypeSSNComp(String uid, String name, Int inputSize,
+                               Int outputSize, Logger::Level logLevel)
+    : SSNComp(uid, name, inputSize, outputSize, logLevel) {
+  **mIntfCurrent = MatrixComp::Zero(inputSize, 1);
+  **mIntfVoltage = MatrixComp::Zero(outputSize, 1);
+}
+
+Attribute<MatrixComp>::Ptr DP::ITypeSSNComp::inputAttribute() const {
+  return mIntfCurrent;
+}
+
+Attribute<MatrixComp>::Ptr DP::ITypeSSNComp::outputAttribute() const {
+  return mIntfVoltage;
+}
+
+void DP::ITypeSSNComp::initializeFromNodesAndTerminals(Real frequency) {
+  if (!mParametersSet)
+    throw std::logic_error("setParameters() must be called before "
+                           "initializeFromNodesAndTerminals().");
+
+  Real omega = 2. * PI * frequency;
+  MatrixComp uInit = buildInitialInputFromNodes(frequency);
+  MatrixComp xInit = calculateSteadyStateStateFromInput(uInit, omega);
+  MatrixComp yInit = calculateSteadyStateOutputFromInput(xInit, uInit);
+
+  **mX = xInit;
+  **mIntfCurrent = uInit;
+  **mIntfVoltage = yInit;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- Initialization from nodes and terminals ---"
+                     "\nInput u: {:s}"
+                     "\nOutput y: {:s}"
+                     "\nState x: {:s}"
+                     "\n--- Initialization finished ---",
+                     Logger::matrixCompToString(**mIntfCurrent),
+                     Logger::matrixCompToString(**mIntfVoltage),
+                     Logger::matrixCompToString(**mX));
+}
+
+void DP::ITypeSSNComp::mnaCompUpdateVoltage(const Matrix &) {}
+
+void DP::ITypeSSNComp::mnaCompPostStep(Real, Int,
+                                       Attribute<Matrix>::Ptr &leftVector) {
+  MatrixComp uOld = **mIntfCurrent;
+  mnaCompUpdateVoltage(**leftVector);
+  mnaCompUpdateCurrent(**leftVector);
+  updateState(uOld, **mIntfCurrent);
+}

--- a/dpsim-models/src/DP/DP_Ph1_SSN_Full_Serial_RLC.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SSN_Full_Serial_RLC.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph1_SSN_Full_Serial_RLC.h>
+
+using namespace CPS;
+
+DP::Ph1::SSN::Full_Serial_RLC::Full_Serial_RLC(String uid, String name,
+                                               Logger::Level logLevel)
+    : TwoTerminalVTypeSSNComp(uid, name, logLevel) {}
+
+SimPowerComp<Complex>::Ptr DP::Ph1::SSN::Full_Serial_RLC::clone(String name) {
+  auto copy = Full_Serial_RLC::make(name, mLogLevel);
+  copy->setParameters(mResistance, mInductance, mCapacitance);
+  return copy;
+}
+
+void DP::Ph1::SSN::Full_Serial_RLC::setParameters(Real resistance,
+                                                  Real inductance,
+                                                  Real capacitance) {
+  mResistance = resistance;
+  mInductance = inductance;
+  mCapacitance = capacitance;
+
+  // x = [v_C; i_L], u = port voltage, y = i_L
+  Matrix A = Matrix::Zero(2, 2);
+  A(0, 1) = 1. / mCapacitance;
+  A(1, 0) = -1. / mInductance;
+  A(1, 1) = -mResistance / mInductance;
+  Matrix B = Matrix::Zero(2, 1);
+  B(1, 0) = 1. / mInductance;
+  Matrix C = Matrix::Zero(1, 2);
+  C(0, 1) = 1.;
+  Matrix D = Matrix::Zero(1, 1);
+
+  SSNComp::setParameters(A, B, C, D);
+}

--- a/dpsim-models/src/DP/DP_Ph1_TwoTerminalVTypeSSNComp.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_TwoTerminalVTypeSSNComp.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph1_TwoTerminalVTypeSSNComp.h>
+#include <dpsim-models/MNAStampUtils.h>
+
+using namespace CPS;
+
+DP::Ph1::TwoTerminalVTypeSSNComp::TwoTerminalVTypeSSNComp(
+    String uid, String name, Logger::Level logLevel)
+    : VTypeSSNComp(uid, name, 1, 1, logLevel) {
+  mPhaseType = PhaseType::Single;
+  setTerminalNumber(2);
+}
+
+MatrixComp DP::Ph1::TwoTerminalVTypeSSNComp::buildInitialInputFromNodes(Real) {
+  // v = v_terminal1 - v_terminal0 (DP envelope phasor)
+  MatrixComp vInit = MatrixComp::Zero(1, 1);
+  vInit(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
+  return vInit;
+}
+
+void DP::Ph1::TwoTerminalVTypeSSNComp::mnaCompApplySystemMatrixStamp(
+    SparseMatrixRow &systemMatrix) {
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    MNAStampUtils::stampAdmittance(
+        mW(0, 0), systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
+        terminalNotGrounded(0), terminalNotGrounded(1), mSLog, mNumFreqs, freq);
+  }
+}
+
+void DP::Ph1::TwoTerminalVTypeSSNComp::mnaCompApplyRightSideVectorStamp(
+    Matrix &rightVector) {
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    if (terminalNotGrounded(0))
+      Math::setVectorElement(rightVector, matrixNodeIndex(0), mYHist(0, 0),
+                             mNumFreqs, freq);
+    if (terminalNotGrounded(1))
+      Math::setVectorElement(rightVector, matrixNodeIndex(1), -mYHist(0, 0),
+                             mNumFreqs, freq);
+  }
+}
+
+void DP::Ph1::TwoTerminalVTypeSSNComp::mnaCompUpdateVoltage(
+    const Matrix &leftVector) {
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    (**mIntfVoltage)(0, freq) = 0;
+    if (terminalNotGrounded(1))
+      (**mIntfVoltage)(0, freq) = Math::complexFromVectorElement(
+          leftVector, matrixNodeIndex(1), mNumFreqs, freq);
+    if (terminalNotGrounded(0))
+      (**mIntfVoltage)(0, freq) -= Math::complexFromVectorElement(
+          leftVector, matrixNodeIndex(0), mNumFreqs, freq);
+  }
+}

--- a/dpsim-models/src/DP/DP_SSNComp.cpp
+++ b/dpsim-models/src/DP/DP_SSNComp.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_SSNComp.h>
+#include <dpsim-models/MathUtils.h>
+
+using namespace CPS;
+
+DP::SSNComp::SSNComp(String uid, String name, Int inputSize, Int outputSize,
+                     Logger::Level logLevel)
+    : MNASimPowerComp<Complex>(uid, name, true, true, logLevel), mTimeStep(0.0),
+      mW(MatrixComp::Zero(outputSize, inputSize)),
+      mYHist(MatrixComp::Zero(outputSize, 1)), mInputSize(inputSize),
+      mOutputSize(outputSize), mX(mAttributes->create<MatrixComp>("x")) {
+  mParametersSet = false;
+}
+
+UInt DP::SSNComp::getStateCount() const { return static_cast<UInt>(mA.rows()); }
+
+const MatrixComp &DP::SSNComp::getDiscreteA() const { return mDiscreteA; }
+
+const MatrixComp &DP::SSNComp::getDiscreteB() const { return mDiscreteB; }
+
+const Matrix &DP::SSNComp::getC() const { return mC; }
+
+void DP::SSNComp::setParameters(const Matrix &A, const Matrix &B,
+                                const Matrix &C, const Matrix &D) {
+  mParametersSet = false;
+
+  if (A.rows() != A.cols())
+    throw std::invalid_argument("A must be square.");
+
+  if (B.rows() != A.rows() || B.cols() != mInputSize)
+    throw std::invalid_argument("B has invalid dimensions.");
+
+  if (C.rows() != mOutputSize || C.cols() != A.rows())
+    throw std::invalid_argument("C has invalid dimensions.");
+
+  if (D.rows() != mOutputSize || D.cols() != mInputSize)
+    throw std::invalid_argument("D has invalid dimensions.");
+
+  mA = A;
+  mB = B;
+  mC = C;
+  mD = D;
+
+  **mX = MatrixComp::Zero(mA.rows(), 1);
+
+  mDiscreteA = MatrixComp::Zero(mA.rows(), mA.cols());
+  mDiscreteB = MatrixComp::Zero(mB.rows(), mB.cols());
+
+  mW = MatrixComp::Zero(mOutputSize, mInputSize);
+  mYHist = MatrixComp::Zero(mOutputSize, 1);
+
+  mParametersSet = true;
+}
+
+Matrix DP::SSNComp::buildAugmentedA(Real omega) const {
+  const Matrix::Index n = mA.rows();
+  const Matrix wI = omega * Matrix::Identity(n, n);
+
+  Matrix aAug = Matrix::Zero(2 * n, 2 * n);
+  aAug.topLeftCorner(n, n) = mA;
+  aAug.topRightCorner(n, n) = wI;
+  aAug.bottomLeftCorner(n, n) = -wI;
+  aAug.bottomRightCorner(n, n) = mA;
+  return aAug;
+}
+
+Matrix DP::SSNComp::buildAugmentedB() const {
+  const Matrix::Index n = mA.rows();
+
+  Matrix bAug = Matrix::Zero(2 * n, 2 * mInputSize);
+  bAug.topLeftCorner(n, mInputSize) = mB;
+  bAug.bottomRightCorner(n, mInputSize) = mB;
+  return bAug;
+}
+
+void DP::SSNComp::recomputeDiscreteModel(Real omega) {
+  const Matrix::Index n = mA.rows();
+
+  // Discretize the real-augmented model with the same helper as EMT-SSN.
+  const Matrix aAug = buildAugmentedA(omega);
+  const Matrix bAug = buildAugmentedB();
+  Matrix dAaug = Matrix::Zero(2 * n, 2 * n);
+  Matrix dBaug = Matrix::Zero(2 * n, 2 * mInputSize);
+  Math::calculateStateSpaceTrapezoidalMatrices(aAug, bAug, mTimeStep, dAaug,
+                                               dBaug);
+
+  // Fold the [[P, -Q], [Q, P]] rotation blocks back into complex P + jQ.
+  mDiscreteA = dAaug.topLeftCorner(n, n).cast<Complex>() +
+               Complex(0., 1.) * dAaug.bottomLeftCorner(n, n).cast<Complex>();
+  mDiscreteB =
+      dBaug.block(0, 0, n, mInputSize).cast<Complex>() +
+      Complex(0., 1.) * dBaug.block(n, 0, n, mInputSize).cast<Complex>();
+
+  mW = mC.cast<Complex>() * mDiscreteB + mD.cast<Complex>();
+}
+
+MatrixComp DP::SSNComp::calculateHistoryVector() const {
+  return mC.cast<Complex>() *
+         (mDiscreteA * (**mX) + mDiscreteB * (**inputAttribute()));
+}
+
+MatrixComp DP::SSNComp::calculateSteadyStateStateFromInput(const MatrixComp &u,
+                                                           Real omega) const {
+  MatrixComp h =
+      Complex(0., omega) * MatrixComp::Identity(mA.rows(), mA.cols()) -
+      mA.cast<Complex>();
+
+  return h.inverse() * mB.cast<Complex>() * u;
+}
+
+MatrixComp
+DP::SSNComp::calculateSteadyStateOutputFromInput(const MatrixComp &x,
+                                                 const MatrixComp &u) const {
+  return mC.cast<Complex>() * x + mD.cast<Complex>() * u;
+}
+
+void DP::SSNComp::updateState(const MatrixComp &uOld, const MatrixComp &uNew) {
+  **mX = mDiscreteA * (**mX) + mDiscreteB * (uNew + uOld);
+}
+
+void DP::SSNComp::updateStateSpaceModel() {
+  // For linear components, the default implementation does nothing.
+}
+
+void DP::SSNComp::mnaCompInitialize(Real omega, Real timeStep,
+                                    Attribute<Matrix>::Ptr) {
+  if (!mParametersSet)
+    throw std::logic_error(
+        "setParameters() must be called before initialization.");
+
+  if (mNumFreqs != 1)
+    throw std::logic_error(
+        "DP SSN components currently support a single carrier frequency.");
+
+  mTimeStep = timeStep;
+  updateMatrixNodeIndices();
+
+  recomputeDiscreteModel(omega);
+  mYHist = calculateHistoryVector();
+}
+
+void DP::SSNComp::mnaCompAddPreStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes) {
+  modifiedAttributes.push_back(mRightVector);
+  prevStepDependencies.push_back(mX);
+  prevStepDependencies.push_back(inputAttribute());
+}
+
+void DP::SSNComp::mnaCompPreStep(Real time, Int timeStepCount) {
+  updateStateSpaceModel();
+  mYHist = calculateHistoryVector();
+  mnaCompApplyRightSideVectorStamp(**mRightVector);
+}
+
+void DP::SSNComp::mnaCompAddPostStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes,
+    Attribute<Matrix>::Ptr &leftVector) {
+  attributeDependencies.push_back(leftVector);
+  modifiedAttributes.push_back(inputAttribute());
+  modifiedAttributes.push_back(outputAttribute());
+  modifiedAttributes.push_back(mX);
+}

--- a/dpsim-models/src/DP/DP_VTypeSSNComp.cpp
+++ b/dpsim-models/src/DP/DP_VTypeSSNComp.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_VTypeSSNComp.h>
+
+using namespace CPS;
+
+DP::VTypeSSNComp::VTypeSSNComp(String uid, String name, Int inputSize,
+                               Int outputSize, Logger::Level logLevel)
+    : SSNComp(uid, name, inputSize, outputSize, logLevel) {
+  **mIntfVoltage = MatrixComp::Zero(inputSize, 1);
+  **mIntfCurrent = MatrixComp::Zero(outputSize, 1);
+}
+
+Attribute<MatrixComp>::Ptr DP::VTypeSSNComp::inputAttribute() const {
+  return mIntfVoltage;
+}
+
+Attribute<MatrixComp>::Ptr DP::VTypeSSNComp::outputAttribute() const {
+  return mIntfCurrent;
+}
+
+void DP::VTypeSSNComp::initializeFromNodesAndTerminals(Real frequency) {
+  if (!mParametersSet)
+    throw std::logic_error("setParameters() must be called before "
+                           "initializeFromNodesAndTerminals().");
+
+  Real omega = 2. * PI * frequency;
+  MatrixComp uInit = buildInitialInputFromNodes(frequency);
+  MatrixComp xInit = calculateSteadyStateStateFromInput(uInit, omega);
+  MatrixComp yInit = calculateSteadyStateOutputFromInput(xInit, uInit);
+
+  **mX = xInit;
+  **mIntfVoltage = uInit;
+  **mIntfCurrent = yInit;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- Initialization from nodes and terminals ---"
+                     "\nInput u: {:s}"
+                     "\nOutput y: {:s}"
+                     "\nState x: {:s}"
+                     "\n--- Initialization finished ---",
+                     Logger::matrixCompToString(**mIntfVoltage),
+                     Logger::matrixCompToString(**mIntfCurrent),
+                     Logger::matrixCompToString(**mX));
+}
+
+void DP::VTypeSSNComp::mnaCompUpdateCurrent(const Matrix &) {
+  **mIntfCurrent = mW * (**mIntfVoltage) + mYHist;
+}
+
+void DP::VTypeSSNComp::mnaCompPostStep(Real, Int,
+                                       Attribute<Matrix>::Ptr &leftVector) {
+  MatrixComp uOld = **mIntfVoltage;
+  mnaCompUpdateVoltage(**leftVector);
+  mnaCompUpdateCurrent(**leftVector);
+  updateState(uOld, **mIntfVoltage);
+}

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -41,6 +41,7 @@ set(CIRCUIT_SOURCES
 	Circuits/EMT_RC_split_decoupled_node_DC.cpp
 	Circuits/EMT_RC_split_decoupled_node.cpp
 	Circuits/EMT_RC_split_decoupled_node_Ph3.cpp
+	Circuits/DP_Ph1_SSN_Full_Serial_RLC.cpp
 
 	# EMT examples with PF initialization
 	Circuits/EMT_Slack_PiLine_PQLoad_with_PF_Init.cpp

--- a/dpsim/examples/cxx/Circuits/DP_Ph1_SSN_Full_Serial_RLC.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_Ph1_SSN_Full_Serial_RLC.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::DP;
+
+// Classical DP reference: series R-L-C built from discrete components.
+void DP_Ph1_RLCVs_RC() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "DP_Ph1_SSN_Full_Serial_RLC_RC";
+
+  auto n1 = SimNode::make("n1");
+  auto n2 = SimNode::make("n2");
+  auto n3 = SimNode::make("n3");
+
+  auto r = Ph1::Resistor::make("r_rc");
+  r->setParameters(10.0);
+  auto l = Ph1::Inductor::make("l_rc");
+  l->setParameters(0.01);
+  auto c = Ph1::Capacitor::make("c_rc");
+  c->setParameters(0.002);
+
+  auto vs = Ph1::VoltageSource::make("vs_rc");
+  vs->setParameters(CPS::Math::polar(1.0, CPS::Math::degToRad(-90.0)));
+
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  r->connect(SimNode::List{n1, n2});
+  l->connect(SimNode::List{n2, n3});
+  c->connect(SimNode::List{n3, SimNode::GND});
+
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2, n3},
+                            SystemComponentList{vs, r, l, c});
+
+  Logger::setLogDir("logs/" + simName);
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v_l_rc", l->attribute("v_intf"));
+  logger->logAttribute("i_l_rc", l->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+// DP V-type SSN: the same series RLC one-port as a single SSN component.
+void DP_Ph1_RLCVs_SSN() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "DP_Ph1_SSN_Full_Serial_RLC_SSN";
+
+  auto n1 = SimNode::make("n1");
+
+  auto rlc = Ph1::SSN::Full_Serial_RLC::make("rlc");
+  rlc->setParameters(10.0, 0.01, 0.002);
+
+  auto vs = Ph1::VoltageSource::make("vs");
+  vs->setParameters(CPS::Math::polar(1.0, CPS::Math::degToRad(-90.0)));
+
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  rlc->connect(SimNode::List{n1, SimNode::GND});
+
+  auto sys =
+      SystemTopology(50, SystemNodeList{n1}, SystemComponentList{vs, rlc});
+
+  Logger::setLogDir("logs/" + simName);
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v_rlc_ssn", rlc->attribute("v_intf"));
+  logger->logAttribute("i_rlc_ssn", rlc->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+int main(int argc, char *argv[]) {
+  DP_Ph1_RLCVs_RC();
+  DP_Ph1_RLCVs_SSN();
+}

--- a/dpsim/src/pybind/DPComponents.cpp
+++ b/dpsim/src/pybind/DPComponents.cpp
@@ -184,6 +184,16 @@ void addDPPh1Components(py::module_ mDPPh1) {
            &CPS::DP::Ph1::varResSwitch::setInitParameters, "time_step"_a)
       .def("connect", &CPS::DP::Ph1::varResSwitch::connect);
 
+  py::class_<CPS::DP::Ph1::SSN::Full_Serial_RLC,
+             std::shared_ptr<CPS::DP::Ph1::SSN::Full_Serial_RLC>,
+             CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "Full_Serial_RLC",
+                                              py::multiple_inheritance())
+      .def(py::init<std::string>())
+      .def(py::init<std::string, CPS::Logger::Level>())
+      .def("set_parameters", &CPS::DP::Ph1::SSN::Full_Serial_RLC::setParameters,
+           "R"_a, "L"_a, "C"_a)
+      .def("connect", &CPS::DP::Ph1::SSN::Full_Serial_RLC::connect);
+
   py::class_<CPS::DP::Ph1::SynchronGeneratorTrStab,
              std::shared_ptr<CPS::DP::Ph1::SynchronGeneratorTrStab>,
              CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "SynchronGeneratorTrStab",


### PR DESCRIPTION
Adds the State-Space Nodal (SSN) method to the DP (dynamic phasor / shifted-frequency) domain, mirroring the landed EMT-SSN hierarchy.

## New additions
- `CPS::DP::SSNComp` base + `VTypeSSNComp` / `ITypeSSNComp`: real-augmented carrier shift `A_aug=[[A,ωI],[-ωI,A]]`, discretized with the existing trapezoidal helper, folded to a complex envelope Norton model.
- `DP::Ph1::TwoTerminalVTypeSSNComp` single-phase two-terminal stamping layer.
- `DP::Ph1::SSN::Full_Serial_RLC` reference component with Python binding and a C++ example.

## Validation
Cross-domain (SP / DP / EMT / DP-SSN / EMT-SSN) on a series RLC: DP-SSN reproduces classical DP and matches the EMT waveform to ~1e-6 (steady and off-nominal excitation).

### Obs
Base-class design needs to be coordinated with @georgii-tishenin and @matthiasmees  to keep the EMT and DP SSN approaches aligned.