### PR TITLE
fix: SP::Ph1::Capacitor produces NaN admittance for zero capacitance

### DIFF
--- a/dpsim-models/include/dpsim-models/MathUtils.h
+++ b/dpsim-models/include/dpsim-models/MathUtils.h
@@ -34,6 +34,11 @@ public:
   static Complex polar(Real abs, Real phase);
   static Complex polarDeg(Real abs, Real phase);
 
+  // -Ofast/-ffast-math folds std::isnan/isfinite to false; test the IEEE-754
+  // exponent bits directly instead.
+  static bool isFinite(Real value);
+  static bool isFinite(Complex value);
+
   // #### Vector Operations ####
   //
   // | Re(row,0)_harm1 | Re(row,colOffset)_harm1 |

--- a/dpsim-models/src/MathUtils.cpp
+++ b/dpsim-models/src/MathUtils.cpp
@@ -8,6 +8,9 @@
 
 #include <dpsim-models/MathUtils.h>
 
+#include <cstdint>
+#include <cstring>
+
 using namespace CPS;
 
 // #### Angular Operations ####
@@ -53,6 +56,16 @@ Complex Math::polar(Real abs, Real phase) {
 
 Complex Math::polarDeg(Real abs, Real phase) {
   return std::polar<Real>(abs, degToRad(phase));
+}
+
+bool Math::isFinite(Real value) {
+  uint64_t bits;
+  std::memcpy(&bits, &value, sizeof(bits));
+  return (bits & 0x7FF0000000000000ULL) != 0x7FF0000000000000ULL;
+}
+
+bool Math::isFinite(Complex value) {
+  return isFinite(value.real()) && isFinite(value.imag());
 }
 
 void Math::setVectorElement(Matrix &mat, Matrix::Index row, Complex value,

--- a/dpsim-models/src/SP/SP_Ph1_Capacitor.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Capacitor.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *********************************************************************************/
 
+#include <dpsim-models/MathUtils.h>
 #include <dpsim-models/SP/SP_Ph1_Capacitor.h>
 
 using namespace CPS;
@@ -28,8 +29,10 @@ void SP::Ph1::Capacitor::initializeFromNodesAndTerminals(Real frequency) {
 
   Real omega = 2 * PI * frequency;
   mSusceptance = Complex(0, omega * **mCapacitance);
+  // Capacitor admittance is the susceptance (jwC); compute it directly to
+  // avoid manufacturing NaN at C = 0 via a 1/impedance round-trip.
+  mAdmittance = mSusceptance;
   mImpedance = Complex(1, 0) / mSusceptance;
-  mAdmittance = Complex(1, 0) / mImpedance;
   (**mIntfVoltage)(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
   **mIntfCurrent = mSusceptance * **mIntfVoltage;
 
@@ -129,7 +132,7 @@ void SP::Ph1::Capacitor::calculatePerUnitParameters(Real baseApparentPower) {
                      mBaseVoltage, mBaseImpedance);
 
   mImpedancePerUnit = mImpedance / mBaseImpedance;
-  mAdmittancePerUnit = 1. / mImpedancePerUnit;
+  mAdmittancePerUnit = mSusceptance * mBaseImpedance;
   SPDLOG_LOGGER_INFO(mSLog, "Impedance={} [pu]  Admittance={} [pu]",
                      Logger::complexToString(mImpedancePerUnit),
                      Logger::complexToString(mAdmittancePerUnit));
@@ -138,13 +141,13 @@ void SP::Ph1::Capacitor::calculatePerUnitParameters(Real baseApparentPower) {
 void SP::Ph1::Capacitor::pfApplyAdmittanceMatrixStamp(SparseMatrixCompRow &Y) {
   int bus1 = this->matrixNodeIndex(0);
 
-  if (std::isinf(mAdmittancePerUnit.real()) ||
-      std::isinf(mAdmittancePerUnit.imag())) {
-    std::cout << "Y:" << mAdmittancePerUnit << std::endl;
-    std::stringstream ss;
-    ss << "Capacitor >>" << this->name()
-       << ": infinite or nan values at node: " << bus1;
-    throw std::invalid_argument(ss.str());
+  if (!Math::isFinite(mAdmittancePerUnit)) {
+    SPDLOG_LOGGER_ERROR(mSLog,
+                        "Capacitor {}: non-finite per-unit admittance {} at "
+                        "node {}",
+                        this->name(),
+                        Logger::complexToString(mAdmittancePerUnit), bus1);
+    throw InvalidArgumentException();
   }
 
   //set the circuit matrix values


### PR DESCRIPTION
## Problem
A capacitor's admittance is jwC, but the code computed 1/(1/jwC), which is NaN at C = 0. One zero-C capacitor then poisons the Y diagonal and breaks the power flow (hit in practice via a transformer snubber with no rated power).

## Fix 
Take admittance straight from the susceptance. Identical for C != 0; C = 0 now gives 0, so existing results are unchanged (WSCC-9 unaffected). Also drops the dead isinf/cout guard (isinf is folded to false under -Ofast), replacing it with a logger check on a new shared Math::isFinite helper (bit-pattern test, so it stays correct under -ffast-math) that other PF stamps can reuse.

