### PR TITLE
Fix DiakopticsSolver::collectVirtualNodes to recurse into subcomponent virtual nodes

### DIFF
--- a/dpsim/src/DiakopticsSolver.cpp
+++ b/dpsim/src/DiakopticsSolver.cpp
@@ -151,6 +151,25 @@ void DiakopticsSolver<VarType>::collectVirtualNodes(int net) {
         mSubnets[net].nodes.push_back(pComp->virtualNode(node));
       }
     }
+
+    if (pComp->hasSubComponents()) {
+      for (auto pSubComp : pComp->subComponents()) {
+        for (UInt node = 0; node < pSubComp->virtualNodesNumber(); ++node) {
+          auto vnode = pSubComp->virtualNode(node);
+          bool alreadyRegistered = false;
+          for (auto registeredNode : mSubnets[net].nodes) {
+            if (registeredNode == vnode) {
+              alreadyRegistered = true;
+              break;
+            }
+          }
+          if (alreadyRegistered)
+            continue;
+          ++(mSubnets[net].mVirtualNodeNum);
+          mSubnets[net].nodes.push_back(vnode);
+        }
+      }
+    }
   }
   SPDLOG_LOGGER_INFO(mSLog, "Subnet {} has {} real network nodes.", net,
                      mSubnets[net].mRealNetNodeNum);


### PR DESCRIPTION
A composite component placed inside a subnet produced an ill-conditioned subnet. EMT::Ph3::NetworkInjection reports virtualNodesNumber() == 0 but wraps a VoltageSource subcomponent whose virtual node never got a matrix index in the subnet. Without that index, the voltage source could not set the voltage at its node, and the simulation diverged.

Cause: collectVirtualNodes only iterated each component's own virtualNode(...). The monolithic MnaSolver::collectVirtualNodes already recurses into subComponents(); the diakoptics version did not.

Fix: After registering a component's own virtual nodes, also iterate pComp->subComponents() and register each subcomponent's virtual node (with a dedup check), exactly like the standard MNA solver implementation.

Resolves #522