### PR TITLE
feat: harmonics-domain support for CompositePowerComp

### DIFF
--- a/dpsim-models/include/dpsim-models/CompositePowerComp.h
+++ b/dpsim-models/include/dpsim-models/CompositePowerComp.h
@@ -195,12 +195,9 @@ public:
   };
 
 protected:
-  /// Refreshes each subcomponent's own right-vector contribution, then calls
-  /// mnaParentPreStepHarm (which typically sums them via
-  /// mnaCompApplyRightSideVectorStampHarm, mirroring mnaParentPreStep).
+  /// Refreshes subcomponents' right-vector contributions, then mnaParentPreStepHarm
   void mnaCompPreStepHarm(Real time, Int timeStepCount);
-  /// Drives subcomponents' post-step voltage/current update (respecting
-  /// before/after-parent order), then calls mnaParentPostStepHarm.
+  /// Drives subcomponents' post-step update, then mnaParentPostStepHarm
   void mnaCompPostStepHarm(Real time, Int timeStepCount,
                            std::vector<Attribute<Matrix>::Ptr> &leftVectors);
 };

--- a/dpsim-models/include/dpsim-models/CompositePowerComp.h
+++ b/dpsim-models/include/dpsim-models/CompositePowerComp.h
@@ -103,6 +103,15 @@ public:
                                  AttributeBase::List &attributeDependencies,
                                  AttributeBase::List &modifiedAttributes,
                                  Attribute<Matrix>::Ptr &leftVector) override;
+  /// Initializes variables of components, harmonics domain
+  void mnaCompInitializeHarm(
+      Real omega, Real timeStep,
+      std::vector<Attribute<Matrix>::Ptr> leftVectors) override;
+  /// Stamps system matrix for a single frequency index
+  void mnaCompApplySystemMatrixStampHarm(SparseMatrixRow &systemMatrix,
+                                         Int freqIdx) override;
+  /// Stamps right side (source) vector, harmonics domain
+  void mnaCompApplyRightSideVectorStampHarm(Matrix &sourceVector) override;
 
   // #### MNA Parent Functions ####
   virtual void mnaParentInitialize(Real omega, Real timeStep,
@@ -135,5 +144,64 @@ public:
                                    Attribute<Matrix>::Ptr &leftVector){
       // By default, the parent has no custom post-step-dependencies, only the subcomponents' dependencies are added
   };
+
+  // #### MNA Parent Functions, harmonics domain ####
+  virtual void
+  mnaParentInitializeHarm(Real omega, Real timeStep,
+                          std::vector<Attribute<Matrix>::Ptr> leftVectors){};
+  virtual void
+  mnaParentApplySystemMatrixStampHarm(SparseMatrixRow &systemMatrix,
+                                      Int freqIdx){};
+  virtual void mnaParentApplyRightSideVectorStampHarm(Matrix &rightVector){};
+  virtual void mnaParentPreStepHarm(Real time, Int timeStepCount){};
+  virtual void
+  mnaParentPostStepHarm(Real time, Int timeStepCount,
+                        std::vector<Attribute<Matrix>::Ptr> &leftVectors){};
+
+  class MnaPreStepHarm : public Task {
+  public:
+    explicit MnaPreStepHarm(CompositePowerComp<VarType> &comp)
+        : Task(**comp.mName + ".MnaPreStepHarm"), mComp(comp) {
+      comp.mnaAddPreStepDependencies(
+          mPrevStepDependencies, mAttributeDependencies, mModifiedAttributes);
+    }
+    void execute(Real time, Int timeStepCount) override {
+      mComp.mnaCompPreStepHarm(time, timeStepCount);
+    }
+
+  private:
+    CompositePowerComp<VarType> &mComp;
+  };
+
+  class MnaPostStepHarm : public Task {
+  public:
+    MnaPostStepHarm(CompositePowerComp<VarType> &comp,
+                    const std::vector<Attribute<Matrix>::Ptr> &leftVectors)
+        : Task(**comp.mName + ".MnaPostStepHarm"), mComp(comp),
+          mLeftVectors(leftVectors) {
+      comp.mnaAddPostStepDependencies(mPrevStepDependencies,
+                                      mAttributeDependencies,
+                                      mModifiedAttributes, mLeftVectors[0]);
+      for (UInt i = 1; i < mLeftVectors.size(); i++)
+        mAttributeDependencies.push_back(mLeftVectors[i]);
+    }
+    void execute(Real time, Int timeStepCount) override {
+      mComp.mnaCompPostStepHarm(time, timeStepCount, mLeftVectors);
+    }
+
+  private:
+    CompositePowerComp<VarType> &mComp;
+    std::vector<Attribute<Matrix>::Ptr> mLeftVectors;
+  };
+
+protected:
+  /// Refreshes each subcomponent's own right-vector contribution, then calls
+  /// mnaParentPreStepHarm (which typically sums them via
+  /// mnaCompApplyRightSideVectorStampHarm, mirroring mnaParentPreStep).
+  void mnaCompPreStepHarm(Real time, Int timeStepCount);
+  /// Drives subcomponents' post-step voltage/current update (respecting
+  /// before/after-parent order), then calls mnaParentPostStepHarm.
+  void mnaCompPostStepHarm(Real time, Int timeStepCount,
+                           std::vector<Attribute<Matrix>::Ptr> &leftVectors);
 };
 } // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Capacitor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Capacitor.h
@@ -66,12 +66,15 @@ public:
   void mnaCompApplyRightSideVectorStampHarm(Matrix &rightVector) override;
   /// Update interface voltage from MNA system result
   void mnaCompUpdateVoltage(const Matrix &leftVector) override;
-  void mnaCompUpdateVoltageHarm(const Matrix &leftVector, Int freqIdx);
+  void mnaCompUpdateVoltageHarm(const Matrix &leftVector, Int freqIdx) override;
   void mnaCompApplyRightSideVectorStampHarm(Matrix &sourceVector,
                                             Int freqIdx) override;
   /// Update interface current from MNA system result
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;
+  /// All frequencies at once, used by this component's own MnaPostStepHarm task
   void mnaCompUpdateCurrentHarm();
+  /// Single frequency index, overrides the generic MNASimPowerComp hook
+  void mnaCompUpdateCurrentHarm(Int freqIdx) override;
   /// MNA pre step operations
   void mnaCompPreStep(Real time, Int timeStepCount) override;
   /// MNA post step operations

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inductor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inductor.h
@@ -70,10 +70,13 @@ public:
   void mnaCompApplyRightSideVectorStampHarm(Matrix &rightVector) override;
   /// Update interface voltage from MNA system results
   void mnaCompUpdateVoltage(const Matrix &leftVector) override;
-  void mnaCompUpdateVoltageHarm(const Matrix &leftVector, Int freqIdx);
+  void mnaCompUpdateVoltageHarm(const Matrix &leftVector, Int freqIdx) override;
   /// Update interface current from MNA system results
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;
+  /// All frequencies at once, used by this component's own MnaPostStepHarm task
   void mnaCompUpdateCurrentHarm();
+  /// Single frequency index, overrides the generic MNASimPowerComp hook
+  void mnaCompUpdateCurrentHarm(Int freqIdx) override;
   /// MNA pre step operations
   void mnaCompPreStep(Real time, Int timeStepCount) override;
   /// MNA post step operations

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Resistor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Resistor.h
@@ -54,7 +54,7 @@ public:
   /// All frequencies at once, used by this component's own MnaPostStepHarm task
   void mnaCompUpdateCurrentHarm();
   /// Single frequency index, overrides the generic MNASimPowerComp hook
-  void mnaCompUpdateCurrentHarm(Int freqIdx);
+  void mnaCompUpdateCurrentHarm(Int freqIdx) override;
   /// MNA pre and post step operations
   void mnaCompPostStep(Real time, Int timeStepCount,
                        Attribute<Matrix>::Ptr &leftVector);

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Resistor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Resistor.h
@@ -51,7 +51,10 @@ public:
   void mnaCompUpdateVoltageHarm(const Matrix &leftVector, Int freqIdx);
   /// Update interface current from MNA system result
   void mnaCompUpdateCurrent(const Matrix &leftVector);
+  /// All frequencies at once, used by this component's own MnaPostStepHarm task
   void mnaCompUpdateCurrentHarm();
+  /// Single frequency index, overrides the generic MNASimPowerComp hook
+  void mnaCompUpdateCurrentHarm(Int freqIdx);
   /// MNA pre and post step operations
   void mnaCompPostStep(Real time, Int timeStepCount,
                        Attribute<Matrix>::Ptr &leftVector);

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Transformer.h
@@ -80,15 +80,24 @@ public:
                            Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix
   void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
+  /// Stamps system matrix for a single frequency index
+  void mnaCompApplySystemMatrixStampHarm(SparseMatrixRow &systemMatrix,
+                                         Int freqIdx) override;
   /// Updates internal current variable of the component
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;
+  void mnaCompUpdateCurrentHarm(Int freqIdx) override;
   /// Updates internal voltage variable of the component
   void mnaCompUpdateVoltage(const Matrix &leftVector) override;
+  void mnaCompUpdateVoltageHarm(const Matrix &leftVector, Int freqIdx) override;
   /// MNA pre step operations
   void mnaParentPreStep(Real time, Int timeStepCount) override;
+  void mnaParentPreStepHarm(Real time, Int timeStepCount) override;
   /// MNA post step operations
   void mnaParentPostStep(Real time, Int timeStepCount,
                          Attribute<Matrix>::Ptr &leftVector) override;
+  void mnaParentPostStepHarm(
+      Real time, Int timeStepCount,
+      std::vector<Attribute<Matrix>::Ptr> &leftVectors) override;
   /// Add MNA pre step dependencies
   void mnaParentAddPreStepDependencies(
       AttributeBase::List &prevStepDependencies,

--- a/dpsim-models/include/dpsim-models/MNASimPowerComp.h
+++ b/dpsim-models/include/dpsim-models/MNASimPowerComp.h
@@ -71,6 +71,8 @@ public:
   void mnaApplyRightSideVectorStampHarm(Matrix &sourceVector) final;
   void mnaApplyRightSideVectorStampHarm(Matrix &sourceVector,
                                         Int freqIdx) final;
+  void mnaUpdateVoltageHarm(const Matrix &leftVector, Int freqIdx) final;
+  void mnaUpdateCurrentHarm(Int freqIdx) final;
 
   // MNA Interface methods that can be overridden by components
   virtual void mnaCompInitialize(Real omega, Real timeStep,
@@ -99,6 +101,8 @@ public:
   virtual void mnaCompApplyRightSideVectorStampHarm(Matrix &sourceVector);
   virtual void mnaCompApplyRightSideVectorStampHarm(Matrix &sourceVector,
                                                     Int freqIdx);
+  virtual void mnaCompUpdateVoltageHarm(const Matrix &leftVector, Int freqIdx);
+  virtual void mnaCompUpdateCurrentHarm(Int freqIdx);
 
   const Task::List &mnaTasks() const final;
   Attribute<Matrix>::Ptr getRightVector() const final;

--- a/dpsim-models/include/dpsim-models/Solver/MNAInterface.h
+++ b/dpsim-models/include/dpsim-models/Solver/MNAInterface.h
@@ -64,8 +64,7 @@ public:
   virtual void mnaApplyRightSideVectorStampHarm(Matrix &sourceVector) = 0;
   virtual void mnaApplyRightSideVectorStampHarm(Matrix &sourceVector,
                                                 Int freqIdx) = 0;
-  /// Update interface voltage for a single frequency index (harmonics domain).
-  /// Not pure virtual: only composites need to call this on subcomponents.
+  /// Not pure virtual: only composites call this on subcomponents
   virtual void mnaUpdateVoltageHarm(const Matrix &leftVector, Int freqIdx) {}
   /// Update interface current for a single frequency index (harmonics domain).
   virtual void mnaUpdateCurrentHarm(Int freqIdx) {}

--- a/dpsim-models/include/dpsim-models/Solver/MNAInterface.h
+++ b/dpsim-models/include/dpsim-models/Solver/MNAInterface.h
@@ -64,6 +64,11 @@ public:
   virtual void mnaApplyRightSideVectorStampHarm(Matrix &sourceVector) = 0;
   virtual void mnaApplyRightSideVectorStampHarm(Matrix &sourceVector,
                                                 Int freqIdx) = 0;
+  /// Update interface voltage for a single frequency index (harmonics domain).
+  /// Not pure virtual: only composites need to call this on subcomponents.
+  virtual void mnaUpdateVoltageHarm(const Matrix &leftVector, Int freqIdx) {}
+  /// Update interface current for a single frequency index (harmonics domain).
+  virtual void mnaUpdateCurrentHarm(Int freqIdx) {}
   /// Return list of MNA tasks
   virtual const Task::List &mnaTasks() const = 0;
   // Return right vector attribute

--- a/dpsim-models/src/CompositePowerComp.cpp
+++ b/dpsim-models/src/CompositePowerComp.cpp
@@ -144,6 +144,80 @@ void CompositePowerComp<VarType>::mnaCompAddPostStepDependencies(
                                    modifiedAttributes, leftVector);
 }
 
+template <typename VarType>
+void CompositePowerComp<VarType>::mnaCompInitializeHarm(
+    Real omega, Real timeStep,
+    std::vector<Attribute<Matrix>::Ptr> leftVectors) {
+  SimPowerComp<VarType>::updateMatrixNodeIndices();
+
+  for (auto subComp : mSubcomponentsMNA) {
+    subComp->mnaInitializeHarm(omega, timeStep, leftVectors);
+  }
+
+  **this->mRightVector =
+      Matrix::Zero(leftVectors[0]->get().rows(), this->mNumFreqs);
+
+  this->mMnaTasks.push_back(
+      std::make_shared<typename CompositePowerComp<VarType>::MnaPreStepHarm>(
+          *this));
+  this->mMnaTasks.push_back(
+      std::make_shared<typename CompositePowerComp<VarType>::MnaPostStepHarm>(
+          *this, leftVectors));
+
+  mnaParentInitializeHarm(omega, timeStep, leftVectors);
+}
+
+template <typename VarType>
+void CompositePowerComp<VarType>::mnaCompApplySystemMatrixStampHarm(
+    SparseMatrixRow &systemMatrix, Int freqIdx) {
+  for (auto subComp : mSubcomponentsMNA) {
+    subComp->mnaApplySystemMatrixStampHarm(systemMatrix, freqIdx);
+  }
+  mnaParentApplySystemMatrixStampHarm(systemMatrix, freqIdx);
+}
+
+template <typename VarType>
+void CompositePowerComp<VarType>::mnaCompApplyRightSideVectorStampHarm(
+    Matrix &sourceVector) {
+  sourceVector.setZero();
+  for (auto stamp : mRightVectorStamps) {
+    if ((**stamp).size() != 0) {
+      sourceVector += **stamp;
+    }
+  }
+  mnaParentApplyRightSideVectorStampHarm(sourceVector);
+}
+
+template <typename VarType>
+void CompositePowerComp<VarType>::mnaCompPreStepHarm(Real time,
+                                                     Int timeStepCount) {
+  for (auto subComp : mSubcomponentsMNA) {
+    Matrix &rightVec = **subComp->getRightVector();
+    if (rightVec.size() != 0)
+      subComp->mnaApplyRightSideVectorStampHarm(rightVec);
+  }
+  mnaParentPreStepHarm(time, timeStepCount);
+}
+
+template <typename VarType>
+void CompositePowerComp<VarType>::mnaCompPostStepHarm(
+    Real time, Int timeStepCount,
+    std::vector<Attribute<Matrix>::Ptr> &leftVectors) {
+  for (auto subComp : mSubcomponentsPostStepBeforeParent) {
+    for (UInt freq = 0; freq < this->mNumFreqs; freq++)
+      subComp->mnaUpdateVoltageHarm(**leftVectors[freq], freq);
+    for (UInt freq = 0; freq < this->mNumFreqs; freq++)
+      subComp->mnaUpdateCurrentHarm(freq);
+  }
+  mnaParentPostStepHarm(time, timeStepCount, leftVectors);
+  for (auto subComp : mSubcomponentsPostStepAfterParent) {
+    for (UInt freq = 0; freq < this->mNumFreqs; freq++)
+      subComp->mnaUpdateVoltageHarm(**leftVectors[freq], freq);
+    for (UInt freq = 0; freq < this->mNumFreqs; freq++)
+      subComp->mnaUpdateCurrentHarm(freq);
+  }
+}
+
 // Declare specializations to move definitions to .cpp
 template class CPS::CompositePowerComp<Real>;
 template class CPS::CompositePowerComp<Complex>;

--- a/dpsim-models/src/DP/DP_Ph1_Capacitor.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Capacitor.cpp
@@ -294,11 +294,14 @@ void DP::Ph1::Capacitor::mnaCompUpdateCurrent(const Matrix &leftVector) {
 }
 
 void DP::Ph1::Capacitor::mnaCompUpdateCurrentHarm() {
-  for (UInt freq = 0; freq < mNumFreqs; freq++) {
-    (**mIntfCurrent)(0, freq) =
-        mEquivCond(freq, 0) * (**mIntfVoltage)(0, freq) +
-        mEquivCurrent(freq, 0);
-    SPDLOG_LOGGER_DEBUG(mSLog, "Current {:s}",
-                        Logger::phasorToString((**mIntfCurrent)(0, freq)));
-  }
+  for (UInt freq = 0; freq < mNumFreqs; freq++)
+    mnaCompUpdateCurrentHarm(freq);
+}
+
+void DP::Ph1::Capacitor::mnaCompUpdateCurrentHarm(Int freqIdx) {
+  (**mIntfCurrent)(0, freqIdx) =
+      mEquivCond(freqIdx, 0) * (**mIntfVoltage)(0, freqIdx) +
+      mEquivCurrent(freqIdx, 0);
+  SPDLOG_LOGGER_DEBUG(mSLog, "Current {:s}",
+                      Logger::phasorToString((**mIntfCurrent)(0, freqIdx)));
 }

--- a/dpsim-models/src/DP/DP_Ph1_Inductor.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Inductor.cpp
@@ -258,13 +258,16 @@ void DP::Ph1::Inductor::mnaCompUpdateCurrent(const Matrix &leftVector) {
 }
 
 void DP::Ph1::Inductor::mnaCompUpdateCurrentHarm() {
-  for (UInt freq = 0; freq < mNumFreqs; freq++) {
-    (**mIntfCurrent)(0, freq) =
-        mEquivCond(freq, 0) * (**mIntfVoltage)(0, freq) +
-        mEquivCurrent(freq, 0);
-    SPDLOG_LOGGER_DEBUG(mSLog, "Current {:s}",
-                        Logger::phasorToString((**mIntfCurrent)(0, freq)));
-  }
+  for (UInt freq = 0; freq < mNumFreqs; freq++)
+    mnaCompUpdateCurrentHarm(freq);
+}
+
+void DP::Ph1::Inductor::mnaCompUpdateCurrentHarm(Int freqIdx) {
+  (**mIntfCurrent)(0, freqIdx) =
+      mEquivCond(freqIdx, 0) * (**mIntfVoltage)(0, freqIdx) +
+      mEquivCurrent(freqIdx, 0);
+  SPDLOG_LOGGER_DEBUG(mSLog, "Current {:s}",
+                      Logger::phasorToString((**mIntfCurrent)(0, freqIdx)));
 }
 
 // #### Tear Methods ####

--- a/dpsim-models/src/DP/DP_Ph1_Resistor.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Resistor.cpp
@@ -157,11 +157,14 @@ void DP::Ph1::Resistor::mnaCompUpdateVoltageHarm(const Matrix &leftVector,
 }
 
 void DP::Ph1::Resistor::mnaCompUpdateCurrentHarm() {
-  for (UInt freq = 0; freq < mNumFreqs; freq++) {
-    (**mIntfCurrent)(0, freq) = (**mIntfVoltage)(0, freq) / **mResistance;
-    SPDLOG_LOGGER_DEBUG(mSLog, "Current {:s}",
-                        Logger::phasorToString((**mIntfCurrent)(0, freq)));
-  }
+  for (UInt freq = 0; freq < mNumFreqs; freq++)
+    mnaCompUpdateCurrentHarm(freq);
+}
+
+void DP::Ph1::Resistor::mnaCompUpdateCurrentHarm(Int freqIdx) {
+  (**mIntfCurrent)(0, freqIdx) = (**mIntfVoltage)(0, freqIdx) / **mResistance;
+  SPDLOG_LOGGER_DEBUG(mSLog, "Current {:s}",
+                      Logger::phasorToString((**mIntfCurrent)(0, freqIdx)));
 }
 
 // #### Tear Methods ####

--- a/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Transformer.cpp
@@ -246,6 +246,29 @@ void DP::Ph1::Transformer::mnaCompApplySystemMatrixStamp(
   }
 }
 
+void DP::Ph1::Transformer::mnaCompApplySystemMatrixStampHarm(
+    SparseMatrixRow &systemMatrix, Int freqIdx) {
+  // Ideal transformer equations, frequency-independent
+  if (terminalNotGrounded(0)) {
+    Math::setMatrixElement(systemMatrix, mVirtualNodes[0]->matrixNodeIndex(),
+                           mVirtualNodes[1]->matrixNodeIndex(),
+                           Complex(-1.0, 0));
+    Math::setMatrixElement(systemMatrix, mVirtualNodes[1]->matrixNodeIndex(),
+                           mVirtualNodes[0]->matrixNodeIndex(),
+                           Complex(1.0, 0));
+  }
+  if (terminalNotGrounded(1)) {
+    Math::setMatrixElement(systemMatrix, matrixNodeIndex(1),
+                           mVirtualNodes[1]->matrixNodeIndex(), **mRatio);
+    Math::setMatrixElement(systemMatrix, mVirtualNodes[1]->matrixNodeIndex(),
+                           matrixNodeIndex(1), -**mRatio);
+  }
+
+  for (auto subcomp : mSubComponents)
+    if (auto mnasubcomp = std::dynamic_pointer_cast<MNAInterface>(subcomp))
+      mnasubcomp->mnaApplySystemMatrixStampHarm(systemMatrix, freqIdx);
+}
+
 void DP::Ph1::Transformer::mnaParentAddPreStepDependencies(
     AttributeBase::List &prevStepDependencies,
     AttributeBase::List &attributeDependencies,
@@ -257,6 +280,10 @@ void DP::Ph1::Transformer::mnaParentAddPreStepDependencies(
 
 void DP::Ph1::Transformer::mnaParentPreStep(Real time, Int timeStepCount) {
   this->mnaApplyRightSideVectorStamp(**this->mRightVector);
+}
+
+void DP::Ph1::Transformer::mnaParentPreStepHarm(Real time, Int timeStepCount) {
+  this->mnaApplyRightSideVectorStampHarm(**this->mRightVector);
 }
 
 void DP::Ph1::Transformer::mnaParentAddPostStepDependencies(
@@ -275,8 +302,21 @@ void DP::Ph1::Transformer::mnaParentPostStep(
   this->mnaUpdateCurrent(**leftVector);
 }
 
+void DP::Ph1::Transformer::mnaParentPostStepHarm(
+    Real time, Int timeStepCount,
+    std::vector<Attribute<Matrix>::Ptr> &leftVectors) {
+  for (UInt freq = 0; freq < mNumFreqs; freq++)
+    this->mnaUpdateVoltageHarm(**leftVectors[freq], freq);
+  for (UInt freq = 0; freq < mNumFreqs; freq++)
+    this->mnaUpdateCurrentHarm(freq);
+}
+
 void DP::Ph1::Transformer::mnaCompUpdateCurrent(const Matrix &leftVector) {
   (**mIntfCurrent)(0, 0) = mSubInductor->intfCurrent()(0, 0);
+}
+
+void DP::Ph1::Transformer::mnaCompUpdateCurrentHarm(Int freqIdx) {
+  (**mIntfCurrent)(0, freqIdx) = mSubInductor->intfCurrent()(0, freqIdx);
 }
 
 void DP::Ph1::Transformer::mnaCompUpdateVoltage(const Matrix &leftVector) {
@@ -289,4 +329,16 @@ void DP::Ph1::Transformer::mnaCompUpdateVoltage(const Matrix &leftVector) {
                                leftVector, mVirtualNodes[0]->matrixNodeIndex());
   SPDLOG_LOGGER_DEBUG(mSLog, "Voltage {:s}",
                       Logger::phasorToString((**mIntfVoltage)(0, 0)));
+}
+
+void DP::Ph1::Transformer::mnaCompUpdateVoltageHarm(const Matrix &leftVector,
+                                                    Int freqIdx) {
+  // v1 - v0
+  (**mIntfVoltage)(0, freqIdx) = 0;
+  (**mIntfVoltage)(0, freqIdx) =
+      Math::complexFromVectorElement(leftVector, matrixNodeIndex(1));
+  (**mIntfVoltage)(0, freqIdx) =
+      (**mIntfVoltage)(0, freqIdx) -
+      Math::complexFromVectorElement(leftVector,
+                                     mVirtualNodes[0]->matrixNodeIndex());
 }

--- a/dpsim-models/src/MNASimPowerComp.cpp
+++ b/dpsim-models/src/MNASimPowerComp.cpp
@@ -103,6 +103,7 @@ template <typename VarType>
 void MNASimPowerComp<VarType>::mnaApplySystemMatrixStampHarm(
     SparseMatrixRow &systemMatrix, Int freqIdx) {
   this->mnaCompApplySystemMatrixStampHarm(systemMatrix, freqIdx);
+  systemMatrix.makeCompressed();
 };
 
 template <typename VarType>

--- a/dpsim-models/src/MNASimPowerComp.cpp
+++ b/dpsim-models/src/MNASimPowerComp.cpp
@@ -118,6 +118,17 @@ void MNASimPowerComp<VarType>::mnaApplyRightSideVectorStampHarm(
 };
 
 template <typename VarType>
+void MNASimPowerComp<VarType>::mnaUpdateVoltageHarm(const Matrix &leftVector,
+                                                    Int freqIdx) {
+  this->mnaCompUpdateVoltageHarm(leftVector, freqIdx);
+};
+
+template <typename VarType>
+void MNASimPowerComp<VarType>::mnaUpdateCurrentHarm(Int freqIdx) {
+  this->mnaCompUpdateCurrentHarm(freqIdx);
+};
+
+template <typename VarType>
 void MNASimPowerComp<VarType>::mnaCompInitialize(
     Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
   // Empty default implementation. Can be overridden by child classes if desired.
@@ -194,6 +205,17 @@ void MNASimPowerComp<VarType>::mnaCompApplyRightSideVectorStampHarm(
 template <typename VarType>
 void MNASimPowerComp<VarType>::mnaCompApplyRightSideVectorStampHarm(
     Matrix &sourceVector, Int freqIdx) {
+  // Empty default implementation. Can be overridden by child classes if desired.
+}
+
+template <typename VarType>
+void MNASimPowerComp<VarType>::mnaCompUpdateVoltageHarm(
+    const Matrix &leftVector, Int freqIdx) {
+  // Empty default implementation. Can be overridden by child classes if desired.
+}
+
+template <typename VarType>
+void MNASimPowerComp<VarType>::mnaCompUpdateCurrentHarm(Int freqIdx) {
   // Empty default implementation. Can be overridden by child classes if desired.
 }
 

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -142,6 +142,7 @@ set(INVERTER_SOURCES
 	Components/DP_Inverter_Grid_Parallel_FreqSplit.cpp
 	Components/DP_Inverter_Grid_Sequential_FreqSplit.cpp
 	Components/EMT_Ph3_GFM_Test.cpp
+	Components/DP_Transformer_Harmonics.cpp
 )
 
 set(SSN_SOURCES

--- a/dpsim/examples/cxx/Components/DP_Transformer_Harmonics.cpp
+++ b/dpsim/examples/cxx/Components/DP_Transformer_Harmonics.cpp
@@ -1,0 +1,57 @@
+/* Copyright 2017-2021 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::DP;
+using namespace CPS::DP::Ph1;
+
+int main(int argc, char *argv[]) {
+  Real timeStep = 0.0001;
+  Real finalTime = 0.002;
+  String simName = "DP_Transformer_Harmonics";
+  Logger::setLogDir("logs/" + simName);
+
+  Matrix frequencies(2, 1);
+  frequencies << 50, 250;
+
+  auto n1 = SimNode::make("n1");
+  auto n2 = SimNode::make("n2");
+
+  Logger::Level level = Logger::Level::off;
+
+  auto vs = VoltageSource::make("vs", level);
+  vs->setParameters(Complex(1000, 0));
+
+  auto trafo = Transformer::make("trafo", level);
+  trafo->setParameters(1000, 1000, 1e6, 1.0, 0.0, 1.0, 0.01);
+
+  auto load = Resistor::make("load", level);
+  load->setParameters(100);
+
+  vs->connect({SimNode::GND, n1});
+  trafo->connect({n1, n2});
+  load->connect({n2, SimNode::GND});
+
+  auto sys = SystemTopology(50, frequencies, SystemNodeList{n1, n2},
+                            SystemComponentList{vs, trafo, load});
+
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v1", n1->attribute("v"));
+  logger->logAttribute("v2", n2->attribute("v"));
+
+  Simulation sim(simName, level);
+  sim.setSystem(sys);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doFrequencyParallelization(true);
+  sim.addLogger(logger);
+
+  sim.run();
+}

--- a/dpsim/include/dpsim/MNASolverDirect.h
+++ b/dpsim/include/dpsim/MNASolverDirect.h
@@ -126,6 +126,10 @@ protected:
   void switchedMatrixStamp(
       std::size_t index,
       std::vector<std::shared_ptr<CPS::MNAInterface>> &comp) override;
+  /// Applies a component and switch stamp to the matrix with the given switch index and frequency index
+  void switchedMatrixStamp(std::size_t swIdx, Int freqIdx,
+                           CPS::MNAInterface::List &components,
+                           CPS::MNASwitchInterface::List &switches) override;
 
   // #### Methods for system recomputation over time ####
   /// Stamps components into the variable system matrix

--- a/dpsim/include/dpsim/MNASolverDirect.h
+++ b/dpsim/include/dpsim/MNASolverDirect.h
@@ -229,9 +229,8 @@ public:
         if (it->getRightVector()->get().size() != 0)
           mAttributeDependencies.push_back(it->getRightVector());
       }
-      for (auto node : solver.mNodes) {
-        mModifiedAttributes.push_back(node->mVoltage);
-      }
+      // Unlike SolveTask, this does not modify node voltages directly;
+      // SimNode::MnaPostStepHarm does that from mLeftSideVectorHarm.
       for (auto leftVec : solver.mLeftSideVectorHarm) {
         mModifiedAttributes.push_back(leftVec);
       }

--- a/dpsim/include/dpsim/MNASolverDirect.h
+++ b/dpsim/include/dpsim/MNASolverDirect.h
@@ -229,8 +229,7 @@ public:
         if (it->getRightVector()->get().size() != 0)
           mAttributeDependencies.push_back(it->getRightVector());
       }
-      // Unlike SolveTask, this does not modify node voltages directly;
-      // SimNode::MnaPostStepHarm does that from mLeftSideVectorHarm.
+      // Unlike SolveTask, this doesn't modify node voltages (SimNode::MnaPostStepHarm does)
       for (auto leftVec : solver.mLeftSideVectorHarm) {
         mModifiedAttributes.push_back(leftVec);
       }

--- a/dpsim/src/MNASolver.cpp
+++ b/dpsim/src/MNASolver.cpp
@@ -572,11 +572,14 @@ template <> void MnaSolver<Real>::createEmptyVectors() {
 
 template <> void MnaSolver<Complex>::createEmptyVectors() {
   if (mFrequencyParallel) {
+    // mLeftSideVectorHarm's entries already exist (pushed empty in
+    // initialize()); resize them here rather than push_back'ing new ones,
+    // which would leave the vector holding double the real frequency count.
     for (Int freq = 0; freq < mSystem.mFrequencies.size(); ++freq) {
       mRightSideVectorHarm.push_back(
           Matrix::Zero(2 * (mNumMatrixNodeIndices), 1));
-      mLeftSideVectorHarm.push_back(AttributeStatic<Matrix>::make(
-          Matrix::Zero(2 * (mNumMatrixNodeIndices), 1)));
+      **mLeftSideVectorHarm[freq] =
+          Matrix::Zero(2 * (mNumMatrixNodeIndices), 1);
     }
   } else {
     mRightSideVector = Matrix::Zero(

--- a/dpsim/src/MNASolver.cpp
+++ b/dpsim/src/MNASolver.cpp
@@ -572,9 +572,7 @@ template <> void MnaSolver<Real>::createEmptyVectors() {
 
 template <> void MnaSolver<Complex>::createEmptyVectors() {
   if (mFrequencyParallel) {
-    // mLeftSideVectorHarm's entries already exist (pushed empty in
-    // initialize()); resize them here rather than push_back'ing new ones,
-    // which would leave the vector holding double the real frequency count.
+    // Entries already exist (pushed empty in initialize()); resize, don't push_back
     for (Int freq = 0; freq < mSystem.mFrequencies.size(); ++freq) {
       mRightSideVectorHarm.push_back(
           Matrix::Zero(2 * (mNumMatrixNodeIndices), 1));

--- a/dpsim/src/MNASolverDirect.cpp
+++ b/dpsim/src/MNASolverDirect.cpp
@@ -60,6 +60,28 @@ void MnaSolverDirect<VarType>::switchedMatrixStamp(
 }
 
 template <typename VarType>
+void MnaSolverDirect<VarType>::switchedMatrixStamp(
+    std::size_t swIdx, Int freqIdx, CPS::MNAInterface::List &components,
+    CPS::MNASwitchInterface::List &switches) {
+  auto bit = std::bitset<SWITCH_NUM>(swIdx);
+  auto &sys = mSwitchedMatrices[bit][freqIdx];
+  for (auto component : components) {
+    component->mnaApplySystemMatrixStampHarm(sys, freqIdx);
+  }
+  for (UInt i = 0; i < switches.size(); ++i)
+    switches[i]->mnaApplySwitchSystemMatrixStamp(bit[i], sys, freqIdx);
+
+  // Compute LU-factorization for system matrix
+  mDirectLinearSolvers[bit][freqIdx]->preprocessing(
+      sys, mListVariableSystemMatrixEntries);
+  auto start = std::chrono::steady_clock::now();
+  mDirectLinearSolvers[bit][freqIdx]->factorize(sys);
+  auto end = std::chrono::steady_clock::now();
+  std::chrono::duration<Real> diff = end - start;
+  mFactorizeTimes.push_back(diff.count());
+}
+
+template <typename VarType>
 void MnaSolverDirect<VarType>::stampVariableSystemMatrix() {
 
   this->mDirectLinearSolverVariableSystemMatrix =

--- a/examples/Notebooks/Components/DP_Transformer_Harmonics.ipynb
+++ b/examples/Notebooks/Components/DP_Transformer_Harmonics.ipynb
@@ -1,0 +1,358 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c2563519",
+   "metadata": {},
+   "source": [
+    "# Composite Transformer under Parallel Harmonics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4da6896b",
+   "metadata": {},
+   "source": [
+    "CompositePowerComp did not support the harmonics domain, so a composite component (like the DP transformer, which is built from an inductor and several snubber elements) could not be simulated with `do_frequency_parallelization(True)`. This notebook builds a small circuit with a composite transformer, runs it in parallel-harmonics mode with two declared frequencies, and cross-checks the fundamental-frequency result against an independent single-frequency reference run of the same circuit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62b0bcdd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T08:24:39.336836Z",
+     "iopub.status.busy": "2026-07-09T08:24:39.336654Z",
+     "iopub.status.idle": "2026-07-09T08:24:40.586008Z",
+     "shell.execute_reply": "2026-07-09T08:24:40.584504Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import villas.dataprocessing.readtools as rt\n",
+    "import matplotlib.pyplot as plt\n",
+    "import dpsimpy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a0a5311",
+   "metadata": {},
+   "source": [
+    "## Parallel harmonics run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d172182d",
+   "metadata": {},
+   "source": [
+    "The source only excites the fundamental (50 Hz); the second declared frequency (250 Hz) carries no excitation, so its voltage should come out at exactly zero at both nodes. That is itself a useful check: it confirms the per-frequency solves are independent and not bleeding into each other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0694c22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T08:24:40.590230Z",
+     "iopub.status.busy": "2026-07-09T08:24:40.589691Z",
+     "iopub.status.idle": "2026-07-09T08:24:40.603481Z",
+     "shell.execute_reply": "2026-07-09T08:24:40.602154Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "time_step = 0.0001\n",
+    "final_time = 0.01\n",
+    "sim_name = \"DP_Transformer_Harmonics\"\n",
+    "dpsimpy.Logger.set_log_dir(\"logs/\" + sim_name)\n",
+    "\n",
+    "frequencies = [50, 250]\n",
+    "\n",
+    "n1 = dpsimpy.dp.SimNode(\"n1\")\n",
+    "n2 = dpsimpy.dp.SimNode(\"n2\")\n",
+    "\n",
+    "log_level = dpsimpy.LogLevel.off\n",
+    "\n",
+    "vs = dpsimpy.dp.ph1.VoltageSource(\"vs\", log_level)\n",
+    "vs.set_parameters(complex(1000, 0))\n",
+    "\n",
+    "trafo = dpsimpy.dp.ph1.Transformer(\"trafo\", log_level)\n",
+    "trafo.set_parameters(\n",
+    "    nom_voltage_end_1=1000,\n",
+    "    nom_voltage_end_2=1000,\n",
+    "    rated_power=1e6,\n",
+    "    ratio_abs=1.0,\n",
+    "    ratio_phase=0.0,\n",
+    "    resistance=1.0,\n",
+    "    inductance=0.01,\n",
+    ")\n",
+    "\n",
+    "load = dpsimpy.dp.ph1.Resistor(\"load\", log_level)\n",
+    "load.set_parameters(100)\n",
+    "\n",
+    "vs.connect([dpsimpy.dp.SimNode.gnd, n1])\n",
+    "trafo.connect([n1, n2])\n",
+    "load.connect([n2, dpsimpy.dp.SimNode.gnd])\n",
+    "\n",
+    "sys = dpsimpy.SystemTopology(50, frequencies, [n1, n2], [vs, trafo, load])\n",
+    "\n",
+    "logger = dpsimpy.Logger(sim_name)\n",
+    "logger.log_attribute(\"v1\", \"v\", n1, 1, 2)\n",
+    "logger.log_attribute(\"v2\", \"v\", n2, 1, 2)\n",
+    "\n",
+    "sim = dpsimpy.Simulation(sim_name, log_level)\n",
+    "sim.set_system(sys)\n",
+    "sim.set_time_step(time_step)\n",
+    "sim.set_final_time(final_time)\n",
+    "sim.add_logger(logger)\n",
+    "sim.do_frequency_parallelization(True)\n",
+    "\n",
+    "sim.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89e2698e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T08:24:40.605953Z",
+     "iopub.status.busy": "2026-07-09T08:24:40.605687Z",
+     "iopub.status.idle": "2026-07-09T08:24:40.615783Z",
+     "shell.execute_reply": "2026-07-09T08:24:40.614577Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "log_path = \"logs/\" + sim_name + \"/\" + sim_name + \".csv\"\n",
+    "ts_dpsim = rt.read_timeseries_dpsim(log_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2a48d42",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T08:24:40.618258Z",
+     "iopub.status.busy": "2026-07-09T08:24:40.617986Z",
+     "iopub.status.idle": "2026-07-09T08:24:41.152221Z",
+     "shell.execute_reply": "2026-07-09T08:24:41.151016Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(ts_dpsim[\"v1_0_0\"].time, ts_dpsim[\"v1_0_0\"].values, label=\"v1, 50 Hz\")\n",
+    "plt.plot(ts_dpsim[\"v2_0_0\"].time, ts_dpsim[\"v2_0_0\"].values, label=\"v2, 50 Hz\")\n",
+    "plt.xlabel(\"time (s)\")\n",
+    "plt.ylabel(\"voltage phasor magnitude component (V)\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6105d72",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T08:24:41.156728Z",
+     "iopub.status.busy": "2026-07-09T08:24:41.156496Z",
+     "iopub.status.idle": "2026-07-09T08:24:41.341076Z",
+     "shell.execute_reply": "2026-07-09T08:24:41.340076Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(ts_dpsim[\"v1_0_1\"].time, ts_dpsim[\"v1_0_1\"].values, label=\"v1, 250 Hz\")\n",
+    "plt.plot(ts_dpsim[\"v2_0_1\"].time, ts_dpsim[\"v2_0_1\"].values, label=\"v2, 250 Hz\")\n",
+    "plt.xlabel(\"time (s)\")\n",
+    "plt.ylabel(\"voltage phasor magnitude component (V)\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f397180b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T08:24:41.344066Z",
+     "iopub.status.busy": "2026-07-09T08:24:41.343784Z",
+     "iopub.status.idle": "2026-07-09T08:24:41.347988Z",
+     "shell.execute_reply": "2026-07-09T08:24:41.347092Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "assert np.allclose(ts_dpsim[\"v1_0_1\"].values, 0.0)\n",
+    "assert np.allclose(ts_dpsim[\"v2_0_1\"].values, 0.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36a86b3a",
+   "metadata": {},
+   "source": [
+    "## Reference: single-frequency sequential run of the same circuit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74e26db6",
+   "metadata": {},
+   "source": [
+    "Same topology and parameters, run without harmonics at all, i.e. the well-tested path that composite components have always supported. The fundamental-frequency result above should match this exactly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64b6a74a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T08:24:41.350636Z",
+     "iopub.status.busy": "2026-07-09T08:24:41.350419Z",
+     "iopub.status.idle": "2026-07-09T08:24:41.361211Z",
+     "shell.execute_reply": "2026-07-09T08:24:41.359951Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "sim_name_ref = \"DP_Transformer_Harmonics_Reference\"\n",
+    "dpsimpy.Logger.set_log_dir(\"logs/\" + sim_name_ref)\n",
+    "\n",
+    "n1_ref = dpsimpy.dp.SimNode(\"n1\")\n",
+    "n2_ref = dpsimpy.dp.SimNode(\"n2\")\n",
+    "\n",
+    "vs_ref = dpsimpy.dp.ph1.VoltageSource(\"vs\", log_level)\n",
+    "vs_ref.set_parameters(complex(1000, 0))\n",
+    "\n",
+    "trafo_ref = dpsimpy.dp.ph1.Transformer(\"trafo\", log_level)\n",
+    "trafo_ref.set_parameters(\n",
+    "    nom_voltage_end_1=1000,\n",
+    "    nom_voltage_end_2=1000,\n",
+    "    rated_power=1e6,\n",
+    "    ratio_abs=1.0,\n",
+    "    ratio_phase=0.0,\n",
+    "    resistance=1.0,\n",
+    "    inductance=0.01,\n",
+    ")\n",
+    "\n",
+    "load_ref = dpsimpy.dp.ph1.Resistor(\"load\", log_level)\n",
+    "load_ref.set_parameters(100)\n",
+    "\n",
+    "vs_ref.connect([dpsimpy.dp.SimNode.gnd, n1_ref])\n",
+    "trafo_ref.connect([n1_ref, n2_ref])\n",
+    "load_ref.connect([n2_ref, dpsimpy.dp.SimNode.gnd])\n",
+    "\n",
+    "sys_ref = dpsimpy.SystemTopology(50, [n1_ref, n2_ref], [vs_ref, trafo_ref, load_ref])\n",
+    "\n",
+    "logger_ref = dpsimpy.Logger(sim_name_ref)\n",
+    "logger_ref.log_attribute(\"v1\", \"v\", n1_ref)\n",
+    "logger_ref.log_attribute(\"v2\", \"v\", n2_ref)\n",
+    "\n",
+    "sim_ref = dpsimpy.Simulation(sim_name_ref, log_level)\n",
+    "sim_ref.set_system(sys_ref)\n",
+    "sim_ref.set_time_step(time_step)\n",
+    "sim_ref.set_final_time(final_time)\n",
+    "sim_ref.add_logger(logger_ref)\n",
+    "\n",
+    "sim_ref.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50c5b7c9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T08:24:41.363614Z",
+     "iopub.status.busy": "2026-07-09T08:24:41.363377Z",
+     "iopub.status.idle": "2026-07-09T08:24:41.370683Z",
+     "shell.execute_reply": "2026-07-09T08:24:41.369450Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "log_path_ref = \"logs/\" + sim_name_ref + \"/\" + sim_name_ref + \".csv\"\n",
+    "ts_dpsim_ref = rt.read_timeseries_dpsim(log_path_ref)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5244dfc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T08:24:41.373163Z",
+     "iopub.status.busy": "2026-07-09T08:24:41.372856Z",
+     "iopub.status.idle": "2026-07-09T08:24:41.563518Z",
+     "shell.execute_reply": "2026-07-09T08:24:41.561898Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(\n",
+    "    ts_dpsim[\"v2_0_0\"].time, ts_dpsim[\"v2_0_0\"].values, label=\"v2, parallel harmonics\"\n",
+    ")\n",
+    "plt.plot(\n",
+    "    ts_dpsim_ref[\"v2\"].time,\n",
+    "    ts_dpsim_ref[\"v2\"].values,\n",
+    "    label=\"v2, sequential reference\",\n",
+    "    linestyle=\"--\",\n",
+    ")\n",
+    "plt.xlabel(\"time (s)\")\n",
+    "plt.ylabel(\"voltage (V)\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ede6398",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T08:24:41.566310Z",
+     "iopub.status.busy": "2026-07-09T08:24:41.566024Z",
+     "iopub.status.idle": "2026-07-09T08:24:41.571510Z",
+     "shell.execute_reply": "2026-07-09T08:24:41.570504Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "assert np.allclose(ts_dpsim[\"v1_0_0\"].values, ts_dpsim_ref[\"v1\"].values)\n",
+    "assert np.allclose(ts_dpsim[\"v2_0_0\"].values, ts_dpsim_ref[\"v2\"].values)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

`CompositePowerComp` had no harmonics-domain (parallel-frequency) hooks, so a composite component like the DP transformer could not be used with `doFrequencyParallelization(true)`. This adds that support and wires up `DP::Ph1::Transformer` as the first consumer, plus the per-frequency current update needed on its DP `Resistor`/`Inductor`/`Capacitor` subcomponents.

Scoping and testing this surfaced several independent, pre-existing bugs in the harmonics-parallel solver path that had never been exercised end-to-end before (no committed example combines frequency-parallel mode with a real per-step logger). All are fixed here:

- Per-frequency system-matrix stamping was dead code (never invoked by any solver).
- `mLeftSideVectorHarm` was populated twice during init, leaving it at double the real frequency count.
- The per-frequency system-matrix dispatch never called `makeCompressed()`, so KLU read a malformed matrix and silently no-op'd instead of solving.
- `SolveTaskHarm` incorrectly declared that it modifies node voltage (copied from the non-Harm `SolveTask`, where that's true but here it isn't), confusing the scheduler's dependency graph.