### PR TITLE
fix: guard PF convergence check against non-finite mismatch

### DIFF
--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *********************************************************************************/
 
+#include <dpsim-models/MathUtils.h>
 #include <dpsim/PFSolver.h>
 #include <dpsim/SequentialScheduler.h>
 #include <iostream>
@@ -467,6 +468,10 @@ CPS::Real PFSolver::B(int i, int j) { return mY.coeff(i, j).imag(); }
 CPS::Bool PFSolver::checkConvergence() {
   // Converged if all mismatches are below the tolerance
   for (CPS::UInt i = 0; i < mNumUnknowns; i++) {
+    if (!Math::isFinite(mF(i))) {
+      SPDLOG_LOGGER_WARN(mSLog, "mF[{}] not finite (NaN/Inf)", i);
+      return false;
+    }
     if (abs(mF(i)) > mTolerance)
       return false;
   }


### PR DESCRIPTION
`checkConvergence()` tested `abs(mF(i)) > tol`, but `abs(NaN) > tol` is `false` in IEEE-754, so a NaN mismatch made the solver report convergence after one iteration and hide a broken solve.

Fix: treat any non-finite `mF(i)` as not converged (return `false`, log a warning). The finiteness test is a bit-pattern check, since the project's `-Ofast` build folds `std::isnan` to false.

Needs #519 merged first to use the helper function.