### PR TITLE
feat: configurable PFSolver base-power fallback and working max-iterations setter

### DIFF
--- a/dpsim/include/dpsim/PFSolver.h
+++ b/dpsim/include/dpsim/PFSolver.h
@@ -85,6 +85,8 @@ protected:
   CPS::UInt mIterations;
   /// Base power of per-unit system
   CPS::Real mBaseApparentPower;
+  /// Fallback base apparent power if no generator or transformer rating is found
+  CPS::Real mBaseApparentPowerFallback = 100e6;
   /// Convergence flag
   CPS::Bool isConverged = false;
   /// Flag whether solution vectors are initialized
@@ -164,6 +166,20 @@ public:
   }
 
   CPS::Bool getKeepLastSolution() const { return mKeepLastSolution; }
+
+  void setBaseApparentPowerFallback(CPS::Real baseApparentPowerFallback) {
+    mBaseApparentPowerFallback = baseApparentPowerFallback;
+  }
+
+  CPS::Real getBaseApparentPowerFallback() const {
+    return mBaseApparentPowerFallback;
+  }
+
+  void setMaxIterations(CPS::UInt maxIterations) {
+    mMaxIterations = maxIterations;
+  }
+
+  CPS::UInt getMaxIterations() const { return mMaxIterations; }
 
   class SolveTask : public CPS::Task {
   public:

--- a/dpsim/include/dpsim/Simulation.h
+++ b/dpsim/include/dpsim/Simulation.h
@@ -43,6 +43,13 @@ public:
 
   const CPS::Attribute<Bool>::Ptr mPFKeepLastSolution;
 
+  /// Fallback base apparent power used by the PF solver when no
+  /// generator or transformer rating is available to derive it from.
+  const CPS::Attribute<Real>::Ptr mPFBaseApparentPowerFallback;
+
+  /// Maximum number of Newton-Raphson iterations for the PF solver.
+  const CPS::Attribute<CPS::UInt>::Ptr mPFMaxIterations;
+
   /// Use the sparse-Jacobian powerflow solver (scales to large grids).
   /// Default false (dense solver); opt in via setPFSolverUseSparse(true).
   /// Ignored (dense solver used) if no sparse linear solver is available.
@@ -241,6 +248,14 @@ public:
   void setPFKeepLastSolution(Bool value);
 
   Bool getPFKeepLastSolution() const;
+
+  void setPFBaseApparentPowerFallback(Real value);
+
+  Real getPFBaseApparentPowerFallback() const;
+
+  void setPFMaxIterations(CPS::UInt value);
+
+  CPS::UInt getPFMaxIterations() const;
 
   void setPFSolverUseSparse(Bool value);
 

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -146,7 +146,7 @@ void PFSolver::setBaseApparentPower() {
   if (maxPower != 0.)
     mBaseApparentPower = pow(10, 1 + floor(log10(maxPower)));
   else {
-    mBaseApparentPower = 100000000;
+    mBaseApparentPower = mBaseApparentPowerFallback;
     SPDLOG_LOGGER_WARN(mSLog,
                        "No suitable quantity found for setting "
                        "mBaseApparentPower. Using {} VA.",

--- a/dpsim/src/Simulation.cpp
+++ b/dpsim/src/Simulation.cpp
@@ -36,6 +36,8 @@ Simulation::Simulation(String name, Logger::Level logLevel)
       mFinalTime(AttributeStatic<Real>::make(0.001)),
       mTimeStep(AttributeStatic<Real>::make(0.001)),
       mPFKeepLastSolution(CPS::AttributeStatic<Bool>::make(false)),
+      mPFBaseApparentPowerFallback(CPS::AttributeStatic<Real>::make(100e6)),
+      mPFMaxIterations(CPS::AttributeStatic<CPS::UInt>::make(20)),
       mPFSolverUseSparse(CPS::AttributeStatic<Bool>::make(false)),
       mSplitSubnets(AttributeStatic<Bool>::make(true)),
       mSteadyStateInit(AttributeStatic<Bool>::make(false)),
@@ -49,6 +51,8 @@ Simulation::Simulation(String name, CommandLineArgs &args)
       mFinalTime(AttributeStatic<Real>::make(args.duration)),
       mTimeStep(AttributeStatic<Real>::make(args.timeStep)),
       mPFKeepLastSolution(CPS::AttributeStatic<Bool>::make(false)),
+      mPFBaseApparentPowerFallback(CPS::AttributeStatic<Real>::make(100e6)),
+      mPFMaxIterations(CPS::AttributeStatic<CPS::UInt>::make(20)),
       mPFSolverUseSparse(CPS::AttributeStatic<Bool>::make(false)),
       mSplitSubnets(AttributeStatic<Bool>::make(true)),
       mSteadyStateInit(AttributeStatic<Bool>::make(false)),
@@ -123,6 +127,8 @@ template <typename VarType> void Simulation::createSolvers() {
 #endif
 
     pfSolver->setKeepLastSolution(**mPFKeepLastSolution);
+    pfSolver->setBaseApparentPowerFallback(**mPFBaseApparentPowerFallback);
+    pfSolver->setMaxIterations(**mPFMaxIterations);
 
     solver = pfSolver;
 
@@ -341,6 +347,20 @@ void Simulation::setPFKeepLastSolution(Bool value) {
 }
 
 Bool Simulation::getPFKeepLastSolution() const { return **mPFKeepLastSolution; }
+
+void Simulation::setPFBaseApparentPowerFallback(Real value) {
+  **mPFBaseApparentPowerFallback = value;
+}
+
+Real Simulation::getPFBaseApparentPowerFallback() const {
+  return **mPFBaseApparentPowerFallback;
+}
+
+void Simulation::setPFMaxIterations(CPS::UInt value) {
+  **mPFMaxIterations = value;
+}
+
+CPS::UInt Simulation::getPFMaxIterations() const { return **mPFMaxIterations; }
 
 void Simulation::setPFSolverUseSparse(Bool value) {
   **mPFSolverUseSparse = value;

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -219,6 +219,12 @@ PYBIND11_MODULE(dpsimpy, m) {
            &DPsim::Simulation::setPFKeepLastSolution)
       .def("get_pf_keep_last_solution",
            &DPsim::Simulation::getPFKeepLastSolution)
+      .def("set_pf_base_apparent_power_fallback",
+           &DPsim::Simulation::setPFBaseApparentPowerFallback)
+      .def("get_pf_base_apparent_power_fallback",
+           &DPsim::Simulation::getPFBaseApparentPowerFallback)
+      .def("set_pf_max_iterations", &DPsim::Simulation::setPFMaxIterations)
+      .def("get_pf_max_iterations", &DPsim::Simulation::getPFMaxIterations)
       .def("set_pf_solver_use_sparse", &DPsim::Simulation::setPFSolverUseSparse)
       .def("get_pf_solver_use_sparse", &DPsim::Simulation::getPFSolverUseSparse)
       .def("set_domain", &DPsim::Simulation::setDomain)


### PR DESCRIPTION
## Summary
- Adds `setBaseApparentPowerFallback()`/`getBaseApparentPowerFallback()` to `PFSolver`, wired through `Simulation` and pybind the same way as `setKeepLastSolution()`. Defaults to the existing hardcoded 100e6 VA, so behavior is unchanged unless a caller opts in.
- Adds `setMaxIterations()`/`getMaxIterations()` to `PFSolver`, operating on its own `mMaxIterations` field rather than the base `Solver::mMaxIterations` that `Simulation::setMaxNumberOfIterations()` writes to (a same-named field it shadows, which meant that call had zero effect on the PF solver's actual iteration cap, silently stuck at its hardcoded default of 20).

Idea prompted by a branch from Matthias, which only hardcoded a different fallback constant; no code from those commits is reused here.