### PR TITLE
feat: add DP_Ph3 SSN base and generic components with examples

### DIFF
--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -87,12 +87,17 @@
 
 #include <dpsim-models/DP/DP_Ph3_Capacitor.h>
 #include <dpsim-models/DP/DP_Ph3_CurrentSource.h>
+#include <dpsim-models/DP/DP_Ph3_GenericTwoTerminalITypeSSN.h>
+#include <dpsim-models/DP/DP_Ph3_GenericTwoTerminalVTypeSSN.h>
 #include <dpsim-models/DP/DP_Ph3_Inductor.h>
 #include <dpsim-models/DP/DP_Ph3_PiLine.h>
 #include <dpsim-models/DP/DP_Ph3_Resistor.h>
+#include <dpsim-models/DP/DP_Ph3_SSN_Full_Serial_RLC.h>
 #include <dpsim-models/DP/DP_Ph3_SeriesResistor.h>
 #include <dpsim-models/DP/DP_Ph3_SeriesSwitch.h>
 #include <dpsim-models/DP/DP_Ph3_SynchronGeneratorDQTrapez.h>
+#include <dpsim-models/DP/DP_Ph3_TwoTerminalITypeSSNComp.h>
+#include <dpsim-models/DP/DP_Ph3_TwoTerminalVTypeSSNComp.h>
 #include <dpsim-models/DP/DP_Ph3_VoltageSource.h>
 #ifdef WITH_SUNDIALS
 #include <dpsim-models/DP/DP_Ph3_SynchronGeneratorDQODE.h>

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_GenericTwoTerminalITypeSSN.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_GenericTwoTerminalITypeSSN.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_Ph3_TwoTerminalITypeSSNComp.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph3 {
+
+/// \brief Generic three-phase, two-terminal I-type SSN component.
+///
+/// Parametrized directly by arbitrary state-space matrices A, B, C, D
+/// (input = port current abc, output = port voltage abc).
+class GenericTwoTerminalITypeSSN final
+    : public TwoTerminalITypeSSNComp,
+      public SharedFactory<GenericTwoTerminalITypeSSN> {
+public:
+  using SharedFactory<GenericTwoTerminalITypeSSN>::make;
+
+  GenericTwoTerminalITypeSSN(String uid, String name,
+                             Logger::Level logLevel = Logger::Level::off);
+  GenericTwoTerminalITypeSSN(String name,
+                             Logger::Level logLevel = Logger::Level::off)
+      : GenericTwoTerminalITypeSSN(name, name, logLevel) {}
+
+  SimPowerComp<Complex>::Ptr clone(String name) override final;
+};
+
+} // namespace Ph3
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_GenericTwoTerminalVTypeSSN.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_GenericTwoTerminalVTypeSSN.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_Ph3_TwoTerminalVTypeSSNComp.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph3 {
+
+/// \brief Generic three-phase, two-terminal V-type SSN component.
+///
+/// Parametrized directly by arbitrary state-space matrices A, B, C, D
+/// (input = port voltage abc, output = port current abc).
+class GenericTwoTerminalVTypeSSN final
+    : public TwoTerminalVTypeSSNComp,
+      public SharedFactory<GenericTwoTerminalVTypeSSN> {
+public:
+  using SharedFactory<GenericTwoTerminalVTypeSSN>::make;
+
+  GenericTwoTerminalVTypeSSN(String uid, String name,
+                             Logger::Level logLevel = Logger::Level::off);
+  GenericTwoTerminalVTypeSSN(String name,
+                             Logger::Level logLevel = Logger::Level::off)
+      : GenericTwoTerminalVTypeSSN(name, name, logLevel) {}
+
+  SimPowerComp<Complex>::Ptr clone(String name) override final;
+};
+
+} // namespace Ph3
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_SSN_Full_Serial_RLC.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_SSN_Full_Serial_RLC.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/Base/Base_Ph3_Capacitor.h>
+#include <dpsim-models/Base/Base_Ph3_Inductor.h>
+#include <dpsim-models/Base/Base_Ph3_Resistor.h>
+#include <dpsim-models/DP/DP_Ph3_TwoTerminalVTypeSSNComp.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph3 {
+namespace SSN {
+
+/// \brief Series RLC one-port as a three-phase DP V-type SSN component.
+///
+/// States x = [vC_abc; iL_abc], input = port voltage abc, output = inductor
+/// current abc. R, L, C are 3x3 matrices, allowing phase coupling.
+class Full_Serial_RLC final : public TwoTerminalVTypeSSNComp,
+                              public SharedFactory<Full_Serial_RLC>,
+                              public Base::Ph3::Resistor,
+                              public Base::Ph3::Inductor,
+                              public Base::Ph3::Capacitor {
+public:
+  using SharedFactory<Full_Serial_RLC>::make;
+
+  Full_Serial_RLC(String uid, String name,
+                  Logger::Level logLevel = Logger::Level::off);
+  Full_Serial_RLC(String name, Logger::Level logLevel = Logger::Level::off)
+      : Full_Serial_RLC(name, name, logLevel) {}
+
+  SimPowerComp<Complex>::Ptr clone(String name) override;
+
+  void setParameters(const Matrix &resistance, const Matrix &inductance,
+                     const Matrix &capacitance);
+};
+
+} // namespace SSN
+} // namespace Ph3
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_TwoTerminalITypeSSNComp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_TwoTerminalITypeSSNComp.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_ITypeSSNComp.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph3 {
+
+/// \brief Three-phase, two-terminal I-type SSN stamping layer.
+///
+/// Provides the concrete MNA stamps (Norton-equivalent 3x3 complex admittance
+/// G = W^-1, history current, node voltage read) shared by three-phase
+/// two-terminal I-type SSN components.
+class TwoTerminalITypeSSNComp : public ITypeSSNComp {
+protected:
+  TwoTerminalITypeSSNComp(String uid, String name,
+                          Logger::Level logLevel = Logger::Level::off);
+
+  MatrixComp buildInitialInputFromNodes(Real frequency) override final;
+
+public:
+  void
+  mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override final;
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override final;
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override final;
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override final;
+};
+
+} // namespace Ph3
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_TwoTerminalVTypeSSNComp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_TwoTerminalVTypeSSNComp.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_VTypeSSNComp.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph3 {
+
+/// \brief Three-phase, two-terminal V-type SSN stamping layer.
+///
+/// Provides the concrete MNA stamps (3x3 complex Norton admittance, history
+/// current, node voltage read) shared by three-phase two-terminal V-type SSN
+/// components. Each phase carries an independent complex envelope shifted by
+/// the same single carrier frequency (see DP::SSNComp).
+class TwoTerminalVTypeSSNComp : public VTypeSSNComp {
+protected:
+  TwoTerminalVTypeSSNComp(String uid, String name,
+                          Logger::Level logLevel = Logger::Level::off);
+
+  MatrixComp buildInitialInputFromNodes(Real frequency) override final;
+
+public:
+  void
+  mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override final;
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override final;
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override final;
+};
+
+} // namespace Ph3
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -75,6 +75,12 @@ list(APPEND MODELS_SOURCES
 	# DP/DP_Ph3_SynchronGeneratorVBR.cpp
 	# DP/DP_Ph3_SynchronGeneratorVBRStandalone.cpp
 
+	DP/DP_Ph3_TwoTerminalVTypeSSNComp.cpp
+	DP/DP_Ph3_TwoTerminalITypeSSNComp.cpp
+	DP/DP_Ph3_SSN_Full_Serial_RLC.cpp
+	DP/DP_Ph3_GenericTwoTerminalVTypeSSN.cpp
+	DP/DP_Ph3_GenericTwoTerminalITypeSSN.cpp
+
 	EMT/EMT_SSNComp.cpp
 	EMT/EMT_VTypeSSNComp.cpp
 	EMT/EMT_VTypeVariableSSNComp.cpp

--- a/dpsim-models/src/DP/DP_Ph3_GenericTwoTerminalITypeSSN.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_GenericTwoTerminalITypeSSN.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph3_GenericTwoTerminalITypeSSN.h>
+
+using namespace CPS;
+
+DP::Ph3::GenericTwoTerminalITypeSSN::GenericTwoTerminalITypeSSN(
+    String uid, String name, Logger::Level logLevel)
+    : TwoTerminalITypeSSNComp(uid, name, logLevel) {}
+
+SimPowerComp<Complex>::Ptr
+DP::Ph3::GenericTwoTerminalITypeSSN::clone(String name) {
+  auto copy = GenericTwoTerminalITypeSSN::make(name, mLogLevel);
+  copy->setParameters(mA, mB, mC, mD);
+  return copy;
+}

--- a/dpsim-models/src/DP/DP_Ph3_GenericTwoTerminalVTypeSSN.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_GenericTwoTerminalVTypeSSN.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph3_GenericTwoTerminalVTypeSSN.h>
+
+using namespace CPS;
+
+DP::Ph3::GenericTwoTerminalVTypeSSN::GenericTwoTerminalVTypeSSN(
+    String uid, String name, Logger::Level logLevel)
+    : TwoTerminalVTypeSSNComp(uid, name, logLevel) {}
+
+SimPowerComp<Complex>::Ptr
+DP::Ph3::GenericTwoTerminalVTypeSSN::clone(String name) {
+  auto copy = GenericTwoTerminalVTypeSSN::make(name, mLogLevel);
+  copy->setParameters(mA, mB, mC, mD);
+  return copy;
+}

--- a/dpsim-models/src/DP/DP_Ph3_SSN_Full_Serial_RLC.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_SSN_Full_Serial_RLC.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph3_SSN_Full_Serial_RLC.h>
+
+using namespace CPS;
+
+DP::Ph3::SSN::Full_Serial_RLC::Full_Serial_RLC(String uid, String name,
+                                               Logger::Level logLevel)
+    : TwoTerminalVTypeSSNComp(uid, name, logLevel),
+      Base::Ph3::Resistor(mAttributes), Base::Ph3::Inductor(mAttributes),
+      Base::Ph3::Capacitor(mAttributes) {}
+
+SimPowerComp<Complex>::Ptr DP::Ph3::SSN::Full_Serial_RLC::clone(String name) {
+  auto copy = SharedFactory<Full_Serial_RLC>::make(name, mLogLevel);
+  copy->setParameters(**mResistance, **mInductance, **mCapacitance);
+  return copy;
+}
+
+void DP::Ph3::SSN::Full_Serial_RLC::setParameters(const Matrix &resistance,
+                                                  const Matrix &inductance,
+                                                  const Matrix &capacitance) {
+  if (resistance.rows() != 3 || resistance.cols() != 3)
+    throw std::invalid_argument("Resistance matrix must have size 3 x 3.");
+
+  if (inductance.rows() != 3 || inductance.cols() != 3)
+    throw std::invalid_argument("Inductance matrix must have size 3 x 3.");
+
+  if (capacitance.rows() != 3 || capacitance.cols() != 3)
+    throw std::invalid_argument("Capacitance matrix must have size 3 x 3.");
+
+  **mResistance = resistance;
+  **mInductance = inductance;
+  **mCapacitance = capacitance;
+
+  Matrix inverseInductance = inductance.inverse();
+  Matrix inverseCapacitance = capacitance.inverse();
+  Matrix identity3 = Matrix::Identity(3, 3);
+
+  // State choice:
+  // x = [uC_abc; i_abc]  -> 6x1
+  // u = v_abc            -> 3x1
+  // y = i_abc            -> 3x1
+
+  Matrix aMatrix = Matrix::Zero(6, 6);
+  aMatrix.block(0, 3, 3, 3) = inverseCapacitance;
+  aMatrix.block(3, 0, 3, 3) = -inverseInductance;
+  aMatrix.block(3, 3, 3, 3) = -inverseInductance * resistance;
+
+  Matrix bMatrix = Matrix::Zero(6, 3);
+  bMatrix.block(3, 0, 3, 3) = inverseInductance;
+
+  Matrix cMatrix = Matrix::Zero(3, 6);
+  cMatrix.block(0, 3, 3, 3) = identity3;
+
+  Matrix dMatrix = Matrix::Zero(3, 3);
+
+  SSNComp::setParameters(aMatrix, bMatrix, cMatrix, dMatrix);
+}

--- a/dpsim-models/src/DP/DP_Ph3_TwoTerminalITypeSSNComp.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_TwoTerminalITypeSSNComp.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph3_TwoTerminalITypeSSNComp.h>
+#include <dpsim-models/MNAStampUtils.h>
+
+using namespace CPS;
+
+DP::Ph3::TwoTerminalITypeSSNComp::TwoTerminalITypeSSNComp(
+    String uid, String name, Logger::Level logLevel)
+    : ITypeSSNComp(uid, name, 3, 3, logLevel) {
+  mPhaseType = PhaseType::ABC;
+  setTerminalNumber(2);
+}
+
+MatrixComp DP::Ph3::TwoTerminalITypeSSNComp::buildInitialInputFromNodes(Real) {
+  // Interface current convention: positive current flows from terminal1 to
+  // terminal0. No initial terminal current is available here, so start at
+  // zero.
+  return MatrixComp::Zero(3, 1);
+}
+
+void DP::Ph3::TwoTerminalITypeSSNComp::mnaCompApplySystemMatrixStamp(
+    SparseMatrixRow &systemMatrix) {
+  // Norton-equivalent admittance G = W^-1 (v = W i + yHist => i = G v - G yHist).
+  MatrixComp g = mW.inverse();
+
+  MNAStampUtils::stampAdmittanceMatrix(
+      g, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
+      terminalNotGrounded(0), terminalNotGrounded(1), mSLog);
+}
+
+void DP::Ph3::TwoTerminalITypeSSNComp::mnaCompApplyRightSideVectorStamp(
+    Matrix &rightVector) {
+  MatrixComp iHist = -mW.inverse() * mYHist;
+
+  if (terminalNotGrounded(0)) {
+    for (Int phase = 0; phase < 3; ++phase)
+      Math::setVectorElement(rightVector, matrixNodeIndex(0, phase),
+                             iHist(phase, 0));
+  }
+  if (terminalNotGrounded(1)) {
+    for (Int phase = 0; phase < 3; ++phase)
+      Math::setVectorElement(rightVector, matrixNodeIndex(1, phase),
+                             -iHist(phase, 0));
+  }
+}
+
+void DP::Ph3::TwoTerminalITypeSSNComp::mnaCompUpdateCurrent(const Matrix &) {
+  // i = W^-1 (v - yHist)
+  **mIntfCurrent = mW.inverse() * (**mIntfVoltage - mYHist);
+}
+
+void DP::Ph3::TwoTerminalITypeSSNComp::mnaCompUpdateVoltage(
+    const Matrix &leftVector) {
+  **mIntfVoltage = MatrixComp::Zero(3, 1);
+
+  if (terminalNotGrounded(1)) {
+    for (Int phase = 0; phase < 3; ++phase)
+      (**mIntfVoltage)(phase, 0) =
+          Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, phase));
+  }
+  if (terminalNotGrounded(0)) {
+    for (Int phase = 0; phase < 3; ++phase)
+      (**mIntfVoltage)(phase, 0) -=
+          Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, phase));
+  }
+}

--- a/dpsim-models/src/DP/DP_Ph3_TwoTerminalVTypeSSNComp.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_TwoTerminalVTypeSSNComp.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph3_TwoTerminalVTypeSSNComp.h>
+#include <dpsim-models/MNAStampUtils.h>
+
+using namespace CPS;
+
+DP::Ph3::TwoTerminalVTypeSSNComp::TwoTerminalVTypeSSNComp(
+    String uid, String name, Logger::Level logLevel)
+    : VTypeSSNComp(uid, name, 3, 3, logLevel) {
+  mPhaseType = PhaseType::ABC;
+  setTerminalNumber(2);
+}
+
+MatrixComp DP::Ph3::TwoTerminalVTypeSSNComp::buildInitialInputFromNodes(Real) {
+  MatrixComp vInit = MatrixComp::Zero(3, 1);
+
+  // v = v_terminal1 - v_terminal0 (DP envelope phasor), balanced default.
+  vInit(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
+  vInit(1, 0) = vInit(0, 0) * SHIFT_TO_PHASE_B;
+  vInit(2, 0) = vInit(0, 0) * SHIFT_TO_PHASE_C;
+
+  return vInit;
+}
+
+void DP::Ph3::TwoTerminalVTypeSSNComp::mnaCompApplySystemMatrixStamp(
+    SparseMatrixRow &systemMatrix) {
+  MNAStampUtils::stampAdmittanceMatrix(
+      mW, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
+      terminalNotGrounded(0), terminalNotGrounded(1), mSLog);
+}
+
+void DP::Ph3::TwoTerminalVTypeSSNComp::mnaCompApplyRightSideVectorStamp(
+    Matrix &rightVector) {
+  if (terminalNotGrounded(0)) {
+    for (Int phase = 0; phase < 3; ++phase)
+      Math::setVectorElement(rightVector, matrixNodeIndex(0, phase),
+                             mYHist(phase, 0));
+  }
+  if (terminalNotGrounded(1)) {
+    for (Int phase = 0; phase < 3; ++phase)
+      Math::setVectorElement(rightVector, matrixNodeIndex(1, phase),
+                             -mYHist(phase, 0));
+  }
+}
+
+void DP::Ph3::TwoTerminalVTypeSSNComp::mnaCompUpdateVoltage(
+    const Matrix &leftVector) {
+  **mIntfVoltage = MatrixComp::Zero(3, 1);
+
+  if (terminalNotGrounded(1)) {
+    for (Int phase = 0; phase < 3; ++phase)
+      (**mIntfVoltage)(phase, 0) =
+          Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, phase));
+  }
+  if (terminalNotGrounded(0)) {
+    for (Int phase = 0; phase < 3; ++phase)
+      (**mIntfVoltage)(phase, 0) -=
+          Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, phase));
+  }
+}

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -44,6 +44,10 @@ set(CIRCUIT_SOURCES
 	Circuits/DP_Ph1_SSN_Full_Serial_RLC.cpp
 	Circuits/DP_Ph1_General2TerminalSSN.cpp
 	Circuits/DP_Ph3_R3C1L1CS1.cpp
+	Circuits/DP_Ph3_RLC1VS1_RC_vs_SSN.cpp
+	Circuits/DP_Ph3_R3C1L1CS1_RC_vs_SSN.cpp
+	Circuits/DP_Ph3_R3C1L1CS1_RC_vs_SSN_Fault.cpp
+	Circuits/EMT_Ph3_R3C1L1CS1_RC_vs_SSN_Fault.cpp
 
 	# EMT examples with PF initialization
 	Circuits/EMT_Slack_PiLine_PQLoad_with_PF_Init.cpp

--- a/dpsim/examples/cxx/Circuits/DP_Ph3_R3C1L1CS1_RC_vs_SSN.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_Ph3_R3C1L1CS1_RC_vs_SSN.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::DP;
+
+// Classical DP reference: current source into a resistive network with a
+// shunt inductor and a series capacitor, built from discrete three-phase
+// components.
+void DP_Ph3_R3_C1_L1_CS1() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simNameRC = "DP_Ph3_R3C1L1CS1_RC_vs_SSN_RC";
+
+  auto n1 = SimNode::make("n1", PhaseType::ABC);
+  auto n2 = SimNode::make("n2", PhaseType::ABC);
+
+  Matrix param = Matrix::Zero(3, 3);
+  param << 1., 0, 0, 0, 1., 0, 0, 0, 1.;
+
+  auto cs0 = Ph3::CurrentSource::make("CS0");
+  cs0->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(1.0, 0.0)));
+
+  auto r1 = Ph3::Resistor::make("R1");
+  r1->setParameters(10 * param);
+
+  auto r2 = Ph3::Resistor::make("R2");
+  r2->setParameters(param);
+
+  auto r3 = Ph3::Resistor::make("R3");
+  r3->setParameters(5 * param);
+
+  auto l1 = Ph3::Inductor::make("L1");
+  l1->setParameters(0.02 * param);
+
+  auto c1 = Ph3::Capacitor::make("C1");
+  c1->setParameters(0.001 * param);
+
+  cs0->connect(SimNode::List{n1, SimNode::GND});
+  r1->connect(SimNode::List{n2, n1});
+  r2->connect(SimNode::List{n2, SimNode::GND});
+  r3->connect(SimNode::List{n2, SimNode::GND});
+  l1->connect(SimNode::List{n2, SimNode::GND});
+  c1->connect(SimNode::List{n1, n2});
+
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2},
+                            SystemComponentList{cs0, r1, r2, r3, l1, c1});
+
+  Logger::setLogDir("logs/" + simNameRC);
+  auto logger = DataLogger::make(simNameRC);
+  logger->logAttribute("V1_RC", n1->attribute("v"));
+  logger->logAttribute("V2_RC", n2->attribute("v"));
+  logger->logAttribute("V_C1_RC", c1->attribute("v_intf"));
+  logger->logAttribute("I_L1_RC", l1->attribute("i_intf"));
+
+  Simulation sim(simNameRC, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+// DP SSN: the same circuit with L1 as a generic V-type SSN component and C1
+// as a generic I-type SSN component, both parametrized directly by (A, B, C,
+// D) instead of dedicated Inductor/Capacitor classes.
+void DP_Ph3_SSN_R3_C1_L1_CS1() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simNameSSN = "DP_Ph3_R3C1L1CS1_RC_vs_SSN_SSN";
+
+  auto n1 = SimNode::make("n1", PhaseType::ABC);
+  auto n2 = SimNode::make("n2", PhaseType::ABC);
+
+  Matrix param = Matrix::Zero(3, 3);
+  param << 1., 0, 0, 0, 1., 0, 0, 0, 1.;
+  Matrix identity3 = Matrix::Identity(3, 3);
+
+  auto cs0 = Ph3::CurrentSource::make("CS0");
+  cs0->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(1.0, 0.0)));
+
+  auto r1 = Ph3::Resistor::make("R1");
+  r1->setParameters(10 * param);
+
+  auto r2 = Ph3::Resistor::make("R2");
+  r2->setParameters(param);
+
+  auto r3 = Ph3::Resistor::make("R3");
+  r3->setParameters(5 * param);
+
+  // Shunt inductor as V-type SSN: x = i_abc, u = v_abc, y = i_abc.
+  Matrix inductance = 0.02 * param;
+  auto l1 = Ph3::GenericTwoTerminalVTypeSSN::make("L1_genVSSN");
+  l1->setParameters(Matrix::Zero(3, 3), inductance.inverse(), identity3,
+                    Matrix::Zero(3, 3));
+
+  // Series capacitor as I-type SSN: x = vC_abc, u = i_abc, y = v_abc.
+  Matrix capacitance = 0.001 * param;
+  auto c1 = Ph3::GenericTwoTerminalITypeSSN::make("C1_genISSN");
+  c1->setParameters(Matrix::Zero(3, 3), capacitance.inverse(), identity3,
+                    Matrix::Zero(3, 3));
+
+  cs0->connect(SimNode::List{n1, SimNode::GND});
+  r1->connect(SimNode::List{n2, n1});
+  r2->connect(SimNode::List{n2, SimNode::GND});
+  r3->connect(SimNode::List{n2, SimNode::GND});
+  l1->connect(SimNode::List{n2, SimNode::GND});
+  c1->connect(SimNode::List{n1, n2});
+
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2},
+                            SystemComponentList{cs0, r1, r2, r3, l1, c1});
+
+  Logger::setLogDir("logs/" + simNameSSN);
+  auto logger = DataLogger::make(simNameSSN);
+  logger->logAttribute("V1_SSN", n1->attribute("v"));
+  logger->logAttribute("V2_SSN", n2->attribute("v"));
+  logger->logAttribute("V_C1_SSN", c1->attribute("v_intf"));
+  logger->logAttribute("I_L1_SSN", l1->attribute("i_intf"));
+
+  Simulation sim(simNameSSN, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+int main(int argc, char *argv[]) {
+  DP_Ph3_R3_C1_L1_CS1();
+  DP_Ph3_SSN_R3_C1_L1_CS1();
+}

--- a/dpsim/examples/cxx/Circuits/DP_Ph3_R3C1L1CS1_RC_vs_SSN_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_Ph3_R3C1L1CS1_RC_vs_SSN_Fault.cpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::DP;
+
+// Same R3-C1-L1-CS1 topology as DP_Ph3_R3C1L1CS1_RC_vs_SSN.cpp, but with a
+// three-phase-to-ground fault applied at node n2 to exercise the SSN
+// discontinuity handling (CDA half-step) under a transient excitation.
+static const Real switchOpenR = 1e6;
+static const Real switchClosedR = 0.001;
+static const Real startTimeFault = 0.03;
+static const Real endTimeFault = 0.06;
+
+void DP_Ph3_R3_C1_L1_CS1_Fault_RC() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simNameRC = "DP_Ph3_R3C1L1CS1_RC_vs_SSN_Fault_RC";
+
+  auto n1 = SimNode::make("n1", PhaseType::ABC);
+  auto n2 = SimNode::make("n2", PhaseType::ABC);
+
+  Matrix param = Matrix::Zero(3, 3);
+  param << 1., 0, 0, 0, 1., 0, 0, 0, 1.;
+
+  auto cs0 = Ph3::CurrentSource::make("CS0");
+  cs0->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(1.0, 0.0)));
+
+  auto r1 = Ph3::Resistor::make("R1");
+  r1->setParameters(10 * param);
+  auto r2 = Ph3::Resistor::make("R2");
+  r2->setParameters(param);
+  auto r3 = Ph3::Resistor::make("R3");
+  r3->setParameters(5 * param);
+  auto l1 = Ph3::Inductor::make("L1");
+  l1->setParameters(0.02 * param);
+  auto c1 = Ph3::Capacitor::make("C1");
+  c1->setParameters(0.001 * param);
+
+  auto fault = Ph3::SeriesSwitch::make("fault");
+  fault->setParameters(switchOpenR, switchClosedR);
+  fault->open();
+
+  cs0->connect(SimNode::List{n1, SimNode::GND});
+  r1->connect(SimNode::List{n2, n1});
+  r2->connect(SimNode::List{n2, SimNode::GND});
+  r3->connect(SimNode::List{n2, SimNode::GND});
+  l1->connect(SimNode::List{n2, SimNode::GND});
+  c1->connect(SimNode::List{n1, n2});
+  fault->connect(SimNode::List{n2, SimNode::GND});
+
+  auto sys =
+      SystemTopology(50, SystemNodeList{n1, n2},
+                     SystemComponentList{cs0, r1, r2, r3, l1, c1, fault});
+
+  Logger::setLogDir("logs/" + simNameRC);
+  auto logger = DataLogger::make(simNameRC);
+  logger->logAttribute("V2_RC", n2->attribute("v"));
+  logger->logAttribute("I_L1_RC", l1->attribute("i_intf"));
+
+  Simulation sim(simNameRC, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addEvent(SwitchEvent::make(startTimeFault, fault, true));
+  sim.addEvent(SwitchEvent::make(endTimeFault, fault, false));
+  sim.run();
+}
+
+void DP_Ph3_R3_C1_L1_CS1_Fault_SSN() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simNameSSN = "DP_Ph3_R3C1L1CS1_RC_vs_SSN_Fault_SSN";
+
+  auto n1 = SimNode::make("n1", PhaseType::ABC);
+  auto n2 = SimNode::make("n2", PhaseType::ABC);
+
+  Matrix param = Matrix::Zero(3, 3);
+  param << 1., 0, 0, 0, 1., 0, 0, 0, 1.;
+  Matrix identity3 = Matrix::Identity(3, 3);
+
+  auto cs0 = Ph3::CurrentSource::make("CS0");
+  cs0->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(1.0, 0.0)));
+
+  auto r1 = Ph3::Resistor::make("R1");
+  r1->setParameters(10 * param);
+  auto r2 = Ph3::Resistor::make("R2");
+  r2->setParameters(param);
+  auto r3 = Ph3::Resistor::make("R3");
+  r3->setParameters(5 * param);
+
+  Matrix inductance = 0.02 * param;
+  auto l1 = Ph3::GenericTwoTerminalVTypeSSN::make("L1_genVSSN");
+  l1->setParameters(Matrix::Zero(3, 3), inductance.inverse(), identity3,
+                    Matrix::Zero(3, 3));
+
+  Matrix capacitance = 0.001 * param;
+  auto c1 = Ph3::GenericTwoTerminalITypeSSN::make("C1_genISSN");
+  c1->setParameters(Matrix::Zero(3, 3), capacitance.inverse(), identity3,
+                    Matrix::Zero(3, 3));
+
+  auto fault = Ph3::SeriesSwitch::make("fault");
+  fault->setParameters(switchOpenR, switchClosedR);
+  fault->open();
+
+  cs0->connect(SimNode::List{n1, SimNode::GND});
+  r1->connect(SimNode::List{n2, n1});
+  r2->connect(SimNode::List{n2, SimNode::GND});
+  r3->connect(SimNode::List{n2, SimNode::GND});
+  l1->connect(SimNode::List{n2, SimNode::GND});
+  c1->connect(SimNode::List{n1, n2});
+  fault->connect(SimNode::List{n2, SimNode::GND});
+
+  auto sys =
+      SystemTopology(50, SystemNodeList{n1, n2},
+                     SystemComponentList{cs0, r1, r2, r3, l1, c1, fault});
+
+  Logger::setLogDir("logs/" + simNameSSN);
+  auto logger = DataLogger::make(simNameSSN);
+  logger->logAttribute("V2_SSN", n2->attribute("v"));
+  logger->logAttribute("I_L1_SSN", l1->attribute("i_intf"));
+
+  Simulation sim(simNameSSN, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addEvent(SwitchEvent::make(startTimeFault, fault, true));
+  sim.addEvent(SwitchEvent::make(endTimeFault, fault, false));
+  sim.run();
+}
+
+int main(int argc, char *argv[]) {
+  DP_Ph3_R3_C1_L1_CS1_Fault_RC();
+  DP_Ph3_R3_C1_L1_CS1_Fault_SSN();
+}

--- a/dpsim/examples/cxx/Circuits/DP_Ph3_RLC1VS1_RC_vs_SSN.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_Ph3_RLC1VS1_RC_vs_SSN.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::DP;
+
+// Classical DP reference: series R-L-C built from discrete three-phase
+// components, voltage-driven.
+void DP_Ph3_RLC1_VS1() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simNameRC = "DP_Ph3_RLC1VS1_RC_vs_SSN_RC";
+
+  auto n1 = SimNode::make("n1", PhaseType::ABC);
+  auto n2 = SimNode::make("n2", PhaseType::ABC);
+  auto n3 = SimNode::make("n3", PhaseType::ABC);
+
+  Matrix param = Matrix::Zero(3, 3);
+  param << 1., 0, 0, 0, 1., 0, 0, 0, 1.;
+
+  auto vs0 = Ph3::VoltageSource::make("VS0");
+  vs0->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(1.0, 0.0)));
+
+  auto r1 = Ph3::Resistor::make("R1");
+  r1->setParameters(1. * param);
+
+  auto l1 = Ph3::Inductor::make("L1");
+  l1->setParameters(0.05 * param);
+
+  auto c1 = Ph3::Capacitor::make("C1");
+  c1->setParameters(0.01 * param);
+
+  vs0->connect(SimNode::List{n1, SimNode::GND});
+  r1->connect(SimNode::List{n1, n2});
+  l1->connect(SimNode::List{n2, n3});
+  c1->connect(SimNode::List{n3, SimNode::GND});
+
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2, n3},
+                            SystemComponentList{vs0, r1, l1, c1});
+
+  Logger::setLogDir("logs/" + simNameRC);
+  auto logger = DataLogger::make(simNameRC);
+  logger->logAttribute("I_L1_RC", l1->attribute("i_intf"));
+  logger->logAttribute("V1_RC", n1->attribute("v"));
+
+  Simulation sim(simNameRC, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+// DP V-type SSN: the same series RLC one-port as a single three-phase SSN
+// component.
+void DP_Ph3_SSN_RLC1_VS1() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simNameSSN = "DP_Ph3_RLC1VS1_RC_vs_SSN_SSN";
+
+  auto n1 = SimNode::make("n1", PhaseType::ABC);
+
+  Matrix param = Matrix::Zero(3, 3);
+  param << 1., 0, 0, 0, 1., 0, 0, 0, 1.;
+
+  auto vs0 = Ph3::VoltageSource::make("VS0");
+  vs0->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(1.0, 0.0)));
+
+  auto rlc = Ph3::SSN::Full_Serial_RLC::make("RLC");
+  rlc->setParameters(1. * param, 0.05 * param, 0.01 * param);
+
+  vs0->connect(SimNode::List{n1, SimNode::GND});
+  rlc->connect(SimNode::List{n1, SimNode::GND});
+
+  auto sys =
+      SystemTopology(50, SystemNodeList{n1}, SystemComponentList{vs0, rlc});
+
+  Logger::setLogDir("logs/" + simNameSSN);
+  auto logger = DataLogger::make(simNameSSN);
+  logger->logAttribute("I_RLC_SSN", rlc->attribute("i_intf"));
+  logger->logAttribute("V1_SSN", n1->attribute("v"));
+
+  Simulation sim(simNameSSN, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setSolverType(Solver::Type::MNA);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+int main(int argc, char *argv[]) {
+  DP_Ph3_RLC1_VS1();
+  DP_Ph3_SSN_RLC1_VS1();
+}

--- a/dpsim/examples/cxx/Circuits/EMT_Ph3_R3C1L1CS1_RC_vs_SSN_Fault.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_Ph3_R3C1L1CS1_RC_vs_SSN_Fault.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::EMT;
+
+// EMT counterpart of DP_Ph3_R3C1L1CS1_RC_vs_SSN_Fault.cpp, used as the
+// cross-domain reference for the DP-SSN three-phase fault validation: same
+// topology, parameters and fault timing, run in the EMT (time-domain) frame
+// instead of DP (dynamic phasor / SFA).
+static const Real switchOpenR = 1e6;
+static const Real switchClosedR = 0.001;
+static const Real startTimeFault = 0.03;
+static const Real endTimeFault = 0.06;
+
+void EMT_Ph3_R3_C1_L1_CS1_Fault_RC() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simNameRC = "EMT_Ph3_R3C1L1CS1_RC_vs_SSN_Fault_RC";
+
+  auto n1 = SimNode::make("n1", PhaseType::ABC);
+  auto n2 = SimNode::make("n2", PhaseType::ABC);
+
+  Matrix param = Matrix::Zero(3, 3);
+  param << 1., 0, 0, 0, 1., 0, 0, 0, 1.;
+
+  auto cs0 = Ph3::CurrentSource::make("CS0");
+  cs0->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(1.0, 0.0)),
+      50.0);
+
+  auto r1 = Ph3::Resistor::make("R1");
+  r1->setParameters(10 * param);
+  auto r2 = Ph3::Resistor::make("R2");
+  r2->setParameters(param);
+  auto r3 = Ph3::Resistor::make("R3");
+  r3->setParameters(5 * param);
+  auto l1 = Ph3::Inductor::make("L1");
+  l1->setParameters(0.02 * param);
+  auto c1 = Ph3::Capacitor::make("C1");
+  c1->setParameters(0.001 * param);
+
+  auto fault = Ph3::SeriesSwitch::make("fault");
+  fault->setParameters(switchOpenR, switchClosedR);
+  fault->open();
+
+  cs0->connect(SimNode::List{n1, SimNode::GND});
+  r1->connect(SimNode::List{n2, n1});
+  r2->connect(SimNode::List{n2, SimNode::GND});
+  r3->connect(SimNode::List{n2, SimNode::GND});
+  l1->connect(SimNode::List{n2, SimNode::GND});
+  c1->connect(SimNode::List{n1, n2});
+  fault->connect(SimNode::List{n2, SimNode::GND});
+
+  auto sys =
+      SystemTopology(50, SystemNodeList{n1, n2},
+                     SystemComponentList{cs0, r1, r2, r3, l1, c1, fault});
+
+  Logger::setLogDir("logs/" + simNameRC);
+  auto logger = DataLogger::make(simNameRC);
+  logger->logAttribute("V2_RC", n2->attribute("v"));
+  logger->logAttribute("I_L1_RC", l1->attribute("i_intf"));
+
+  Simulation sim(simNameRC, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::EMT);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addEvent(SwitchEvent::make(startTimeFault, fault, true));
+  sim.addEvent(SwitchEvent::make(endTimeFault, fault, false));
+  sim.run();
+}
+
+void EMT_Ph3_R3_C1_L1_CS1_Fault_SSN() {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simNameSSN = "EMT_Ph3_R3C1L1CS1_RC_vs_SSN_Fault_SSN";
+
+  auto n1 = SimNode::make("n1", PhaseType::ABC);
+  auto n2 = SimNode::make("n2", PhaseType::ABC);
+
+  Matrix param = Matrix::Zero(3, 3);
+  param << 1., 0, 0, 0, 1., 0, 0, 0, 1.;
+  Matrix identity3 = Matrix::Identity(3, 3);
+
+  auto cs0 = Ph3::CurrentSource::make("CS0");
+  cs0->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(1.0, 0.0)),
+      50.0);
+
+  auto r1 = Ph3::Resistor::make("R1");
+  r1->setParameters(10 * param);
+  auto r2 = Ph3::Resistor::make("R2");
+  r2->setParameters(param);
+  auto r3 = Ph3::Resistor::make("R3");
+  r3->setParameters(5 * param);
+
+  Matrix inductance = 0.02 * param;
+  auto l1 = Ph3::GenericTwoTerminalVTypeSSN::make("L1_genVSSN");
+  l1->setParameters(Matrix::Zero(3, 3), inductance.inverse(), identity3,
+                    Matrix::Zero(3, 3));
+
+  Matrix capacitance = 0.001 * param;
+  auto c1 = Ph3::GenericTwoTerminalITypeSSN::make("C1_genISSN");
+  c1->setParameters(Matrix::Zero(3, 3), capacitance.inverse(), identity3,
+                    Matrix::Zero(3, 3));
+
+  auto fault = Ph3::SeriesSwitch::make("fault");
+  fault->setParameters(switchOpenR, switchClosedR);
+  fault->open();
+
+  cs0->connect(SimNode::List{n1, SimNode::GND});
+  r1->connect(SimNode::List{n2, n1});
+  r2->connect(SimNode::List{n2, SimNode::GND});
+  r3->connect(SimNode::List{n2, SimNode::GND});
+  l1->connect(SimNode::List{n2, SimNode::GND});
+  c1->connect(SimNode::List{n1, n2});
+  fault->connect(SimNode::List{n2, SimNode::GND});
+
+  auto sys =
+      SystemTopology(50, SystemNodeList{n1, n2},
+                     SystemComponentList{cs0, r1, r2, r3, l1, c1, fault});
+
+  Logger::setLogDir("logs/" + simNameSSN);
+  auto logger = DataLogger::make(simNameSSN);
+  logger->logAttribute("V2_SSN", n2->attribute("v"));
+  logger->logAttribute("I_L1_SSN", l1->attribute("i_intf"));
+
+  Simulation sim(simNameSSN, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::EMT);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addEvent(SwitchEvent::make(startTimeFault, fault, true));
+  sim.addEvent(SwitchEvent::make(endTimeFault, fault, false));
+  sim.run();
+}
+
+int main(int argc, char *argv[]) {
+  EMT_Ph3_R3_C1_L1_CS1_Fault_RC();
+  EMT_Ph3_R3_C1_L1_CS1_Fault_SSN();
+}

--- a/dpsim/src/pybind/DPComponents.cpp
+++ b/dpsim/src/pybind/DPComponents.cpp
@@ -526,4 +526,38 @@ void addDPPh3Components(py::module_ mDPPh3) {
       .def("open", &CPS::DP::Ph3::SeriesSwitch::open)
       .def("close", &CPS::DP::Ph3::SeriesSwitch::close)
       .def("connect", &CPS::DP::Ph3::SeriesSwitch::connect);
+
+  py::class_<CPS::DP::Ph3::SSN::Full_Serial_RLC,
+             std::shared_ptr<CPS::DP::Ph3::SSN::Full_Serial_RLC>,
+             CPS::SimPowerComp<CPS::Complex>>(mDPPh3, "Full_Serial_RLC",
+                                              py::multiple_inheritance())
+      .def(py::init<std::string>())
+      .def(py::init<std::string, CPS::Logger::Level>())
+      .def("set_parameters", &CPS::DP::Ph3::SSN::Full_Serial_RLC::setParameters,
+           "R"_a, "L"_a, "C"_a)
+      .def("connect", &CPS::DP::Ph3::SSN::Full_Serial_RLC::connect);
+
+  py::class_<CPS::DP::Ph3::GenericTwoTerminalVTypeSSN,
+             std::shared_ptr<CPS::DP::Ph3::GenericTwoTerminalVTypeSSN>,
+             CPS::SimPowerComp<CPS::Complex>>(
+      mDPPh3, "GenericTwoTerminalVTypeSSN", py::multiple_inheritance())
+      .def(py::init<std::string>())
+      .def(py::init<std::string, CPS::Logger::Level>())
+      .def("set_parameters",
+           &CPS::DP::Ph3::GenericTwoTerminalVTypeSSN::setParameters, "A"_a,
+           "B"_a, "C"_a, "D"_a)
+      .def("connect", &CPS::DP::Ph3::GenericTwoTerminalVTypeSSN::connect)
+      .def_property_readonly("x", createAttributeGetter<CPS::MatrixComp>("x"));
+
+  py::class_<CPS::DP::Ph3::GenericTwoTerminalITypeSSN,
+             std::shared_ptr<CPS::DP::Ph3::GenericTwoTerminalITypeSSN>,
+             CPS::SimPowerComp<CPS::Complex>>(
+      mDPPh3, "GenericTwoTerminalITypeSSN", py::multiple_inheritance())
+      .def(py::init<std::string>())
+      .def(py::init<std::string, CPS::Logger::Level>())
+      .def("set_parameters",
+           &CPS::DP::Ph3::GenericTwoTerminalITypeSSN::setParameters, "A"_a,
+           "B"_a, "C"_a, "D"_a)
+      .def("connect", &CPS::DP::Ph3::GenericTwoTerminalITypeSSN::connect)
+      .def_property_readonly("x", createAttributeGetter<CPS::MatrixComp>("x"));
 }


### PR DESCRIPTION
## Summary
- Add `DP::Ph3::TwoTerminalVTypeSSNComp`/`TwoTerminalITypeSSNComp` stamping layer, `GenericTwoTerminalVTypeSSN`/`ITypeSSN`, and `SSN::Full_Serial_RLC` (mirrors the EMT_Ph3 SSN hierarchy for the DP/SFA domain).
- Bind the 3 new classes under `dp.ph3` in pybind.
- Add DP analogues of the `EMT_Ph3_RLC1VS1_RC_vs_SSN` / `EMT_Ph3_R3C1L1CS1_RC_vs_SSN` cxx examples, plus a new DP/EMT three-phase-fault pair.

Best merged after #538.