### PR TITLE
DP_Ph3: add CurrentSource, fix per-phase source signals

### DIFF
--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -86,6 +86,7 @@
 #include <dpsim-models/DP/DP_VTypeSSNComp.h>
 
 #include <dpsim-models/DP/DP_Ph3_Capacitor.h>
+#include <dpsim-models/DP/DP_Ph3_CurrentSource.h>
 #include <dpsim-models/DP/DP_Ph3_Inductor.h>
 #include <dpsim-models/DP/DP_Ph3_PiLine.h>
 #include <dpsim-models/DP/DP_Ph3_Resistor.h>

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_CurrentSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_CurrentSource.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Signal/SineWaveGenerator.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 
 namespace CPS {
@@ -15,9 +16,16 @@ namespace Ph3 {
 /// This involves the stamping of the current to the right side vector.
 class CurrentSource : public MNASimPowerComp<Complex>,
                       public SharedFactory<CurrentSource> {
+private:
+  void updateCurrent(Real time);
+  /// Rotates the per-phase envelope at mSrcFreq (offset from the carrier)
+  CPS::Signal::SignalGenerator::Ptr mSrcSig;
+
 public:
   /// Reference current phasor, independent per phase (A, B, C)
   const Attribute<MatrixComp>::Ptr mCurrentRef;
+  /// Signal frequency, as an offset from the domain carrier (0 = steady)
+  const Attribute<Real>::Ptr mSrcFreq;
   /// Defines UID, name and logging level
   CurrentSource(String uid, String name,
                 Logger::Level logLevel = Logger::Level::off);
@@ -29,8 +37,8 @@ public:
   // #### General ####
   /// Initializes component from power flow data
   void initializeFromNodesAndTerminals(Real frequency) override;
-  /// Setter for reference current, one phasor per phase
-  void setParameters(MatrixComp currentRef);
+  /// Setter for reference current per phase and offset from the carrier
+  void setParameters(MatrixComp currentRef, Real srcFreq = 0.0);
 
   // #### MNA section ####
   /// Initializes internal variables of the component

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_CurrentSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_CurrentSource.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Solver/MNAInterface.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph3 {
+/// \brief Ideal current source model
+///
+/// This model uses modified nodal analysis to represent an ideal current source.
+/// This involves the stamping of the current to the right side vector.
+class CurrentSource : public MNASimPowerComp<Complex>,
+                      public SharedFactory<CurrentSource> {
+public:
+  /// Reference current phasor, independent per phase (A, B, C)
+  const Attribute<MatrixComp>::Ptr mCurrentRef;
+  /// Defines UID, name and logging level
+  CurrentSource(String uid, String name,
+                Logger::Level logLevel = Logger::Level::off);
+  /// Defines name and logging level
+  CurrentSource(String name, Logger::Level logLevel = Logger::Level::off)
+      : CurrentSource(name, name, logLevel) {}
+
+  SimPowerComp<Complex>::Ptr clone(String name) override;
+  // #### General ####
+  /// Initializes component from power flow data
+  void initializeFromNodesAndTerminals(Real frequency) override;
+  /// Setter for reference current, one phasor per phase
+  void setParameters(MatrixComp currentRef);
+
+  // #### MNA section ####
+  /// Initializes internal variables of the component
+  void mnaCompInitialize(Real omega, Real timeStep,
+                         Attribute<Matrix>::Ptr leftVector) override;
+  /// Stamps right side (source) vector
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
+  /// Returns voltage through the component
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
+  /// MNA pre step operations
+  void mnaCompPreStep(Real time, Int timeStepCount) override;
+  /// MNA post step operations
+  void mnaCompPostStep(Real time, Int timeStepCount,
+                       Attribute<Matrix>::Ptr &leftVector) override;
+  /// Add MNA pre step dependencies
+  void mnaCompAddPreStepDependencies(
+      AttributeBase::List &prevStepDependencies,
+      AttributeBase::List &attributeDependencies,
+      AttributeBase::List &modifiedAttributes) override;
+  /// Add MNA post step dependencies
+  void
+  mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
+                                 AttributeBase::List &attributeDependencies,
+                                 AttributeBase::List &modifiedAttributes,
+                                 Attribute<Matrix>::Ptr &leftVector) override;
+};
+} // namespace Ph3
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_VoltageSource.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Signal/SineWaveGenerator.h>
 #include <dpsim-models/Solver/DAEInterface.h>
 #include <dpsim-models/Solver/MNAInterface.h>
 
@@ -28,10 +29,14 @@ class VoltageSource : public MNASimPowerComp<Complex>,
                       public SharedFactory<VoltageSource> {
 private:
   void updateVoltage(Real time);
+  /// Rotates the per-phase envelope at mSrcFreq (offset from the carrier)
+  CPS::Signal::SignalGenerator::Ptr mSrcSig;
 
 public:
   /// Reference voltage phasor, independent per phase (A, B, C)
   const Attribute<MatrixComp>::Ptr mVoltageRef;
+  /// Signal frequency, as an offset from the domain carrier (0 = steady)
+  const Attribute<Real>::Ptr mSrcFreq;
   /// Defines UID, name, component parameters and logging level
   VoltageSource(String uid, String name,
                 Logger::Level loglevel = Logger::Level::off);
@@ -44,8 +49,8 @@ public:
 
   SimPowerComp<Complex>::Ptr clone(String name) override;
 
-  /// Setter for reference voltage, one phasor per phase
-  void setParameters(MatrixComp voltageRef);
+  /// Setter for reference voltage per phase and offset from the carrier
+  void setParameters(MatrixComp voltageRef, Real srcFreq = 0.0);
   // #### General ####
   /// Initializes component from power flow data
   void initializeFromNodesAndTerminals(Real frequency) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_VoltageSource.h
@@ -30,7 +30,8 @@ private:
   void updateVoltage(Real time);
 
 public:
-  const Attribute<Complex>::Ptr mVoltageRef;
+  /// Reference voltage phasor, independent per phase (A, B, C)
+  const Attribute<MatrixComp>::Ptr mVoltageRef;
   /// Defines UID, name, component parameters and logging level
   VoltageSource(String uid, String name,
                 Logger::Level loglevel = Logger::Level::off);
@@ -38,12 +39,13 @@ public:
   VoltageSource(String name, Logger::Level logLevel = Logger::Level::off)
       : VoltageSource(name, name, logLevel) {}
   /// Defines name, component parameters and logging level
-  VoltageSource(String name, Complex voltage,
+  VoltageSource(String name, MatrixComp voltage,
                 Logger::Level logLevel = Logger::Level::off);
 
   SimPowerComp<Complex>::Ptr clone(String name) override;
 
-  void setParameters(Complex voltageRef);
+  /// Setter for reference voltage, one phasor per phase
+  void setParameters(MatrixComp voltageRef);
   // #### General ####
   /// Initializes component from power flow data
   void initializeFromNodesAndTerminals(Real frequency) override;

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -62,6 +62,7 @@ list(APPEND MODELS_SOURCES
 	DP/DP_Ph1_GenericTwoTerminalITypeSSN.cpp
 
 	DP/DP_Ph3_VoltageSource.cpp
+	DP/DP_Ph3_CurrentSource.cpp
 	DP/DP_Ph3_Capacitor.cpp
 	DP/DP_Ph3_Inductor.cpp
 	DP/DP_Ph3_Resistor.cpp

--- a/dpsim-models/src/DP/DP_Ph3_CurrentSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_CurrentSource.cpp
@@ -8,7 +8,8 @@ using namespace CPS;
 DP::Ph3::CurrentSource::CurrentSource(String uid, String name,
                                       Logger::Level logLevel)
     : MNASimPowerComp<Complex>(uid, name, true, true, logLevel),
-      mCurrentRef(mAttributes->create<MatrixComp>("I_ref")) {
+      mCurrentRef(mAttributes->create<MatrixComp>("I_ref")),
+      mSrcFreq(mAttributes->createDynamic<Real>("f_src")) {
   mPhaseType = PhaseType::ABC;
   setVirtualNodeNumber(0);
   setTerminalNumber(2);
@@ -19,12 +20,25 @@ DP::Ph3::CurrentSource::CurrentSource(String uid, String name,
 
 SimPowerComp<Complex>::Ptr DP::Ph3::CurrentSource::clone(String name) {
   auto copy = CurrentSource::make(name, mLogLevel);
-  copy->setParameters(**mCurrentRef);
+  copy->setParameters(**mCurrentRef, **mSrcFreq);
   return copy;
 }
 
-void DP::Ph3::CurrentSource::setParameters(MatrixComp currentRef) {
+void DP::Ph3::CurrentSource::setParameters(MatrixComp currentRef,
+                                           Real srcFreq) {
+  auto srcSigSine = Signal::SineWaveGenerator::make(**mName + "_sw");
+  srcSigSine->setParameters(Complex(1, 0), srcFreq);
+  mSrcSig = srcSigSine;
+  mSrcFreq->setReference(mSrcSig->mFreq);
+
   **mCurrentRef = currentRef;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\nCurrent reference phasor [A]: {:s}"
+                     "\nFrequency [Hz]: {:s}",
+                     Logger::matrixCompToString(currentRef),
+                     Logger::realToString(srcFreq));
+
   mParametersSet = true;
 }
 
@@ -39,6 +53,7 @@ void DP::Ph3::CurrentSource::initializeFromNodesAndTerminals(Real frequency) {
 void DP::Ph3::CurrentSource::mnaCompInitialize(
     Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
   updateMatrixNodeIndices();
+  updateCurrent(0);
 }
 
 void DP::Ph3::CurrentSource::mnaCompApplyRightSideVectorStamp(
@@ -61,6 +76,15 @@ void DP::Ph3::CurrentSource::mnaCompApplyRightSideVectorStamp(
   }
 }
 
+void DP::Ph3::CurrentSource::updateCurrent(Real time) {
+  if (mSrcSig != nullptr) {
+    mSrcSig->step(time);
+    **mIntfCurrent = **mCurrentRef * mSrcSig->getSignal();
+  } else {
+    **mIntfCurrent = **mCurrentRef;
+  }
+}
+
 void DP::Ph3::CurrentSource::mnaCompAddPreStepDependencies(
     AttributeBase::List &prevStepDependencies,
     AttributeBase::List &attributeDependencies,
@@ -71,7 +95,7 @@ void DP::Ph3::CurrentSource::mnaCompAddPreStepDependencies(
 }
 
 void DP::Ph3::CurrentSource::mnaCompPreStep(Real time, Int timeStepCount) {
-  **mIntfCurrent = **mCurrentRef;
+  updateCurrent(time);
   mnaCompApplyRightSideVectorStamp(**mRightVector);
 }
 

--- a/dpsim-models/src/DP/DP_Ph3_CurrentSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_CurrentSource.cpp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph3_CurrentSource.h>
+
+using namespace CPS;
+
+DP::Ph3::CurrentSource::CurrentSource(String uid, String name,
+                                      Logger::Level logLevel)
+    : MNASimPowerComp<Complex>(uid, name, true, true, logLevel),
+      mCurrentRef(mAttributes->create<MatrixComp>("I_ref")) {
+  mPhaseType = PhaseType::ABC;
+  setVirtualNodeNumber(0);
+  setTerminalNumber(2);
+  **mCurrentRef = MatrixComp::Zero(3, 1);
+  **mIntfVoltage = MatrixComp::Zero(3, 1);
+  **mIntfCurrent = MatrixComp::Zero(3, 1);
+}
+
+SimPowerComp<Complex>::Ptr DP::Ph3::CurrentSource::clone(String name) {
+  auto copy = CurrentSource::make(name, mLogLevel);
+  copy->setParameters(**mCurrentRef);
+  return copy;
+}
+
+void DP::Ph3::CurrentSource::setParameters(MatrixComp currentRef) {
+  **mCurrentRef = currentRef;
+  mParametersSet = true;
+}
+
+void DP::Ph3::CurrentSource::initializeFromNodesAndTerminals(Real frequency) {
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- Initialization from node voltages and terminal ---"
+                     "\nReference current: {:s}",
+                     Logger::matrixCompToString(**mCurrentRef));
+  mSLog->flush();
+}
+
+void DP::Ph3::CurrentSource::mnaCompInitialize(
+    Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+  updateMatrixNodeIndices();
+}
+
+void DP::Ph3::CurrentSource::mnaCompApplyRightSideVectorStamp(
+    Matrix &rightVector) {
+  if (terminalNotGrounded(1)) {
+    Math::setVectorElement(rightVector, matrixNodeIndex(1, 0),
+                           -(**mIntfCurrent)(0, 0));
+    Math::setVectorElement(rightVector, matrixNodeIndex(1, 1),
+                           -(**mIntfCurrent)(1, 0));
+    Math::setVectorElement(rightVector, matrixNodeIndex(1, 2),
+                           -(**mIntfCurrent)(2, 0));
+  }
+  if (terminalNotGrounded(0)) {
+    Math::setVectorElement(rightVector, matrixNodeIndex(0, 0),
+                           (**mIntfCurrent)(0, 0));
+    Math::setVectorElement(rightVector, matrixNodeIndex(0, 1),
+                           (**mIntfCurrent)(1, 0));
+    Math::setVectorElement(rightVector, matrixNodeIndex(0, 2),
+                           (**mIntfCurrent)(2, 0));
+  }
+}
+
+void DP::Ph3::CurrentSource::mnaCompAddPreStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes) {
+  attributeDependencies.push_back(mCurrentRef);
+  modifiedAttributes.push_back(mRightVector);
+  modifiedAttributes.push_back(mIntfCurrent);
+}
+
+void DP::Ph3::CurrentSource::mnaCompPreStep(Real time, Int timeStepCount) {
+  **mIntfCurrent = **mCurrentRef;
+  mnaCompApplyRightSideVectorStamp(**mRightVector);
+}
+
+void DP::Ph3::CurrentSource::mnaCompAddPostStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes,
+    Attribute<Matrix>::Ptr &leftVector) {
+  attributeDependencies.push_back(leftVector);
+  modifiedAttributes.push_back(mIntfVoltage);
+}
+
+void DP::Ph3::CurrentSource::mnaCompPostStep(
+    Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+  mnaCompUpdateVoltage(**leftVector);
+}
+
+void DP::Ph3::CurrentSource::mnaCompUpdateVoltage(const Matrix &leftVector) {
+  **mIntfVoltage = MatrixComp::Zero(3, 1);
+  if (terminalNotGrounded(1)) {
+    (**mIntfVoltage)(0, 0) =
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 0));
+    (**mIntfVoltage)(1, 0) =
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 1));
+    (**mIntfVoltage)(2, 0) =
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 2));
+  }
+  if (terminalNotGrounded(0)) {
+    (**mIntfVoltage)(0, 0) =
+        (**mIntfVoltage)(0, 0) -
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 0));
+    (**mIntfVoltage)(1, 0) =
+        (**mIntfVoltage)(1, 0) -
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 1));
+    (**mIntfVoltage)(2, 0) =
+        (**mIntfVoltage)(2, 0) -
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 2));
+  }
+}

--- a/dpsim-models/src/DP/DP_Ph3_VoltageSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_VoltageSource.cpp
@@ -13,10 +13,11 @@ using namespace CPS;
 DP::Ph3::VoltageSource::VoltageSource(String uid, String name,
                                       Logger::Level logLevel)
     : MNASimPowerComp<Complex>(uid, name, true, true, logLevel),
-      mVoltageRef(mAttributes->create<Complex>("V_ref")) {
+      mVoltageRef(mAttributes->create<MatrixComp>("V_ref")) {
   mPhaseType = PhaseType::ABC;
   setVirtualNodeNumber(1);
   setTerminalNumber(2);
+  **mVoltageRef = MatrixComp::Zero(3, 1);
   **mIntfVoltage = MatrixComp::Zero(3, 1);
   **mIntfCurrent = MatrixComp::Zero(3, 1);
 }
@@ -27,30 +28,21 @@ SimPowerComp<Complex>::Ptr DP::Ph3::VoltageSource::clone(String name) {
   return copy;
 }
 
-void DP::Ph3::VoltageSource::setParameters(Complex voltageRef) {
+void DP::Ph3::VoltageSource::setParameters(MatrixComp voltageRef) {
   **mVoltageRef = voltageRef;
   mParametersSet = true;
 }
 
 void DP::Ph3::VoltageSource::initializeFromNodesAndTerminals(Real frequency) {
-  if (**mVoltageRef == Complex(0, 0))
-    **mVoltageRef = initialSingleVoltage(1) - initialSingleVoltage(0);
+  if ((**mVoltageRef).isZero())
+    **mVoltageRef = CPS::Math::singlePhaseVariableToThreePhase(
+        initialSingleVoltage(1) - initialSingleVoltage(0));
 }
 
 void DP::Ph3::VoltageSource::mnaCompInitialize(
     Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
   updateMatrixNodeIndices();
-  (**mIntfVoltage)(0, 0) = **mVoltageRef;
-  (**mIntfVoltage)(1, 0) =
-      Complex(Math::abs(**mVoltageRef) *
-                  cos(Math::phase(**mVoltageRef) - 2. / 3. * M_PI),
-              Math::abs(**mVoltageRef) *
-                  sin(Math::phase(**mVoltageRef) - 2. / 3. * M_PI));
-  (**mIntfVoltage)(2, 0) =
-      Complex(Math::abs(**mVoltageRef) *
-                  cos(Math::phase(**mVoltageRef) + 2. / 3. * M_PI),
-              Math::abs(**mVoltageRef) *
-                  sin(Math::phase(**mVoltageRef) + 2. / 3. * M_PI));
+  **mIntfVoltage = **mVoltageRef;
 }
 
 void DP::Ph3::VoltageSource::mnaCompApplySystemMatrixStamp(
@@ -115,18 +107,7 @@ void DP::Ph3::VoltageSource::mnaCompApplyRightSideVectorStamp(
 }
 
 void DP::Ph3::VoltageSource::updateVoltage(Real time) {
-  // can't we just do nothing??
-  (**mIntfVoltage)(0, 0) = **mVoltageRef;
-  (**mIntfVoltage)(1, 0) =
-      Complex(Math::abs(**mVoltageRef) *
-                  cos(Math::phase(**mVoltageRef) - 2. / 3. * M_PI),
-              Math::abs(**mVoltageRef) *
-                  sin(Math::phase(**mVoltageRef) - 2. / 3. * M_PI));
-  (**mIntfVoltage)(2, 0) =
-      Complex(Math::abs(**mVoltageRef) *
-                  cos(Math::phase(**mVoltageRef) + 2. / 3. * M_PI),
-              Math::abs(**mVoltageRef) *
-                  sin(Math::phase(**mVoltageRef) + 2. / 3. * M_PI));
+  **mIntfVoltage = **mVoltageRef;
 }
 
 void DP::Ph3::VoltageSource::mnaCompAddPreStepDependencies(
@@ -172,6 +153,6 @@ void DP::Ph3::VoltageSource::daeResidual(double ttime, const double state[],
                                          std::vector<int> &off) {}
 
 Complex DP::Ph3::VoltageSource::daeInitialize() {
-  (**mIntfVoltage)(0, 0) = **mVoltageRef;
-  return **mVoltageRef;
+  **mIntfVoltage = **mVoltageRef;
+  return (**mVoltageRef)(0, 0);
 }

--- a/dpsim-models/src/DP/DP_Ph3_VoltageSource.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_VoltageSource.cpp
@@ -13,7 +13,8 @@ using namespace CPS;
 DP::Ph3::VoltageSource::VoltageSource(String uid, String name,
                                       Logger::Level logLevel)
     : MNASimPowerComp<Complex>(uid, name, true, true, logLevel),
-      mVoltageRef(mAttributes->create<MatrixComp>("V_ref")) {
+      mVoltageRef(mAttributes->create<MatrixComp>("V_ref")),
+      mSrcFreq(mAttributes->createDynamic<Real>("f_src")) {
   mPhaseType = PhaseType::ABC;
   setVirtualNodeNumber(1);
   setTerminalNumber(2);
@@ -24,12 +25,25 @@ DP::Ph3::VoltageSource::VoltageSource(String uid, String name,
 
 SimPowerComp<Complex>::Ptr DP::Ph3::VoltageSource::clone(String name) {
   auto copy = VoltageSource::make(name, mLogLevel);
-  copy->setParameters(**mVoltageRef);
+  copy->setParameters(**mVoltageRef, **mSrcFreq);
   return copy;
 }
 
-void DP::Ph3::VoltageSource::setParameters(MatrixComp voltageRef) {
+void DP::Ph3::VoltageSource::setParameters(MatrixComp voltageRef,
+                                           Real srcFreq) {
+  auto srcSigSine = Signal::SineWaveGenerator::make(**mName + "_sw");
+  srcSigSine->setParameters(Complex(1, 0), srcFreq);
+  mSrcSig = srcSigSine;
+  mSrcFreq->setReference(mSrcSig->mFreq);
+
   **mVoltageRef = voltageRef;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\nVoltage reference phasor [V]: {:s}"
+                     "\nFrequency [Hz]: {:s}",
+                     Logger::matrixCompToString(voltageRef),
+                     Logger::realToString(srcFreq));
+
   mParametersSet = true;
 }
 
@@ -42,7 +56,7 @@ void DP::Ph3::VoltageSource::initializeFromNodesAndTerminals(Real frequency) {
 void DP::Ph3::VoltageSource::mnaCompInitialize(
     Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
   updateMatrixNodeIndices();
-  **mIntfVoltage = **mVoltageRef;
+  updateVoltage(0);
 }
 
 void DP::Ph3::VoltageSource::mnaCompApplySystemMatrixStamp(
@@ -107,7 +121,12 @@ void DP::Ph3::VoltageSource::mnaCompApplyRightSideVectorStamp(
 }
 
 void DP::Ph3::VoltageSource::updateVoltage(Real time) {
-  **mIntfVoltage = **mVoltageRef;
+  if (mSrcSig != nullptr) {
+    mSrcSig->step(time);
+    **mIntfVoltage = **mVoltageRef * mSrcSig->getSignal();
+  } else {
+    **mIntfVoltage = **mVoltageRef;
+  }
 }
 
 void DP::Ph3::VoltageSource::mnaCompAddPreStepDependencies(

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -43,6 +43,7 @@ set(CIRCUIT_SOURCES
 	Circuits/EMT_RC_split_decoupled_node_Ph3.cpp
 	Circuits/DP_Ph1_SSN_Full_Serial_RLC.cpp
 	Circuits/DP_Ph1_General2TerminalSSN.cpp
+	Circuits/DP_Ph3_R3C1L1CS1.cpp
 
 	# EMT examples with PF initialization
 	Circuits/EMT_Slack_PiLine_PQLoad_with_PF_Init.cpp

--- a/dpsim/examples/cxx/Circuits/DP_Circuits.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_Circuits.cpp
@@ -311,7 +311,7 @@ void DP_Ph3_VS_R2L3(CommandLineArgs &args) {
 
   // Components
   auto vs = Ph3::VoltageSource::make("vs");
-  vs->setParameters(10);
+  vs->setParameters(CPS::Math::singlePhaseVariableToThreePhase(10));
   auto r1 = Ph3::Resistor::make("r_1");
   Matrix r1_param = Matrix::Zero(3, 3);
   r1_param << 1., 0, 0, 0, 1., 0, 0, 0, 1.;
@@ -364,7 +364,7 @@ void DP_Ph3_VS_RC1(CommandLineArgs &args) {
 
   // Components
   auto vs = Ph3::VoltageSource::make("vs");
-  vs->setParameters(Complex(10, 0));
+  vs->setParameters(CPS::Math::singlePhaseVariableToThreePhase(Complex(10, 0)));
   auto r1 = Ph3::Resistor::make("r_1");
   Matrix r1_param = Matrix::Zero(3, 3);
   r1_param << 1., 0, 0, 0, 1., 0, 0, 0, 1.;

--- a/dpsim/examples/cxx/Circuits/DP_Ph3_R3C1L1CS1.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_Ph3_R3C1L1CS1.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::DP;
+
+int main(int argc, char *argv[]) {
+  // Define simulation scenario
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "DP_Ph3_R3C1L1CS1";
+
+  // Nodes
+  auto n1 = SimNode::make("n1", PhaseType::ABC);
+  auto n2 = SimNode::make("n2", PhaseType::ABC);
+
+  // Components
+
+  Matrix param = Matrix::Zero(3, 3);
+  param << 1., 0, 0, 0, 1., 0, 0, 0, 1.;
+
+  auto cs0 = Ph3::CurrentSource::make("CS0");
+  cs0->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(1.0, 0.0)));
+
+  auto r1 = Ph3::Resistor::make("R1");
+  r1->setParameters(10 * param);
+
+  auto r2 = Ph3::Resistor::make("R2");
+  r2->setParameters(param);
+
+  auto r3 = Ph3::Resistor::make("R3");
+  r3->setParameters(5 * param);
+
+  auto l1 = Ph3::Inductor::make("L1");
+  l1->setParameters(0.02 * param);
+
+  auto c1 = Ph3::Capacitor::make("C1");
+  c1->setParameters(0.001 * param);
+
+  // Topology
+  cs0->connect(SimNode::List{n1, SimNode::GND});
+
+  r1->connect(SimNode::List{n2, n1});
+  r2->connect(SimNode::List{n2, SimNode::GND});
+  r3->connect(SimNode::List{n2, SimNode::GND});
+
+  l1->connect(SimNode::List{n2, SimNode::GND});
+
+  c1->connect(SimNode::List{n1, n2});
+
+  // Define system topology
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2},
+                            SystemComponentList{cs0, r1, r2, r3, l1, c1});
+
+  // Logging
+  Logger::setLogDir("logs/" + simName);
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("V1", n1->attribute("v"));
+  logger->logAttribute("V2", n2->attribute("v"));
+  logger->logAttribute("V_C1", c1->attribute("v_intf"));
+  logger->logAttribute("I_L1", l1->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}

--- a/dpsim/examples/cxx/Circuits/DP_PiLine.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_PiLine.cpp
@@ -185,7 +185,8 @@ void simElements3ph() {
 
   // Components
   auto vs = Ph3::VoltageSource::make("v_1");
-  vs->setParameters(CPS::Math::polar(100000, 0));
+  vs->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(100000, 0)));
 
   // Parametrization of components
   Real resistance = 5;
@@ -254,7 +255,8 @@ void simPiLine3ph() {
 
   // Components
   auto vs = Ph3::VoltageSource::make("v_1");
-  vs->setParameters(CPS::Math::polar(100000, 0));
+  vs->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(100000, 0)));
 
   // Parametrization of components
   Real resistance = 5;
@@ -306,7 +308,8 @@ void simPiLineDiakoptics3ph() {
 
   // Components
   auto vs = Ph3::VoltageSource::make("v_1");
-  vs->setParameters(CPS::Math::polar(100000, 0));
+  vs->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(100000, 0)));
 
   // Parametrization of components
   Real resistance = 5;


### PR DESCRIPTION
## Summary
- Add `DP::Ph3::CurrentSource`, the last missing basic DP_Ph3 component needed to port the EMT_Ph3 SSN validation reference circuits to the DP domain.
- Fix `DP::Ph3::VoltageSource` (and the new `CurrentSource`) to take an independent per-phase `MatrixComp` reference instead of a single `Complex` value rotated by a hardcoded +-120 degrees, which could only represent a balanced/symmetric source.
- Add cxx example `DP_Ph3_R3C1L1CS1.cpp` exercising the new component.
