### PR TITLE
ci: cancel superseded workflow runs via concurrency groups

### DIFF
--- a/.github/workflows/build_nix.yaml
+++ b/.github/workflows/build_nix.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 ## Build ##

--- a/.github/workflows/build_nix.yaml
+++ b/.github/workflows/build_nix.yaml
@@ -6,6 +6,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 ## Build ##
 
 jobs:

--- a/.github/workflows/build_test_linux_fedora.yaml
+++ b/.github/workflows/build_test_linux_fedora.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 ## Build ##

--- a/.github/workflows/build_test_linux_fedora.yaml
+++ b/.github/workflows/build_test_linux_fedora.yaml
@@ -6,6 +6,10 @@ on:
     - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 ## Build ##
 
 jobs:

--- a/.github/workflows/build_test_linux_fedora_minimal.yaml
+++ b/.github/workflows/build_test_linux_fedora_minimal.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 ## Build ##

--- a/.github/workflows/build_test_linux_fedora_minimal.yaml
+++ b/.github/workflows/build_test_linux_fedora_minimal.yaml
@@ -6,6 +6,10 @@ on:
     - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 ## Build ##
 
 jobs:

--- a/.github/workflows/build_test_linux_rocky.yaml
+++ b/.github/workflows/build_test_linux_rocky.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 ## Build ##

--- a/.github/workflows/build_test_linux_rocky.yaml
+++ b/.github/workflows/build_test_linux_rocky.yaml
@@ -6,6 +6,10 @@ on:
     - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 ## Build ##
 
 jobs:

--- a/.github/workflows/build_test_windows.yaml
+++ b/.github/workflows/build_test_windows.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 ## Build ##

--- a/.github/workflows/build_test_windows.yaml
+++ b/.github/workflows/build_test_windows.yaml
@@ -6,6 +6,10 @@ on:
     - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 ## Build ##
 
 jobs:

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -8,6 +8,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-sdist:
     name: Build DPsim source distribution

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sonar_cloud.yaml
+++ b/.github/workflows/sonar_cloud.yaml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sonar_cloud.yaml
+++ b/.github/workflows/sonar_cloud.yaml
@@ -6,6 +6,10 @@ on:
       - master
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sonarcloud:
     name: Prepare and run Sonar Scan


### PR DESCRIPTION
Adds a `concurrency` group to the PR-triggered build workflows (Fedora, Fedora Minimal, RockyLinux, Windows, Nix, SonarCloud, PyPI) so a re-push cancels the in-progress run instead of letting the whole matrix finish.

Group is keyed on `${{ github.workflow }}-${{ github.head_ref || github.ref }}`, so each PR (and each branch) only cancels its own superseded runs.

Picks up the suggestion from #301, thanks @Ace2932.