### PR TITLE
SP SynchronGenerator: add reactive-power limits (Qmin/Qmax)

### DIFF
--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include <dpsim-models/MNASimPowerComp.h>
 #include <dpsim-models/Solver/PFSolverInterfaceBus.h>
 
@@ -38,6 +40,14 @@ public:
   const Attribute<Real>::Ptr mSetPointReactivePowerPerUnit;
   /// Voltage set point of the machine [pu]
   const Attribute<Real>::Ptr mSetPointVoltagePerUnit;
+  /// Maximum reactive power limit [VAr] (default +inf = unlimited)
+  const Attribute<Real>::Ptr mReactivePowerMax;
+  /// Minimum reactive power limit [VAr] (default -inf = unlimited)
+  const Attribute<Real>::Ptr mReactivePowerMin;
+  /// Maximum reactive power limit [pu]
+  const Attribute<Real>::Ptr mReactivePowerMaxPerUnit;
+  /// Minimum reactive power limit [pu]
+  const Attribute<Real>::Ptr mReactivePowerMinPerUnit;
 
   /// Defines UID, name and logging level
   SynchronGenerator(String uid, String name,
@@ -45,11 +55,15 @@ public:
   /// Defines name and logging level
   SynchronGenerator(String name, Logger::Level logLevel = Logger::Level::off)
       : SynchronGenerator(name, name, logLevel) {}
-  /// Setter for synchronous generator parameters
+  /// Setter for synchronous generator parameters. qLimMax/qLimMin are the
+  /// reactive-power limits [VAr] enforced by the PF Q-limit outer loop; the
+  /// default +/-inf means unlimited (no PV->PQ switching for this machine).
   void setParameters(Real ratedApparentPower, Real ratedVoltage,
                      Real setPointActivePower, Real setPointVoltage,
                      PowerflowBusType powerflowBusType,
-                     Real setPointReactivepower = 0);
+                     Real setPointReactivepower = 0,
+                     Real qLimMax = std::numeric_limits<Real>::infinity(),
+                     Real qLimMin = -std::numeric_limits<Real>::infinity());
   // #### Powerflow section ####
   Real getBaseVoltage() const;
   /// Set base voltage

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGenerator.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGenerator.cpp
@@ -18,7 +18,15 @@ SP::Ph1::SynchronGenerator::SynchronGenerator(String uid, String name,
       mSetPointVoltage(mAttributes->create<Real>("V_set")),
       mSetPointActivePowerPerUnit(mAttributes->create<Real>("P_set_pu")),
       mSetPointReactivePowerPerUnit(mAttributes->create<Real>("Q_set_pu")),
-      mSetPointVoltagePerUnit(mAttributes->create<Real>("V_set_pu")) {
+      mSetPointVoltagePerUnit(mAttributes->create<Real>("V_set_pu")),
+      mReactivePowerMax(mAttributes->create<Real>(
+          "Q_max", std::numeric_limits<Real>::infinity())),
+      mReactivePowerMin(mAttributes->create<Real>(
+          "Q_min", -std::numeric_limits<Real>::infinity())),
+      mReactivePowerMaxPerUnit(mAttributes->create<Real>(
+          "Q_max_pu", std::numeric_limits<Real>::infinity())),
+      mReactivePowerMinPerUnit(mAttributes->create<Real>(
+          "Q_min_pu", -std::numeric_limits<Real>::infinity())) {
 
   SPDLOG_LOGGER_INFO(mSLog, "Create {} of type {}", name, this->type());
   mSLog->flush();
@@ -29,10 +37,12 @@ SP::Ph1::SynchronGenerator::SynchronGenerator(String uid, String name,
 void SP::Ph1::SynchronGenerator::setParameters(
     Real ratedApparentPower, Real ratedVoltage, Real setPointActivePower,
     Real setPointVoltage, PowerflowBusType powerflowBusType,
-    Real setPointReactivePower) {
+    Real setPointReactivePower, Real qLimMax, Real qLimMin) {
   **mSetPointActivePower = setPointActivePower;
   **mSetPointReactivePower = setPointReactivePower;
   **mSetPointVoltage = setPointVoltage;
+  **mReactivePowerMax = qLimMax;
+  **mReactivePowerMin = qLimMin;
   mPowerflowBusType = powerflowBusType;
 
   SPDLOG_LOGGER_INFO(mSLog, "Rated Apparent Power={} [VA] Rated Voltage={} [V]",
@@ -40,6 +50,8 @@ void SP::Ph1::SynchronGenerator::setParameters(
   SPDLOG_LOGGER_INFO(mSLog,
                      "Active Power Set Point={} [W] Voltage Set Point={} [V]",
                      **mSetPointActivePower, **mSetPointVoltage);
+  SPDLOG_LOGGER_INFO(mSLog, "Reactive Power Limits Qmin={} Qmax={} [VAr]",
+                     **mReactivePowerMin, **mReactivePowerMax);
   mSLog->flush();
 }
 
@@ -63,6 +75,9 @@ void SP::Ph1::SynchronGenerator::calculatePerUnitParameters(
   **mSetPointReactivePowerPerUnit =
       **mSetPointReactivePower / mBaseApparentPower;
   **mSetPointVoltagePerUnit = **mSetPointVoltage / mBaseVoltage;
+  // +/-inf limits divide to +/-inf in pu (still "unlimited"); finite limits scale.
+  **mReactivePowerMaxPerUnit = **mReactivePowerMax / mBaseApparentPower;
+  **mReactivePowerMinPerUnit = **mReactivePowerMin / mBaseApparentPower;
   SPDLOG_LOGGER_INFO(mSLog,
                      "Active Power Set Point={} [pu] Voltage Set Point={} [pu]",
                      **mSetPointActivePowerPerUnit, **mSetPointVoltagePerUnit);

--- a/dpsim/src/pybind/SPComponents.cpp
+++ b/dpsim/src/pybind/SPComponents.cpp
@@ -6,6 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *********************************************************************************/
 
+#include <limits>
+
 #include <DPsim.h>
 #include <dpsim-models/CSVReader.h>
 #include <dpsim-models/IdentifiedObject.h>
@@ -149,7 +151,9 @@ void addSPPh1Components(py::module_ mSPPh1) {
       .def("set_parameters", (&CPS::SP::Ph1::SynchronGenerator::setParameters),
            "rated_apparent_power"_a, "rated_voltage"_a,
            "set_point_active_power"_a, "set_point_voltage"_a,
-           "powerflow_bus_type"_a, "set_point_reactive_power"_a = 0)
+           "powerflow_bus_type"_a, "set_point_reactive_power"_a = 0,
+           "q_limit_max"_a = std::numeric_limits<double>::infinity(),
+           "q_limit_min"_a = -std::numeric_limits<double>::infinity())
       .def("set_base_voltage", &CPS::SP::Ph1::SynchronGenerator::setBaseVoltage,
            "base_voltage"_a)
       .def("connect", &CPS::SP::Ph1::SynchronGenerator::connect)


### PR DESCRIPTION
## Summary
- Add `mQLimMax`/`mQLimMin` (default ±infinity, i.e. unlimited) to `SP::Ph1::SynchronGenerator`
- New `setParameters` overload with optional `qLimMax`/`qLimMin`, exposed to Python as keyword args `q_limit_max`/`q_limit_min`
- No behavioral change as generators with no limits set (the default) are unaffected

This is a foundation commit for a follow-up PR that adds PV<->PQ outer-loop enforcement of these limits in `PFSolver`.
