### PR TITLE
DP: fix double carrier-shift in MixedVTypeVariableSSNComp init

### DIFF
--- a/dpsim-models/src/DP/DP_Ph1_MixedVTypeVariableSSNComp.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_MixedVTypeVariableSSNComp.cpp
@@ -186,23 +186,18 @@ void DP::Ph1::MixedVTypeVariableSSNComp::initializeFromNodesAndTerminals(
                      "\n--- Initialization from nodes and terminals ---");
 
   Bool converged = false;
-  const Real omega = 2.0 * PI * frequency;
+
+  Matrix uColumn = Matrix::Zero(2, 1);
+  uColumn(0, 0) = u.real();
+  uColumn(1, 0) = u.imag();
 
   for (Int iter = 0; iter < mInitializationMaxIterations; ++iter) {
     const Matrix xPrev = **mX;
 
     updateComponentParameters();
 
-    MatrixComp h =
-        Complex(0.0, omega) * MatrixComp::Identity(stateSize(), stateSize()) -
-        mA.cast<Complex>();
-    MatrixComp uColumn = MatrixComp::Zero(2, 1);
-    uColumn(0, 0) = u.real();
-    uColumn(1, 0) = u.imag();
-    MatrixComp xInit =
-        h.inverse() * (mB.cast<Complex>() * uColumn + mE.cast<Complex>());
-
-    **mX = xInit.real();
+    // mA is already carrier-shifted, so steady state is 0 = mA*x + mB*u + mE.
+    **mX = -mA.inverse() * (mB * uColumn + mE);
 
     if ((**mX).isApprox(xPrev, mInitializationTolerance)) {
       converged = true;

--- a/dpsim/examples/cxx/Components/DP_Ph1_MixedVariableSSN_vs_FixedSSN.cpp
+++ b/dpsim/examples/cxx/Components/DP_Ph1_MixedVariableSSN_vs_FixedSSN.cpp
@@ -24,10 +24,14 @@ Real systemFreq = 50.0;
 SimNode::Ptr buildAndRun(const String &simName,
                          CPS::SimPowerComp<Complex>::Ptr rlc,
                          Bool systemMatrixRecomputation) {
+  const Complex sourceVoltage =
+      CPS::Math::polar(1.0, CPS::Math::degToRad(-90.0));
+
   auto n1 = SimNode::make("n1");
+  n1->setInitialVoltage(sourceVoltage);
 
   auto vs = Ph1::VoltageSource::make("vs_" + simName);
-  vs->setParameters(CPS::Math::polar(1.0, CPS::Math::degToRad(-90.0)));
+  vs->setParameters(sourceVoltage);
 
   vs->connect(SimNode::List{SimNode::GND, n1});
   rlc->connect(SimNode::List{n1, SimNode::GND});


### PR DESCRIPTION
## Summary
`MixedVTypeVariableSSNComp::initializeFromNodesAndTerminals()` re-applied the carrier shift (`jω·I − A`) on top of an `mA` that variable components already hand it pre-shifted, doubling it. Fixed by solving the steady state directly against `mA`. Updated the comparison example to set an explicit initial voltage so it actually catches this.

Discovered by @georgii-tishenin while reviewing #544. Fixed here.

Closes #566