### PR TITLE
DP/SFA SSN: generic two-terminal V/I-type components

### DIFF
--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -59,6 +59,8 @@
 #include <dpsim-models/DP/DP_ITypeSSNComp.h>
 #include <dpsim-models/DP/DP_Ph1_ControlledCurrentSource.h>
 #include <dpsim-models/DP/DP_Ph1_ControlledVoltageSource.h>
+#include <dpsim-models/DP/DP_Ph1_GenericTwoTerminalITypeSSN.h>
+#include <dpsim-models/DP/DP_Ph1_GenericTwoTerminalVTypeSSN.h>
 #include <dpsim-models/DP/DP_Ph1_RxLine.h>
 #include <dpsim-models/DP/DP_Ph1_SSN_Full_Serial_RLC.h>
 #include <dpsim-models/DP/DP_Ph1_SVC.h>
@@ -74,6 +76,7 @@
 #include <dpsim-models/DP/DP_Ph1_SynchronGeneratorIdeal.h>
 #include <dpsim-models/DP/DP_Ph1_SynchronGeneratorTrStab.h>
 #include <dpsim-models/DP/DP_Ph1_Transformer.h>
+#include <dpsim-models/DP/DP_Ph1_TwoTerminalITypeSSNComp.h>
 #include <dpsim-models/DP/DP_Ph1_TwoTerminalVTypeSSNComp.h>
 #include <dpsim-models/DP/DP_Ph1_VoltageSource.h>
 #include <dpsim-models/DP/DP_Ph1_VoltageSourceNorton.h>

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_GenericTwoTerminalITypeSSN.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_GenericTwoTerminalITypeSSN.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_Ph1_TwoTerminalITypeSSNComp.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph1 {
+
+/// \brief Generic single-phase, two-terminal I-type SSN component.
+///
+/// Parametrized directly by arbitrary state-space matrices A, B, C, D
+/// (input = port current, output = port voltage).
+class GenericTwoTerminalITypeSSN final
+    : public TwoTerminalITypeSSNComp,
+      public SharedFactory<GenericTwoTerminalITypeSSN> {
+public:
+  using SharedFactory<GenericTwoTerminalITypeSSN>::make;
+
+  GenericTwoTerminalITypeSSN(String uid, String name,
+                             Logger::Level logLevel = Logger::Level::off);
+  GenericTwoTerminalITypeSSN(String name,
+                             Logger::Level logLevel = Logger::Level::off)
+      : GenericTwoTerminalITypeSSN(name, name, logLevel) {}
+
+  SimPowerComp<Complex>::Ptr clone(String name) override final;
+};
+
+} // namespace Ph1
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_GenericTwoTerminalVTypeSSN.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_GenericTwoTerminalVTypeSSN.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_Ph1_TwoTerminalVTypeSSNComp.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph1 {
+
+/// \brief Generic single-phase, two-terminal V-type SSN component.
+///
+/// Parametrized directly by arbitrary state-space matrices A, B, C, D
+/// (input = port voltage, output = port current).
+class GenericTwoTerminalVTypeSSN final
+    : public TwoTerminalVTypeSSNComp,
+      public SharedFactory<GenericTwoTerminalVTypeSSN> {
+public:
+  using SharedFactory<GenericTwoTerminalVTypeSSN>::make;
+
+  GenericTwoTerminalVTypeSSN(String uid, String name,
+                             Logger::Level logLevel = Logger::Level::off);
+  GenericTwoTerminalVTypeSSN(String name,
+                             Logger::Level logLevel = Logger::Level::off)
+      : GenericTwoTerminalVTypeSSN(name, name, logLevel) {}
+
+  SimPowerComp<Complex>::Ptr clone(String name) override final;
+};
+
+} // namespace Ph1
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_TwoTerminalITypeSSNComp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_TwoTerminalITypeSSNComp.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_ITypeSSNComp.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph1 {
+
+/// \brief Single-phase, two-terminal I-type SSN stamping layer.
+///
+/// Provides the concrete MNA stamps (Norton-equivalent admittance G = W^-1,
+/// history current, node voltage read) shared by single-phase two-terminal
+/// I-type SSN components.
+class TwoTerminalITypeSSNComp : public ITypeSSNComp {
+protected:
+  TwoTerminalITypeSSNComp(String uid, String name,
+                          Logger::Level logLevel = Logger::Level::off);
+
+  MatrixComp buildInitialInputFromNodes(Real frequency) override final;
+
+public:
+  void
+  mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override final;
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override final;
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override final;
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override final;
+};
+
+} // namespace Ph1
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -56,7 +56,10 @@ list(APPEND MODELS_SOURCES
 	DP/DP_VTypeSSNComp.cpp
 	DP/DP_ITypeSSNComp.cpp
 	DP/DP_Ph1_TwoTerminalVTypeSSNComp.cpp
+	DP/DP_Ph1_TwoTerminalITypeSSNComp.cpp
 	DP/DP_Ph1_SSN_Full_Serial_RLC.cpp
+	DP/DP_Ph1_GenericTwoTerminalVTypeSSN.cpp
+	DP/DP_Ph1_GenericTwoTerminalITypeSSN.cpp
 
 	DP/DP_Ph3_VoltageSource.cpp
 	DP/DP_Ph3_Capacitor.cpp

--- a/dpsim-models/src/DP/DP_Ph1_GenericTwoTerminalITypeSSN.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_GenericTwoTerminalITypeSSN.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph1_GenericTwoTerminalITypeSSN.h>
+
+using namespace CPS;
+
+DP::Ph1::GenericTwoTerminalITypeSSN::GenericTwoTerminalITypeSSN(
+    String uid, String name, Logger::Level logLevel)
+    : TwoTerminalITypeSSNComp(uid, name, logLevel) {}
+
+SimPowerComp<Complex>::Ptr
+DP::Ph1::GenericTwoTerminalITypeSSN::clone(String name) {
+  auto copy = GenericTwoTerminalITypeSSN::make(name, mLogLevel);
+  copy->setParameters(mA, mB, mC, mD);
+  return copy;
+}

--- a/dpsim-models/src/DP/DP_Ph1_GenericTwoTerminalVTypeSSN.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_GenericTwoTerminalVTypeSSN.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph1_GenericTwoTerminalVTypeSSN.h>
+
+using namespace CPS;
+
+DP::Ph1::GenericTwoTerminalVTypeSSN::GenericTwoTerminalVTypeSSN(
+    String uid, String name, Logger::Level logLevel)
+    : TwoTerminalVTypeSSNComp(uid, name, logLevel) {}
+
+SimPowerComp<Complex>::Ptr
+DP::Ph1::GenericTwoTerminalVTypeSSN::clone(String name) {
+  auto copy = GenericTwoTerminalVTypeSSN::make(name, mLogLevel);
+  copy->setParameters(mA, mB, mC, mD);
+  return copy;
+}

--- a/dpsim-models/src/DP/DP_Ph1_TwoTerminalITypeSSNComp.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_TwoTerminalITypeSSNComp.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph1_TwoTerminalITypeSSNComp.h>
+#include <dpsim-models/MNAStampUtils.h>
+
+using namespace CPS;
+
+DP::Ph1::TwoTerminalITypeSSNComp::TwoTerminalITypeSSNComp(
+    String uid, String name, Logger::Level logLevel)
+    : ITypeSSNComp(uid, name, 1, 1, logLevel) {
+  mPhaseType = PhaseType::Single;
+  setTerminalNumber(2);
+}
+
+MatrixComp DP::Ph1::TwoTerminalITypeSSNComp::buildInitialInputFromNodes(Real) {
+  // Interface current convention: positive current flows from terminal1 to
+  // terminal0. No initial terminal current is available here, so start at zero.
+  return MatrixComp::Zero(1, 1);
+}
+
+void DP::Ph1::TwoTerminalITypeSSNComp::mnaCompApplySystemMatrixStamp(
+    SparseMatrixRow &systemMatrix) {
+  // Norton-equivalent admittance G = W^-1 (v = W i + yHist => i = G v - G yHist).
+  Complex g = Complex(1., 0.) / mW(0, 0);
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    MNAStampUtils::stampAdmittance(
+        g, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
+        terminalNotGrounded(0), terminalNotGrounded(1), mSLog, mNumFreqs, freq);
+  }
+}
+
+void DP::Ph1::TwoTerminalITypeSSNComp::mnaCompApplyRightSideVectorStamp(
+    Matrix &rightVector) {
+  Complex iHist = -mYHist(0, 0) / mW(0, 0);
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    if (terminalNotGrounded(0))
+      Math::setVectorElement(rightVector, matrixNodeIndex(0), iHist, mNumFreqs,
+                             freq);
+    if (terminalNotGrounded(1))
+      Math::setVectorElement(rightVector, matrixNodeIndex(1), -iHist, mNumFreqs,
+                             freq);
+  }
+}
+
+void DP::Ph1::TwoTerminalITypeSSNComp::mnaCompUpdateCurrent(const Matrix &) {
+  // i = W^-1 (v - yHist)
+  **mIntfCurrent = mW.inverse() * (**mIntfVoltage - mYHist);
+}
+
+void DP::Ph1::TwoTerminalITypeSSNComp::mnaCompUpdateVoltage(
+    const Matrix &leftVector) {
+  // v = v_terminal1 - v_terminal0 (DP envelope phasor)
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    (**mIntfVoltage)(0, freq) = 0;
+    if (terminalNotGrounded(1))
+      (**mIntfVoltage)(0, freq) = Math::complexFromVectorElement(
+          leftVector, matrixNodeIndex(1), mNumFreqs, freq);
+    if (terminalNotGrounded(0))
+      (**mIntfVoltage)(0, freq) -= Math::complexFromVectorElement(
+          leftVector, matrixNodeIndex(0), mNumFreqs, freq);
+  }
+}

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -42,6 +42,7 @@ set(CIRCUIT_SOURCES
 	Circuits/EMT_RC_split_decoupled_node.cpp
 	Circuits/EMT_RC_split_decoupled_node_Ph3.cpp
 	Circuits/DP_Ph1_SSN_Full_Serial_RLC.cpp
+	Circuits/DP_Ph1_General2TerminalSSN.cpp
 
 	# EMT examples with PF initialization
 	Circuits/EMT_Slack_PiLine_PQLoad_with_PF_Init.cpp

--- a/dpsim/examples/cxx/Circuits/DP_Ph1_General2TerminalSSN.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_Ph1_General2TerminalSSN.cpp
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::DP;
+
+// V-type reference: series R-L-C from discrete components, voltage-driven.
+void DP_Ph1_RLCVs_RC() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "DP_Ph1_General2TerminalSSN_RLCVs_RC";
+
+  auto n1 = SimNode::make("n1");
+  auto n2 = SimNode::make("n2");
+  auto n3 = SimNode::make("n3");
+
+  auto r = Ph1::Resistor::make("r_rc");
+  r->setParameters(10.0);
+  auto l = Ph1::Inductor::make("l_rc");
+  l->setParameters(0.01);
+  auto c = Ph1::Capacitor::make("c_rc");
+  c->setParameters(0.002);
+
+  auto vs = Ph1::VoltageSource::make("vs_rc");
+  vs->setParameters(CPS::Math::polar(1.0, CPS::Math::degToRad(-90.0)));
+
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  r->connect(SimNode::List{n1, n2});
+  l->connect(SimNode::List{n2, n3});
+  c->connect(SimNode::List{n3, SimNode::GND});
+
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2, n3},
+                            SystemComponentList{vs, r, l, c});
+
+  Logger::setLogDir("logs/" + simName);
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v_l_rc", l->attribute("v_intf"));
+  logger->logAttribute("i_l_rc", l->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+// V-type generic SSN: the same series RLC one-port supplied as (A, B, C, D).
+void DP_Ph1_RLCVs_genVSSN() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "DP_Ph1_General2TerminalSSN_RLCVs_genVSSN";
+
+  auto n1 = SimNode::make("n1");
+
+  auto rlc = Ph1::GenericTwoTerminalVTypeSSN::make("rlc_genSSN");
+
+  double r = 10.0;
+  double l = 0.01;
+  double c = 0.002;
+
+  // States x = [v_C; i_L], input = port voltage, output = port current (i_L).
+  Matrix A = Matrix::Zero(2, 2);
+  A(0, 1) = 1. / c;
+  A(1, 0) = -1. / l;
+  A(1, 1) = -r / l;
+  Matrix B = Matrix::Zero(2, 1);
+  B(1, 0) = 1. / l;
+  Matrix C = Matrix::Zero(1, 2);
+  C(0, 1) = 1.;
+  Matrix D = Matrix::Zero(1, 1);
+  rlc->setParameters(A, B, C, D);
+
+  auto vs = Ph1::VoltageSource::make("vs");
+  vs->setParameters(CPS::Math::polar(1.0, CPS::Math::degToRad(-90.0)));
+
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  rlc->connect(SimNode::List{n1, SimNode::GND});
+
+  auto sys =
+      SystemTopology(50, SystemNodeList{n1}, SystemComponentList{vs, rlc});
+
+  Logger::setLogDir("logs/" + simName);
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v_rlc_genSSN", rlc->attribute("v_intf"));
+  logger->logAttribute("i_rlc_genSSN", rlc->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+// I-type reference: current source feeding a parallel R-C from discrete parts.
+void DP_Ph1_C1R1Is_RC() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "DP_Ph1_General2TerminalSSN_C1R1Is_RC";
+
+  auto n1 = SimNode::make("n1");
+
+  auto cs = Ph1::CurrentSource::make("cs_rc");
+  cs->setParameters(CPS::Math::polar(1.0, CPS::Math::degToRad(-90.0)));
+
+  auto r = Ph1::Resistor::make("r_rc");
+  r->setParameters(10.0);
+  auto c = Ph1::Capacitor::make("c_rc");
+  c->setParameters(0.002);
+
+  cs->connect(SimNode::List{SimNode::GND, n1});
+  r->connect(SimNode::List{n1, SimNode::GND});
+  c->connect(SimNode::List{n1, SimNode::GND});
+
+  auto sys =
+      SystemTopology(50, SystemNodeList{n1}, SystemComponentList{cs, r, c});
+
+  Logger::setLogDir("logs/" + simName);
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v_c_rc", c->attribute("v_intf"));
+  logger->logAttribute("i_c_rc", c->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+// I-type generic SSN: the capacitor supplied as (A, B, C, D), current-driven.
+void DP_Ph1_C1R1Is_genISSN() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "DP_Ph1_General2TerminalSSN_C1R1Is_genISSN";
+
+  auto n1 = SimNode::make("n1");
+
+  auto cap = Ph1::GenericTwoTerminalITypeSSN::make("c_genSSN");
+
+  // dv_C/dt = i_C/C, y = v_C --> u = i_C, x = v_C, A = 0, B = 1/C, C = 1, D = 0.
+  double c = 0.002;
+  Matrix A = Matrix::Zero(1, 1);
+  Matrix B = Matrix::Zero(1, 1);
+  B(0, 0) = 1. / c;
+  Matrix C = Matrix::Zero(1, 1);
+  C(0, 0) = 1.;
+  Matrix D = Matrix::Zero(1, 1);
+  cap->setParameters(A, B, C, D);
+
+  auto cs = Ph1::CurrentSource::make("cs");
+  cs->setParameters(CPS::Math::polar(1.0, CPS::Math::degToRad(-90.0)));
+
+  auto r = Ph1::Resistor::make("r_genSSN");
+  r->setParameters(10.0);
+
+  cs->connect(SimNode::List{SimNode::GND, n1});
+  r->connect(SimNode::List{n1, SimNode::GND});
+  cap->connect(SimNode::List{n1, SimNode::GND});
+
+  auto sys =
+      SystemTopology(50, SystemNodeList{n1}, SystemComponentList{cs, r, cap});
+
+  Logger::setLogDir("logs/" + simName);
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v_c_genSSN", cap->attribute("v_intf"));
+  logger->logAttribute("i_c_genSSN", cap->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+int main(int argc, char *argv[]) {
+  DP_Ph1_RLCVs_RC();
+  DP_Ph1_RLCVs_genVSSN();
+
+  DP_Ph1_C1R1Is_RC();
+  DP_Ph1_C1R1Is_genISSN();
+}

--- a/dpsim/src/pybind/DPComponents.cpp
+++ b/dpsim/src/pybind/DPComponents.cpp
@@ -194,6 +194,30 @@ void addDPPh1Components(py::module_ mDPPh1) {
            "R"_a, "L"_a, "C"_a)
       .def("connect", &CPS::DP::Ph1::SSN::Full_Serial_RLC::connect);
 
+  py::class_<CPS::DP::Ph1::GenericTwoTerminalVTypeSSN,
+             std::shared_ptr<CPS::DP::Ph1::GenericTwoTerminalVTypeSSN>,
+             CPS::SimPowerComp<CPS::Complex>>(
+      mDPPh1, "GenericTwoTerminalVTypeSSN", py::multiple_inheritance())
+      .def(py::init<std::string>())
+      .def(py::init<std::string, CPS::Logger::Level>())
+      .def("set_parameters",
+           &CPS::DP::Ph1::GenericTwoTerminalVTypeSSN::setParameters, "A"_a,
+           "B"_a, "C"_a, "D"_a)
+      .def("connect", &CPS::DP::Ph1::GenericTwoTerminalVTypeSSN::connect)
+      .def_property_readonly("x", createAttributeGetter<CPS::MatrixComp>("x"));
+
+  py::class_<CPS::DP::Ph1::GenericTwoTerminalITypeSSN,
+             std::shared_ptr<CPS::DP::Ph1::GenericTwoTerminalITypeSSN>,
+             CPS::SimPowerComp<CPS::Complex>>(
+      mDPPh1, "GenericTwoTerminalITypeSSN", py::multiple_inheritance())
+      .def(py::init<std::string>())
+      .def(py::init<std::string, CPS::Logger::Level>())
+      .def("set_parameters",
+           &CPS::DP::Ph1::GenericTwoTerminalITypeSSN::setParameters, "A"_a,
+           "B"_a, "C"_a, "D"_a)
+      .def("connect", &CPS::DP::Ph1::GenericTwoTerminalITypeSSN::connect)
+      .def_property_readonly("x", createAttributeGetter<CPS::MatrixComp>("x"));
+
   py::class_<CPS::DP::Ph1::SynchronGeneratorTrStab,
              std::shared_ptr<CPS::DP::Ph1::SynchronGeneratorTrStab>,
              CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "SynchronGeneratorTrStab",


### PR DESCRIPTION
Adds user-parametrizable single-phase SSN one-ports to the DP domain: declare any linear two-terminal component by its state-space `(A, B, C, D)` and simulate it. Builds on the DP SSN base hierarchy in #515.

## New additions
- `DP::Ph1::TwoTerminalITypeSSNComp`: single-phase I-type stamping layer (Norton-equivalent admittance `G = W^-1`, history current, complex node read). The V-type stamping layer already existed; this adds its I-type counterpart.
- `DP::Ph1::GenericTwoTerminalVTypeSSN` / `GenericTwoTerminalITypeSSN`: concrete components parametrized directly by `(A, B, C, D)`, with Python bindings (`dp.ph1.GenericTwoTerminalVTypeSSN` / `...ITypeSSN`, `x` exposed read-only).
- C++ example `DP_Ph1_General2TerminalSSN.cpp`.

## Validation
On the example circuits, the generic SSN one-ports reproduce equivalent discrete-component references.

The I-type case exercises the `W^-1` inversion path for the first time in the DP domain.

## Obs
- Should be merged after #515.
- Cross domain notebook validation as follow-up.