### PR TITLE
SP power-flow: remove dead isinf guards and unused capacitor fields

### DIFF
--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Capacitor.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Capacitor.h
@@ -33,13 +33,9 @@ protected:
   /// base current [A]
   Real mBaseCurrent;
 
-  /// Impedance [pu]
-  Complex mImpedancePerUnit;
   /// Admittance [pu]
   Complex mAdmittancePerUnit;
 
-  /// Impedance [Ohm]
-  Complex mImpedance;
   /// Admittance [S]
   Complex mAdmittance;
   /// Susceptance [S]

--- a/dpsim-models/src/SP/SP_Ph1_Capacitor.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Capacitor.cpp
@@ -32,16 +32,13 @@ void SP::Ph1::Capacitor::initializeFromNodesAndTerminals(Real frequency) {
   // Capacitor admittance is the susceptance (jwC); compute it directly to
   // avoid manufacturing NaN at C = 0 via a 1/impedance round-trip.
   mAdmittance = mSusceptance;
-  mImpedance = Complex(1, 0) / mSusceptance;
   (**mIntfVoltage)(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
   **mIntfCurrent = mSusceptance * **mIntfVoltage;
 
   SPDLOG_LOGGER_INFO(mSLog,
                      "\nCapacitance [F]: {:s}"
-                     "\nImpedance [Ohm]: {:s}"
                      "\nAdmittance [S]: {:s}",
                      Logger::realToString(**mCapacitance),
-                     Logger::complexToString(mImpedance),
                      Logger::complexToString(mAdmittance));
   SPDLOG_LOGGER_INFO(mSLog,
                      "\n--- Initialization from powerflow ---"
@@ -131,10 +128,8 @@ void SP::Ph1::Capacitor::calculatePerUnitParameters(Real baseApparentPower) {
   SPDLOG_LOGGER_INFO(mSLog, "Base Voltage={} [V]  Base Impedance={} [Ohm]",
                      mBaseVoltage, mBaseImpedance);
 
-  mImpedancePerUnit = mImpedance / mBaseImpedance;
   mAdmittancePerUnit = mSusceptance * mBaseImpedance;
-  SPDLOG_LOGGER_INFO(mSLog, "Impedance={} [pu]  Admittance={} [pu]",
-                     Logger::complexToString(mImpedancePerUnit),
+  SPDLOG_LOGGER_INFO(mSLog, "Admittance={} [pu]",
                      Logger::complexToString(mAdmittancePerUnit));
 }
 

--- a/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *********************************************************************************/
 
+#include <dpsim-models/MathUtils.h>
 #include <dpsim-models/SP/SP_Ph1_PiLine.h>
 
 using namespace CPS;
@@ -133,16 +134,13 @@ void SP::Ph1::PiLine::pfApplyAdmittanceMatrixStamp(SparseMatrixCompRow &Y) {
   //check for inf or nan
   for (int i = 0; i < 2; i++)
     for (int j = 0; j < 2; j++)
-      if (std::isinf(mY_element.coeff(i, j).real()) ||
-          std::isinf(mY_element.coeff(i, j).imag())) {
-        std::cout << mY_element << std::endl;
-        std::stringstream ss;
-        ss << "Line>>" << this->name()
-           << ": infinite or nan values in the element Y at: " << i << "," << j;
-        throw std::invalid_argument(ss.str());
-        std::cout << "Line>>" << this->name()
-                  << ": infinite or nan values in the element Y at: " << i
-                  << "," << j << std::endl;
+      if (!Math::isFinite(mY_element.coeff(i, j))) {
+        SPDLOG_LOGGER_ERROR(
+            mSLog,
+            "Line {}: non-finite per-unit admittance {} in element Y({},{})",
+            this->name(), Logger::complexToString(mY_element.coeff(i, j)), i,
+            j);
+        throw InvalidArgumentException();
       }
 
   //set the circuit matrix values

--- a/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
@@ -7,6 +7,7 @@
  *********************************************************************************/
 
 #include "dpsim-models/SP/SP_Ph1_RXLine.h"
+#include "dpsim-models/MathUtils.h"
 
 using namespace CPS;
 
@@ -81,16 +82,13 @@ void SP::Ph1::RXLine::pfApplyAdmittanceMatrixStamp(SparseMatrixCompRow &Y) {
   //check for inf or nan
   for (int i = 0; i < 2; i++)
     for (int j = 0; j < 2; j++)
-      if (std::isinf(mY_element.coeff(i, j).real()) ||
-          std::isinf(mY_element.coeff(i, j).imag())) {
-        std::cout << mY_element << std::endl;
-        std::stringstream ss;
-        ss << "Line>>" << this->name()
-           << ": infinite or nan values in the element Y at: " << i << "," << j;
-        throw std::invalid_argument(ss.str());
-        std::cout << "Line>>" << this->name()
-                  << ": infinite or nan values in the element Y at: " << i
-                  << "," << j << std::endl;
+      if (!Math::isFinite(mY_element.coeff(i, j))) {
+        SPDLOG_LOGGER_ERROR(
+            mSLog,
+            "Line {}: non-finite per-unit admittance {} in element Y({},{})",
+            this->name(), Logger::complexToString(mY_element.coeff(i, j)), i,
+            j);
+        throw InvalidArgumentException();
       }
 
   //set the circuit matrix values

--- a/dpsim-models/src/SP/SP_Ph1_Resistor.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Resistor.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *********************************************************************************/
 
+#include <dpsim-models/MathUtils.h>
 #include <dpsim-models/SP/SP_Ph1_Resistor.h>
 
 using namespace CPS;
@@ -74,12 +75,12 @@ void SP::Ph1::Resistor::pfApplyAdmittanceMatrixStamp(SparseMatrixCompRow &Y) {
   int bus1 = this->matrixNodeIndex(0);
   Complex Y_element = Complex(mConductancePerUnit, 0);
 
-  if (std::isinf(Y_element.real()) || std::isinf(Y_element.imag())) {
-    std::cout << "Y:" << Y_element << std::endl;
-    std::stringstream ss;
-    ss << "Resistor >>" << this->name()
-       << ": infinite or nan values at node: " << bus1;
-    throw std::invalid_argument(ss.str());
+  if (!Math::isFinite(Y_element)) {
+    SPDLOG_LOGGER_ERROR(mSLog,
+                        "Resistor {}: non-finite per-unit admittance {} at "
+                        "node {}",
+                        this->name(), Logger::complexToString(Y_element), bus1);
+    throw InvalidArgumentException();
   }
 
   //set the circuit matrix values

--- a/dpsim-models/src/SP/SP_Ph1_Shunt.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Shunt.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *********************************************************************************/
 
+#include <dpsim-models/MathUtils.h>
 #include <dpsim-models/SP/SP_Ph1_Shunt.h>
 
 using namespace CPS;
@@ -56,12 +57,12 @@ void SP::Ph1::Shunt::pfApplyAdmittanceMatrixStamp(SparseMatrixCompRow &Y) {
   int bus1 = this->matrixNodeIndex(0);
   Complex Y_element = Complex(**mConductancePerUnit, **mSusceptancePerUnit);
 
-  if (std::isinf(Y_element.real()) || std::isinf(Y_element.imag())) {
-    std::cout << "Y:" << Y_element << std::endl;
-    std::stringstream ss;
-    ss << "Shunt>>" << this->name()
-       << ": infinite or nan values at node: " << bus1;
-    throw std::invalid_argument(ss.str());
+  if (!Math::isFinite(Y_element)) {
+    SPDLOG_LOGGER_ERROR(mSLog,
+                        "Shunt {}: non-finite per-unit admittance {} at "
+                        "node {}",
+                        this->name(), Logger::complexToString(Y_element), bus1);
+    throw InvalidArgumentException();
   }
 
   //set the circuit matrix values

--- a/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *********************************************************************************/
 
+#include <dpsim-models/MathUtils.h>
 #include <dpsim-models/SP/SP_Ph1_SolidStateTransformer.h>
 
 using namespace CPS;
@@ -63,11 +64,12 @@ void SP::Ph1::SolidStateTransformer::initializeParentFromNodesAndTerminals(
   mSubLoadSide1->setParameters(**mPref, **mQ1ref, mNominalVoltageEnd1);
   mSubLoadSide2->setParameters(mP2, **mQ2ref, mNominalVoltageEnd2);
 
-  if (std::isinf(mP2)) {
-    std::stringstream ss;
-    ss << "SST >>" << this->name()
-       << ": infinite or nan values. Or initialized before setting parameters.";
-    throw std::invalid_argument(ss.str());
+  if (!Math::isFinite(mP2)) {
+    SPDLOG_LOGGER_ERROR(mSLog,
+                        "SST {}: non-finite secondary-side power {} (or "
+                        "initialized before setting parameters)",
+                        this->name(), mP2);
+    throw InvalidArgumentException();
   }
   if ((**mPref * mP2) > 0) {
     throw std::invalid_argument(

--- a/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Transformer.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *********************************************************************************/
 
+#include <dpsim-models/MathUtils.h>
 #include <dpsim-models/SP/SP_Ph1_Transformer.h>
 
 using namespace CPS;
@@ -307,15 +308,14 @@ void SP::Ph1::Transformer::pfApplyAdmittanceMatrixStamp(
   //check for inf or nan
   for (int i = 0; i < 2; i++)
     for (int j = 0; j < 2; j++)
-      if (std::isinf(mY_element.coeff(i, j).real()) ||
-          std::isinf(mY_element.coeff(i, j).imag())) {
-        std::cout << mY_element << std::endl;
-        std::cout << "Zl:" << mLeakage << std::endl;
-        std::cout << "tap:" << mRatioAbsPerUnit << std::endl;
-        std::stringstream ss;
-        ss << "Transformer>>" << this->name()
-           << ": infinite or nan values in the element Y at: " << i << "," << j;
-        throw std::invalid_argument(ss.str());
+      if (!Math::isFinite(mY_element.coeff(i, j))) {
+        SPDLOG_LOGGER_ERROR(
+            mSLog,
+            "Transformer {}: non-finite per-unit admittance {} "
+            "in element Y({},{}) (leakage {}, tap {})",
+            this->name(), Logger::complexToString(mY_element.coeff(i, j)), i, j,
+            Logger::complexToString(mLeakage), mRatioAbsPerUnit);
+        throw InvalidArgumentException();
       }
 
   //set the circuit matrix values


### PR DESCRIPTION
## What

Cleanup of dead NaN/inf-guard code in the SP power-flow admittance stamps.

Under `-Ofast`/`-ffast-math` the compiler folds `std::isnan`/`std::isinf`/`std::isfinite` to a compile-time `false`, so every `std::isinf` finite-guard in the SP tree was silently dead. This replaces them with the bit-pattern `CPS::Math::isFinite`, which actually works in this compilation conditions.

### Capacitor (follow-up to Georgii's review on #519)
- Remove dead `mImpedance` / `mImpedancePerUnit` fields and their computations/log lines. The admittance path uses `mSusceptance` directly; the impedance round-trip was unused.

### Dead-guard sweep (implement pattern)
Same dead `std::isinf` + paired `std::cout` pattern across 6 more SP components, each rerouted through `SPDLOG_LOGGER_ERROR` + `throw InvalidArgumentException()` and the `std::cout` dropped:
- `SP_Ph1_Resistor`, `SP_Ph1_Shunt`, `SP_Ph1_PiLine`, `SP_Ph1_RXLine`, `SP_Ph1_Transformer`, `SP_Ph1_SolidStateTransformer`