### PR TITLE
DP/SFA SSN: single-phase validation and accuracy notebooks

### DIFF
--- a/docs/hugo/content/en/docs/Concepts/state-space-nodal.md
+++ b/docs/hugo/content/en/docs/Concepts/state-space-nodal.md
@@ -1,0 +1,101 @@
+---
+title: "State-Space Nodal"
+linkTitle: "State-Space Nodal"
+date: 2026-06-23
+---
+
+The state-space nodal (SSN) method represents a component by its own continuous
+state-space model and couples it to the network through the nodal admittance
+matrix. A component is described by
+
+```math
+\frac{d\mathbf{x}}{dt} = \mathbf{A}\mathbf{x} + \mathbf{B}\mathbf{u},
+\qquad
+\mathbf{y} = \mathbf{C}\mathbf{x} + \mathbf{D}\mathbf{u},
+```
+
+where $\mathbf{x}$ is the internal state, and the input $\mathbf{u}$ and output
+$\mathbf{y}$ are the terminal quantities exchanged with the network (a voltage and
+the corresponding current). Trapezoidal discretisation of $(\mathbf{A}, \mathbf{B})$
+yields a discrete model $(\mathbf{A}_d, \mathbf{B}_d)$ and a Norton equivalent: a
+constant conductance $\mathbf{W}$ stamped into the system matrix plus a history
+current source recomputed each step from the previous state and input. Because the
+component is solved simultaneously with the network in the same nodal system, SSN
+is numerically robust without the parasitic snubbers that delayed
+current-injection schemes require.
+
+This builds directly on [Nodal Analysis]({{< ref "nodal-analysis.md" >}}) and is
+the companion of
+[State-Space Extraction]({{< ref "state-space-extraction-theory.md" >}}), which
+recovers a state-space model from an MNA simulation rather than starting from one.
+
+# Shift to the Dynamic-Phasor Envelope
+
+In the [Dynamic Phasors]({{< ref "dyn-phasors.md" >}}) (shifted-frequency)
+domain a physical quantity is written as a slowly varying complex envelope on a
+carrier $\omega_s$,
+
+```math
+x(t) = \operatorname{Re}\{\, X(t)\, e^{j \omega_s t} \,\},
+```
+
+so that differentiation maps to
+$\frac{dx}{dt} \rightarrow \frac{dX}{dt} + j \omega_s X$. The physical
+state-space model therefore becomes, for the envelope,
+
+```math
+\frac{d\mathbf{X}}{dt} = (\mathbf{A} - j \omega_s \mathbf{I})\,\mathbf{X}
++ \mathbf{B}\,\mathbf{U}.
+```
+
+DPsim does not solve the dynamic-phasor system as a complex matrix: every
+complex admittance $g = g_r + j g_i$ is stamped as a real $2 \times 2$ block
+$\left[\begin{smallmatrix} g_r & -g_i \\ g_i & g_r \end{smallmatrix}\right]$, with the real
+and imaginary node parts living in separate halves of a real-valued system. The
+DP-SSN model matches this by carrying the envelope in real/imaginary-split form
+$[\mathbf{X}_r; \mathbf{X}_i]$ and writing the carrier shift explicitly as a real
+augmented model,
+
+```math
+\mathbf{A}_\text{aug} =
+\begin{bmatrix} \mathbf{A} & \omega_s \mathbf{I} \\ -\omega_s \mathbf{I} & \mathbf{A} \end{bmatrix},
+\qquad
+\mathbf{B}_\text{aug} = \begin{bmatrix} \mathbf{B} & \mathbf{0} \\ \mathbf{0} & \mathbf{B} \end{bmatrix}.
+```
+
+The same real trapezoidal discretisation used by the EMT SSN models then applies
+unchanged, the Norton conductance comes out as a real block that stamps directly
+into the augmented network, and the interface reads and writes the real and
+imaginary node halves directly with no complex assembly. The $\pm \omega_s$
+coupling block is algebraically exact; placing a rotating-frame term inside the
+real state matrix follows the established SSN practice for rotating-machine
+models.
+
+# Components
+
+The single-phase dynamic-phasor SSN models are:
+
+* `Full_Serial_RLC`, a series resistor-inductor-capacitor one-port with a
+  hand-derived state-space model, used as the reference component.
+* `GenericTwoTerminalVTypeSSN` and `GenericTwoTerminalITypeSSN`, which accept a
+  user-supplied $(\mathbf{A}, \mathbf{B}, \mathbf{C}, \mathbf{D})$ and build the
+  V-type (voltage input, current output) or I-type (current input, voltage
+  output) stamping accordingly.
+
+All three reproduce the classical dynamic-phasor stamping of the same circuit,
+and the reconstructed time-domain waveform matches the EMT and EMT-SSN results
+within discretisation error.
+
+# Validation and Examples
+
+Two notebooks accompany the models, both on a single-carrier series RLC one-port.
+`examples/Notebooks/Circuits/DP_generalizedSSN_RLC.ipynb` validates the DP-SSN
+models against the classical dynamic-phasor stamping and the EMT and EMT-SSN
+waveforms. `examples/Notebooks/Circuits/DP_SSN_RLC_accuracy.ipynb` studies the
+time-step and frequency-dependent accuracy against a small-step EMT reference.
+
+# Further Reading
+
+* C. Dufour, J. Mahseredjian, and J. Bélanger, *A Combined State-Space Nodal Method for the Simulation of Power System Transients*, *IEEE Transactions on Power Delivery*, vol. 26, no. 2, pp. 928–935, 2011. <https://doi.org/10.1109/TPWRD.2010.2090364>
+* C. Dufour and D. S. Nasrallah, *State-space-nodal rotating machine models with improved numerical stability*, *IECON 2016 – 42nd Annual Conference of the IEEE Industrial Electronics Society*, 2016. <https://doi.org/10.1109/IECON.2016.7793690>
+* A. A. Kida, A. C. S. Lima, F. A. Moreira, J. R. Martí, and J. Tarazona, *Inaccuracies due to the frequency warping in simulation of electrical systems using combined state–space nodal analysis*, *Electric Power Systems Research*, vol. 223, art. 109657, 2023. <https://doi.org/10.1016/j.epsr.2023.109657>

--- a/examples/Notebooks/Circuits/DP_SSN_RLC_accuracy.ipynb
+++ b/examples/Notebooks/Circuits/DP_SSN_RLC_accuracy.ipynb
@@ -14,9 +14,9 @@
     "extracted by a least-squares fit over the second half of each run.\n",
     "\n",
     "Three sweeps:\n",
-    "- time step, with the source on the carrier;\n",
-    "- signal frequency, at a fine time step;\n",
-    "- signal frequency, at a large time step."
+    "- time step, with the source on the carrier (absolute phasor error);\n",
+    "- signal frequency around the carrier, at a fine time step (relative error);\n",
+    "- signal frequency around the carrier, at a large time step (relative error)."
    ]
   },
   {
@@ -236,27 +236,34 @@
    "source": [
     "## Sweep over signal frequency (fine time step)\n",
     "\n",
-    "The source is now detuned from the 50 Hz carrier. The DP envelope rotates at the\n",
-    "offset `f_sig - f0`, so DP-SSN warps according to that offset rather than the\n",
-    "absolute signal frequency. Near the carrier DP-SSN is far more accurate; the\n",
-    "advantage shrinks as the signal moves away and the envelope mode climbs in\n",
-    "frequency."
+    "The source is now detuned from the carrier and swept on both sides of it. The DP\n",
+    "envelope rotates at the offset `f_sig - f0`, so DP-SSN warps with that offset,\n",
+    "whereas EMT-SSN warps with the absolute signal frequency. The error is reported\n",
+    "relative to the reference phasor, because the RLC response amplitude varies by\n",
+    "orders of magnitude across the band.\n",
+    "\n",
+    "At this fine step both methods sit near the floor set by the reference\n",
+    "discretisation (~1e-7 relative), so the point-to-point detail is not physically\n",
+    "meaningful, only the trend is. DP-SSN is most accurate at the carrier. Below\n",
+    "roughly 25-30 Hz the envelope rotates fast enough that EMT-SSN, sitting at a low\n",
+    "absolute frequency, warps less and wins."
    ]
   },
   {
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "freqs = [50, 55, 60, 70, 90, 120, 160]\n",
+    "freqs = [10, 20, 25, 30, 35, 40, 45, 50, 55, 60, 70, 90, 120, 160]\n",
     "refs = [reference_phasor(f) for f in freqs]\n",
+    "carrier = freqs.index(50)\n",
     "\n",
     "dt_fine = 1e-4\n",
-    "emt_fine = [emt_ssn_error(f, dt_fine, r) for f, r in zip(freqs, refs)]\n",
-    "dp_fine = [dp_ssn_error(f, dt_fine, r) for f, r in zip(freqs, refs)]\n",
+    "emt_fine = [emt_ssn_error(f, dt_fine, r) / abs(r) for f, r in zip(freqs, refs)]\n",
+    "dp_fine = [dp_ssn_error(f, dt_fine, r) / abs(r) for f, r in zip(freqs, refs)]\n",
     "\n",
     "for f, ee, ed in zip(freqs, emt_fine, dp_fine):\n",
     "    print(\n",
-    "        f\"f_sig={f:3d} Hz (offset {f - f0:+.0f})  EMT-SSN err={ee:.3e}  DP-SSN err={ed:.3e}  ratio={ee / ed:.0f}\"\n",
+    "        f\"f_sig={f:3d} Hz (offset {f - f0:+.0f})  EMT-SSN rel={ee:.3e}  DP-SSN rel={ed:.3e}  ratio={ee / ed:.2f}\"\n",
     "    )"
    ],
    "execution_count": null,
@@ -271,7 +278,7 @@
     "plt.semilogy(freqs, dp_fine, \"s-\", label=\"DP-SSN\")\n",
     "plt.axvline(f0, color=\"0.7\", linestyle=\":\", label=\"carrier\")\n",
     "plt.xlabel(\"signal frequency [Hz]\")\n",
-    "plt.ylabel(\"steady-state phasor error [A]\")\n",
+    "plt.ylabel(\"relative phasor error\")\n",
     "plt.title(\"Accuracy versus signal frequency (fine step, dt = 1e-4 s)\")\n",
     "plt.legend()\n",
     "plt.grid(True, which=\"both\", linestyle=\":\")\n",
@@ -284,8 +291,10 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "# DP-SSN is at least as accurate as EMT-SSN across the swept band\n",
-    "assert all(ed < ee for ed, ee in zip(dp_fine, emt_fine))"
+    "# DP-SSN wins at the carrier; far below it the fast-rotating envelope makes\n",
+    "# EMT-SSN the more accurate method (the crossover near 25-30 Hz).\n",
+    "assert dp_fine[carrier] < emt_fine[carrier]\n",
+    "assert dp_fine[0] > emt_fine[0]"
    ],
    "execution_count": null,
    "outputs": []
@@ -296,9 +305,11 @@
    "source": [
     "## Sweep over signal frequency (large time step)\n",
     "\n",
-    "The same frequency sweep at a large step makes the effect dramatic: at the\n",
-    "carrier DP-SSN is orders of magnitude more accurate, and the advantage erodes as\n",
-    "the signal detunes and the envelope mode moves into the warped band."
+    "The same symmetric sweep at a large step makes the effect dramatic and clears the\n",
+    "floor. At the carrier DP-SSN is orders of magnitude more accurate; the advantage\n",
+    "falls off on either side as the envelope offset grows, and below the crossover\n",
+    "(~25-30 Hz) it drops below one, where EMT-SSN at a low absolute frequency warps\n",
+    "less than the fast-rotating DP envelope."
    ]
   },
   {
@@ -306,12 +317,12 @@
    "metadata": {},
    "source": [
     "dt_big = 2e-3\n",
-    "emt_big = [emt_ssn_error(f, dt_big, r) for f, r in zip(freqs, refs)]\n",
-    "dp_big = [dp_ssn_error(f, dt_big, r) for f, r in zip(freqs, refs)]\n",
+    "emt_big = [emt_ssn_error(f, dt_big, r) / abs(r) for f, r in zip(freqs, refs)]\n",
+    "dp_big = [dp_ssn_error(f, dt_big, r) / abs(r) for f, r in zip(freqs, refs)]\n",
     "\n",
     "for f, ee, ed in zip(freqs, emt_big, dp_big):\n",
     "    print(\n",
-    "        f\"f_sig={f:3d} Hz (offset {f - f0:+.0f})  EMT-SSN err={ee:.3e}  DP-SSN err={ed:.3e}  ratio={ee / ed:.0f}\"\n",
+    "        f\"f_sig={f:3d} Hz (offset {f - f0:+.0f})  EMT-SSN rel={ee:.3e}  DP-SSN rel={ed:.3e}  ratio={ee / ed:.2f}\"\n",
     "    )"
    ],
    "execution_count": null,
@@ -326,7 +337,7 @@
     "plt.semilogy(freqs, dp_big, \"s-\", label=\"DP-SSN\")\n",
     "plt.axvline(f0, color=\"0.7\", linestyle=\":\", label=\"carrier\")\n",
     "plt.xlabel(\"signal frequency [Hz]\")\n",
-    "plt.ylabel(\"steady-state phasor error [A]\")\n",
+    "plt.ylabel(\"relative phasor error\")\n",
     "plt.title(\"Accuracy versus signal frequency (large step, dt = 2e-3 s)\")\n",
     "plt.legend()\n",
     "plt.grid(True, which=\"both\", linestyle=\":\")\n",
@@ -340,10 +351,10 @@
    "metadata": {},
    "source": [
     "advantage = [ee / ed for ee, ed in zip(emt_big, dp_big)]\n",
-    "print(\"DP-SSN advantage at the carrier:\", advantage[0], \"x\")\n",
-    "print(\"DP-SSN advantage at the largest offset:\", advantage[-1], \"x\")\n",
-    "assert advantage[0] > 100\n",
-    "assert advantage[0] > advantage[-1]"
+    "print(\"DP-SSN advantage at the carrier:\", advantage[carrier], \"x\")\n",
+    "print(\"DP-SSN advantage far below the carrier:\", advantage[0], \"x\")\n",
+    "assert advantage[carrier] > 100  # DP-SSN dominates at the carrier\n",
+    "assert advantage[0] < 1  # EMT-SSN wins far below it (the crossover)"
    ],
    "execution_count": null,
    "outputs": []

--- a/examples/Notebooks/Circuits/DP_SSN_RLC_accuracy.ipynb
+++ b/examples/Notebooks/Circuits/DP_SSN_RLC_accuracy.ipynb
@@ -1,0 +1,373 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DP/SFA SSN accuracy: time-step and frequency sweeps\n",
+    "\n",
+    "The companion notebook `DP_generalizedSSN_RLC` showed that the DP SSN components\n",
+    "reproduce the classical circuit. This notebook quantifies the shifted-frequency\n",
+    "accuracy advantage on the same series RLC one-port (R = 10 Ohm, L = 0.01 H,\n",
+    "C = 0.002 F), using a small-step EMT simulation as the reference (the true\n",
+    "value). Accuracy is the error of the steady-state inductor-current phasor,\n",
+    "extracted by a least-squares fit over the second half of each run.\n",
+    "\n",
+    "Three sweeps:\n",
+    "- time step, with the source on the carrier;\n",
+    "- signal frequency, at a fine time step;\n",
+    "- signal frequency, at a large time step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import dpsimpy\n",
+    "from villas.dataprocessing.readtools import read_timeseries_csv"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "R = 10.0\n",
+    "L = 0.01\n",
+    "C = 0.002\n",
+    "\n",
+    "f0 = 50.0\n",
+    "vref = 1.0 * np.exp(1j * np.deg2rad(-90.0))\n",
+    "\n",
+    "dt_ref = 1e-5\n",
+    "tf = 0.3\n",
+    "\n",
+    "log_dir = \"logs\""
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def run(sim_name, system, domain, comp, attr, dt):\n",
+    "    dpsimpy.Logger.set_log_dir(f\"{log_dir}/{sim_name}\")\n",
+    "    logger = dpsimpy.Logger(sim_name)\n",
+    "    logger.log_attribute(\"y\", attr, comp)\n",
+    "\n",
+    "    sim = dpsimpy.Simulation(sim_name, dpsimpy.LogLevel.off)\n",
+    "    sim.set_system(system)\n",
+    "    sim.set_domain(domain)\n",
+    "    sim.set_time_step(dt)\n",
+    "    sim.set_final_time(tf)\n",
+    "    sim.add_logger(logger)\n",
+    "    sim.run()\n",
+    "\n",
+    "    return read_timeseries_csv(\n",
+    "        f\"{log_dir}/{sim_name}/{sim_name}.csv\", print_status=False\n",
+    "    )[\"y\"]\n",
+    "\n",
+    "\n",
+    "def steady_phasor(series, w):\n",
+    "    # Steady-state phasor via least-squares fit to cos/sin at w: the metric that\n",
+    "    # exposes frequency warping (a raw-waveform RMSE hides it at large steps).\n",
+    "    t, y = series.time, series.values\n",
+    "    half = slice(len(t) // 2, None)\n",
+    "    ts, ys = t[half], y[half]\n",
+    "    basis = np.column_stack([np.cos(w * ts), np.sin(w * ts), np.ones_like(ts)])\n",
+    "    a, b, _ = np.linalg.lstsq(basis, ys, rcond=None)[0]\n",
+    "    return a - 1j * b\n",
+    "\n",
+    "\n",
+    "def dp_node(name):\n",
+    "    return dpsimpy.dp.SimNode(name)\n",
+    "\n",
+    "\n",
+    "def emt_node(name):\n",
+    "    return dpsimpy.emt.SimNode(name, dpsimpy.PhaseType.Single)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def build_ssn(ph1, node, gnd, src_freq):\n",
+    "    n1 = node(\"n1\")\n",
+    "    vs = ph1.VoltageSource(\"vs\")\n",
+    "    vs.set_parameters(vref, src_freq)\n",
+    "    rlc = ph1.Full_Serial_RLC(\"rlc\")\n",
+    "    rlc.set_parameters(R, L, C)\n",
+    "    vs.connect([gnd, n1])\n",
+    "    rlc.connect([n1, gnd])\n",
+    "    return dpsimpy.SystemTopology(f0, [n1], [vs, rlc]), rlc\n",
+    "\n",
+    "\n",
+    "def build_rlc(ph1, node, gnd, src_freq):\n",
+    "    n1, n2, n3 = node(\"n1\"), node(\"n2\"), node(\"n3\")\n",
+    "    vs = ph1.VoltageSource(\"vs\")\n",
+    "    vs.set_parameters(vref, src_freq)\n",
+    "    res = ph1.Resistor(\"r\")\n",
+    "    res.set_parameters(R)\n",
+    "    ind = ph1.Inductor(\"l\")\n",
+    "    ind.set_parameters(L)\n",
+    "    cap = ph1.Capacitor(\"c\")\n",
+    "    cap.set_parameters(C)\n",
+    "    vs.connect([gnd, n1])\n",
+    "    res.connect([n1, n2])\n",
+    "    ind.connect([n2, n3])\n",
+    "    cap.connect([n3, gnd])\n",
+    "    return dpsimpy.SystemTopology(f0, [n1, n2, n3], [vs, res, ind, cap]), ind"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`reference_phasor` runs a fine-step EMT simulation and returns the\n",
+    "steady-state phasor at the signal frequency (the truth). `emt_ssn_error` and\n",
+    "`dp_ssn_error` run the SSN models at a given step and signal frequency and\n",
+    "return the phasor error against that reference. The DP source frequency is the\n",
+    "offset from the carrier; the DP result is reconstructed with `frequency_shift`\n",
+    "before the phasor is extracted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "dp_gnd = dpsimpy.dp.SimNode.gnd\n",
+    "emt_gnd = dpsimpy.emt.SimNode.gnd\n",
+    "\n",
+    "\n",
+    "def reference_phasor(f_sig):\n",
+    "    sys, comp = build_rlc(dpsimpy.emt.ph1, emt_node, emt_gnd, f_sig)\n",
+    "    series = run(f\"REF_{f_sig:g}Hz\", sys, dpsimpy.Domain.EMT, comp, \"i_intf\", dt_ref)\n",
+    "    return steady_phasor(series, 2.0 * np.pi * f_sig)\n",
+    "\n",
+    "\n",
+    "def emt_ssn_error(f_sig, dt, ref):\n",
+    "    sys, comp = build_ssn(dpsimpy.emt.ph1, emt_node, emt_gnd, f_sig)\n",
+    "    series = run(\n",
+    "        f\"EMT_SSN_{f_sig:g}Hz_{dt:.0e}\", sys, dpsimpy.Domain.EMT, comp, \"i_intf\", dt\n",
+    "    )\n",
+    "    return np.abs(steady_phasor(series, 2.0 * np.pi * f_sig) - ref)\n",
+    "\n",
+    "\n",
+    "def dp_ssn_error(f_sig, dt, ref):\n",
+    "    sys, comp = build_ssn(dpsimpy.dp.ph1, dp_node, dp_gnd, f_sig - f0)\n",
+    "    series = run(\n",
+    "        f\"DP_SSN_{f_sig:g}Hz_{dt:.0e}\", sys, dpsimpy.Domain.DP, comp, \"i_intf\", dt\n",
+    "    )\n",
+    "    shifted = series.frequency_shift(f0)\n",
+    "    return np.abs(steady_phasor(shifted, 2.0 * np.pi * f_sig) - ref)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sweep over time step (source on the carrier)\n",
+    "\n",
+    "Trapezoidal integration warps the L and C companion models by\n",
+    "`Psi(w) = tan(w h / 2) / (w h / 2)`, distorting the impedance at the oscillation\n",
+    "frequency. With the source on the carrier the EMT-SSN 50 Hz forced response sits\n",
+    "where `Psi > 1`, so its error grows as the step `h` grows. In DP-SSN the forced\n",
+    "response is the DC of the envelope (`Psi ~ 1`), so the error stays flat."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "ref_carrier = reference_phasor(f0)\n",
+    "steps = [5e-3, 2e-3, 1e-3, 5e-4, 2e-4, 1e-4]\n",
+    "\n",
+    "err_emt = [emt_ssn_error(f0, dt, ref_carrier) for dt in steps]\n",
+    "err_dp = [dp_ssn_error(f0, dt, ref_carrier) for dt in steps]\n",
+    "\n",
+    "for dt, ee, ed in zip(steps, err_emt, err_dp):\n",
+    "    print(\n",
+    "        f\"dt={dt:.0e}  EMT-SSN err={ee:.3e}  DP-SSN err={ed:.3e}  ratio={ee / ed:.0f}\"\n",
+    "    )"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "plt.figure(figsize=(9, 4))\n",
+    "plt.loglog(steps, err_emt, \"o-\", label=\"EMT-SSN\")\n",
+    "plt.loglog(steps, err_dp, \"s-\", label=\"DP-SSN\")\n",
+    "plt.xlabel(\"time step [s]\")\n",
+    "plt.ylabel(\"steady-state phasor error [A]\")\n",
+    "plt.title(\"Accuracy versus time step (source on the 50 Hz carrier)\")\n",
+    "plt.legend()\n",
+    "plt.grid(True, which=\"both\", linestyle=\":\")\n",
+    "plt.show()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "assert err_dp[0] < err_emt[0] / 100\n",
+    "assert max(err_dp) < 20 * min(err_dp)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sweep over signal frequency (fine time step)\n",
+    "\n",
+    "The source is now detuned from the 50 Hz carrier. The DP envelope rotates at the\n",
+    "offset `f_sig - f0`, so DP-SSN warps according to that offset rather than the\n",
+    "absolute signal frequency. Near the carrier DP-SSN is far more accurate; the\n",
+    "advantage shrinks as the signal moves away and the envelope mode climbs in\n",
+    "frequency."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "freqs = [50, 55, 60, 70, 90, 120, 160]\n",
+    "refs = [reference_phasor(f) for f in freqs]\n",
+    "\n",
+    "dt_fine = 1e-4\n",
+    "emt_fine = [emt_ssn_error(f, dt_fine, r) for f, r in zip(freqs, refs)]\n",
+    "dp_fine = [dp_ssn_error(f, dt_fine, r) for f, r in zip(freqs, refs)]\n",
+    "\n",
+    "for f, ee, ed in zip(freqs, emt_fine, dp_fine):\n",
+    "    print(\n",
+    "        f\"f_sig={f:3d} Hz (offset {f - f0:+.0f})  EMT-SSN err={ee:.3e}  DP-SSN err={ed:.3e}  ratio={ee / ed:.0f}\"\n",
+    "    )"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "plt.figure(figsize=(9, 4))\n",
+    "plt.semilogy(freqs, emt_fine, \"o-\", label=\"EMT-SSN\")\n",
+    "plt.semilogy(freqs, dp_fine, \"s-\", label=\"DP-SSN\")\n",
+    "plt.axvline(f0, color=\"0.7\", linestyle=\":\", label=\"carrier\")\n",
+    "plt.xlabel(\"signal frequency [Hz]\")\n",
+    "plt.ylabel(\"steady-state phasor error [A]\")\n",
+    "plt.title(\"Accuracy versus signal frequency (fine step, dt = 1e-4 s)\")\n",
+    "plt.legend()\n",
+    "plt.grid(True, which=\"both\", linestyle=\":\")\n",
+    "plt.show()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# DP-SSN is at least as accurate as EMT-SSN across the swept band\n",
+    "assert all(ed < ee for ed, ee in zip(dp_fine, emt_fine))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sweep over signal frequency (large time step)\n",
+    "\n",
+    "The same frequency sweep at a large step makes the effect dramatic: at the\n",
+    "carrier DP-SSN is orders of magnitude more accurate, and the advantage erodes as\n",
+    "the signal detunes and the envelope mode moves into the warped band."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "dt_big = 2e-3\n",
+    "emt_big = [emt_ssn_error(f, dt_big, r) for f, r in zip(freqs, refs)]\n",
+    "dp_big = [dp_ssn_error(f, dt_big, r) for f, r in zip(freqs, refs)]\n",
+    "\n",
+    "for f, ee, ed in zip(freqs, emt_big, dp_big):\n",
+    "    print(\n",
+    "        f\"f_sig={f:3d} Hz (offset {f - f0:+.0f})  EMT-SSN err={ee:.3e}  DP-SSN err={ed:.3e}  ratio={ee / ed:.0f}\"\n",
+    "    )"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "plt.figure(figsize=(9, 4))\n",
+    "plt.semilogy(freqs, emt_big, \"o-\", label=\"EMT-SSN\")\n",
+    "plt.semilogy(freqs, dp_big, \"s-\", label=\"DP-SSN\")\n",
+    "plt.axvline(f0, color=\"0.7\", linestyle=\":\", label=\"carrier\")\n",
+    "plt.xlabel(\"signal frequency [Hz]\")\n",
+    "plt.ylabel(\"steady-state phasor error [A]\")\n",
+    "plt.title(\"Accuracy versus signal frequency (large step, dt = 2e-3 s)\")\n",
+    "plt.legend()\n",
+    "plt.grid(True, which=\"both\", linestyle=\":\")\n",
+    "plt.show()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "advantage = [ee / ed for ee, ed in zip(emt_big, dp_big)]\n",
+    "print(\"DP-SSN advantage at the carrier:\", advantage[0], \"x\")\n",
+    "print(\"DP-SSN advantage at the largest offset:\", advantage[-1], \"x\")\n",
+    "assert advantage[0] > 100\n",
+    "assert advantage[0] > advantage[-1]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/Notebooks/Circuits/DP_generalizedSSN_RLC.ipynb
+++ b/examples/Notebooks/Circuits/DP_generalizedSSN_RLC.ipynb
@@ -1,0 +1,349 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DP/SFA state-space nodal (SSN) for a series RLC\n",
+    "\n",
+    "This notebook validates the DP-domain SSN components on a series RLC one-port\n",
+    "(R = 10 Ohm, L = 0.01 H, C = 0.002 F):\n",
+    "\n",
+    "- the dedicated `dp.ph1.Full_Serial_RLC`,\n",
+    "- the generic `dp.ph1.GenericTwoTerminalVTypeSSN`, parametrized directly by\n",
+    "  continuous-time state-space matrices `(A, B, C, D)`,\n",
+    "- the generic `dp.ph1.GenericTwoTerminalITypeSSN` for a current-driven capacitor.\n",
+    "\n",
+    "Each SSN component is compared against the same circuit built from classical\n",
+    "R, L, C elements in the DP domain, where the dynamic phasor envelopes must\n",
+    "agree. The DP-SSN envelope is reconstructed to the time domain and overlaid on\n",
+    "the EMT and EMT-SSN waveforms. The accuracy study (time-step and signal-frequency\n",
+    "sweeps) lives in the companion notebook `DP_SSN_RLC_accuracy`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import dpsimpy\n",
+    "from villas.dataprocessing.readtools import read_timeseries_csv\n",
+    "from villas.dataprocessing.timeseries import TimeSeries"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "R = 10.0\n",
+    "L = 0.01\n",
+    "C = 0.002\n",
+    "\n",
+    "f0 = 50.0\n",
+    "vref = 1.0 * np.exp(1j * np.deg2rad(-90.0))\n",
+    "\n",
+    "time_step = 1e-4\n",
+    "final_time = 0.1\n",
+    "\n",
+    "log_dir = \"logs\""
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def run(sim_name, system, domain, comp, attr):\n",
+    "    dpsimpy.Logger.set_log_dir(f\"{log_dir}/{sim_name}\")\n",
+    "    logger = dpsimpy.Logger(sim_name)\n",
+    "    logger.log_attribute(\"y\", attr, comp)\n",
+    "\n",
+    "    sim = dpsimpy.Simulation(sim_name, dpsimpy.LogLevel.off)\n",
+    "    sim.set_system(system)\n",
+    "    sim.set_domain(domain)\n",
+    "    sim.set_time_step(time_step)\n",
+    "    sim.set_final_time(final_time)\n",
+    "    sim.add_logger(logger)\n",
+    "    sim.run()\n",
+    "\n",
+    "    results = read_timeseries_csv(\n",
+    "        f\"{log_dir}/{sim_name}/{sim_name}.csv\", print_status=False\n",
+    "    )\n",
+    "    return results[\"y\"]\n",
+    "\n",
+    "\n",
+    "def dp_node(name):\n",
+    "    return dpsimpy.dp.SimNode(name)\n",
+    "\n",
+    "\n",
+    "def emt_node(name):\n",
+    "    return dpsimpy.emt.SimNode(name, dpsimpy.PhaseType.Single)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Series RLC across DP, EMT, and SSN\n",
+    "\n",
+    "The same one-port is driven by a 50 Hz voltage source. The DP source frequency\n",
+    "is the offset from the carrier (0 = steady on the nominal carrier), while the\n",
+    "EMT source frequency is the absolute 50 Hz. `build_rlc` assembles the classical\n",
+    "network; `build_ssn` replaces it with the single `Full_Serial_RLC` component."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def build_rlc(ph1, node, gnd, src_freq):\n",
+    "    n1, n2, n3 = node(\"n1\"), node(\"n2\"), node(\"n3\")\n",
+    "    vs = ph1.VoltageSource(\"vs\")\n",
+    "    vs.set_parameters(vref, src_freq)\n",
+    "    res = ph1.Resistor(\"r\")\n",
+    "    res.set_parameters(R)\n",
+    "    ind = ph1.Inductor(\"l\")\n",
+    "    ind.set_parameters(L)\n",
+    "    cap = ph1.Capacitor(\"c\")\n",
+    "    cap.set_parameters(C)\n",
+    "    vs.connect([gnd, n1])\n",
+    "    res.connect([n1, n2])\n",
+    "    ind.connect([n2, n3])\n",
+    "    cap.connect([n3, gnd])\n",
+    "    return dpsimpy.SystemTopology(f0, [n1, n2, n3], [vs, res, ind, cap]), ind\n",
+    "\n",
+    "\n",
+    "def build_ssn(ph1, node, gnd, src_freq):\n",
+    "    n1 = node(\"n1\")\n",
+    "    vs = ph1.VoltageSource(\"vs\")\n",
+    "    vs.set_parameters(vref, src_freq)\n",
+    "    rlc = ph1.Full_Serial_RLC(\"rlc\")\n",
+    "    rlc.set_parameters(R, L, C)\n",
+    "    vs.connect([gnd, n1])\n",
+    "    rlc.connect([n1, gnd])\n",
+    "    return dpsimpy.SystemTopology(f0, [n1], [vs, rlc]), rlc"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "dp_gnd = dpsimpy.dp.SimNode.gnd\n",
+    "emt_gnd = dpsimpy.emt.SimNode.gnd\n",
+    "\n",
+    "sys, comp = build_rlc(dpsimpy.dp.ph1, dp_node, dp_gnd, 0.0)\n",
+    "dp_rlc = run(\"DP_RLC_classical\", sys, dpsimpy.Domain.DP, comp, \"i_intf\")\n",
+    "\n",
+    "sys, comp = build_ssn(dpsimpy.dp.ph1, dp_node, dp_gnd, 0.0)\n",
+    "dp_ssn = run(\"DP_RLC_SSN\", sys, dpsimpy.Domain.DP, comp, \"i_intf\")\n",
+    "\n",
+    "sys, comp = build_rlc(dpsimpy.emt.ph1, emt_node, emt_gnd, f0)\n",
+    "emt_rlc = run(\"EMT_RLC_classical\", sys, dpsimpy.Domain.EMT, comp, \"i_intf\")\n",
+    "\n",
+    "sys, comp = build_ssn(dpsimpy.emt.ph1, emt_node, emt_gnd, f0)\n",
+    "emt_ssn = run(\"EMT_RLC_SSN\", sys, dpsimpy.Domain.EMT, comp, \"i_intf\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "dp_rlc_emt = dp_rlc.frequency_shift(f0)\n",
+    "dp_ssn_emt = dp_ssn.frequency_shift(f0)\n",
+    "\n",
+    "plt.figure(figsize=(9, 4))\n",
+    "plt.plot(emt_rlc.time, emt_rlc.values, color=\"0.6\", linewidth=3, label=\"EMT classical\")\n",
+    "plt.plot(emt_ssn.time, emt_ssn.values, linestyle=\"--\", label=\"EMT-SSN\")\n",
+    "plt.plot(\n",
+    "    dp_rlc_emt.time,\n",
+    "    dp_rlc_emt.values,\n",
+    "    linestyle=\":\",\n",
+    "    label=\"DP classical (reconstructed)\",\n",
+    ")\n",
+    "plt.plot(\n",
+    "    dp_ssn_emt.time, dp_ssn_emt.values, linestyle=\"-.\", label=\"DP-SSN (reconstructed)\"\n",
+    ")\n",
+    "plt.xlabel(\"time [s]\")\n",
+    "plt.ylabel(\"inductor current [A]\")\n",
+    "plt.title(\"Series RLC inductor current: classical vs SSN, EMT vs DP\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The DP-SSN envelope must reproduce the classical DP envelope exactly, since\n",
+    "both are solved in the same DP network. The reconstructed DP-SSN waveform must\n",
+    "match the EMT-SSN waveform within trapezoidal discretization error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "max_env_err = np.max(np.abs(dp_ssn.values - dp_rlc.values))\n",
+    "print(\"DP-SSN vs DP classical, max |envelope error|:\", max_env_err)\n",
+    "assert max_env_err < 1e-9\n",
+    "\n",
+    "rmse = TimeSeries.rmse(dp_ssn_emt, emt_ssn)\n",
+    "print(\"DP-SSN reconstructed vs EMT-SSN, RMSE:\", rmse)\n",
+    "assert rmse < 1e-3"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generic V-type from (A, B, C, D)\n",
+    "\n",
+    "The series RLC is now declared directly by its state space, with states\n",
+    "`x = [v_C; i_L]`, input = port voltage, output = port current `i_L`. The result\n",
+    "must equal the dedicated `Full_Serial_RLC` envelope to machine precision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "A = [[0.0, 1.0 / C], [-1.0 / L, -R / L]]\n",
+    "B = [[0.0], [1.0 / L]]\n",
+    "Cm = [[0.0, 1.0]]\n",
+    "D = [[0.0]]\n",
+    "\n",
+    "n1 = dp_node(\"n1\")\n",
+    "vs = dpsimpy.dp.ph1.VoltageSource(\"vs\")\n",
+    "vs.set_parameters(vref, 0.0)\n",
+    "gen = dpsimpy.dp.ph1.GenericTwoTerminalVTypeSSN(\"rlc_gen\")\n",
+    "gen.set_parameters(A, B, Cm, D)\n",
+    "vs.connect([dp_gnd, n1])\n",
+    "gen.connect([n1, dp_gnd])\n",
+    "sys = dpsimpy.SystemTopology(f0, [n1], [vs, gen])\n",
+    "gen_v = run(\"DP_RLC_genV\", sys, dpsimpy.Domain.DP, gen, \"i_intf\")\n",
+    "\n",
+    "max_err = np.max(np.abs(gen_v.values - dp_ssn.values))\n",
+    "print(\"generic V-type vs Full_Serial_RLC, max |envelope error|:\", max_err)\n",
+    "assert max_err < 1e-9"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generic I-type from (A, B, C, D)\n",
+    "\n",
+    "A capacitor is expressed as a current-driven I-type one-port (input = port\n",
+    "current, output = port voltage) with `dv_C/dt = i_C / C`, so `A = 0`, `B = 1/C`,\n",
+    "`C = 1`, `D = 0`. It is placed in parallel with a resistor and excited by a\n",
+    "current source, and compared against the same circuit using a classical\n",
+    "capacitor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "n1 = dp_node(\"n1\")\n",
+    "cs = dpsimpy.dp.ph1.CurrentSource(\"cs\")\n",
+    "cs.set_parameters(vref)\n",
+    "res = dpsimpy.dp.ph1.Resistor(\"r\")\n",
+    "res.set_parameters(R)\n",
+    "cap = dpsimpy.dp.ph1.Capacitor(\"c\")\n",
+    "cap.set_parameters(C)\n",
+    "cs.connect([dp_gnd, n1])\n",
+    "res.connect([n1, dp_gnd])\n",
+    "cap.connect([n1, dp_gnd])\n",
+    "sys = dpsimpy.SystemTopology(f0, [n1], [cs, res, cap])\n",
+    "rc_v = run(\"DP_RC_classical\", sys, dpsimpy.Domain.DP, cap, \"v_intf\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "Ai = [[0.0]]\n",
+    "Bi = [[1.0 / C]]\n",
+    "Ci = [[1.0]]\n",
+    "Di = [[0.0]]\n",
+    "\n",
+    "n1 = dp_node(\"n1\")\n",
+    "cs = dpsimpy.dp.ph1.CurrentSource(\"cs\")\n",
+    "cs.set_parameters(vref)\n",
+    "res = dpsimpy.dp.ph1.Resistor(\"r\")\n",
+    "res.set_parameters(R)\n",
+    "geni = dpsimpy.dp.ph1.GenericTwoTerminalITypeSSN(\"c_gen\")\n",
+    "geni.set_parameters(Ai, Bi, Ci, Di)\n",
+    "cs.connect([dp_gnd, n1])\n",
+    "res.connect([n1, dp_gnd])\n",
+    "geni.connect([n1, dp_gnd])\n",
+    "sys = dpsimpy.SystemTopology(f0, [n1], [cs, res, geni])\n",
+    "geni_v = run(\"DP_RC_genI\", sys, dpsimpy.Domain.DP, geni, \"v_intf\")\n",
+    "\n",
+    "max_err = np.max(np.abs(geni_v.values - rc_v.values))\n",
+    "print(\"generic I-type vs classical capacitor, max |envelope error|:\", max_err)\n",
+    "assert max_err < 1e-9"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "rc_emt = rc_v.frequency_shift(f0)\n",
+    "geni_emt = geni_v.frequency_shift(f0)\n",
+    "\n",
+    "plt.figure(figsize=(9, 4))\n",
+    "plt.plot(rc_emt.time, rc_emt.values, color=\"0.6\", linewidth=3, label=\"classical R-C\")\n",
+    "plt.plot(geni_emt.time, geni_emt.values, linestyle=\"--\", label=\"generic I-type SSN\")\n",
+    "plt.xlabel(\"time [s]\")\n",
+    "plt.ylabel(\"capacitor voltage [V]\")\n",
+    "plt.title(\"Current-driven capacitor: classical vs I-type SSN\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Adds two Python notebooks and a documentation page for the single-phase DP SSN components, on top of the generic V/I-type work in #516 (now merged).

## Notebooks

`DP_generalizedSSN_RLC.ipynb` (validation). A series RLC across DP and EMT, classical vs SSN: the dedicated `Full_Serial_RLC` and the generic `GenericTwoTerminalVTypeSSN` / `GenericTwoTerminalITypeSSN` reproduce the classical DP envelopes, and the DP-SSN envelope reconstructed to the time domain matches the EMT and EMT-SSN waveforms.

`DP_SSN_RLC_accuracy.ipynb` (accuracy study). Steady-state phasor error against a small-step EMT reference, swept over time step and signal frequency, characterising the shifted-frequency accuracy of DP-SSN relative to EMT-SSN.

## Documentation

Adds `docs/hugo/content/en/docs/Concepts/state-space-nodal.md`, a concept page for State-Space Nodal in the dynamic phasor domain: the SSN method, the real-augmented SFA frequency shift, the available components (`Full_Serial_RLC`, generic V/I-type), and a validation-and-examples section pointing to the two notebooks. Includes references to the foundational SSN and frequency-warping literature.

## Notes

Builds on #516 (generic two-terminal V/I-type components)
