### PR TITLE
Add DP_Ph1_Shunt and EMT_Ph3_Shunt components

### DIFF
--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -64,6 +64,7 @@
 #include <dpsim-models/DP/DP_Ph1_RxLine.h>
 #include <dpsim-models/DP/DP_Ph1_SSN_Full_Serial_RLC.h>
 #include <dpsim-models/DP/DP_Ph1_SVC.h>
+#include <dpsim-models/DP/DP_Ph1_Shunt.h>
 #include <dpsim-models/DP/DP_Ph1_Switch.h>
 #include <dpsim-models/DP/DP_Ph1_SynchronGenerator3OrderVBR.h>
 #include <dpsim-models/DP/DP_Ph1_SynchronGenerator4OrderPCM.h>
@@ -159,6 +160,7 @@
 #include <dpsim-models/EMT/EMT_Ph3_PiecewiseLinearInductor.h>
 #include <dpsim-models/EMT/EMT_Ph3_RXLoad.h>
 #include <dpsim-models/EMT/EMT_Ph3_RxLine.h>
+#include <dpsim-models/EMT/EMT_Ph3_Shunt.h>
 #include <dpsim-models/EMT/EMT_Ph3_Switch.h>
 #include <dpsim-models/EMT/EMT_Ph3_SynchronGeneratorIdeal.h>
 #include <dpsim-models/EMT/EMT_Ph3_SynchronGeneratorTrStab.h>

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Shunt.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Shunt.h
@@ -1,0 +1,62 @@
+/* Copyright 2017-2021 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#pragma once
+
+#include <dpsim-models/CompositePowerComp.h>
+#include <dpsim-models/DP/DP_Ph1_Capacitor.h>
+#include <dpsim-models/DP/DP_Ph1_Resistor.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph1 {
+
+class Shunt : public CompositePowerComp<Complex>, public SharedFactory<Shunt> {
+public:
+  /// Conductance [S]
+  const Attribute<Real>::Ptr mConductance;
+  /// Susceptance [S]
+  const Attribute<Real>::Ptr mSusceptance;
+
+  /// Capacitor between terminal and ground
+  std::shared_ptr<Capacitor> mSubCapacitor;
+  /// Resistor between terminal and ground
+  std::shared_ptr<Resistor> mSubResistor;
+
+public:
+  /// Defines UID, name, component parameters and logging level
+  Shunt(String uid, String name, Logger::Level logLevel = Logger::Level::off);
+
+  /// Defines name and logging level
+  Shunt(String name, Logger::Level logLevel = Logger::Level::off)
+      : Shunt(name, name, logLevel) {}
+
+  // #### General ####
+  /// Set shunt DPecific parameters
+  void setParameters(Real conductance, Real susceptance);
+
+  // #### MNA section ####
+  /// Initializes component from power flow data
+  void initializeFromNodesAndTerminals(Real frequency) final;
+  /// Updates internal current variable of the component
+  void mnaCompUpdateCurrent(const Matrix &leftVector) final;
+  /// Updates internal voltage variable of the component
+  void mnaCompUpdateVoltage(const Matrix &leftVector) final;
+  /// MNA post-step operations
+  void mnaParentPostStep(Real time, Int timeStepCount,
+                         Attribute<Matrix>::Ptr &leftVector) final;
+  /// add MNA post-step dependencies
+  void
+  mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
+                                   AttributeBase::List &attributeDependencies,
+                                   AttributeBase::List &modifiedAttributes,
+                                   Attribute<Matrix>::Ptr &leftVector) final;
+};
+} // namespace Ph1
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Shunt.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Shunt.h
@@ -42,7 +42,14 @@ public:
 
   // #### MNA section ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency) final;
+  void initializeParentFromNodesAndTerminals(Real frequency);
+  /// Add MNA pre step dependencies
+  void mnaParentAddPreStepDependencies(
+      AttributeBase::List &prevStepDependencies,
+      AttributeBase::List &attributeDependencies,
+      AttributeBase::List &modifiedAttributes) final;
+  /// MNA pre step operations
+  void mnaParentPreStep(Real time, Int timeStepCount) final;
   /// Updates internal current variable of the component
   void mnaCompUpdateCurrent(const Matrix &leftVector) final;
   /// Updates internal voltage variable of the component

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Shunt.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Shunt.h
@@ -9,19 +9,20 @@
 #pragma once
 
 #include <dpsim-models/CompositePowerComp.h>
-#include <dpsim-models/DP/DP_Ph1_Capacitor.h>
-#include <dpsim-models/DP/DP_Ph1_Resistor.h>
+#include <dpsim-models/EMT/EMT_Ph3_Capacitor.h>
+#include <dpsim-models/EMT/EMT_Ph3_Resistor.h>
+#include <dpsim-models/Solver/MNAInterface.h>
 
 namespace CPS {
-namespace DP {
-namespace Ph1 {
+namespace EMT {
+namespace Ph3 {
 
-class Shunt : public CompositePowerComp<Complex>, public SharedFactory<Shunt> {
-public:
+class Shunt : public CompositePowerComp<Real>, public SharedFactory<Shunt> {
+private:
   /// Conductance [S]
-  const Attribute<Real>::Ptr mConductance;
+  Matrix mConductance;
   /// Susceptance [S]
-  const Attribute<Real>::Ptr mSusceptance;
+  Matrix mSusceptance;
 
   /// Capacitor between terminal and ground
   std::shared_ptr<Capacitor> mSubCapacitor;
@@ -39,6 +40,7 @@ public:
   // #### General ####
   /// Set shunt specific parameters
   void setParameters(Real conductance, Real susceptance);
+  void setParameters(Matrix conductance, Matrix susceptance);
 
   // #### MNA section ####
   /// Initializes component from power flow data
@@ -57,6 +59,6 @@ public:
                                    AttributeBase::List &modifiedAttributes,
                                    Attribute<Matrix>::Ptr &leftVector) final;
 };
-} // namespace Ph1
-} // namespace DP
+} // namespace Ph3
+} // namespace EMT
 } // namespace CPS

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Shunt.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Shunt.h
@@ -44,7 +44,14 @@ public:
 
   // #### MNA section ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency) final;
+  void initializeParentFromNodesAndTerminals(Real frequency) final;
+  /// Add MNA pre step dependencies
+  void mnaParentAddPreStepDependencies(
+      AttributeBase::List &prevStepDependencies,
+      AttributeBase::List &attributeDependencies,
+      AttributeBase::List &modifiedAttributes) final;
+  /// MNA pre step operations
+  void mnaParentPreStep(Real time, Int timeStepCount) final;
   /// Updates internal current variable of the component
   void mnaCompUpdateCurrent(const Matrix &leftVector) final;
   /// Updates internal voltage variable of the component

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -34,6 +34,7 @@ list(APPEND MODELS_SOURCES
 	DP/DP_Ph1_VoltageSource.cpp
 	DP/DP_Ph1_VoltageSourceRamp.cpp
 	DP/DP_Ph1_VoltageSourceNorton.cpp
+	DP/DP_Ph1_Shunt.cpp
 	DP/DP_Ph1_Switch.cpp
 	DP/DP_Ph1_SynchronGeneratorIdeal.cpp
 	DP/DP_Ph1_SynchronGeneratorTrStab.cpp
@@ -117,6 +118,7 @@ list(APPEND MODELS_SOURCES
 	EMT/EMT_Ph3_RXLoad.cpp
 	EMT/EMT_Ph3_NetworkInjection.cpp
 	EMT/EMT_Ph3_Transformer.cpp
+	EMT/EMT_Ph3_Shunt.cpp
 	EMT/EMT_Ph3_Switch.cpp
 	EMT/EMT_Ph3_ReducedOrderSynchronGeneratorVBR.cpp
 	EMT/EMT_Ph3_SynchronGenerator3OrderVBR.cpp

--- a/dpsim-models/src/DP/DP_Ph1_Shunt.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Shunt.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 DP::Ph1::Shunt::Shunt(String uid, String name, Logger::Level logLevel)
-    : CompositePowerComp<Complex>(uid, name, false, true, logLevel),
+    : CompositePowerComp<Complex>(uid, name, true, true, logLevel),
       mConductance(mAttributes->create<Real>("G")),
       mSusceptance(mAttributes->create<Real>("B")) {
 
@@ -28,7 +28,7 @@ void DP::Ph1::Shunt::setParameters(Real conductance, Real susceptance) {
 }
 
 /// MNA Section
-void DP::Ph1::Shunt::initializeFromNodesAndTerminals(Real frequency) {
+void DP::Ph1::Shunt::initializeParentFromNodesAndTerminals(Real frequency) {
 
   // Static calculation
   Real omega = 2. * PI * frequency;
@@ -44,8 +44,8 @@ void DP::Ph1::Shunt::initializeFromNodesAndTerminals(Real frequency) {
     mSubResistor->setParameters(1. / **mConductance);
     mSubResistor->initialize(mFrequencies);
     mSubResistor->initializeFromNodesAndTerminals(frequency);
-    addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
-                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
+    addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
+                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
   }
 
   if (**mSusceptance > 0) {
@@ -55,7 +55,8 @@ void DP::Ph1::Shunt::initializeFromNodesAndTerminals(Real frequency) {
     mSubCapacitor->connect(SimNode::List{SimNode::GND, mTerminals[0]->node()});
     mSubCapacitor->initialize(mFrequencies);
     mSubCapacitor->initializeFromNodesAndTerminals(frequency);
-    addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
+    addMNASubComponent(mSubCapacitor,
+                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
   }
 
@@ -68,6 +69,17 @@ void DP::Ph1::Shunt::initializeFromNodesAndTerminals(Real frequency) {
                      Logger::phasorToString((**mIntfVoltage)(0, 0)),
                      Logger::phasorToString((**mIntfCurrent)(0, 0)),
                      Logger::phasorToString(initialSingleVoltage(0)));
+}
+
+void DP::Ph1::Shunt::mnaParentAddPreStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes) {
+  modifiedAttributes.push_back(mRightVector);
+}
+
+void DP::Ph1::Shunt::mnaParentPreStep(Real time, Int timeStepCount) {
+  mnaCompApplyRightSideVectorStamp(**mRightVector);
 }
 
 void DP::Ph1::Shunt::mnaParentAddPostStepDependencies(

--- a/dpsim-models/src/DP/DP_Ph1_Shunt.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Shunt.cpp
@@ -1,0 +1,101 @@
+/* Copyright 2017-2021 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <dpsim-models/DP/DP_Ph1_Shunt.h>
+
+using namespace CPS;
+
+DP::Ph1::Shunt::Shunt(String uid, String name, Logger::Level logLevel)
+    : CompositePowerComp<Complex>(uid, name, false, true, logLevel),
+      mConductance(mAttributes->create<Real>("G")),
+      mSusceptance(mAttributes->create<Real>("B")) {
+
+  SPDLOG_LOGGER_INFO(mSLog, "Create {} of type {}", this->type(), name);
+  setTerminalNumber(1);
+}
+
+void DP::Ph1::Shunt::setParameters(Real conductance, Real susceptance) {
+  **mConductance = conductance;
+  **mSusceptance = susceptance;
+  SPDLOG_LOGGER_INFO(mSLog, "Conductance={} [S] Susceptance={} [Ohm] ",
+                     conductance, susceptance);
+  mParametersSet = true;
+}
+
+/// MNA Section
+void DP::Ph1::Shunt::initializeFromNodesAndTerminals(Real frequency) {
+
+  // Static calculation
+  Real omega = 2. * PI * frequency;
+  Complex admittance = Complex(**mConductance, **mSusceptance);
+  (**mIntfVoltage)(0, 0) = initialSingleVoltage(0);
+  (**mIntfCurrent)(0, 0) = (**mIntfVoltage)(0, 0) * admittance;
+
+  // Create series rl sub component
+  if (**mConductance > 0) {
+    mSubResistor =
+        std::make_shared<DP::Ph1::Resistor>(**mName + "_Res", mLogLevel);
+    mSubResistor->connect(SimNode::List{SimNode::GND, mTerminals[0]->node()});
+    mSubResistor->setParameters(1. / **mConductance);
+    mSubResistor->initialize(mFrequencies);
+    mSubResistor->initializeFromNodesAndTerminals(frequency);
+    addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
+                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
+  }
+
+  if (**mSusceptance > 0) {
+    mSubCapacitor =
+        std::make_shared<DP::Ph1::Capacitor>(**mName + "_cap", mLogLevel);
+    mSubCapacitor->setParameters(**mSusceptance / omega);
+    mSubCapacitor->connect(SimNode::List{SimNode::GND, mTerminals[0]->node()});
+    mSubCapacitor->initialize(mFrequencies);
+    mSubCapacitor->initializeFromNodesAndTerminals(frequency);
+    addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
+                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
+  }
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- Initialization from powerflow ---"
+                     "\nVoltage across: {:s}"
+                     "\nCurrent: {:s}"
+                     "\nTerminal voltage: {:s}"
+                     "\n--- Initialization from powerflow finished ---",
+                     Logger::phasorToString((**mIntfVoltage)(0, 0)),
+                     Logger::phasorToString((**mIntfCurrent)(0, 0)),
+                     Logger::phasorToString(initialSingleVoltage(0)));
+}
+
+void DP::Ph1::Shunt::mnaParentAddPostStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes,
+    Attribute<Matrix>::Ptr &leftVector) {
+  attributeDependencies.push_back(leftVector);
+  modifiedAttributes.push_back(mIntfVoltage);
+  modifiedAttributes.push_back(mIntfCurrent);
+}
+
+void DP::Ph1::Shunt::mnaParentPostStep(Real time, Int timeStepCount,
+                                       Attribute<Matrix>::Ptr &leftVector) {
+  this->mnaUpdateVoltage(**leftVector);
+  this->mnaUpdateCurrent(**leftVector);
+}
+
+void DP::Ph1::Shunt::mnaCompUpdateVoltage(const Matrix &leftVector) {
+  (**mIntfVoltage)(0, 0) =
+      Math::complexFromVectorElement(leftVector, matrixNodeIndex(0));
+}
+
+void DP::Ph1::Shunt::mnaCompUpdateCurrent(const Matrix &leftVector) {
+  (**mIntfCurrent)(0, 0) = 0;
+
+  if (**mConductance > 0)
+    (**mIntfCurrent)(0, 0) += mSubResistor->intfCurrent()(0, 0);
+  if (**mSusceptance > 0)
+    (**mIntfCurrent)(0, 0) += mSubCapacitor->intfCurrent()(0, 0);
+}

--- a/dpsim-models/src/DP/DP_Ph1_Shunt.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Shunt.cpp
@@ -45,7 +45,7 @@ void DP::Ph1::Shunt::initializeFromNodesAndTerminals(Real frequency) {
     mSubResistor->initialize(mFrequencies);
     mSubResistor->initializeFromNodesAndTerminals(frequency);
     addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
-                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
+                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
   }
 
   if (**mSusceptance > 0) {
@@ -56,7 +56,7 @@ void DP::Ph1::Shunt::initializeFromNodesAndTerminals(Real frequency) {
     mSubCapacitor->initialize(mFrequencies);
     mSubCapacitor->initializeFromNodesAndTerminals(frequency);
     addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
-                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
+                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
   }
 
   SPDLOG_LOGGER_INFO(mSLog,

--- a/dpsim-models/src/EMT/EMT_Ph3_Shunt.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Shunt.cpp
@@ -1,0 +1,118 @@
+/* Copyright 2017-2021 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <dpsim-models/EMT/EMT_Ph3_Shunt.h>
+
+using namespace CPS;
+
+EMT::Ph3::Shunt::Shunt(String uid, String name, Logger::Level logLevel)
+    : CompositePowerComp<Real>(uid, name, false, true, logLevel) {
+
+  mConductance = Matrix::Zero(3, 3);
+  mSusceptance = Matrix::Zero(3, 3);
+  SPDLOG_LOGGER_INFO(mSLog, "Create {} of type {}", this->type(), name);
+  setTerminalNumber(1);
+}
+
+void EMT::Ph3::Shunt::setParameters(Real conductance, Real susceptance) {
+  this->setParameters(Math::singlePhaseParameterToThreePhase(conductance),
+                      Math::singlePhaseParameterToThreePhase(susceptance));
+}
+
+void EMT::Ph3::Shunt::setParameters(Matrix conductance, Matrix susceptance) {
+  mConductance = conductance;
+  mSusceptance = susceptance;
+  SPDLOG_LOGGER_INFO(mSLog, "Conductance={} [S] Susceptance={} [Ohm] ",
+                     Logger::matrixToString(mConductance),
+                     Logger::matrixToString(mSusceptance));
+  mParametersSet = true;
+}
+
+/// MNA Section
+void EMT::Ph3::Shunt::initializeFromNodesAndTerminals(Real frequency) {
+
+  // Static calculation
+  Real omega = 2. * PI * frequency;
+  MatrixComp admittance = Matrix::Zero(3, 3);
+  admittance << Complex(mConductance(0, 0), mSusceptance(0, 0)), 0, 0, 0,
+      Complex(mConductance(1, 1), mSusceptance(1, 1)), 0, 0, 0,
+      Complex(mConductance(2, 2), mSusceptance(2, 2));
+  MatrixComp vInitABC = MatrixComp::Zero(3, 1);
+  vInitABC(0, 0) = RMS3PH_TO_PEAK1PH * mTerminals[0]->initialSingleVoltage();
+  vInitABC(1, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_B;
+  vInitABC(2, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_C;
+  **mIntfVoltage = vInitABC.real();
+  **mIntfCurrent = (admittance * vInitABC).real();
+
+  // Create series rl sub component
+  if (mConductance(0, 0) > 0) {
+    mSubResistor =
+        std::make_shared<EMT::Ph3::Resistor>(**mName + "_Res", mLogLevel);
+    mSubResistor->connect({SimNode::GND, mTerminals[0]->node()});
+    mSubResistor->setParameters(mConductance.inverse());
+    mSubResistor->initialize(mFrequencies);
+    mSubResistor->initializeFromNodesAndTerminals(frequency);
+    addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
+                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
+  }
+
+  if (mSusceptance(0, 0) > 0) {
+    mSubCapacitor =
+        std::make_shared<EMT::Ph3::Capacitor>(**mName + "_cap", mLogLevel);
+    mSubCapacitor->setParameters(mSusceptance * (1 / omega));
+    mSubCapacitor->connect({SimNode::GND, mTerminals[0]->node()});
+    mSubCapacitor->initialize(mFrequencies);
+    mSubCapacitor->initializeFromNodesAndTerminals(frequency);
+    addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
+                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
+  }
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- Initialization from powerflow ---"
+                     "\nVoltage across: {:s}"
+                     "\nCurrent: {:s}"
+                     "\nTerminal voltage: {:s}"
+                     "\n--- Initialization from powerflow finished ---",
+                     Logger::phasorToString((**mIntfVoltage)(0, 0)),
+                     Logger::phasorToString((**mIntfCurrent)(0, 0)),
+                     Logger::phasorToString(initialSingleVoltage(0)));
+}
+
+void EMT::Ph3::Shunt::mnaParentAddPostStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes,
+    Attribute<Matrix>::Ptr &leftVector) {
+  attributeDependencies.push_back(leftVector);
+  modifiedAttributes.push_back(mIntfVoltage);
+  modifiedAttributes.push_back(mIntfCurrent);
+}
+
+void EMT::Ph3::Shunt::mnaParentPostStep(Real time, Int timeStepCount,
+                                        Attribute<Matrix>::Ptr &leftVector) {
+  this->mnaUpdateVoltage(**leftVector);
+  this->mnaUpdateCurrent(**leftVector);
+}
+
+void EMT::Ph3::Shunt::mnaCompUpdateVoltage(const Matrix &leftVector) {
+  (**mIntfVoltage)(0, 0) =
+      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 0));
+  (**mIntfVoltage)(1, 0) =
+      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 1));
+  (**mIntfVoltage)(2, 0) =
+      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 2));
+}
+
+void EMT::Ph3::Shunt::mnaCompUpdateCurrent(const Matrix &leftVector) {
+  **mIntfCurrent = Matrix::Zero(3, 1);
+
+  if (mConductance(0, 0) > 0)
+    **mIntfCurrent += mSubResistor->intfCurrent();
+  if (mSusceptance(0, 0) > 0)
+    **mIntfCurrent += mSubCapacitor->intfCurrent();
+}

--- a/dpsim-models/src/EMT/EMT_Ph3_Shunt.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Shunt.cpp
@@ -12,7 +12,7 @@ using namespace CPS;
 
 EMT::Ph3::Shunt::Shunt(String uid, String name, Logger::Level logLevel)
     : CompositePowerComp<Real>(uid, name, true, true, logLevel) {
-
+  mPhaseType = PhaseType::ABC;
   mConductance = Matrix::Zero(3, 3);
   mSusceptance = Matrix::Zero(3, 3);
   SPDLOG_LOGGER_INFO(mSLog, "Create {} of type {}", this->type(), name);

--- a/dpsim-models/src/EMT/EMT_Ph3_Shunt.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Shunt.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 EMT::Ph3::Shunt::Shunt(String uid, String name, Logger::Level logLevel)
-    : CompositePowerComp<Real>(uid, name, false, true, logLevel) {
+    : CompositePowerComp<Real>(uid, name, true, true, logLevel) {
 
   mConductance = Matrix::Zero(3, 3);
   mSusceptance = Matrix::Zero(3, 3);
@@ -34,7 +34,7 @@ void EMT::Ph3::Shunt::setParameters(Matrix conductance, Matrix susceptance) {
 }
 
 /// MNA Section
-void EMT::Ph3::Shunt::initializeFromNodesAndTerminals(Real frequency) {
+void EMT::Ph3::Shunt::initializeParentFromNodesAndTerminals(Real frequency) {
 
   // Static calculation
   Real omega = 2. * PI * frequency;
@@ -57,7 +57,7 @@ void EMT::Ph3::Shunt::initializeFromNodesAndTerminals(Real frequency) {
     mSubResistor->setParameters(mConductance.inverse());
     mSubResistor->initialize(mFrequencies);
     mSubResistor->initializeFromNodesAndTerminals(frequency);
-    addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
+    addMNASubComponent(mSubResistor, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
                        MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
   }
 
@@ -68,8 +68,9 @@ void EMT::Ph3::Shunt::initializeFromNodesAndTerminals(Real frequency) {
     mSubCapacitor->connect({SimNode::GND, mTerminals[0]->node()});
     mSubCapacitor->initialize(mFrequencies);
     mSubCapacitor->initializeFromNodesAndTerminals(frequency);
-    addMNASubComponent(mSubCapacitor, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
-                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
+    addMNASubComponent(mSubCapacitor,
+                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
+                       MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
   }
 
   SPDLOG_LOGGER_INFO(mSLog,
@@ -81,6 +82,17 @@ void EMT::Ph3::Shunt::initializeFromNodesAndTerminals(Real frequency) {
                      Logger::phasorToString((**mIntfVoltage)(0, 0)),
                      Logger::phasorToString((**mIntfCurrent)(0, 0)),
                      Logger::phasorToString(initialSingleVoltage(0)));
+}
+
+void EMT::Ph3::Shunt::mnaParentAddPreStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes) {
+  modifiedAttributes.push_back(mRightVector);
+}
+
+void EMT::Ph3::Shunt::mnaParentPreStep(Real time, Int timeStepCount) {
+  mnaCompApplyRightSideVectorStamp(**mRightVector);
 }
 
 void EMT::Ph3::Shunt::mnaParentAddPostStepDependencies(

--- a/dpsim/src/pybind/DPComponents.cpp
+++ b/dpsim/src/pybind/DPComponents.cpp
@@ -155,6 +155,14 @@ void addDPPh1Components(py::module_ mDPPh1) {
            "active_power"_a, "reactive_power"_a, "volt"_a)
       .def("connect", &CPS::DP::Ph1::RXLoad::connect);
 
+  py::class_<CPS::DP::Ph1::Shunt, std::shared_ptr<CPS::DP::Ph1::Shunt>,
+             CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "Shunt",
+                                              py::multiple_inheritance())
+      .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
+           "loglevel"_a = CPS::Logger::Level::off)
+      .def("set_parameters", &CPS::DP::Ph1::Shunt::setParameters, "G"_a, "B"_a)
+      .def("connect", &CPS::DP::Ph1::Shunt::connect);
+
   py::class_<CPS::DP::Ph1::Switch, std::shared_ptr<CPS::DP::Ph1::Switch>,
              CPS::SimPowerComp<CPS::Complex>, CPS::Base::Ph1::Switch>(
       mDPPh1, "Switch", py::multiple_inheritance())

--- a/dpsim/src/pybind/EMTComponents.cpp
+++ b/dpsim/src/pybind/EMTComponents.cpp
@@ -298,6 +298,17 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
            "reactance_in_series"_a = false)
       .def("connect", &CPS::EMT::Ph3::RXLoad::connect);
 
+  py::class_<CPS::EMT::Ph3::Shunt, std::shared_ptr<CPS::EMT::Ph3::Shunt>,
+             CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "Shunt",
+                                           py::multiple_inheritance())
+      .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
+           "loglevel"_a = CPS::Logger::Level::off)
+      .def("set_parameters",
+           static_cast<void (CPS::EMT::Ph3::Shunt::*)(CPS::Real, CPS::Real)>(
+               &CPS::EMT::Ph3::Shunt::setParameters),
+           "G"_a, "B"_a)
+      .def("connect", &CPS::EMT::Ph3::Shunt::connect);
+
   py::class_<CPS::EMT::Ph3::Switch, std::shared_ptr<CPS::EMT::Ph3::Switch>,
              CPS::SimPowerComp<CPS::Real>, CPS::Base::Ph3::Switch>(
       mEMTPh3, "Switch", py::multiple_inheritance())

--- a/examples/Notebooks/Circuits/EMT_DP_VS_Shunt.ipynb
+++ b/examples/Notebooks/Circuits/EMT_DP_VS_Shunt.ipynb
@@ -1,0 +1,333 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from villas.dataprocessing.readtools import *\n",
+    "from villas.dataprocessing.timeseries import *\n",
+    "from villas.dataprocessing.timeseries import TimeSeries as ts\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import dpsimpy\n",
+    "\n",
+    "# %matplotlib widget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Voltage Source + Resistor + Shunt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_step = 0.00005\n",
+    "final_time = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_name = \"EMT_VoltageSource_Resistor_Shunt\"\n",
+    "dpsimpy.Logger.set_log_dir(\"logs/\" + sim_name)\n",
+    "\n",
+    "# Nodes\n",
+    "gnd = dpsimpy.emt.SimNode.gnd\n",
+    "n1 = dpsimpy.emt.SimNode(\"n1\", dpsimpy.PhaseType.ABC)\n",
+    "n2 = dpsimpy.emt.SimNode(\"n2\", dpsimpy.PhaseType.ABC)\n",
+    "\n",
+    "# Components\n",
+    "vs = dpsimpy.emt.ph3.VoltageSource(\"vs1\")\n",
+    "vs.set_parameters(\n",
+    "    dpsimpy.Math.single_phase_variable_to_three_phase(complex(100000, 0)), 50\n",
+    ")\n",
+    "\n",
+    "res = dpsimpy.emt.ph3.Resistor(\"R1\", dpsimpy.LogLevel.debug)\n",
+    "res.set_parameters(dpsimpy.Math.single_phase_parameter_to_three_phase(5))\n",
+    "\n",
+    "shunt = dpsimpy.emt.ph3.Shunt(\"Shunt1\", dpsimpy.LogLevel.debug)\n",
+    "shunt.set_parameters(0.1, 3.14159)\n",
+    "\n",
+    "# Topology\n",
+    "vs.connect([gnd, n1])\n",
+    "res.connect([n1, n2])\n",
+    "shunt.connect([n2])\n",
+    "\n",
+    "sys = dpsimpy.SystemTopology(50, [n1, n2], [vs, res, shunt])\n",
+    "\n",
+    "# Logging\n",
+    "logger = dpsimpy.Logger(sim_name)\n",
+    "logger.log_attribute(\"v1\", \"v\", n1)\n",
+    "logger.log_attribute(\"v2\", \"v\", n2)\n",
+    "logger.log_attribute(\"iR\", \"i_intf\", res)\n",
+    "logger.log_attribute(\"iShunt\", \"i_intf\", shunt)\n",
+    "\n",
+    "# Simulation\n",
+    "sim = dpsimpy.Simulation(sim_name)\n",
+    "sim.set_system(sys)\n",
+    "sim.set_time_step(time_step)\n",
+    "sim.set_final_time(final_time)\n",
+    "sim.set_domain(dpsimpy.Domain.EMT)\n",
+    "sim.add_logger(logger)\n",
+    "sim.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_name = \"DP_VoltageSource_Resistor_Shunt\"\n",
+    "dpsimpy.Logger.set_log_dir(\"logs/\" + sim_name)\n",
+    "\n",
+    "# Nodes\n",
+    "gnd = dpsimpy.dp.SimNode.gnd\n",
+    "n1 = dpsimpy.dp.SimNode(\"n1\")\n",
+    "n2 = dpsimpy.dp.SimNode(\"n2\")\n",
+    "\n",
+    "# Components\n",
+    "vs = dpsimpy.dp.ph1.VoltageSource(\"vs1\")\n",
+    "vs.set_parameters(complex(100000, 0))\n",
+    "\n",
+    "res = dpsimpy.dp.ph1.Resistor(\"R1\", dpsimpy.LogLevel.debug)\n",
+    "res.set_parameters(5)\n",
+    "\n",
+    "shunt = dpsimpy.dp.ph1.Shunt(\"Shunt1\", dpsimpy.LogLevel.debug)\n",
+    "shunt.set_parameters(0.1, 3.14159)\n",
+    "\n",
+    "# Topology\n",
+    "vs.connect([gnd, n1])\n",
+    "res.connect([n1, n2])\n",
+    "shunt.connect([n2])\n",
+    "\n",
+    "sys = dpsimpy.SystemTopology(50, [n1, n2], [vs, res, shunt])\n",
+    "\n",
+    "# Logging\n",
+    "logger = dpsimpy.Logger(sim_name)\n",
+    "logger.log_attribute(\"v1\", \"v\", n1)\n",
+    "logger.log_attribute(\"v2\", \"v\", n2)\n",
+    "logger.log_attribute(\"iR\", \"i_intf\", res)\n",
+    "logger.log_attribute(\"iShunt\", \"i_intf\", shunt)\n",
+    "\n",
+    "# Simulation\n",
+    "sim = dpsimpy.Simulation(sim_name)\n",
+    "sim.set_system(sys)\n",
+    "sim.set_time_step(time_step)\n",
+    "sim.set_final_time(final_time)\n",
+    "sim.set_domain(dpsimpy.Domain.DP)\n",
+    "sim.add_logger(logger)\n",
+    "sim.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_name = \"VoltageSource_Resistor_Shunt\"\n",
+    "\n",
+    "path_DP = \"logs/\" + \"DP_\" + model_name + \"/\"\n",
+    "dpsim_result_file_DP = path_DP + \"DP_\" + model_name + \".csv\"\n",
+    "ts_dpsim_DP = read_timeseries_csv(dpsim_result_file_DP)\n",
+    "ts_dpsim_DP_shifted = ts.frequency_shift_list(ts_dpsim_DP, 50)\n",
+    "\n",
+    "path_EMT = \"logs/\" + \"EMT_\" + model_name + \"/\"\n",
+    "dpsim_result_file_EMT = path_EMT + \"EMT_\" + model_name + \".csv\"\n",
+    "ts_dpsim_EMT = read_timeseries_csv(dpsim_result_file_EMT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot voltages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "\n",
+    "# EMT\n",
+    "var_names = [\"v1_0\", \"v2_0\"]\n",
+    "for var_name in var_names:\n",
+    "    plt.plot(\n",
+    "        ts_dpsim_EMT[var_name].time,\n",
+    "        np.sqrt(3 / 2) * ts_dpsim_EMT[var_name].values,\n",
+    "        label=var_name,\n",
+    "    )\n",
+    "\n",
+    "# DP\n",
+    "var_names = [\"v1_shift\", \"v2_shift\"]\n",
+    "for var_name in var_names:\n",
+    "    plt.plot(\n",
+    "        ts_dpsim_DP_shifted[var_name].time,\n",
+    "        ts_dpsim_DP_shifted[var_name].values,\n",
+    "        label=var_name + \" (DP)\",\n",
+    "        linestyle=\"-.\",\n",
+    "    )\n",
+    "\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot currents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "\n",
+    "# EMT\n",
+    "var_names = [\"iR_0\", \"iShunt_0\"]\n",
+    "for var_name in var_names:\n",
+    "    plt.plot(\n",
+    "        ts_dpsim_EMT[var_name].time,\n",
+    "        np.sqrt(3 / 2) * ts_dpsim_EMT[var_name].values,\n",
+    "        label=var_name,\n",
+    "    )\n",
+    "\n",
+    "# DP\n",
+    "var_names = [\"iR_shift\", \"iShunt_shift\"]\n",
+    "for var_name in var_names:\n",
+    "    plt.plot(\n",
+    "        ts_dpsim_DP_shifted[var_name].time,\n",
+    "        ts_dpsim_DP_shifted[var_name].values,\n",
+    "        label=var_name + \" (DP)\",\n",
+    "        linestyle=\"-.\",\n",
+    "    )\n",
+    "\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Comparison DP vs. EMT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "for name in [(\"v1_0\", \"v1_shift\"), (\"v2_0\", \"v2_shift\")]:\n",
+    "    plt.plot(\n",
+    "        ts_dpsim_EMT[name[0]].time,\n",
+    "        np.sqrt(3 / 2) * ts_dpsim_EMT[name[0]].values\n",
+    "        - ts_dpsim_DP_shifted[name[1]].values,\n",
+    "        label=name[0] + \" vs. \" + name[1],\n",
+    "    )\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "for name in [(\"iR_0\", \"iR_shift\"), (\"iShunt_0\", \"iShunt_shift\")]:\n",
+    "    plt.plot(\n",
+    "        ts_dpsim_EMT[name[0]].time,\n",
+    "        np.sqrt(3 / 2) * ts_dpsim_EMT[name[0]].values\n",
+    "        - ts_dpsim_DP_shifted[name[1]].values,\n",
+    "        label=name[0] + \" vs. \" + name[1],\n",
+    "    )\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Assertion DP vs. EMT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compare_errors_abs = []\n",
+    "compare_errors_rel = []\n",
+    "for name in [\n",
+    "    (\"v1_0\", \"v1_shift\"),\n",
+    "    (\"v2_0\", \"v2_shift\"),\n",
+    "    (\"iR_0\", \"iR_shift\"),\n",
+    "    (\"iShunt_0\", \"iShunt_shift\"),\n",
+    "]:\n",
+    "    compare_errors_abs.append(\n",
+    "        np.absolute(\n",
+    "            np.sqrt(3 / 2) * ts_dpsim_EMT[name[0]].values\n",
+    "            - ts_dpsim_DP_shifted[name[1]].values\n",
+    "        ).max()\n",
+    "    )\n",
+    "    compare_errors_rel.append(\n",
+    "        np.absolute(\n",
+    "            np.sqrt(3 / 2) * ts_dpsim_EMT[name[0]].values\n",
+    "            - ts_dpsim_DP_shifted[name[1]].values\n",
+    "        ).max()\n",
+    "        / ts_dpsim_DP_shifted[name[1]].values.max()\n",
+    "    )\n",
+    "    print(name[0] + \" vs. \" + name[1] + \" (abs): \" + str(compare_errors_abs[-1]))\n",
+    "    print(name[0] + \" vs. \" + name[1] + \" (rel): \" + str(compare_errors_rel[-1]))\n",
+    "print(\"Max rel error: \" + \"{:.2}\".format(np.max(compare_errors_rel) * 100) + \"%\")\n",
+    "assert np.max(compare_errors_rel) < 1e-3"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
Ports `DP_Ph1_Shunt`/`EMT_Ph3_Shunt` from Martin Moraga's `benchmark-networks-cosim` branch (`b20c93645`, `1eb85066c`), adapted to the current `CompositePowerComp` API by Matthias Mees (`597df28c5`). 

Adapted to current ways.
