### PR TITLE
DP: add Ph1 variable-SSN base for mixed real+complex state components

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,8 @@
 /dpsim-models/include/dpsim-models/DP/DP_Ph1_varResSwitch.h @gnakti
 /dpsim-models/include/dpsim-models/DP/DP_Ph1_TwoTerminalVTypeSSNComp.h @leonardocarreras
 /dpsim-models/include/dpsim-models/DP/DP_Ph1_SSN_Full_Serial_RLC.h @leonardocarreras
+/dpsim-models/include/dpsim-models/DP/DP_Ph1_MixedVTypeVariableSSNComp.h @leonardocarreras
+/dpsim-models/include/dpsim-models/DP/DP_Ph1_SSN_Variable_Serial_RLC.h @leonardocarreras
 /dpsim-models/include/dpsim-models/EMT/EMT_SSNComp.h @georgii-tishenin
 /dpsim-models/include/dpsim-models/EMT/EMT_VTypeSSNComp.h @georgii-tishenin
 /dpsim-models/include/dpsim-models/EMT/EMT_VTypeVariableSSNComp.h @georgii-tishenin
@@ -61,6 +63,8 @@
 /dpsim-models/src/DP/DP_Ph1_varResSwitch.cpp @gnakti
 /dpsim-models/src/DP/DP_Ph1_TwoTerminalVTypeSSNComp.cpp @leonardocarreras
 /dpsim-models/src/DP/DP_Ph1_SSN_Full_Serial_RLC.cpp @leonardocarreras
+/dpsim-models/src/DP/DP_Ph1_MixedVTypeVariableSSNComp.cpp @leonardocarreras
+/dpsim-models/src/DP/DP_Ph1_SSN_Variable_Serial_RLC.cpp @leonardocarreras
 /dpsim-models/src/EMT/EMT_SSNComp.cpp @georgii-tishenin
 /dpsim-models/src/EMT/EMT_VTypeSSNComp.cpp @georgii-tishenin
 /dpsim-models/src/EMT/EMT_VTypeVariableSSNComp.cpp @georgii-tishenin

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_MixedVTypeVariableSSNComp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_MixedVTypeVariableSSNComp.h
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Solver/MNAInterface.h>
+#include <dpsim-models/Solver/MNAVariableCompInterface.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph1 {
+
+/// Single-phase, two-terminal, variable V-type SSN base with a mixed
+/// real + complex-envelope state, packed as one real vector.
+class MixedVTypeVariableSSNComp : public MNASimPowerComp<Complex>,
+                                  public MNAVariableCompInterface {
+private:
+  Bool mParameterChanged;
+
+protected:
+  static constexpr Int mInitializationMaxIterations = 10;
+  static constexpr Real mInitializationTolerance = 1e-9;
+
+  const Int mRealStateCount;
+  const Int mComplexStateCount;
+
+  Real mTimeStep;
+
+  /// Continuous-time real model over the packed state and packed [Re,Im] input/output.
+  Matrix mA, mB, mC, mD, mE, mF;
+  /// Discretized (trapezoidal) real operators.
+  Matrix mdA, mdB, mdE;
+
+  /// Complex Norton admittance / history current stamped into the network.
+  Complex mW;
+  Complex mYHist;
+
+  /// Packed real state: [realStates..., Re(cplxState0), Im(cplxState0), ...].
+  const Attribute<Matrix>::Ptr mX;
+
+  MixedVTypeVariableSSNComp(String uid, String name, Int realStateCount,
+                            Int complexStateCount,
+                            Logger::Level logLevel = Logger::Level::off);
+
+  /// Total packed real state size: realStateCount + 2*complexStateCount.
+  Int stateSize() const;
+
+  static Matrix packComplex(const Complex &c);
+  static Complex unpackComplex(const Matrix &v);
+
+  Attribute<MatrixComp>::Ptr inputAttribute() const;
+  Attribute<MatrixComp>::Ptr outputAttribute() const;
+
+  /// Default: v = v_terminal1 - v_terminal0.
+  virtual MatrixComp buildInitialInputFromNodes(Real frequency);
+
+  void setParameters(const Matrix &A, const Matrix &B, const Matrix &C,
+                     const Matrix &D);
+  void setParameters(const Matrix &A, const Matrix &B, const Matrix &C,
+                     const Matrix &D, const Matrix &E, const Matrix &F);
+
+  const Matrix &stateOffset() const;
+  const Matrix &outputOffset() const;
+  void setStateOffset(const Matrix &E);
+  void setOutputOffset(const Matrix &F);
+
+  virtual Matrix calculateHistoryVectorReal() const;
+  virtual void updateState(const Complex &uOld, const Complex &uNew);
+  virtual void recomputeDiscreteModel();
+
+  /// Rebuild A/B/C/D/E/F from the current state/input; returns true if the stamp changed.
+  virtual Bool updateComponentParameters() = 0;
+  void updateStateSpaceModel();
+
+public:
+  Bool hasParameterChanged() override final;
+
+  /// Fixed-point steady-state init; valid only when mRealStateCount == 0, override otherwise.
+  void initializeFromNodesAndTerminals(Real frequency) override;
+
+  void mnaCompInitialize(Real omega, Real timeStep,
+                         Attribute<Matrix>::Ptr leftVector) override final;
+  void mnaCompAddPreStepDependencies(
+      AttributeBase::List &prevStepDependencies,
+      AttributeBase::List &attributeDependencies,
+      AttributeBase::List &modifiedAttributes) override final;
+  void mnaCompPreStep(Real time, Int timeStepCount) override final;
+  void mnaCompAddPostStepDependencies(
+      AttributeBase::List &prevStepDependencies,
+      AttributeBase::List &attributeDependencies,
+      AttributeBase::List &modifiedAttributes,
+      Attribute<Matrix>::Ptr &leftVector) override final;
+
+  void
+  mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override final;
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override final;
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override final;
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override final;
+  void mnaCompPostStep(Real time, Int timeStepCount,
+                       Attribute<Matrix>::Ptr &leftVector) override final;
+};
+
+} // namespace Ph1
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SSN_Variable_Serial_RLC.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SSN_Variable_Serial_RLC.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/DP/DP_Ph1_MixedVTypeVariableSSNComp.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph1 {
+namespace SSN {
+
+/// Series RLC one-port on MixedVTypeVariableSSNComp; R/L/C held constant.
+/// States x = [v_C; i_L], input = port voltage, output = inductor current.
+class Variable_Serial_RLC final : public MixedVTypeVariableSSNComp,
+                                  public SharedFactory<Variable_Serial_RLC> {
+public:
+  using SharedFactory<Variable_Serial_RLC>::make;
+
+  Variable_Serial_RLC(String uid, String name,
+                      Logger::Level logLevel = Logger::Level::off);
+  Variable_Serial_RLC(String name, Logger::Level logLevel = Logger::Level::off)
+      : Variable_Serial_RLC(name, name, logLevel) {}
+
+  SimPowerComp<Complex>::Ptr clone(String name) override;
+
+  void setParameters(Real resistance, Real inductance, Real capacitance,
+                     Real omegaN);
+
+protected:
+  Bool updateComponentParameters() override;
+
+private:
+  Real mResistance = 0.;
+  Real mInductance = 0.;
+  Real mCapacitance = 0.;
+  Real mOmegaN = 0.;
+
+  void buildStateSpaceModel(Matrix &A, Matrix &B, Matrix &C, Matrix &D) const;
+};
+
+} // namespace SSN
+} // namespace Ph1
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -58,6 +58,8 @@ list(APPEND MODELS_SOURCES
 	DP/DP_ITypeSSNComp.cpp
 	DP/DP_Ph1_TwoTerminalVTypeSSNComp.cpp
 	DP/DP_Ph1_TwoTerminalITypeSSNComp.cpp
+	DP/DP_Ph1_MixedVTypeVariableSSNComp.cpp
+	DP/DP_Ph1_SSN_Variable_Serial_RLC.cpp
 	DP/DP_Ph1_SSN_Full_Serial_RLC.cpp
 	DP/DP_Ph1_GenericTwoTerminalVTypeSSN.cpp
 	DP/DP_Ph1_GenericTwoTerminalITypeSSN.cpp

--- a/dpsim-models/src/DP/DP_Ph1_MixedVTypeVariableSSNComp.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_MixedVTypeVariableSSNComp.cpp
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph1_MixedVTypeVariableSSNComp.h>
+#include <dpsim-models/MNAStampUtils.h>
+#include <dpsim-models/MathUtils.h>
+
+using namespace CPS;
+
+DP::Ph1::MixedVTypeVariableSSNComp::MixedVTypeVariableSSNComp(
+    String uid, String name, Int realStateCount, Int complexStateCount,
+    Logger::Level logLevel)
+    : MNASimPowerComp<Complex>(uid, name, true, true, logLevel),
+      mParameterChanged(false), mRealStateCount(realStateCount),
+      mComplexStateCount(complexStateCount), mTimeStep(0.0), mW(0.0, 0.0),
+      mYHist(0.0, 0.0), mX(mAttributes->create<Matrix>("x")) {
+  mPhaseType = PhaseType::Single;
+  setTerminalNumber(2);
+
+  **mIntfVoltage = MatrixComp::Zero(1, 1);
+  **mIntfCurrent = MatrixComp::Zero(1, 1);
+
+  mParametersSet = false;
+}
+
+Int DP::Ph1::MixedVTypeVariableSSNComp::stateSize() const {
+  return mRealStateCount + 2 * mComplexStateCount;
+}
+
+Matrix DP::Ph1::MixedVTypeVariableSSNComp::packComplex(const Complex &c) {
+  Matrix v(2, 1);
+  v(0, 0) = c.real();
+  v(1, 0) = c.imag();
+  return v;
+}
+
+Complex DP::Ph1::MixedVTypeVariableSSNComp::unpackComplex(const Matrix &v) {
+  return Complex(v(0, 0), v(1, 0));
+}
+
+Attribute<MatrixComp>::Ptr
+DP::Ph1::MixedVTypeVariableSSNComp::inputAttribute() const {
+  return mIntfVoltage;
+}
+
+Attribute<MatrixComp>::Ptr
+DP::Ph1::MixedVTypeVariableSSNComp::outputAttribute() const {
+  return mIntfCurrent;
+}
+
+MatrixComp
+DP::Ph1::MixedVTypeVariableSSNComp::buildInitialInputFromNodes(Real) {
+  MatrixComp vInit = MatrixComp::Zero(1, 1);
+  vInit(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
+  return vInit;
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::setParameters(const Matrix &A,
+                                                       const Matrix &B,
+                                                       const Matrix &C,
+                                                       const Matrix &D) {
+  setParameters(A, B, C, D, Matrix::Zero(A.rows(), 1), Matrix::Zero(2, 1));
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::setParameters(
+    const Matrix &A, const Matrix &B, const Matrix &C, const Matrix &D,
+    const Matrix &E, const Matrix &F) {
+  mParametersSet = false;
+
+  const Matrix::Index n = stateSize();
+
+  if (A.rows() != n || A.cols() != n)
+    throw std::invalid_argument("A has invalid dimensions.");
+
+  if (B.rows() != n || B.cols() != 2)
+    throw std::invalid_argument("B has invalid dimensions.");
+
+  if (C.rows() != 2 || C.cols() != n)
+    throw std::invalid_argument("C has invalid dimensions.");
+
+  if (D.rows() != 2 || D.cols() != 2)
+    throw std::invalid_argument("D has invalid dimensions.");
+
+  if (E.rows() != n || E.cols() != 1)
+    throw std::invalid_argument("E has invalid dimensions.");
+
+  if (F.rows() != 2 || F.cols() != 1)
+    throw std::invalid_argument("F has invalid dimensions.");
+
+  mA = A;
+  mB = B;
+  mC = C;
+  mD = D;
+  mE = E;
+  mF = F;
+
+  **mX = Matrix::Zero(n, 1);
+
+  mdA = Matrix::Zero(n, n);
+  mdB = Matrix::Zero(n, 2);
+  mdE = Matrix::Zero(n, 1);
+
+  mW = Complex(0.0, 0.0);
+  mYHist = Complex(0.0, 0.0);
+
+  mParametersSet = true;
+}
+
+const Matrix &DP::Ph1::MixedVTypeVariableSSNComp::stateOffset() const {
+  return mE;
+}
+
+const Matrix &DP::Ph1::MixedVTypeVariableSSNComp::outputOffset() const {
+  return mF;
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::setStateOffset(const Matrix &E) {
+  if (E.rows() != stateSize() || E.cols() != 1)
+    throw std::invalid_argument("State offset vector has invalid dimensions.");
+
+  mE = E;
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::setOutputOffset(const Matrix &F) {
+  if (F.rows() != 2 || F.cols() != 1)
+    throw std::invalid_argument("Output offset vector has invalid dimensions.");
+
+  mF = F;
+}
+
+Matrix DP::Ph1::MixedVTypeVariableSSNComp::calculateHistoryVectorReal() const {
+  const Matrix u = packComplex((**inputAttribute())(0, 0));
+  return mC * (mdA * (**mX) + mdB * u + mdE) + mF;
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::updateState(const Complex &uOld,
+                                                     const Complex &uNew) {
+  const Matrix u2Old = packComplex(uOld);
+  const Matrix u2New = packComplex(uNew);
+  **mX = mdA * (**mX) + mdB * (u2New + u2Old) + mdE;
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::recomputeDiscreteModel() {
+  Math::calculateStateSpaceTrapezoidalMatrices(mA, mB, mE, mTimeStep, mdA, mdB,
+                                               mdE);
+
+  // Fold the 2x2 real u->y block into a complex admittance; requires it to
+  // have the [[a,-b],[b,a]] complex-multiplication structure.
+  const Matrix wReal = mC * mdB + mD;
+  mW = Complex(wReal(0, 0), wReal(1, 0));
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::updateStateSpaceModel() {
+  mParameterChanged = updateComponentParameters();
+
+  if (mParameterChanged)
+    recomputeDiscreteModel();
+}
+
+Bool DP::Ph1::MixedVTypeVariableSSNComp::hasParameterChanged() {
+  return mParameterChanged;
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::initializeFromNodesAndTerminals(
+    Real frequency) {
+  if (!mParametersSet)
+    throw std::logic_error("setParameters() must be called before "
+                           "initializeFromNodesAndTerminals().");
+
+  if (mRealStateCount != 0)
+    throw std::logic_error(
+        "The default initializeFromNodesAndTerminals() only supports a "
+        "purely complex-envelope state (realStateCount() == 0); components "
+        "with real control states must override it.");
+
+  const MatrixComp uInit = buildInitialInputFromNodes(frequency);
+  const Complex u = uInit(0, 0);
+
+  **mIntfVoltage = uInit;
+  **mX = Matrix::Zero(stateSize(), 1);
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- Initialization from nodes and terminals ---");
+
+  Bool converged = false;
+  const Real omega = 2.0 * PI * frequency;
+
+  for (Int iter = 0; iter < mInitializationMaxIterations; ++iter) {
+    const Matrix xPrev = **mX;
+
+    updateComponentParameters();
+
+    MatrixComp h =
+        Complex(0.0, omega) * MatrixComp::Identity(stateSize(), stateSize()) -
+        mA.cast<Complex>();
+    MatrixComp uColumn = MatrixComp::Zero(2, 1);
+    uColumn(0, 0) = u.real();
+    uColumn(1, 0) = u.imag();
+    MatrixComp xInit =
+        h.inverse() * (mB.cast<Complex>() * uColumn + mE.cast<Complex>());
+
+    **mX = xInit.real();
+
+    if ((**mX).isApprox(xPrev, mInitializationTolerance)) {
+      converged = true;
+      break;
+    }
+  }
+
+  if (!converged) {
+    SPDLOG_LOGGER_WARN(
+        mSLog,
+        "Fixed-point initialization did not converge within {} iterations.",
+        mInitializationMaxIterations);
+  }
+
+  updateComponentParameters();
+
+  const Matrix yReal = mC * (**mX) + mD * packComplex(u) + mF;
+  (**mIntfCurrent)(0, 0) = unpackComplex(yReal);
+
+  mParameterChanged = false;
+
+  SPDLOG_LOGGER_INFO(
+      mSLog,
+      "\nInput u: {:s}"
+      "\nOutput y: {:s}"
+      "\nState x: {:s}"
+      "\n--- Initialization from nodes and terminals finished ---",
+      Logger::matrixCompToString(**mIntfVoltage),
+      Logger::matrixCompToString(**mIntfCurrent), Logger::matrixToString(**mX));
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompInitialize(
+    Real, Real timeStep, Attribute<Matrix>::Ptr) {
+  if (!mParametersSet)
+    throw std::logic_error(
+        "setParameters() must be called before initialization.");
+
+  mTimeStep = timeStep;
+  updateMatrixNodeIndices();
+
+  updateComponentParameters();
+  recomputeDiscreteModel();
+  mYHist = unpackComplex(calculateHistoryVectorReal());
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompAddPreStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes) {
+  modifiedAttributes.push_back(mRightVector);
+  prevStepDependencies.push_back(mX);
+  prevStepDependencies.push_back(inputAttribute());
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompPreStep(Real, Int) {
+  updateStateSpaceModel();
+  mYHist = unpackComplex(calculateHistoryVectorReal());
+  mnaCompApplyRightSideVectorStamp(**mRightVector);
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompAddPostStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes,
+    Attribute<Matrix>::Ptr &leftVector) {
+  attributeDependencies.push_back(leftVector);
+  modifiedAttributes.push_back(inputAttribute());
+  modifiedAttributes.push_back(outputAttribute());
+  modifiedAttributes.push_back(mX);
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompApplySystemMatrixStamp(
+    SparseMatrixRow &systemMatrix) {
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    MNAStampUtils::stampAdmittance(
+        mW, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
+        terminalNotGrounded(0), terminalNotGrounded(1), mSLog, mNumFreqs, freq);
+  }
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompApplyRightSideVectorStamp(
+    Matrix &rightVector) {
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    if (terminalNotGrounded(0))
+      Math::setVectorElement(rightVector, matrixNodeIndex(0), mYHist, mNumFreqs,
+                             freq);
+    if (terminalNotGrounded(1))
+      Math::setVectorElement(rightVector, matrixNodeIndex(1), -mYHist,
+                             mNumFreqs, freq);
+  }
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompUpdateVoltage(
+    const Matrix &leftVector) {
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    (**mIntfVoltage)(0, freq) = 0;
+    if (terminalNotGrounded(1))
+      (**mIntfVoltage)(0, freq) = Math::complexFromVectorElement(
+          leftVector, matrixNodeIndex(1), mNumFreqs, freq);
+    if (terminalNotGrounded(0))
+      (**mIntfVoltage)(0, freq) -= Math::complexFromVectorElement(
+          leftVector, matrixNodeIndex(0), mNumFreqs, freq);
+  }
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompUpdateCurrent(const Matrix &) {
+  (**mIntfCurrent)(0, 0) = mW * (**mIntfVoltage)(0, 0) + mYHist;
+}
+
+void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompPostStep(
+    Real, Int, Attribute<Matrix>::Ptr &leftVector) {
+  const Complex uOld = (**mIntfVoltage)(0, 0);
+  mnaCompUpdateVoltage(**leftVector);
+  mnaCompUpdateCurrent(**leftVector);
+  updateState(uOld, (**mIntfVoltage)(0, 0));
+}

--- a/dpsim-models/src/DP/DP_Ph1_SSN_Variable_Serial_RLC.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SSN_Variable_Serial_RLC.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph1_SSN_Variable_Serial_RLC.h>
+
+using namespace CPS;
+
+DP::Ph1::SSN::Variable_Serial_RLC::Variable_Serial_RLC(String uid, String name,
+                                                       Logger::Level logLevel)
+    : MixedVTypeVariableSSNComp(uid, name, 0, 2, logLevel) {}
+
+SimPowerComp<Complex>::Ptr
+DP::Ph1::SSN::Variable_Serial_RLC::clone(String name) {
+  auto copy = Variable_Serial_RLC::make(name, mLogLevel);
+  copy->setParameters(mResistance, mInductance, mCapacitance, mOmegaN);
+  return copy;
+}
+
+void DP::Ph1::SSN::Variable_Serial_RLC::buildStateSpaceModel(Matrix &A,
+                                                             Matrix &B,
+                                                             Matrix &C,
+                                                             Matrix &D) const {
+  // Packed real state [Re(vC), Im(vC), Re(iL), Im(iL)]: series RLC coupling
+  // applied identically to Re/Im, plus -j*omegaN as a same-state rotation.
+  A = Matrix::Zero(4, 4);
+  A(0, 1) = mOmegaN;
+  A(0, 2) = 1. / mCapacitance;
+  A(1, 0) = -mOmegaN;
+  A(1, 3) = 1. / mCapacitance;
+  A(2, 0) = -1. / mInductance;
+  A(2, 2) = -mResistance / mInductance;
+  A(2, 3) = mOmegaN;
+  A(3, 1) = -1. / mInductance;
+  A(3, 2) = -mOmegaN;
+  A(3, 3) = -mResistance / mInductance;
+
+  B = Matrix::Zero(4, 2);
+  B(2, 0) = 1. / mInductance;
+  B(3, 1) = 1. / mInductance;
+
+  C = Matrix::Zero(2, 4);
+  C(0, 2) = 1.;
+  C(1, 3) = 1.;
+
+  D = Matrix::Zero(2, 2);
+}
+
+void DP::Ph1::SSN::Variable_Serial_RLC::setParameters(Real resistance,
+                                                      Real inductance,
+                                                      Real capacitance,
+                                                      Real omegaN) {
+  mResistance = resistance;
+  mInductance = inductance;
+  mCapacitance = capacitance;
+  mOmegaN = omegaN;
+
+  Matrix A, B, C, D;
+  buildStateSpaceModel(A, B, C, D);
+
+  MixedVTypeVariableSSNComp::setParameters(A, B, C, D);
+}
+
+Bool DP::Ph1::SSN::Variable_Serial_RLC::updateComponentParameters() {
+  // Change-check intentionally skipped, to exercise recompute-every-step.
+  buildStateSpaceModel(mA, mB, mC, mD);
+  return true;
+}

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -137,6 +137,7 @@ Components/EMT_Ph3_GenericTwoTerminalVTypeSSN.cpp
 Components/EMT_Ph3_PiecewiseLinearInductor.cpp
 Components/EMT_Ph3_AvVoltSourceInverterStateSpace.cpp
 Components/EMT_Ph3_2T_I_Type_SSN.cpp
+Components/DP_Ph1_MixedVariableSSN_vs_FixedSSN.cpp
 )
 
 set(STATE_SPACE_SOURCES

--- a/dpsim/examples/cxx/Components/DP_Ph1_MixedVariableSSN_vs_FixedSSN.cpp
+++ b/dpsim/examples/cxx/Components/DP_Ph1_MixedVariableSSN_vs_FixedSSN.cpp
@@ -78,20 +78,24 @@ int main(int argc, char *argv[]) {
   const Real vErr = std::abs(vFixed - vVariable);
   const Real tol = 1e-6;
 
-  std::cout << "Final i_intf: fixed=" << iFixed << " variable=" << iVariable
-            << " |diff|=" << iErr << std::endl;
-  std::cout << "Final v_intf: fixed=" << vFixed << " variable=" << vVariable
-            << " |diff|=" << vErr << std::endl;
+  auto log = DPsim::Logger::get("DP_Ph1_MixedVariableSSN_vs_FixedSSN");
+  SPDLOG_LOGGER_INFO(log, "Final i_intf: fixed={} variable={} |diff|={}",
+                     iFixed, iVariable, iErr);
+  SPDLOG_LOGGER_INFO(log, "Final v_intf: fixed={} variable={} |diff|={}",
+                     vFixed, vVariable, vErr);
 
   if (iErr > tol || vErr > tol) {
-    std::cout << "FAIL: Variable-SSN one-port does not match the fixed-SSN "
-                 "reference within tolerance "
-              << tol << std::endl;
+    SPDLOG_LOGGER_ERROR(log,
+                        "FAIL: Variable-SSN one-port does not match the "
+                        "fixed-SSN reference within tolerance {}",
+                        tol);
     return 1;
   }
 
-  std::cout << "PASS: Variable-SSN one-port matches the fixed-SSN reference "
-               "within tolerance "
-            << tol << std::endl;
+  SPDLOG_LOGGER_INFO(
+      log,
+      "PASS: Variable-SSN one-port matches the fixed-SSN reference within "
+      "tolerance {}",
+      tol);
   return 0;
 }

--- a/dpsim/examples/cxx/Components/DP_Ph1_MixedVariableSSN_vs_FixedSSN.cpp
+++ b/dpsim/examples/cxx/Components/DP_Ph1_MixedVariableSSN_vs_FixedSSN.cpp
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+// Plumbing sanity check for DP::Ph1::MixedVTypeVariableSSNComp: a trivial
+// variable one-port (Variable_Serial_RLC, held at constant R/L/C) run
+// side by side with the fixed-parameter reference of the same circuit
+// (Full_Serial_RLC, built on DP::SSNComp) and compared directly.
+
+#include <DPsim.h>
+#include <dpsim-models/DP/DP_Ph1_SSN_Variable_Serial_RLC.h>
+
+using namespace DPsim;
+using namespace CPS::DP;
+
+namespace {
+
+Real timeStep = 0.0001;
+Real finalTime = 0.1;
+Real resistance = 10.0;
+Real inductance = 0.01;
+Real capacitance = 0.002;
+Real systemFreq = 50.0;
+
+SimNode::Ptr buildAndRun(const String &simName,
+                         CPS::SimPowerComp<Complex>::Ptr rlc,
+                         Bool systemMatrixRecomputation) {
+  auto n1 = SimNode::make("n1");
+
+  auto vs = Ph1::VoltageSource::make("vs_" + simName);
+  vs->setParameters(CPS::Math::polar(1.0, CPS::Math::degToRad(-90.0)));
+
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  rlc->connect(SimNode::List{n1, SimNode::GND});
+
+  auto sys = SystemTopology(systemFreq, SystemNodeList{n1},
+                            SystemComponentList{vs, rlc});
+
+  Logger::setLogDir("logs/" + simName);
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v_rlc", rlc->attribute("v_intf"));
+  logger->logAttribute("i_rlc", rlc->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSystemMatrixRecomputation(systemMatrixRecomputation);
+  sim.run();
+
+  return n1;
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  auto rlcFixed = Ph1::SSN::Full_Serial_RLC::make("rlc_fixed");
+  rlcFixed->setParameters(resistance, inductance, capacitance);
+  buildAndRun("DP_Ph1_MixedVariableSSN_vs_FixedSSN_Fixed", rlcFixed, false);
+
+  auto rlcVariable = Ph1::SSN::Variable_Serial_RLC::make("rlc_variable");
+  rlcVariable->setParameters(resistance, inductance, capacitance,
+                             2.0 * PI * systemFreq);
+  buildAndRun("DP_Ph1_MixedVariableSSN_vs_FixedSSN_Variable", rlcVariable,
+              true);
+
+  const Complex iFixed =
+      rlcFixed->attributeTyped<MatrixComp>("i_intf")->get()(0, 0);
+  const Complex iVariable =
+      rlcVariable->attributeTyped<MatrixComp>("i_intf")->get()(0, 0);
+  const Complex vFixed =
+      rlcFixed->attributeTyped<MatrixComp>("v_intf")->get()(0, 0);
+  const Complex vVariable =
+      rlcVariable->attributeTyped<MatrixComp>("v_intf")->get()(0, 0);
+
+  const Real iErr = std::abs(iFixed - iVariable);
+  const Real vErr = std::abs(vFixed - vVariable);
+  const Real tol = 1e-6;
+
+  std::cout << "Final i_intf: fixed=" << iFixed << " variable=" << iVariable
+            << " |diff|=" << iErr << std::endl;
+  std::cout << "Final v_intf: fixed=" << vFixed << " variable=" << vVariable
+            << " |diff|=" << vErr << std::endl;
+
+  if (iErr > tol || vErr > tol) {
+    std::cout << "FAIL: Variable-SSN one-port does not match the fixed-SSN "
+                 "reference within tolerance "
+              << tol << std::endl;
+    return 1;
+  }
+
+  std::cout << "PASS: Variable-SSN one-port matches the fixed-SSN reference "
+               "within tolerance "
+            << tol << std::endl;
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Adds `DP::Ph1::MixedVTypeVariableSSNComp`, a per-step relinearized SSN base for components whose state mixes baseband real states with carrier-band complex states, packed into one real vector and folded to/from a complex Norton stamp at the network boundary.
- Adds a plumbing-only sanity component/example (`Variable_Serial_RLC`) verifying the new base against the existing fixed-parameter SSN RLC one-port.
