### PR TITLE
feat: configurable PF solver Newton step clamp

### DIFF
--- a/dpsim/include/dpsim/PFSolver.h
+++ b/dpsim/include/dpsim/PFSolver.h
@@ -110,6 +110,11 @@ protected:
   /// Use last converged solution as initial guess
   CPS::Bool mKeepLastSolution = false;
 
+  /// Max |dV| per Newton step [pu]; caps PFSolverPowerPolar::updateSolution()'s step scaling
+  CPS::Real mMaxDVoltagePerUnitPerStep = 0.1;
+  /// Max |dTheta| per Newton step [rad]; caps PFSolverPowerPolar::updateSolution()'s step scaling
+  CPS::Real mMaxDThetaRadPerStep = 0.2;
+
   /// Generate initial solution for current time step
   virtual void generateInitialSolution(Real time,
                                        bool keep_last_solution = false) = 0;
@@ -223,6 +228,13 @@ public:
   }
 
   CPS::UInt getMaxIterations() const { return mMaxIterations; }
+
+  /// Relax or tighten the per-iteration Newton step clamp (defaults: 0.1 pu / 0.2 rad).
+  void setMaxStepPerIteration(CPS::Real maxDVoltagePerUnit,
+                              CPS::Real maxDThetaRad) {
+    mMaxDVoltagePerUnitPerStep = maxDVoltagePerUnit;
+    mMaxDThetaRadPerStep = maxDThetaRad;
+  }
 
   class SolveTask : public CPS::Task {
   public:

--- a/dpsim/include/dpsim/PFSolver.h
+++ b/dpsim/include/dpsim/PFSolver.h
@@ -10,6 +10,7 @@
 
 #include <cmath>
 #include <iterator>
+#include <stdexcept>
 
 #include "dpsim-models/Components.h"
 #include "dpsim-models/SystemTopology.h"
@@ -230,8 +231,14 @@ public:
   CPS::UInt getMaxIterations() const { return mMaxIterations; }
 
   /// Relax or tighten the per-iteration Newton step clamp (defaults: 0.1 pu / 0.2 rad).
+  /// Both limits must be positive: a zero clamp nulls the Newton step (the solve
+  /// stalls) and a negative one reverses it (the solve diverges).
   void setMaxStepPerIteration(CPS::Real maxDVoltagePerUnit,
                               CPS::Real maxDThetaRad) {
+    if (maxDVoltagePerUnit <= 0 || maxDThetaRad <= 0)
+      throw std::invalid_argument(
+          "PFSolver: Newton step clamp limits must be positive "
+          "(maxDVoltagePerUnit [pu] and maxDThetaRad [rad]).");
     mMaxDVoltagePerUnitPerStep = maxDVoltagePerUnit;
     mMaxDThetaRadPerStep = maxDThetaRad;
   }

--- a/dpsim/include/dpsim/Simulation.h
+++ b/dpsim/include/dpsim/Simulation.h
@@ -50,6 +50,12 @@ public:
   /// Maximum number of Newton-Raphson iterations for the PF solver.
   const CPS::Attribute<CPS::UInt>::Ptr mPFMaxIterations;
 
+  /// Max |dV| per Newton step [pu] for the PF solver; default 0.1
+  const CPS::Attribute<Real>::Ptr mPFMaxDVoltagePerUnitPerStep;
+
+  /// Max |dTheta| per Newton step [rad] for the PF solver; default 0.2
+  const CPS::Attribute<Real>::Ptr mPFMaxDThetaRadPerStep;
+
   /// Use the sparse-Jacobian powerflow solver (scales to large grids).
   /// Default false (dense solver); opt in via setPFSolverUseSparse(true).
   /// Ignored (dense solver used) if no sparse linear solver is available.
@@ -275,6 +281,14 @@ public:
   void setPFMaxIterations(CPS::UInt value);
 
   CPS::UInt getPFMaxIterations() const;
+
+  /// Relax or tighten the PF solver's per-iteration Newton step clamp (defaults: 0.1 pu / 0.2 rad).
+  void setPFSolverMaxStepPerIteration(Real maxDVoltagePerUnit,
+                                      Real maxDThetaRad);
+
+  Real getPFSolverMaxDVoltagePerUnitPerStep() const;
+
+  Real getPFSolverMaxDThetaRadPerStep() const;
 
   void setPFSolverUseSparse(Bool value);
 

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -293,9 +293,10 @@ void PFSolverPowerPolar::calculateJacobian() {
 void PFSolverPowerPolar::updateSolution() {
   UInt npqpv = mNumPQBuses + mNumPVBuses;
 
-  // Scale the whole step by one factor to bound the max change without altering direction.
-  const double maxDVpu = 0.1;      // max |dV| per step [pu]
-  const double maxDThetaRad = 0.2; // max |dTheta| per step [rad]
+  // Scale the whole Newton step by one factor (=1 near solution) to bound the
+  // max voltage/angle change without altering the search direction.
+  const double maxDVpu = mMaxDVoltagePerUnitPerStep;
+  const double maxDThetaRad = mMaxDThetaRadPerStep;
 
   // mX: [0,npqpv) angle incr (PQ+PV), then rel. voltage dV/V (PQ only).
   double scale = 1.0;

--- a/dpsim/src/Simulation.cpp
+++ b/dpsim/src/Simulation.cpp
@@ -38,6 +38,8 @@ Simulation::Simulation(String name, Logger::Level logLevel)
       mPFKeepLastSolution(CPS::AttributeStatic<Bool>::make(false)),
       mPFBaseApparentPowerFallback(CPS::AttributeStatic<Real>::make(100e6)),
       mPFMaxIterations(CPS::AttributeStatic<CPS::UInt>::make(20)),
+      mPFMaxDVoltagePerUnitPerStep(CPS::AttributeStatic<Real>::make(0.1)),
+      mPFMaxDThetaRadPerStep(CPS::AttributeStatic<Real>::make(0.2)),
       mPFSolverUseSparse(CPS::AttributeStatic<Bool>::make(false)),
       mPFEnforceReactiveLimits(CPS::AttributeStatic<Bool>::make(false)),
       mPFBaseVoltageLooseTolerance(CPS::AttributeStatic<Real>::make(0.1)),
@@ -56,6 +58,8 @@ Simulation::Simulation(String name, CommandLineArgs &args)
       mPFKeepLastSolution(CPS::AttributeStatic<Bool>::make(false)),
       mPFBaseApparentPowerFallback(CPS::AttributeStatic<Real>::make(100e6)),
       mPFMaxIterations(CPS::AttributeStatic<CPS::UInt>::make(20)),
+      mPFMaxDVoltagePerUnitPerStep(CPS::AttributeStatic<Real>::make(0.1)),
+      mPFMaxDThetaRadPerStep(CPS::AttributeStatic<Real>::make(0.2)),
       mPFSolverUseSparse(CPS::AttributeStatic<Bool>::make(false)),
       mPFEnforceReactiveLimits(CPS::AttributeStatic<Bool>::make(false)),
       mPFBaseVoltageLooseTolerance(CPS::AttributeStatic<Real>::make(0.1)),
@@ -138,6 +142,8 @@ template <typename VarType> void Simulation::createSolvers() {
     pfSolver->setEnforceReactiveLimits(**mPFEnforceReactiveLimits);
     pfSolver->setBaseVoltageLooseTolerance(**mPFBaseVoltageLooseTolerance);
     pfSolver->setBaseVoltageStrictTolerance(**mPFBaseVoltageStrictTolerance);
+    pfSolver->setMaxStepPerIteration(**mPFMaxDVoltagePerUnitPerStep,
+                                     **mPFMaxDThetaRadPerStep);
 
     solver = pfSolver;
 
@@ -370,6 +376,20 @@ void Simulation::setPFMaxIterations(CPS::UInt value) {
 }
 
 CPS::UInt Simulation::getPFMaxIterations() const { return **mPFMaxIterations; }
+
+void Simulation::setPFSolverMaxStepPerIteration(Real maxDVoltagePerUnit,
+                                                Real maxDThetaRad) {
+  **mPFMaxDVoltagePerUnitPerStep = maxDVoltagePerUnit;
+  **mPFMaxDThetaRadPerStep = maxDThetaRad;
+}
+
+Real Simulation::getPFSolverMaxDVoltagePerUnitPerStep() const {
+  return **mPFMaxDVoltagePerUnitPerStep;
+}
+
+Real Simulation::getPFSolverMaxDThetaRadPerStep() const {
+  return **mPFMaxDThetaRadPerStep;
+}
 
 void Simulation::setPFSolverUseSparse(Bool value) {
   **mPFSolverUseSparse = value;

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -247,6 +247,12 @@ PYBIND11_MODULE(dpsimpy, m) {
            &DPsim::Simulation::getPFBaseApparentPowerFallback)
       .def("set_pf_max_iterations", &DPsim::Simulation::setPFMaxIterations)
       .def("get_pf_max_iterations", &DPsim::Simulation::getPFMaxIterations)
+      .def("set_pf_solver_max_step_per_iteration",
+           &DPsim::Simulation::setPFSolverMaxStepPerIteration)
+      .def("get_pf_solver_max_dvoltage_per_unit_per_step",
+           &DPsim::Simulation::getPFSolverMaxDVoltagePerUnitPerStep)
+      .def("get_pf_solver_max_dtheta_rad_per_step",
+           &DPsim::Simulation::getPFSolverMaxDThetaRadPerStep)
       .def("set_pf_solver_use_sparse", &DPsim::Simulation::setPFSolverUseSparse)
       .def("get_pf_solver_use_sparse", &DPsim::Simulation::getPFSolverUseSparse)
       .def("set_pf_solver_enforce_q_limits",


### PR DESCRIPTION
## Summary
- PFSolverPowerPolar::updateSolution() clamps the per-iteration Newton step (max |dV| 0.1 pu, max |dTheta| 0.2 rad) with hardcoded constants. Exposes these as a configurable pair via PFSolver::setMaxStepPerIteration(), wired through Simulation::setPFSolverMaxStepPerIteration() and the matching pybind binding, following the existing setPFMaxIterations/setPFBaseApparentPowerFallback pattern.
- Defaults unchanged (0.1 pu / 0.2 rad), so behavior is identical unless a caller opts in.