### PR TITLE
fix: refresh matrix-node-index cache after terminal swap in SP Transformer PF

### DIFF
--- a/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
@@ -107,6 +107,8 @@ void SP::Ph1::Transformer::createSubComponents() {
         mNominalVoltageEnd1, mNominalVoltageEnd2);
     SPDLOG_LOGGER_INFO(mSLog, "Tap Ratio = {} [ ] Phase Shift = {} [deg]",
                        mRatioAbs, mRatioPhase);
+    // Refresh index cache after terminal swap so pfApplyAdmittanceMatrixStamp uses the correct order.
+    updateMatrixNodeIndices();
   }
 
   // Create series sub components


### PR DESCRIPTION
`SP::Ph1::Transformer` swaps its terminals when `|ratio| < 1` to keep the HV side at position 0, but the `mMatrixNodeIndices` cache was populated before the swap. As a result `pfApplyAdmittanceMatrixStamp` stamped admittances at the wrong node indices.

Fix: call `updateMatrixNodeIndices()` at the end of the terminal-swap block so the power-flow stamp uses the corrected ordering.
