### PR TITLE
fix: ExternalNetworkInjection voltage target unit disambiguation

### DIFF
--- a/dpsim-models/include/dpsim-models/CIM/Reader.h
+++ b/dpsim-models/include/dpsim-models/CIM/Reader.h
@@ -77,6 +77,9 @@ template <typename T> const auto &cimString(const T &field) {
 class InvalidTopology {};
 
 class Reader {
+public:
+  enum class VoltageTargetUnit { Auto, PerUnit, Absolute };
+
 private:
   /// CIM logger
   Logger::Log mSLog;
@@ -108,6 +111,8 @@ private:
   std::map<String, TopologicalTerminal::Ptr> mPowerflowTerminals;
   ///
   Bool mUseProtectionSwitches = false;
+  /// Applies to ExternalNetworkInjection.RegulatingControl.targetValue only
+  VoltageTargetUnit mExtnetVoltageTargetUnit = VoltageTargetUnit::Auto;
 
   // #### shunt component settings ####
   /// activates global shunt capacitor setting
@@ -209,6 +214,7 @@ public:
   void setShuntConductance(Real v);
   /// If set, some components like loads include protection switches
   void useProtectionSwitches(Bool value = true);
+  void setExtnetVoltageTargetUnit(VoltageTargetUnit unit);
 };
 } // namespace CIM
 } // namespace CPS

--- a/dpsim-models/src/CIM/Reader.cpp
+++ b/dpsim-models/src/CIM/Reader.cpp
@@ -59,6 +59,10 @@ void Reader::useProtectionSwitches(Bool value) {
   mUseProtectionSwitches = value;
 }
 
+void Reader::setExtnetVoltageTargetUnit(VoltageTargetUnit unit) {
+  mExtnetVoltageTargetUnit = unit;
+}
+
 Real Reader::unitValue(Real value, CIMPP::UnitMultiplier mult) {
   switch (mult) {
   case UnitMultiplier::p:
@@ -1076,9 +1080,24 @@ Reader::mapExternalNetworkInjection(CIMPP::ExternalNetworkInjection *extnet) {
 
       try {
         if (extnet->RegulatingControl) {
-          // targetValue is an absolute voltage (own UnitMultiplier), not a per-unit factor to multiply baseVoltage by.
-          Real voltageSetPoint = unitValue(
-              extnet->RegulatingControl->targetValue.value, UnitMultiplier::k);
+          // targetValueUnitMultiplier is uninitialized if unset, so Auto guesses by magnitude
+          Real rawTarget = extnet->RegulatingControl->targetValue.value;
+          Bool perUnit;
+          switch (mExtnetVoltageTargetUnit) {
+          case VoltageTargetUnit::PerUnit:
+            perUnit = true;
+            break;
+          case VoltageTargetUnit::Absolute:
+            perUnit = false;
+            break;
+          case VoltageTargetUnit::Auto:
+          default:
+            perUnit = std::abs(rawTarget) >= 0.5 && std::abs(rawTarget) <= 1.5;
+            break;
+          }
+          Real voltageSetPoint = perUnit
+                                     ? rawTarget * baseVoltage
+                                     : unitValue(rawTarget, UnitMultiplier::k);
           SPDLOG_LOGGER_INFO(mSLog, "       Voltage set-point={}",
                              voltageSetPoint);
           cpsextnet->setParameters(voltageSetPoint);

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -448,6 +448,12 @@ PYBIND11_MODULE(dpsimpy, m) {
       .def("__str__", &getAttributeList);
 
 #ifdef WITH_CIM
+  py::enum_<CPS::CIM::Reader::VoltageTargetUnit>(m,
+                                                 "CIMReaderVoltageTargetUnit")
+      .value("Auto", CPS::CIM::Reader::VoltageTargetUnit::Auto)
+      .value("PerUnit", CPS::CIM::Reader::VoltageTargetUnit::PerUnit)
+      .value("Absolute", CPS::CIM::Reader::VoltageTargetUnit::Absolute);
+
   py::class_<CPS::CIM::Reader>(m, "CIMReader")
       .def(py::init<std::string, CPS::Logger::Level, CPS::Logger::Level>(),
            "name"_a, "loglevel"_a = CPS::Logger::Level::info,
@@ -455,7 +461,9 @@ PYBIND11_MODULE(dpsimpy, m) {
       .def("loadCIM", (CPS::SystemTopology(CPS::CIM::Reader::*)(
                           CPS::Real, const std::list<CPS::String> &,
                           CPS::Domain, CPS::PhaseType, CPS::GeneratorType)) &
-                          CPS::CIM::Reader::loadCIM);
+                          CPS::CIM::Reader::loadCIM)
+      .def("set_extnet_voltage_target_unit",
+           &CPS::CIM::Reader::setExtnetVoltageTargetUnit, "unit"_a);
 #endif
 
   py::class_<CPS::CSVReader>(m, "CSVReader")


### PR DESCRIPTION
## Summary
- #558 broke CI on master: `PF_Sparse_vs_Dense.ipynb` stopped converging on `case14`/`case145`/`case300`
- Cause: `RegulatingControl.targetValue` for `ExternalNetworkInjection` is per-unit in matpower-derived CIM data but absolute (own `UnitMultiplier`) in other kind of CIM files.
- `Auto` (default) now guesses per-unit vs. absolute by magnitude; added `CIMReader.set_extnet_voltage_target_unit(Auto|PerUnit|Absolute)` for callers who know their data's convention