### PR TITLE
fix: add missing Shunt branch to PFSolver::determineNodeBaseVoltages()

### DIFF
--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_Shunt.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_Shunt.h
@@ -45,6 +45,8 @@ public:
   void setParameters(Real conductance, Real susceptance);
 
   // #### Powerflow section ####
+  /// Get base voltage
+  Real getBaseVoltage() const;
   /// Set base voltage
   void setBaseVoltage(Real baseVoltage);
   /// Initializes component from power flow data

--- a/dpsim-models/src/SP/SP_Ph1_Shunt.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_Shunt.cpp
@@ -31,6 +31,8 @@ void SP::Ph1::Shunt::setParameters(Real conductance, Real susceptance) {
 }
 
 // #### Powerflow section ####
+Real SP::Ph1::Shunt::getBaseVoltage() const { return mBaseVoltage; }
+
 void SP::Ph1::Shunt::setBaseVoltage(Real baseVoltage) {
   mBaseVoltage = baseVoltage;
 }

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -344,6 +344,13 @@ void PFSolver::determineNodeBaseVoltages() {
             mSLog, "Choose base voltage of {}V to convert pu-solution of {}.",
             baseVoltage_, extnet->name(), node->name());
         break;
+      } else if (std::shared_ptr<CPS::SP::Ph1::Shunt> shunt =
+                     std::dynamic_pointer_cast<CPS::SP::Ph1::Shunt>(comp)) {
+        baseVoltage_ = shunt->getBaseVoltage();
+        SPDLOG_LOGGER_INFO(
+            mSLog, "Choose base voltage of {}V to convert pu-solution of {}.",
+            baseVoltage_, shunt->name(), node->name());
+        break;
       } else {
         SPDLOG_LOGGER_WARN(mSLog, "Unable to get base voltage at {}",
                            node->name());


### PR DESCRIPTION
## Summary
- A node whose only attached component is a Shunt fell through to
  "Unable to get base voltage" and resolved to 0. Adds the missing
  Shunt branch, plus the `getBaseVoltage()` getter it needs.
- Ported from Ghassen Nakti's `a633b3d9e`, restricted to the Shunt
  branch and adapted to use `getBaseVoltage()` to match master's
  convention.