### PR TITLE
ci: patch + dev suffix for Test PyPI publishes

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -23,6 +23,11 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Set development version for Test PyPI
+      if: "!startsWith(github.ref, 'refs/tags')"
+      shell: bash
+      run: python3 scripts/set_dev_version.py pyproject.toml ${{ github.run_number }}
+
     - name: Build DPsim source distribution
       shell: bash
       run: python3 -m build --sdist --outdir dist/
@@ -45,6 +50,11 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Set development version for Test PyPI
+      if: "!startsWith(github.ref, 'refs/tags')"
+      shell: bash
+      run: python3 scripts/set_dev_version.py pyproject.toml ${{ github.run_number }}
 
     - name: Build wheel
       uses: pypa/cibuildwheel@v3.4.1

--- a/scripts/set_dev_version.py
+++ b/scripts/set_dev_version.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+# SPDX-License-Identifier: MPL-2.0
 # Bumps patch + appends .devN so Test PyPI never sees a reused, stale version.
 
 import re

--- a/scripts/set_dev_version.py
+++ b/scripts/set_dev_version.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Bumps patch + appends .devN so Test PyPI never sees a reused, stale version.
+
+import re
+import sys
+
+
+def main() -> None:
+    path, run_number = sys.argv[1], sys.argv[2]
+
+    with open(path) as f:
+        content = f.read()
+
+    match = re.search(r'(?m)^version = "(\d+)\.(\d+)\.(\d+)"', content)
+    if not match:
+        sys.exit(f'could not find a version = "X.Y.Z" line in {path}')
+
+    major, minor, patch = match.groups()
+    dev_version = f"{major}.{minor}.{int(patch) + 1}.dev{run_number}"
+
+    content = (
+        content[: match.start()] + f'version = "{dev_version}"' + content[match.end() :]
+    )
+
+    with open(path, "w") as f:
+        f.write(content)
+
+    print(f"set version to {dev_version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Test PyPI now rejects new file uploads on releases older than 14 days (HTTPError 400).

Each Test PyPI build now gets a unique` X.Y.(Z+1).devN` version instead using `github.run_number`