### PR TITLE
fix: exclude MNA fallback shunt from standalone PiLine powerflow stamp

### DIFF
--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
@@ -31,6 +31,10 @@ class PiLine : public CompositePowerComp<Complex>,
 private:
   /// base voltage [V]
   Real mBaseVoltage;
+  /// true if mParallelCap was never given a real value in setParameters() and holds the MNA-conditioning fallback instead
+  bool mParallelCapIsFallback = false;
+  /// true if mParallelCond was never given a real value in setParameters() and holds the MNA-conditioning fallback instead
+  bool mParallelCondIsFallback = false;
 
 public:
   // #### Power flow results ####

--- a/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
@@ -42,14 +42,17 @@ void SP::Ph1::PiLine::setParameters(Real resistance, Real inductance,
 
   if (capacitance > 0) {
     **mParallelCap = capacitance;
+    mParallelCapIsFallback = false;
   } else {
     **mParallelCap = 1e-12;
+    mParallelCapIsFallback = true;
     SPDLOG_LOGGER_WARN(
         mSLog, "Zero value for Capacitance, setting default value of C={} [F]",
         **mParallelCap);
   }
   if (conductance > 0) {
     **mParallelCond = conductance;
+    mParallelCondIsFallback = false;
   } else {
     if (mBehaviour == Behaviour::Initialization)
       **mParallelCond =
@@ -58,6 +61,7 @@ void SP::Ph1::PiLine::setParameters(Real resistance, Real inductance,
               : 1e-6; // init mode for initFromPowerFlow of mna system components
     else
       **mParallelCond = (conductance > 0) ? conductance : 1e-6;
+    mParallelCondIsFallback = true;
     SPDLOG_LOGGER_WARN(
         mSLog, "Zero value for Conductance, setting default value of G={} [S]",
         **mParallelCond);
@@ -118,11 +122,21 @@ void SP::Ph1::PiLine::pfApplyAdmittanceMatrixStamp(SparseMatrixCompRow &Y) {
   int bus1 = this->matrixNodeIndex(0);
   int bus2 = this->matrixNodeIndex(1);
 
+  // Exclude MNA-conditioning fallback shunt from standalone PF, keep it for Initialization
+  Real parallelCondPerUnit =
+      (mBehaviour == Behaviour::PFSimulation && mParallelCondIsFallback)
+          ? 0.
+          : mParallelCondPerUnit;
+  Real parallelCapPerUnit =
+      (mBehaviour == Behaviour::PFSimulation && mParallelCapIsFallback)
+          ? 0.
+          : mParallelCapPerUnit;
+
   //create the element admittance matrix
   Complex y =
       Complex(1, 0) / Complex(mSeriesResPerUnit, 1. * mSeriesIndPerUnit);
   Complex ys =
-      Complex(mParallelCondPerUnit, 1. * mParallelCapPerUnit) / Complex(2, 0);
+      Complex(parallelCondPerUnit, 1. * parallelCapPerUnit) / Complex(2, 0);
 
   //Fill the internal matrix
   mY_element = MatrixComp(2, 2);


### PR DESCRIPTION
## Summary

`SP::Ph1::PiLine::setParameters()` silently substitutes tiny non-physical values (1e-6 S conductance, 1e-12 F capacitance) whenever the caller passes a zero/unset shunt.

This PR excludes that fallback term from `pfApplyAdmittanceMatrixStamp()` specifically when the component is running standalone power flow (`Behaviour::PFSimulation`). The MNA SP/DP/EMT Initialization (`Behaviour::Initialization`) still happens correctly.

This substitutes a similar idea from Ghassen Nakti's d74dd7a99 ("reduce default conductance value of line", shrinking the PiLine fallback constant from 1e-6 to 1e-12)