### PR TITLE
Add IEEE 9-bus 4th-order SG examples (SP, DP, EMT)

### DIFF
--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -71,6 +71,11 @@ set(CIRCUIT_SOURCES
 	Circuits/EMT_DP_SP_Trafo.cpp
 	Circuits/EMT_DP_SP_Slack_PiLine_PQLoad_FrequencyRamp_CosineFM.cpp
 
+	# IEEE 9-bus, 4th-order synchronous generators (PF-initialized)
+	Circuits/SP_Ph1_IEEE9_4Order.cpp
+	Circuits/DP_Ph1_IEEE9_4Order.cpp
+	Circuits/EMT_Ph3_IEEE9_4Order.cpp
+
 	#SMIB
 	Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp
 	Circuits/DP_SynGenTrStab_SMIB_SteadyState.cpp
@@ -156,6 +161,9 @@ StateSpace/DP_Ph1_Switch_StateSpaceExtraction.cpp
 # Targets required for tests in the Jupyter Notebooks. This list is only for grouping the (already configured) targets, so every entry
 # also has to appear in another list in this file.
 list(APPEND TEST_SOURCES
+	Circuits/SP_Ph1_IEEE9_4Order.cpp
+	Circuits/DP_Ph1_IEEE9_4Order.cpp
+	Circuits/EMT_Ph3_IEEE9_4Order.cpp
 	Circuits/SP_ReducedOrderSG_SMIB_Fault.cpp
 	Circuits/DP_ReducedOrderSG_SMIB_Fault.cpp
 	Circuits/EMT_ReducedOrderSG_SMIB_Fault.cpp

--- a/dpsim/examples/cxx/Circuits/DP_Ph1_IEEE9_4Order.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_Ph1_IEEE9_4Order.cpp
@@ -1,0 +1,511 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include "../Examples.h"
+#include "../GeneratorFactory.h"
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS;
+
+SystemTopology buildTopology(CommandLineArgs &args,
+                             std::shared_ptr<DataLoggerInterface> logger) {
+
+  String simName = args.name;
+
+  CPS::CIM::Examples::Grids::IEEE9::ScenarioConfig ieee9(args.sysFreq);
+
+  // Power flow simulation
+  String simNamePF = simName + "_PF";
+  CPS::Logger::setLogDir("logs/" + simNamePF);
+
+  // Nodes
+  auto n1PF = SimNode<Complex>::make("BUS1", PhaseType::Single);
+  auto n2PF = SimNode<Complex>::make("BUS2", PhaseType::Single);
+  auto n3PF = SimNode<Complex>::make("BUS3", PhaseType::Single);
+  auto n4PF = SimNode<Complex>::make("BUS4", PhaseType::Single);
+  auto n5PF = SimNode<Complex>::make("BUS5", PhaseType::Single);
+  auto n6PF = SimNode<Complex>::make("BUS6", PhaseType::Single);
+  auto n7PF = SimNode<Complex>::make("BUS7", PhaseType::Single);
+  auto n8PF = SimNode<Complex>::make("BUS8", PhaseType::Single);
+  auto n9PF = SimNode<Complex>::make("BUS9", PhaseType::Single);
+
+  auto gen1PF = SP::Ph1::SynchronGenerator::make(ieee9.gen1.Name,
+                                                 CPS::Logger::Level::off);
+  gen1PF->setParameters(ieee9.gen1.RatedPower, ieee9.gen1.RatedVoltage,
+                        ieee9.gen1.InitialPower, ieee9.gen1.InitialVoltage,
+                        ieee9.gen1.BusType);
+  gen1PF->setBaseVoltage(ieee9.gen1.RatedVoltage);
+
+  auto gen2PF = SP::Ph1::SynchronGenerator::make(ieee9.gen2.Name,
+                                                 CPS::Logger::Level::off);
+  gen2PF->setParameters(ieee9.gen2.RatedPower, ieee9.gen2.RatedVoltage,
+                        ieee9.gen2.InitialPower, ieee9.gen2.InitialVoltage,
+                        ieee9.gen2.BusType);
+  gen2PF->setBaseVoltage(ieee9.gen2.RatedVoltage);
+
+  auto gen3PF = SP::Ph1::SynchronGenerator::make(ieee9.gen3.Name,
+                                                 CPS::Logger::Level::off);
+  gen3PF->setParameters(ieee9.gen3.RatedPower, ieee9.gen3.RatedVoltage,
+                        ieee9.gen3.InitialPower, ieee9.gen3.InitialVoltage,
+                        ieee9.gen3.BusType);
+  gen3PF->setBaseVoltage(ieee9.gen3.RatedVoltage);
+
+  // Loads
+  auto load5PF = SP::Ph1::Load::make(ieee9.load5.Name, CPS::Logger::Level::off);
+  load5PF->setParameters(ieee9.load5.RealPower, ieee9.load5.ReactivePower,
+                         ieee9.load5.BaseVoltage);
+  load5PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  auto load6PF = SP::Ph1::Load::make(ieee9.load6.Name, CPS::Logger::Level::off);
+  load6PF->setParameters(ieee9.load6.RealPower, ieee9.load6.ReactivePower,
+                         ieee9.load6.BaseVoltage);
+  load6PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  auto load8PF = SP::Ph1::Load::make(ieee9.load8.Name, CPS::Logger::Level::off);
+  load8PF->setParameters(ieee9.load8.RealPower, ieee9.load8.ReactivePower,
+                         ieee9.load8.BaseVoltage);
+  load8PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  // Transmission Lines
+  auto line54PF =
+      SP::Ph1::PiLine::make(ieee9.line54.Name, CPS::Logger::Level::off);
+  line54PF->setParameters(ieee9.line54.Resistance, ieee9.line54.Inductance,
+                          ieee9.line54.Capacitance, ieee9.line54.Conductance);
+  line54PF->setBaseVoltage(ieee9.line54.BaseVoltage);
+
+  auto line64PF =
+      SP::Ph1::PiLine::make(ieee9.line64.Name, CPS::Logger::Level::off);
+  line64PF->setParameters(ieee9.line64.Resistance, ieee9.line64.Inductance,
+                          ieee9.line64.Capacitance, ieee9.line64.Conductance);
+  line64PF->setBaseVoltage(ieee9.line64.BaseVoltage);
+
+  auto line75PF =
+      SP::Ph1::PiLine::make(ieee9.line75.Name, CPS::Logger::Level::off);
+  line75PF->setParameters(ieee9.line75.Resistance, ieee9.line75.Inductance,
+                          ieee9.line75.Capacitance, ieee9.line75.Conductance);
+  line75PF->setBaseVoltage(ieee9.line75.BaseVoltage);
+
+  auto line96PF =
+      SP::Ph1::PiLine::make(ieee9.line96.Name, CPS::Logger::Level::off);
+  line96PF->setParameters(ieee9.line96.Resistance, ieee9.line96.Inductance,
+                          ieee9.line96.Capacitance, ieee9.line96.Conductance);
+  line96PF->setBaseVoltage(ieee9.line96.BaseVoltage);
+
+  auto line78PF =
+      SP::Ph1::PiLine::make(ieee9.line78.Name, CPS::Logger::Level::off);
+  line78PF->setParameters(ieee9.line78.Resistance, ieee9.line78.Inductance,
+                          ieee9.line78.Capacitance, ieee9.line78.Conductance);
+  line78PF->setBaseVoltage(ieee9.line78.BaseVoltage);
+
+  auto line89PF =
+      SP::Ph1::PiLine::make(ieee9.line89.Name, CPS::Logger::Level::off);
+  line89PF->setParameters(ieee9.line89.Resistance, ieee9.line89.Inductance,
+                          ieee9.line89.Capacitance, ieee9.line89.Conductance);
+  line89PF->setBaseVoltage(ieee9.line89.BaseVoltage);
+
+  // Transformers
+  auto transf14PF =
+      SP::Ph1::Transformer::make(ieee9.transf14.Name, CPS::Logger::Level::off);
+  transf14PF->setParameters(ieee9.transf14.VoltageLVSide,
+                            ieee9.transf14.VoltageHVSide, ieee9.transf14.Ratio,
+                            0.0, ieee9.transf14.Resistance,
+                            ieee9.transf14.Inductance);
+  transf14PF->setBaseVoltage(ieee9.transf14.VoltageHVSide);
+
+  auto transf27PF =
+      SP::Ph1::Transformer::make(ieee9.transf27.Name, CPS::Logger::Level::off);
+  transf27PF->setParameters(ieee9.transf27.VoltageLVSide,
+                            ieee9.transf27.VoltageHVSide, ieee9.transf27.Ratio,
+                            0.0, ieee9.transf27.Resistance,
+                            ieee9.transf27.Inductance);
+  transf27PF->setBaseVoltage(ieee9.transf27.VoltageHVSide);
+
+  auto transf39PF =
+      SP::Ph1::Transformer::make(ieee9.transf39.Name, CPS::Logger::Level::off);
+  transf39PF->setParameters(ieee9.transf39.VoltageLVSide,
+                            ieee9.transf39.VoltageHVSide, ieee9.transf39.Ratio,
+                            0.0, ieee9.transf39.Resistance,
+                            ieee9.transf39.Inductance);
+  transf39PF->setBaseVoltage(ieee9.transf39.VoltageHVSide);
+
+  // Connect components to nodes
+
+  gen1PF->connect({n1PF});
+  gen2PF->connect({n2PF});
+  gen3PF->connect({n3PF});
+
+  load5PF->connect({n5PF});
+  load6PF->connect({n6PF});
+  load8PF->connect({n8PF});
+
+  line54PF->connect({n5PF, n4PF});
+  line64PF->connect({n6PF, n4PF});
+  line75PF->connect({n7PF, n5PF});
+  line96PF->connect({n9PF, n6PF});
+  line78PF->connect({n7PF, n8PF});
+  line89PF->connect({n8PF, n9PF});
+
+  transf14PF->connect({n1PF, n4PF});
+  transf27PF->connect({n2PF, n7PF});
+  transf39PF->connect({n3PF, n9PF});
+
+  // Create system topology for power flow
+  auto systemPF = SystemTopology(
+      ieee9.nomFreq,
+      SystemNodeList{n1PF, n2PF, n3PF, n4PF, n5PF, n6PF, n7PF, n8PF, n9PF},
+      SystemComponentList{gen1PF, gen2PF, gen3PF, load5PF, load6PF, load8PF,
+                          line54PF, line64PF, line75PF, line96PF, line78PF,
+                          line89PF, transf14PF, transf27PF, transf39PF});
+
+  // Logger
+  auto loggerPF = DataLogger::make(simNamePF, CPS::Logger::Level::off);
+  // Log node voltages
+  loggerPF->logAttribute("v_bus1", n1PF->attribute("v"));
+  loggerPF->logAttribute("v_bus2", n2PF->attribute("v"));
+  loggerPF->logAttribute("v_bus3", n3PF->attribute("v"));
+  loggerPF->logAttribute("v_bus4", n4PF->attribute("v"));
+  loggerPF->logAttribute("v_bus5", n5PF->attribute("v"));
+  loggerPF->logAttribute("v_bus6", n6PF->attribute("v"));
+  loggerPF->logAttribute("v_bus7", n7PF->attribute("v"));
+  loggerPF->logAttribute("v_bus8", n8PF->attribute("v"));
+  loggerPF->logAttribute("v_bus9", n9PF->attribute("v"));
+  // Log node powers
+  loggerPF->logAttribute("s_bus1", n1PF->attribute("s"));
+  loggerPF->logAttribute("s_bus2", n2PF->attribute("s"));
+  loggerPF->logAttribute("s_bus3", n3PF->attribute("s"));
+  loggerPF->logAttribute("s_bus4", n4PF->attribute("s"));
+  loggerPF->logAttribute("s_bus5", n5PF->attribute("s"));
+  loggerPF->logAttribute("s_bus6", n6PF->attribute("s"));
+  loggerPF->logAttribute("s_bus7", n7PF->attribute("s"));
+  loggerPF->logAttribute("s_bus8", n8PF->attribute("s"));
+  loggerPF->logAttribute("s_bus9", n9PF->attribute("s"));
+
+  // Run power flow simulation
+  Simulation simPF(simNamePF, CPS::Logger::Level::off);
+  simPF.setSystem(systemPF);
+  simPF.setTimeStep(args.timeStep);
+  simPF.setFinalTime(1 * args.timeStep);
+  simPF.setDomain(Domain::SP);
+  simPF.setSolverType(Solver::Type::NRP);
+  simPF.setSolverAndComponentBehaviour(Solver::Behaviour::Simulation);
+  simPF.addLogger(loggerPF);
+  simPF.run();
+
+  // DYNAMIC SIMULATION - DP
+
+  String simNameDP = simName + "_DP";
+  CPS::Logger::setLogDir("logs/" + simNameDP);
+
+  // Nodes
+  auto n1DP = SimNode<Complex>::make("BUS1", PhaseType::Single);
+  auto n2DP = SimNode<Complex>::make("BUS2", PhaseType::Single);
+  auto n3DP = SimNode<Complex>::make("BUS3", PhaseType::Single);
+  auto n4DP = SimNode<Complex>::make("BUS4", PhaseType::Single);
+  auto n5DP = SimNode<Complex>::make("BUS5", PhaseType::Single);
+  auto n6DP = SimNode<Complex>::make("BUS6", PhaseType::Single);
+  auto n7DP = SimNode<Complex>::make("BUS7", PhaseType::Single);
+  auto n8DP = SimNode<Complex>::make("BUS8", PhaseType::Single);
+  auto n9DP = SimNode<Complex>::make("BUS9", PhaseType::Single);
+
+  // Generator 1 Initialization
+  auto gen1DP = DP::Ph1::SynchronGenerator4OrderVBR::make(
+      ieee9.gen1.Name, CPS::Logger::Level::off);
+
+  gen1DP->setOperationalParametersPerUnit(
+      ieee9.gen1.RatedPower,   // nomPower [VA]
+      ieee9.gen1.RatedVoltage, // nomVolt [V]
+      ieee9.nomFreq,           // nomFreq [Hz]
+      ieee9.gen1.H, ieee9.gen1.Xd, ieee9.gen1.Xq, ieee9.gen1.Xa,
+      ieee9.gen1.XdPrime, ieee9.gen1.XqPrime, ieee9.gen1.TdoPrime,
+      ieee9.gen1.TqoPrime);
+
+  auto exciter1Params = std::make_shared<Signal::ExciterDC1SimpParameters>();
+  exciter1Params->Ta = ieee9.exc1.TA;
+  exciter1Params->Ka = ieee9.exc1.KA;
+  exciter1Params->Tef = ieee9.exc1.TE;
+  exciter1Params->Kef = ieee9.exc1.KE;
+  exciter1Params->Tf = ieee9.exc1.TF;
+  exciter1Params->Kf = ieee9.exc1.KF;
+  exciter1Params->Tr = 0.01;
+  exciter1Params->MaxVa = ieee9.exc1.VRmax;
+  exciter1Params->MinVa = ieee9.exc1.VRmin;
+  exciter1Params->Bef = std::log(ieee9.exc1.S_EX2 / ieee9.exc1.S_EX1) /
+                        (ieee9.exc1.EX2 - ieee9.exc1.EX1);
+  exciter1Params->Aef =
+      ieee9.exc1.S_EX1 / std::exp(exciter1Params->Bef * ieee9.exc1.EX1);
+  auto exciter1 =
+      Signal::ExciterDC1Simp::make("Gen1_Exciter", CPS::Logger::Level::off);
+  exciter1->setParameters(exciter1Params);
+  gen1DP->addExciter(exciter1);
+
+  CPS::Real T4 = 1.0;
+  CPS::Real T5 = 1.0;
+
+  std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernor1 =
+      Signal::TurbineGovernorType1::make("Gen1_TurbineGovernor",
+                                         CPS::Logger::Level::off);
+
+  turbineGovernor1->setParameters(ieee9.gov1.T2, T4, T5, ieee9.gov1.T3,
+                                  ieee9.gov1.T1, ieee9.gov1.R, ieee9.gov1.Vmin,
+                                  ieee9.gov1.Vmax, 1.0);
+
+  gen1DP->addGovernor(turbineGovernor1);
+
+  auto gen2DP = DP::Ph1::SynchronGenerator4OrderVBR::make(
+      ieee9.gen2.Name, CPS::Logger::Level::off);
+
+  gen2DP->setOperationalParametersPerUnit(
+      ieee9.gen2.RatedPower,   // nomPower [VA]
+      ieee9.gen2.RatedVoltage, // nomVolt [V]
+      ieee9.nomFreq,           // nomFreq [Hz]
+      ieee9.gen2.H, ieee9.gen2.Xd, ieee9.gen2.Xq, ieee9.gen2.Xa,
+      ieee9.gen2.XdPrime, ieee9.gen2.XqPrime, ieee9.gen2.TdoPrime,
+      ieee9.gen2.TqoPrime);
+
+  auto exciter2Params = std::make_shared<Signal::ExciterDC1SimpParameters>();
+  exciter2Params->Ta = ieee9.exc2.TA;
+  exciter2Params->Ka = ieee9.exc2.KA;
+  exciter2Params->Tef = ieee9.exc2.TE;
+  exciter2Params->Kef = ieee9.exc2.KE;
+  exciter2Params->Tf = ieee9.exc2.TF;
+  exciter2Params->Kf = ieee9.exc2.KF;
+  exciter2Params->Tr = 0.01;
+  exciter2Params->MaxVa = ieee9.exc2.VRmax;
+  exciter2Params->MinVa = ieee9.exc2.VRmin;
+  exciter2Params->Bef = std::log(ieee9.exc2.S_EX2 / ieee9.exc2.S_EX1) /
+                        (ieee9.exc2.EX2 - ieee9.exc2.EX1);
+  exciter2Params->Aef =
+      ieee9.exc2.S_EX1 / std::exp(exciter2Params->Bef * ieee9.exc2.EX1);
+  auto exciter2 =
+      Signal::ExciterDC1Simp::make("Gen2_Exciter", CPS::Logger::Level::off);
+  exciter2->setParameters(exciter2Params);
+  gen2DP->addExciter(exciter2);
+
+  std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernor2 =
+      Signal::TurbineGovernorType1::make("Gen2_TurbineGovernor",
+                                         CPS::Logger::Level::off);
+
+  turbineGovernor2->setParameters(ieee9.gov2.T2, T4, T5, ieee9.gov2.T3,
+                                  ieee9.gov2.T1, ieee9.gov2.R, ieee9.gov2.Vmin,
+                                  ieee9.gov2.Vmax, 1.0);
+
+  gen2DP->addGovernor(turbineGovernor2);
+
+  auto gen3DP = DP::Ph1::SynchronGenerator4OrderVBR::make(
+      ieee9.gen3.Name, CPS::Logger::Level::off);
+
+  gen3DP->setOperationalParametersPerUnit(
+      ieee9.gen3.RatedPower,   // nomPower [VA]
+      ieee9.gen3.RatedVoltage, // nomVolt [V]
+      ieee9.nomFreq,           // nomFreq [Hz]
+      ieee9.gen3.H, ieee9.gen3.Xd, ieee9.gen3.Xq, ieee9.gen3.Xa,
+      ieee9.gen3.XdPrime, ieee9.gen3.XqPrime, ieee9.gen3.TdoPrime,
+      ieee9.gen3.TqoPrime);
+
+  auto exciter3Params = std::make_shared<Signal::ExciterDC1SimpParameters>();
+  exciter3Params->Ta = ieee9.exc3.TA;
+  exciter3Params->Ka = ieee9.exc3.KA;
+  exciter3Params->Tef = ieee9.exc3.TE;
+  exciter3Params->Kef = ieee9.exc3.KE;
+  exciter3Params->Tf = ieee9.exc3.TF;
+  exciter3Params->Kf = ieee9.exc3.KF;
+  exciter3Params->Tr = 0.01;
+  exciter3Params->MaxVa = ieee9.exc3.VRmax;
+  exciter3Params->MinVa = ieee9.exc3.VRmin;
+  exciter3Params->Bef = std::log(ieee9.exc3.S_EX2 / ieee9.exc3.S_EX1) /
+                        (ieee9.exc3.EX2 - ieee9.exc3.EX1);
+  exciter3Params->Aef =
+      ieee9.exc3.S_EX1 / std::exp(exciter3Params->Bef * ieee9.exc3.EX1);
+  auto exciter3 =
+      Signal::ExciterDC1Simp::make("Gen3_Exciter", CPS::Logger::Level::off);
+  exciter3->setParameters(exciter3Params);
+  gen3DP->addExciter(exciter3);
+
+  std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernor3 =
+      Signal::TurbineGovernorType1::make("Gen3_TurbineGovernor",
+                                         CPS::Logger::Level::off);
+
+  turbineGovernor3->setParameters(ieee9.gov3.T2, T4, T5, ieee9.gov3.T3,
+                                  ieee9.gov3.T1, ieee9.gov3.R, ieee9.gov3.Vmin,
+                                  ieee9.gov3.Vmax, 1.0);
+
+  gen3DP->addGovernor(turbineGovernor3);
+
+  // Loads
+  auto load5DP =
+      DP::Ph1::RXLoad::make(ieee9.load5.Name, CPS::Logger::Level::off);
+  load5DP->setParameters(ieee9.load5.RealPower, ieee9.load5.ReactivePower,
+                         ieee9.load5.BaseVoltage);
+
+  auto load6DP =
+      DP::Ph1::RXLoad::make(ieee9.load6.Name, CPS::Logger::Level::off);
+  load6DP->setParameters(ieee9.load6.RealPower, ieee9.load6.ReactivePower,
+                         ieee9.load6.BaseVoltage);
+
+  auto load8DP =
+      DP::Ph1::RXLoad::make(ieee9.load8.Name, CPS::Logger::Level::off);
+  load8DP->setParameters(ieee9.load8.RealPower, ieee9.load8.ReactivePower,
+                         ieee9.load8.BaseVoltage);
+
+  // Lines
+  auto line54DP =
+      DP::Ph1::PiLine::make(ieee9.line54.Name, CPS::Logger::Level::off);
+  line54DP->setParameters(ieee9.line54.Resistance, ieee9.line54.Inductance,
+                          ieee9.line54.Capacitance, ieee9.line54.Conductance);
+
+  auto line64DP =
+      DP::Ph1::PiLine::make(ieee9.line64.Name, CPS::Logger::Level::off);
+  line64DP->setParameters(ieee9.line64.Resistance, ieee9.line64.Inductance,
+                          ieee9.line64.Capacitance, ieee9.line64.Conductance);
+
+  auto line75DP =
+      DP::Ph1::PiLine::make(ieee9.line75.Name, CPS::Logger::Level::off);
+  line75DP->setParameters(ieee9.line75.Resistance, ieee9.line75.Inductance,
+                          ieee9.line75.Capacitance, ieee9.line75.Conductance);
+
+  auto line96DP =
+      DP::Ph1::PiLine::make(ieee9.line96.Name, CPS::Logger::Level::off);
+  line96DP->setParameters(ieee9.line96.Resistance, ieee9.line96.Inductance,
+                          ieee9.line96.Capacitance, ieee9.line96.Conductance);
+
+  auto line78DP =
+      DP::Ph1::PiLine::make(ieee9.line78.Name, CPS::Logger::Level::off);
+  line78DP->setParameters(ieee9.line78.Resistance, ieee9.line78.Inductance,
+                          ieee9.line78.Capacitance, ieee9.line78.Conductance);
+
+  auto line89DP =
+      DP::Ph1::PiLine::make(ieee9.line89.Name, CPS::Logger::Level::off);
+  line89DP->setParameters(ieee9.line89.Resistance, ieee9.line89.Inductance,
+                          ieee9.line89.Capacitance, ieee9.line89.Conductance);
+
+  // Transformers
+  auto transf14DP =
+      DP::Ph1::Transformer::make(ieee9.transf14.Name, CPS::Logger::Level::off);
+  transf14DP->setParameters(
+      ieee9.transf14.VoltageLVSide, ieee9.transf14.VoltageHVSide,
+      ieee9.transf14.RatedPower, ieee9.transf14.Ratio, 0.0,
+      ieee9.transf14.Resistance, ieee9.transf14.Inductance);
+
+  auto transf27DP =
+      DP::Ph1::Transformer::make(ieee9.transf27.Name, CPS::Logger::Level::off);
+  transf27DP->setParameters(
+      ieee9.transf27.VoltageLVSide, ieee9.transf27.VoltageHVSide,
+      ieee9.transf27.RatedPower, ieee9.transf27.Ratio, 0.0,
+      ieee9.transf27.Resistance, ieee9.transf27.Inductance);
+
+  auto transf39DP =
+      DP::Ph1::Transformer::make(ieee9.transf39.Name, CPS::Logger::Level::off);
+  transf39DP->setParameters(
+      ieee9.transf39.VoltageLVSide, ieee9.transf39.VoltageHVSide,
+      ieee9.transf39.RatedPower, ieee9.transf39.Ratio, 0.0,
+      ieee9.transf39.Resistance, ieee9.transf39.Inductance);
+
+  // Connect components to nodes
+  gen1DP->connect({n1DP});
+  gen2DP->connect({n2DP});
+  gen3DP->connect({n3DP});
+
+  load5DP->connect({n5DP});
+  load6DP->connect({n6DP});
+  load8DP->connect({n8DP});
+
+  line54DP->connect({n5DP, n4DP});
+  line64DP->connect({n6DP, n4DP});
+  line75DP->connect({n7DP, n5DP});
+  line96DP->connect({n9DP, n6DP});
+  line78DP->connect({n7DP, n8DP});
+  line89DP->connect({n8DP, n9DP});
+
+  transf14DP->connect({n1DP, n4DP});
+  transf27DP->connect({n2DP, n7DP});
+  transf39DP->connect({n3DP, n9DP});
+
+  // Create system topology
+  auto systemDP = SystemTopology(
+      ieee9.nomFreq,
+      SystemNodeList{n1DP, n2DP, n3DP, n4DP, n5DP, n6DP, n7DP, n8DP, n9DP},
+      SystemComponentList{gen1DP, gen2DP, gen3DP, load5DP, load6DP, load8DP,
+                          line54DP, line64DP, line75DP, line96DP, line78DP,
+                          line89DP, transf14DP, transf27DP, transf39DP});
+
+  systemDP.initWithPowerflow(systemPF, Domain::DP);
+
+  // Logger
+  if (logger) {
+    // Logging
+    logger->logAttribute("BUS1", n1DP->attribute("v"));
+    logger->logAttribute("BUS2", n2DP->attribute("v"));
+    logger->logAttribute("BUS3", n3DP->attribute("v"));
+    logger->logAttribute("BUS4", n4DP->attribute("v"));
+    logger->logAttribute("BUS5", n5DP->attribute("v"));
+    logger->logAttribute("BUS6", n6DP->attribute("v"));
+    logger->logAttribute("BUS7", n7DP->attribute("v"));
+    logger->logAttribute("BUS8", n8DP->attribute("v"));
+    logger->logAttribute("BUS9", n9DP->attribute("v"));
+
+    // log generator's current
+    for (auto comp : systemDP.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::DP::Ph1::SynchronGenerator4OrderVBR>(
+              comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+        logger->logAttribute(comp->name() + ".omega", comp->attribute("w_r"));
+        logger->logAttribute(comp->name() + ".delta", comp->attribute("delta"));
+      }
+    }
+
+    // log transfomers voltages & currents
+    for (auto comp : systemDP.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::DP::Ph1::Transformer>(comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+      }
+    }
+
+    // log Lines voltages & currents
+    for (auto comp : systemDP.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::DP::Ph1::PiLine>(comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+      }
+    }
+  }
+
+  return systemDP;
+}
+
+int main(int argc, char *argv[]) {
+  CommandLineArgs args(argc, argv, "DP_Ph1_IEEE9_4Order", 0.00005, 0.01 * 60,
+                       60, -1, CPS::Logger::Level::info,
+                       CPS::Logger::Level::off, false, false, false,
+                       CPS::Domain::DP);
+  std::error_code ec;
+  std::filesystem::create_directories("./logs", ec);
+
+  CPS::Logger::setLogDir("./logs/" + args.name);
+  bool log = args.options.find("log") != args.options.end() &&
+             args.getOptionBool("log");
+
+  std::filesystem::path logFilename = "./logs/" + args.name + ".csv";
+  std::shared_ptr<DataLoggerInterface> logger = nullptr;
+
+  if (log) {
+    logger =
+        RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
+  }
+
+  auto sys = buildTopology(args, logger);
+
+  Simulation sim(args.name, args);
+  sim.setSystem(sys);
+  sim.setDomain(Domain::DP);
+  sim.doSystemMatrixRecomputation(true);
+  if (log) {
+    sim.addLogger(logger);
+  }
+  sim.run();
+
+  CPS::Logger::get("DP-IEEE9-4Order")->info("Simulation finished.");
+}

--- a/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_4Order.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_4Order.cpp
@@ -1,0 +1,545 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include "../Examples.h"
+#include "../GeneratorFactory.h"
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS;
+
+SystemTopology buildTopology(CommandLineArgs &args,
+                             std::shared_ptr<DataLoggerInterface> logger) {
+
+  String simName = args.name;
+
+  CPS::CIM::Examples::Grids::IEEE9::ScenarioConfig ieee9(args.sysFreq);
+
+  // POWER FLOW FOR INITIALIZATION
+  CPS::Logger::get(args.name)->info("Creating power flow initialization.");
+
+  String simNamePF = simName + "_PF";
+  CPS::Logger::setLogDir("logs/" + simNamePF);
+
+  // Nodes
+  auto n1PF = SimNode<Complex>::make("BUS1", PhaseType::Single);
+  auto n2PF = SimNode<Complex>::make("BUS2", PhaseType::Single);
+  auto n3PF = SimNode<Complex>::make("BUS3", PhaseType::Single);
+  auto n4PF = SimNode<Complex>::make("BUS4", PhaseType::Single);
+  auto n5PF = SimNode<Complex>::make("BUS5", PhaseType::Single);
+  auto n6PF = SimNode<Complex>::make("BUS6", PhaseType::Single);
+  auto n7PF = SimNode<Complex>::make("BUS7", PhaseType::Single);
+  auto n8PF = SimNode<Complex>::make("BUS8", PhaseType::Single);
+  auto n9PF = SimNode<Complex>::make("BUS9", PhaseType::Single);
+
+  auto gen1PF = SP::Ph1::SynchronGenerator::make(ieee9.gen1.Name,
+                                                 CPS::Logger::Level::off);
+  gen1PF->setParameters(ieee9.gen1.RatedPower, ieee9.gen1.RatedVoltage,
+                        ieee9.gen1.InitialPower, ieee9.gen1.InitialVoltage,
+                        ieee9.gen1.BusType);
+  gen1PF->setBaseVoltage(ieee9.gen1.RatedVoltage);
+
+  auto gen2PF = SP::Ph1::SynchronGenerator::make(ieee9.gen2.Name,
+                                                 CPS::Logger::Level::off);
+  gen2PF->setParameters(ieee9.gen2.RatedPower, ieee9.gen2.RatedVoltage,
+                        ieee9.gen2.InitialPower, ieee9.gen2.InitialVoltage,
+                        ieee9.gen2.BusType);
+  gen2PF->setBaseVoltage(ieee9.gen2.RatedVoltage);
+
+  auto gen3PF = SP::Ph1::SynchronGenerator::make(ieee9.gen3.Name,
+                                                 CPS::Logger::Level::off);
+  gen3PF->setParameters(ieee9.gen3.RatedPower, ieee9.gen3.RatedVoltage,
+                        ieee9.gen3.InitialPower, ieee9.gen3.InitialVoltage,
+                        ieee9.gen3.BusType);
+  gen3PF->setBaseVoltage(ieee9.gen3.RatedVoltage);
+
+  // Loads
+  auto load5PF = SP::Ph1::Load::make(ieee9.load5.Name, CPS::Logger::Level::off);
+  load5PF->setParameters(ieee9.load5.RealPower, ieee9.load5.ReactivePower,
+                         ieee9.load5.BaseVoltage);
+  load5PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  auto load6PF = SP::Ph1::Load::make(ieee9.load6.Name, CPS::Logger::Level::off);
+  load6PF->setParameters(ieee9.load6.RealPower, ieee9.load6.ReactivePower,
+                         ieee9.load6.BaseVoltage);
+  load6PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  auto load8PF = SP::Ph1::Load::make(ieee9.load8.Name, CPS::Logger::Level::off);
+  load8PF->setParameters(ieee9.load8.RealPower, ieee9.load8.ReactivePower,
+                         ieee9.load8.BaseVoltage);
+  load8PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  // Transmission Lines
+
+  auto line54PF =
+      SP::Ph1::PiLine::make(ieee9.line54.Name, CPS::Logger::Level::off);
+  line54PF->setParameters(ieee9.line54.Resistance, ieee9.line54.Inductance,
+                          ieee9.line54.Capacitance, ieee9.line54.Conductance);
+  line54PF->setBaseVoltage(ieee9.line54.BaseVoltage);
+
+  auto line64PF =
+      SP::Ph1::PiLine::make(ieee9.line64.Name, CPS::Logger::Level::off);
+  line64PF->setParameters(ieee9.line64.Resistance, ieee9.line64.Inductance,
+                          ieee9.line64.Capacitance, ieee9.line64.Conductance);
+  line64PF->setBaseVoltage(ieee9.line64.BaseVoltage);
+
+  auto line75PF =
+      SP::Ph1::PiLine::make(ieee9.line75.Name, CPS::Logger::Level::off);
+  line75PF->setParameters(ieee9.line75.Resistance, ieee9.line75.Inductance,
+                          ieee9.line75.Capacitance, ieee9.line75.Conductance);
+  line75PF->setBaseVoltage(ieee9.line75.BaseVoltage);
+
+  auto line96PF =
+      SP::Ph1::PiLine::make(ieee9.line96.Name, CPS::Logger::Level::off);
+  line96PF->setParameters(ieee9.line96.Resistance, ieee9.line96.Inductance,
+                          ieee9.line96.Capacitance, ieee9.line96.Conductance);
+  line96PF->setBaseVoltage(ieee9.line96.BaseVoltage);
+
+  auto line78PF =
+      SP::Ph1::PiLine::make(ieee9.line78.Name, CPS::Logger::Level::off);
+  line78PF->setParameters(ieee9.line78.Resistance, ieee9.line78.Inductance,
+                          ieee9.line78.Capacitance, ieee9.line78.Conductance);
+  line78PF->setBaseVoltage(ieee9.line78.BaseVoltage);
+
+  auto line89PF =
+      SP::Ph1::PiLine::make(ieee9.line89.Name, CPS::Logger::Level::off);
+  line89PF->setParameters(ieee9.line89.Resistance, ieee9.line89.Inductance,
+                          ieee9.line89.Capacitance, ieee9.line89.Conductance);
+  line89PF->setBaseVoltage(ieee9.line89.BaseVoltage);
+
+  // Transformers
+
+  auto transf14PF =
+      SP::Ph1::Transformer::make(ieee9.transf14.Name, CPS::Logger::Level::off);
+  transf14PF->setParameters(
+      ieee9.transf14.VoltageLVSide, ieee9.transf14.VoltageHVSide,
+      ieee9.transf14.Ratio, 0.0, // No phase shift (ratioPhase = 0.0)
+      ieee9.transf14.Resistance, ieee9.transf14.Inductance);
+  transf14PF->setBaseVoltage(ieee9.transf14.VoltageHVSide);
+
+  auto transf27PF =
+      SP::Ph1::Transformer::make(ieee9.transf27.Name, CPS::Logger::Level::off);
+  transf27PF->setParameters(ieee9.transf27.VoltageLVSide,
+                            ieee9.transf27.VoltageHVSide, ieee9.transf27.Ratio,
+                            0.0, ieee9.transf27.Resistance,
+                            ieee9.transf27.Inductance);
+  transf27PF->setBaseVoltage(ieee9.transf27.VoltageHVSide);
+
+  auto transf39PF =
+      SP::Ph1::Transformer::make(ieee9.transf39.Name, CPS::Logger::Level::off);
+  transf39PF->setParameters(ieee9.transf39.VoltageLVSide,
+                            ieee9.transf39.VoltageHVSide, ieee9.transf39.Ratio,
+                            0.0, ieee9.transf39.Resistance,
+                            ieee9.transf39.Inductance);
+  transf39PF->setBaseVoltage(ieee9.transf39.VoltageHVSide);
+
+  // Connect components
+  gen1PF->connect({n1PF});
+  gen2PF->connect({n2PF});
+  gen3PF->connect({n3PF});
+
+  load5PF->connect({n5PF});
+  load6PF->connect({n6PF});
+  load8PF->connect({n8PF});
+
+  line54PF->connect({n5PF, n4PF});
+  line64PF->connect({n6PF, n4PF});
+  line75PF->connect({n7PF, n5PF});
+  line96PF->connect({n9PF, n6PF});
+  line78PF->connect({n7PF, n8PF});
+  line89PF->connect({n8PF, n9PF});
+
+  transf14PF->connect({n1PF, n4PF});
+  transf27PF->connect({n2PF, n7PF});
+  transf39PF->connect({n3PF, n9PF});
+
+  // Create system topology
+  auto systemPF = SystemTopology(
+      ieee9.nomFreq,
+      SystemNodeList{n1PF, n2PF, n3PF, n4PF, n5PF, n6PF, n7PF, n8PF, n9PF},
+      SystemComponentList{gen1PF, gen2PF, gen3PF, load5PF, load6PF, load8PF,
+                          line54PF, line64PF, line75PF, line96PF, line78PF,
+                          line89PF, transf14PF, transf27PF, transf39PF});
+
+  // Logger
+  auto loggerPF = DataLogger::make(simNamePF, CPS::Logger::Level::off);
+  // Log node voltages
+  loggerPF->logAttribute("v_bus1", n1PF->attribute("v"));
+  loggerPF->logAttribute("v_bus2", n2PF->attribute("v"));
+  loggerPF->logAttribute("v_bus3", n3PF->attribute("v"));
+  loggerPF->logAttribute("v_bus4", n4PF->attribute("v"));
+  loggerPF->logAttribute("v_bus5", n5PF->attribute("v"));
+  loggerPF->logAttribute("v_bus6", n6PF->attribute("v"));
+  loggerPF->logAttribute("v_bus7", n7PF->attribute("v"));
+  loggerPF->logAttribute("v_bus8", n8PF->attribute("v"));
+  loggerPF->logAttribute("v_bus9", n9PF->attribute("v"));
+  // Log node powers
+  loggerPF->logAttribute("s_bus1", n1PF->attribute("s"));
+  loggerPF->logAttribute("s_bus2", n2PF->attribute("s"));
+  loggerPF->logAttribute("s_bus3", n3PF->attribute("s"));
+  loggerPF->logAttribute("s_bus4", n4PF->attribute("s"));
+  loggerPF->logAttribute("s_bus5", n5PF->attribute("s"));
+  loggerPF->logAttribute("s_bus6", n6PF->attribute("s"));
+  loggerPF->logAttribute("s_bus7", n7PF->attribute("s"));
+  loggerPF->logAttribute("s_bus8", n8PF->attribute("s"));
+  loggerPF->logAttribute("s_bus9", n9PF->attribute("s"));
+
+  // Run power flow simulation
+  Simulation simPF(simNamePF, CPS::Logger::Level::off);
+  simPF.setSystem(systemPF);
+  simPF.setTimeStep(args.timeStep);
+  simPF.setFinalTime(1 * args.timeStep);
+  simPF.setDomain(Domain::SP);
+  simPF.setSolverType(Solver::Type::NRP);
+  simPF.setSolverAndComponentBehaviour(Solver::Behaviour::Simulation);
+  simPF.addLogger(loggerPF);
+  simPF.run();
+  CPS::Logger::get(args.name)->info("Power flow simulation finished.");
+
+  // DYNAMIC SIMULATION - EMT
+  CPS::Logger::get(args.name)->info("Dynamic simulation initialization.");
+  String simNameEMT = simName + "_EMT";
+  CPS::Logger::setLogDir("logs/" + simNameEMT);
+
+  // Nodes
+  auto n1EMT = SimNode<Real>::make("BUS1", PhaseType::ABC);
+  auto n2EMT = SimNode<Real>::make("BUS2", PhaseType::ABC);
+  auto n3EMT = SimNode<Real>::make("BUS3", PhaseType::ABC);
+  auto n4EMT = SimNode<Real>::make("BUS4", PhaseType::ABC);
+  auto n5EMT = SimNode<Real>::make("BUS5", PhaseType::ABC);
+  auto n6EMT = SimNode<Real>::make("BUS6", PhaseType::ABC);
+  auto n7EMT = SimNode<Real>::make("BUS7", PhaseType::ABC);
+  auto n8EMT = SimNode<Real>::make("BUS8", PhaseType::ABC);
+  auto n9EMT = SimNode<Real>::make("BUS9", PhaseType::ABC);
+
+  // Generators
+  auto gen1EMT = EMT::Ph3::SynchronGenerator4OrderVBR::make(
+      ieee9.gen1.Name, CPS::Logger::Level::off);
+
+  gen1EMT->setOperationalParametersPerUnit(
+      ieee9.gen1.RatedPower,   // nomPower [VA]
+      ieee9.gen1.RatedVoltage, // nomVolt [V]
+      ieee9.nomFreq,           // nomFreq [Hz]
+      ieee9.gen1.H, ieee9.gen1.Xd, ieee9.gen1.Xq, ieee9.gen1.Xa,
+      ieee9.gen1.XdPrime, ieee9.gen1.XqPrime, ieee9.gen1.TdoPrime,
+      ieee9.gen1.TqoPrime);
+
+  auto exciter1Params = std::make_shared<Signal::ExciterDC1SimpParameters>();
+  exciter1Params->Ta = ieee9.exc1.TA;
+  exciter1Params->Ka = ieee9.exc1.KA;
+  exciter1Params->Tef = ieee9.exc1.TE;
+  exciter1Params->Kef = ieee9.exc1.KE;
+  exciter1Params->Tf = ieee9.exc1.TF;
+  exciter1Params->Kf = ieee9.exc1.KF;
+  exciter1Params->Tr = 0.01;
+  exciter1Params->MaxVa = ieee9.exc1.VRmax;
+  exciter1Params->MinVa = ieee9.exc1.VRmin;
+  exciter1Params->Bef = std::log(ieee9.exc1.S_EX2 / ieee9.exc1.S_EX1) /
+                        (ieee9.exc1.EX2 - ieee9.exc1.EX1);
+  exciter1Params->Aef =
+      ieee9.exc1.S_EX1 / std::exp(exciter1Params->Bef * ieee9.exc1.EX1);
+  auto exciter1 =
+      Signal::ExciterDC1Simp::make("Gen1_Exciter", CPS::Logger::Level::off);
+  exciter1->setParameters(exciter1Params);
+  gen1EMT->addExciter(exciter1);
+
+  // Adaptation of the governor model parameters to the dpsim implementation
+  CPS::Real T4 = 1.0;
+  CPS::Real T5 = 1.0;
+
+  std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernor1 =
+      Signal::TurbineGovernorType1::make("Gen1_TurbineGovernor",
+                                         CPS::Logger::Level::off);
+
+  turbineGovernor1->setParameters(ieee9.gov1.T2, T4, T5, ieee9.gov1.T3,
+                                  ieee9.gov1.T1, ieee9.gov1.R, ieee9.gov1.Vmin,
+                                  ieee9.gov1.Vmax, 1.0);
+
+  gen1EMT->addGovernor(turbineGovernor1);
+
+  auto gen2EMT = EMT::Ph3::SynchronGenerator4OrderVBR::make(
+      ieee9.gen2.Name, CPS::Logger::Level::off);
+
+  gen2EMT->setOperationalParametersPerUnit(
+      ieee9.gen2.RatedPower,   // nomPower [VA]
+      ieee9.gen2.RatedVoltage, // nomVolt [V]
+      ieee9.nomFreq,           // nomFreq [Hz]
+      ieee9.gen2.H, ieee9.gen2.Xd, ieee9.gen2.Xq, ieee9.gen2.Xa,
+      ieee9.gen2.XdPrime, ieee9.gen2.XqPrime, ieee9.gen2.TdoPrime,
+      ieee9.gen2.TqoPrime);
+
+  auto exciter2Params = std::make_shared<Signal::ExciterDC1SimpParameters>();
+  exciter2Params->Ta = ieee9.exc2.TA;
+  exciter2Params->Ka = ieee9.exc2.KA;
+  exciter2Params->Tef = ieee9.exc2.TE;
+  exciter2Params->Kef = ieee9.exc2.KE;
+  exciter2Params->Tf = ieee9.exc2.TF;
+  exciter2Params->Kf = ieee9.exc2.KF;
+  exciter2Params->Tr = 0.01;
+  exciter2Params->MaxVa = ieee9.exc2.VRmax;
+  exciter2Params->MinVa = ieee9.exc2.VRmin;
+  exciter2Params->Bef = std::log(ieee9.exc2.S_EX2 / ieee9.exc2.S_EX1) /
+                        (ieee9.exc2.EX2 - ieee9.exc2.EX1);
+  exciter2Params->Aef =
+      ieee9.exc2.S_EX1 / std::exp(exciter2Params->Bef * ieee9.exc2.EX1);
+  auto exciter2 =
+      Signal::ExciterDC1Simp::make("Gen2_Exciter", CPS::Logger::Level::off);
+  exciter2->setParameters(exciter2Params);
+  gen2EMT->addExciter(exciter2);
+
+  std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernor2 =
+      Signal::TurbineGovernorType1::make("Gen2_TurbineGovernor",
+                                         CPS::Logger::Level::off);
+
+  turbineGovernor2->setParameters(ieee9.gov2.T2, T4, T5, ieee9.gov2.T3,
+                                  ieee9.gov2.T1, ieee9.gov2.R, ieee9.gov2.Vmin,
+                                  ieee9.gov2.Vmax, 1.0);
+
+  gen2EMT->addGovernor(turbineGovernor2);
+
+  auto gen3EMT = EMT::Ph3::SynchronGenerator4OrderVBR::make(
+      ieee9.gen3.Name, CPS::Logger::Level::off);
+
+  gen3EMT->setOperationalParametersPerUnit(
+      ieee9.gen3.RatedPower,   // nomPower [VA]
+      ieee9.gen3.RatedVoltage, // nomVolt [V]
+      ieee9.nomFreq,           // nomFreq [Hz]
+      ieee9.gen3.H, ieee9.gen3.Xd, ieee9.gen3.Xq, ieee9.gen3.Xa,
+      ieee9.gen3.XdPrime, ieee9.gen3.XqPrime, ieee9.gen3.TdoPrime,
+      ieee9.gen3.TqoPrime);
+
+  auto exciter3Params = std::make_shared<Signal::ExciterDC1SimpParameters>();
+  exciter3Params->Ta = ieee9.exc3.TA;
+  exciter3Params->Ka = ieee9.exc3.KA;
+  exciter3Params->Tef = ieee9.exc3.TE;
+  exciter3Params->Kef = ieee9.exc3.KE;
+  exciter3Params->Tf = ieee9.exc3.TF;
+  exciter3Params->Kf = ieee9.exc3.KF;
+  exciter3Params->Tr = 0.01;
+  exciter3Params->MaxVa = ieee9.exc3.VRmax;
+  exciter3Params->MinVa = ieee9.exc3.VRmin;
+  exciter3Params->Bef = std::log(ieee9.exc3.S_EX2 / ieee9.exc3.S_EX1) /
+                        (ieee9.exc3.EX2 - ieee9.exc3.EX1);
+  exciter3Params->Aef =
+      ieee9.exc3.S_EX1 / std::exp(exciter3Params->Bef * ieee9.exc3.EX1);
+  auto exciter3 =
+      Signal::ExciterDC1Simp::make("Gen3_Exciter", CPS::Logger::Level::off);
+  exciter3->setParameters(exciter3Params);
+  gen3EMT->addExciter(exciter3);
+
+  std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernor3 =
+      Signal::TurbineGovernorType1::make("Gen3_TurbineGovernor",
+                                         CPS::Logger::Level::off);
+
+  turbineGovernor3->setParameters(ieee9.gov3.T2, T4, T5, ieee9.gov3.T3,
+                                  ieee9.gov3.T1, ieee9.gov3.R, ieee9.gov3.Vmin,
+                                  ieee9.gov3.Vmax, 1.0);
+
+  gen3EMT->addGovernor(turbineGovernor3);
+
+  // Loads
+  auto load5EMT =
+      EMT::Ph3::RXLoad::make(ieee9.load5.Name, CPS::Logger::Level::off);
+  load5EMT->setParameters(
+      Math::singlePhasePowerToThreePhase(ieee9.load5.RealPower),
+      Math::singlePhasePowerToThreePhase(ieee9.load5.ReactivePower),
+      ieee9.load5.BaseVoltage);
+
+  auto load6EMT =
+      EMT::Ph3::RXLoad::make(ieee9.load6.Name, CPS::Logger::Level::off);
+  load6EMT->setParameters(
+      Math::singlePhasePowerToThreePhase(ieee9.load6.RealPower),
+      Math::singlePhasePowerToThreePhase(ieee9.load6.ReactivePower),
+      ieee9.load6.BaseVoltage);
+
+  auto load8EMT =
+      EMT::Ph3::RXLoad::make(ieee9.load8.Name, CPS::Logger::Level::off);
+  load8EMT->setParameters(
+      Math::singlePhasePowerToThreePhase(ieee9.load8.RealPower),
+      Math::singlePhasePowerToThreePhase(ieee9.load8.ReactivePower),
+      ieee9.load8.BaseVoltage);
+
+  // Lines
+  auto line54EMT =
+      EMT::Ph3::PiLine::make(ieee9.line54.Name, CPS::Logger::Level::off);
+  line54EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line54.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line54.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line54.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line54.Conductance));
+
+  auto line64EMT =
+      EMT::Ph3::PiLine::make(ieee9.line64.Name, CPS::Logger::Level::off);
+  line64EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line64.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line64.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line64.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line64.Conductance));
+
+  auto line75EMT =
+      EMT::Ph3::PiLine::make(ieee9.line75.Name, CPS::Logger::Level::off);
+  line75EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line75.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line75.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line75.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line75.Conductance));
+
+  auto line96EMT =
+      EMT::Ph3::PiLine::make(ieee9.line96.Name, CPS::Logger::Level::off);
+  line96EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line96.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line96.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line96.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line96.Conductance));
+
+  auto line78EMT =
+      EMT::Ph3::PiLine::make(ieee9.line78.Name, CPS::Logger::Level::off);
+  line78EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line78.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line78.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line78.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line78.Conductance));
+
+  auto line89EMT =
+      EMT::Ph3::PiLine::make(ieee9.line89.Name, CPS::Logger::Level::off);
+  line89EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line89.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line89.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line89.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line89.Conductance));
+
+  // Transformers
+  auto transf14EMT =
+      EMT::Ph3::Transformer::make(ieee9.transf14.Name, CPS::Logger::Level::off);
+  transf14EMT->setParameters(
+      ieee9.transf14.VoltageLVSide, ieee9.transf14.VoltageHVSide,
+      ieee9.transf14.RatedPower, ieee9.transf14.Ratio, 0.0,
+      Math::singlePhaseParameterToThreePhase(ieee9.transf14.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.transf14.Inductance));
+
+  auto transf27EMT =
+      EMT::Ph3::Transformer::make(ieee9.transf27.Name, CPS::Logger::Level::off);
+  transf27EMT->setParameters(
+      ieee9.transf27.VoltageLVSide, ieee9.transf27.VoltageHVSide,
+      ieee9.transf27.RatedPower, ieee9.transf27.Ratio, 0.0,
+      Math::singlePhaseParameterToThreePhase(ieee9.transf27.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.transf27.Inductance));
+
+  auto transf39EMT =
+      EMT::Ph3::Transformer::make(ieee9.transf39.Name, CPS::Logger::Level::off);
+  transf39EMT->setParameters(
+      ieee9.transf39.VoltageLVSide, ieee9.transf39.VoltageHVSide,
+      ieee9.transf39.RatedPower, ieee9.transf39.Ratio, 0.0,
+      Math::singlePhaseParameterToThreePhase(ieee9.transf39.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.transf39.Inductance));
+
+  // Connect components to nodes
+  gen1EMT->connect({n1EMT});
+  gen2EMT->connect({n2EMT});
+  gen3EMT->connect({n3EMT});
+
+  load5EMT->connect({n5EMT});
+  load6EMT->connect({n6EMT});
+  load8EMT->connect({n8EMT});
+
+  line54EMT->connect({n5EMT, n4EMT});
+  line64EMT->connect({n6EMT, n4EMT});
+  line75EMT->connect({n7EMT, n5EMT});
+  line96EMT->connect({n9EMT, n6EMT});
+  line78EMT->connect({n7EMT, n8EMT});
+  line89EMT->connect({n8EMT, n9EMT});
+
+  transf14EMT->connect({n1EMT, n4EMT});
+  transf27EMT->connect({n2EMT, n7EMT});
+  transf39EMT->connect({n3EMT, n9EMT});
+
+  // Create system topology
+  auto systemEMT = SystemTopology(
+      ieee9.nomFreq,
+      SystemNodeList{n1EMT, n2EMT, n3EMT, n4EMT, n5EMT, n6EMT, n7EMT, n8EMT,
+                     n9EMT},
+      SystemComponentList{gen1EMT, gen2EMT, gen3EMT, load5EMT, load6EMT,
+                          load8EMT, line54EMT, line64EMT, line75EMT, line96EMT,
+                          line78EMT, line89EMT, transf14EMT, transf27EMT,
+                          transf39EMT});
+
+  systemEMT.initWithPowerflow(systemPF, Domain::EMT);
+
+  // Logger
+  if (logger) {
+    // Logging
+    logger->logAttribute("BUS1", n1EMT->attribute("v"));
+    logger->logAttribute("BUS2", n2EMT->attribute("v"));
+    logger->logAttribute("BUS3", n3EMT->attribute("v"));
+    logger->logAttribute("BUS4", n4EMT->attribute("v"));
+    logger->logAttribute("BUS5", n5EMT->attribute("v"));
+    logger->logAttribute("BUS6", n6EMT->attribute("v"));
+    logger->logAttribute("BUS7", n7EMT->attribute("v"));
+    logger->logAttribute("BUS8", n8EMT->attribute("v"));
+    logger->logAttribute("BUS9", n9EMT->attribute("v"));
+
+    // log generator's current
+    for (auto comp : systemEMT.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::EMT::Ph3::SynchronGenerator4OrderVBR>(
+              comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+        logger->logAttribute(comp->name() + ".omega", comp->attribute("w_r"));
+        logger->logAttribute(comp->name() + ".delta", comp->attribute("delta"));
+      }
+    }
+
+    // log transfomers voltages & currents
+    for (auto comp : systemEMT.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::EMT::Ph3::Transformer>(comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+      }
+    }
+
+    // log Lines voltages & currents
+    for (auto comp : systemEMT.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::EMT::Ph3::PiLine>(comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+      }
+    }
+  }
+
+  return systemEMT;
+}
+
+int main(int argc, char *argv[]) {
+
+  CommandLineArgs args(argc, argv, "EMT_Ph3_IEEE9_4Order", 0.00005, 0.01 * 60,
+                       60, -1, CPS::Logger::Level::info,
+                       CPS::Logger::Level::off, false, false, false,
+                       CPS::Domain::EMT);
+
+  CPS::Logger::setLogDir("./logs/" + args.name);
+  bool log = args.options.find("log") != args.options.end() &&
+             args.getOptionBool("log");
+
+  std::filesystem::path logFilename =
+      "./logs/" + args.name + "/" + args.name + ".csv";
+  std::shared_ptr<DataLoggerInterface> logger = nullptr;
+
+  if (log) {
+    logger =
+        RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
+  }
+
+  auto sys = buildTopology(args, logger);
+
+  Simulation sim(args.name, args);
+  sim.setSystem(sys);
+  sim.setDomain(Domain::EMT);
+  sim.doSystemMatrixRecomputation(true);
+  if (log) {
+    sim.addLogger(logger);
+  }
+  sim.run();
+
+  CPS::Logger::get(args.name)->info("Simulation finished.");
+}

--- a/dpsim/examples/cxx/Circuits/SP_Ph1_IEEE9_4Order.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_Ph1_IEEE9_4Order.cpp
@@ -1,0 +1,509 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include "../Examples.h"
+#include "../GeneratorFactory.h"
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS;
+
+SystemTopology buildTopology(CommandLineArgs &args,
+                             std::shared_ptr<DataLoggerInterface> logger) {
+
+  String simName = args.name;
+
+  CPS::CIM::Examples::Grids::IEEE9::ScenarioConfig ieee9(args.sysFreq);
+
+  // Power flow simulation
+  String simNamePF = simName + "_PF";
+  CPS::Logger::setLogDir("logs/" + simNamePF);
+
+  // Nodes
+  auto n1PF = SimNode<Complex>::make("BUS1", PhaseType::Single);
+  auto n2PF = SimNode<Complex>::make("BUS2", PhaseType::Single);
+  auto n3PF = SimNode<Complex>::make("BUS3", PhaseType::Single);
+  auto n4PF = SimNode<Complex>::make("BUS4", PhaseType::Single);
+  auto n5PF = SimNode<Complex>::make("BUS5", PhaseType::Single);
+  auto n6PF = SimNode<Complex>::make("BUS6", PhaseType::Single);
+  auto n7PF = SimNode<Complex>::make("BUS7", PhaseType::Single);
+  auto n8PF = SimNode<Complex>::make("BUS8", PhaseType::Single);
+  auto n9PF = SimNode<Complex>::make("BUS9", PhaseType::Single);
+
+  auto gen1PF = SP::Ph1::SynchronGenerator::make(ieee9.gen1.Name,
+                                                 CPS::Logger::Level::off);
+  gen1PF->setParameters(ieee9.gen1.RatedPower, ieee9.gen1.RatedVoltage,
+                        ieee9.gen1.InitialPower, ieee9.gen1.InitialVoltage,
+                        ieee9.gen1.BusType);
+  gen1PF->setBaseVoltage(ieee9.gen1.RatedVoltage);
+
+  auto gen2PF = SP::Ph1::SynchronGenerator::make(ieee9.gen2.Name,
+                                                 CPS::Logger::Level::off);
+  gen2PF->setParameters(ieee9.gen2.RatedPower, ieee9.gen2.RatedVoltage,
+                        ieee9.gen2.InitialPower, ieee9.gen2.InitialVoltage,
+                        ieee9.gen2.BusType);
+  gen2PF->setBaseVoltage(ieee9.gen2.RatedVoltage);
+
+  auto gen3PF = SP::Ph1::SynchronGenerator::make(ieee9.gen3.Name,
+                                                 CPS::Logger::Level::off);
+  gen3PF->setParameters(ieee9.gen3.RatedPower, ieee9.gen3.RatedVoltage,
+                        ieee9.gen3.InitialPower, ieee9.gen3.InitialVoltage,
+                        ieee9.gen3.BusType);
+  gen3PF->setBaseVoltage(ieee9.gen3.RatedVoltage);
+
+  // Loads
+  auto load5PF = SP::Ph1::Load::make(ieee9.load5.Name, CPS::Logger::Level::off);
+  load5PF->setParameters(ieee9.load5.RealPower, ieee9.load5.ReactivePower,
+                         ieee9.load5.BaseVoltage);
+  load5PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  auto load6PF = SP::Ph1::Load::make(ieee9.load6.Name, CPS::Logger::Level::off);
+  load6PF->setParameters(ieee9.load6.RealPower, ieee9.load6.ReactivePower,
+                         ieee9.load6.BaseVoltage);
+  load6PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  auto load8PF = SP::Ph1::Load::make(ieee9.load8.Name, CPS::Logger::Level::off);
+  load8PF->setParameters(ieee9.load8.RealPower, ieee9.load8.ReactivePower,
+                         ieee9.load8.BaseVoltage);
+  load8PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  // Transmission Lines
+  auto line54PF =
+      SP::Ph1::PiLine::make(ieee9.line54.Name, CPS::Logger::Level::off);
+  line54PF->setParameters(ieee9.line54.Resistance, ieee9.line54.Inductance,
+                          ieee9.line54.Capacitance, ieee9.line54.Conductance);
+  line54PF->setBaseVoltage(ieee9.line54.BaseVoltage);
+
+  auto line64PF =
+      SP::Ph1::PiLine::make(ieee9.line64.Name, CPS::Logger::Level::off);
+  line64PF->setParameters(ieee9.line64.Resistance, ieee9.line64.Inductance,
+                          ieee9.line64.Capacitance, ieee9.line64.Conductance);
+  line64PF->setBaseVoltage(ieee9.line64.BaseVoltage);
+
+  auto line75PF =
+      SP::Ph1::PiLine::make(ieee9.line75.Name, CPS::Logger::Level::off);
+  line75PF->setParameters(ieee9.line75.Resistance, ieee9.line75.Inductance,
+                          ieee9.line75.Capacitance, ieee9.line75.Conductance);
+  line75PF->setBaseVoltage(ieee9.line75.BaseVoltage);
+
+  auto line96PF =
+      SP::Ph1::PiLine::make(ieee9.line96.Name, CPS::Logger::Level::off);
+  line96PF->setParameters(ieee9.line96.Resistance, ieee9.line96.Inductance,
+                          ieee9.line96.Capacitance, ieee9.line96.Conductance);
+  line96PF->setBaseVoltage(ieee9.line96.BaseVoltage);
+
+  auto line78PF =
+      SP::Ph1::PiLine::make(ieee9.line78.Name, CPS::Logger::Level::off);
+  line78PF->setParameters(ieee9.line78.Resistance, ieee9.line78.Inductance,
+                          ieee9.line78.Capacitance, ieee9.line78.Conductance);
+  line78PF->setBaseVoltage(ieee9.line78.BaseVoltage);
+
+  auto line89PF =
+      SP::Ph1::PiLine::make(ieee9.line89.Name, CPS::Logger::Level::off);
+  line89PF->setParameters(ieee9.line89.Resistance, ieee9.line89.Inductance,
+                          ieee9.line89.Capacitance, ieee9.line89.Conductance);
+  line89PF->setBaseVoltage(ieee9.line89.BaseVoltage);
+
+  // Transformers
+  auto transf14PF =
+      SP::Ph1::Transformer::make(ieee9.transf14.Name, CPS::Logger::Level::off);
+  transf14PF->setParameters(ieee9.transf14.VoltageLVSide,
+                            ieee9.transf14.VoltageHVSide, ieee9.transf14.Ratio,
+                            0.0, ieee9.transf14.Resistance,
+                            ieee9.transf14.Inductance);
+  transf14PF->setBaseVoltage(ieee9.transf14.VoltageHVSide);
+
+  auto transf27PF =
+      SP::Ph1::Transformer::make(ieee9.transf27.Name, CPS::Logger::Level::off);
+  transf27PF->setParameters(ieee9.transf27.VoltageLVSide,
+                            ieee9.transf27.VoltageHVSide, ieee9.transf27.Ratio,
+                            0.0, ieee9.transf27.Resistance,
+                            ieee9.transf27.Inductance);
+  transf27PF->setBaseVoltage(ieee9.transf27.VoltageHVSide);
+
+  auto transf39PF =
+      SP::Ph1::Transformer::make(ieee9.transf39.Name, CPS::Logger::Level::off);
+  transf39PF->setParameters(ieee9.transf39.VoltageLVSide,
+                            ieee9.transf39.VoltageHVSide, ieee9.transf39.Ratio,
+                            0.0, ieee9.transf39.Resistance,
+                            ieee9.transf39.Inductance);
+  transf39PF->setBaseVoltage(ieee9.transf39.VoltageHVSide);
+
+  // Connect components to nodes
+
+  gen1PF->connect({n1PF});
+  gen2PF->connect({n2PF});
+  gen3PF->connect({n3PF});
+
+  load5PF->connect({n5PF});
+  load6PF->connect({n6PF});
+  load8PF->connect({n8PF});
+
+  line54PF->connect({n5PF, n4PF});
+  line64PF->connect({n6PF, n4PF});
+  line75PF->connect({n7PF, n5PF});
+  line96PF->connect({n9PF, n6PF});
+  line78PF->connect({n7PF, n8PF});
+  line89PF->connect({n8PF, n9PF});
+
+  transf14PF->connect({n1PF, n4PF});
+  transf27PF->connect({n2PF, n7PF});
+  transf39PF->connect({n3PF, n9PF});
+
+  // Create system topology for power flow
+  auto systemPF = SystemTopology(
+      ieee9.nomFreq,
+      SystemNodeList{n1PF, n2PF, n3PF, n4PF, n5PF, n6PF, n7PF, n8PF, n9PF},
+      SystemComponentList{gen1PF, gen2PF, gen3PF, load5PF, load6PF, load8PF,
+                          line54PF, line64PF, line75PF, line96PF, line78PF,
+                          line89PF, transf14PF, transf27PF, transf39PF});
+
+  // Logger
+  auto loggerPF = DataLogger::make(simNamePF, CPS::Logger::Level::off);
+  // Log node voltages
+  loggerPF->logAttribute("v_bus1", n1PF->attribute("v"));
+  loggerPF->logAttribute("v_bus2", n2PF->attribute("v"));
+  loggerPF->logAttribute("v_bus3", n3PF->attribute("v"));
+  loggerPF->logAttribute("v_bus4", n4PF->attribute("v"));
+  loggerPF->logAttribute("v_bus5", n5PF->attribute("v"));
+  loggerPF->logAttribute("v_bus6", n6PF->attribute("v"));
+  loggerPF->logAttribute("v_bus7", n7PF->attribute("v"));
+  loggerPF->logAttribute("v_bus8", n8PF->attribute("v"));
+  loggerPF->logAttribute("v_bus9", n9PF->attribute("v"));
+  // Log node powers
+  loggerPF->logAttribute("s_bus1", n1PF->attribute("s"));
+  loggerPF->logAttribute("s_bus2", n2PF->attribute("s"));
+  loggerPF->logAttribute("s_bus3", n3PF->attribute("s"));
+  loggerPF->logAttribute("s_bus4", n4PF->attribute("s"));
+  loggerPF->logAttribute("s_bus5", n5PF->attribute("s"));
+  loggerPF->logAttribute("s_bus6", n6PF->attribute("s"));
+  loggerPF->logAttribute("s_bus7", n7PF->attribute("s"));
+  loggerPF->logAttribute("s_bus8", n8PF->attribute("s"));
+  loggerPF->logAttribute("s_bus9", n9PF->attribute("s"));
+
+  // Run power flow simulation
+  Simulation simPF(simNamePF, CPS::Logger::Level::off);
+  simPF.setSystem(systemPF);
+  simPF.setTimeStep(args.timeStep);
+  simPF.setFinalTime(1 * args.timeStep);
+  simPF.setDomain(Domain::SP);
+  simPF.setSolverType(Solver::Type::NRP);
+  simPF.setSolverAndComponentBehaviour(Solver::Behaviour::Simulation);
+  simPF.addLogger(loggerPF);
+  simPF.run();
+
+  // DYNAMIC SIMULATION - SP
+
+  String simNameSP = simName + "_SP";
+  CPS::Logger::setLogDir("logs/" + simNameSP);
+
+  // Nodes
+  auto n1SP = SimNode<Complex>::make("BUS1", PhaseType::Single);
+  auto n2SP = SimNode<Complex>::make("BUS2", PhaseType::Single);
+  auto n3SP = SimNode<Complex>::make("BUS3", PhaseType::Single);
+  auto n4SP = SimNode<Complex>::make("BUS4", PhaseType::Single);
+  auto n5SP = SimNode<Complex>::make("BUS5", PhaseType::Single);
+  auto n6SP = SimNode<Complex>::make("BUS6", PhaseType::Single);
+  auto n7SP = SimNode<Complex>::make("BUS7", PhaseType::Single);
+  auto n8SP = SimNode<Complex>::make("BUS8", PhaseType::Single);
+  auto n9SP = SimNode<Complex>::make("BUS9", PhaseType::Single);
+
+  // Generator 1 Initialization
+  auto gen1SP = SP::Ph1::SynchronGenerator4OrderVBR::make(
+      ieee9.gen1.Name, CPS::Logger::Level::off);
+
+  gen1SP->setOperationalParametersPerUnit(
+      ieee9.gen1.RatedPower,   // nomPower [VA]
+      ieee9.gen1.RatedVoltage, // nomVolt [V]
+      ieee9.nomFreq,           // nomFreq [Hz]
+      ieee9.gen1.H, ieee9.gen1.Xd, ieee9.gen1.Xq, ieee9.gen1.Xa,
+      ieee9.gen1.XdPrime, ieee9.gen1.XqPrime, ieee9.gen1.TdoPrime,
+      ieee9.gen1.TqoPrime);
+
+  auto exciter1Params = std::make_shared<Signal::ExciterDC1SimpParameters>();
+  exciter1Params->Ta = ieee9.exc1.TA;
+  exciter1Params->Ka = ieee9.exc1.KA;
+  exciter1Params->Tef = ieee9.exc1.TE;
+  exciter1Params->Kef = ieee9.exc1.KE;
+  exciter1Params->Tf = ieee9.exc1.TF;
+  exciter1Params->Kf = ieee9.exc1.KF;
+  exciter1Params->Tr = 0.01;
+  exciter1Params->MaxVa = ieee9.exc1.VRmax;
+  exciter1Params->MinVa = ieee9.exc1.VRmin;
+  exciter1Params->Bef = std::log(ieee9.exc1.S_EX2 / ieee9.exc1.S_EX1) /
+                        (ieee9.exc1.EX2 - ieee9.exc1.EX1);
+  exciter1Params->Aef =
+      ieee9.exc1.S_EX1 / std::exp(exciter1Params->Bef * ieee9.exc1.EX1);
+  auto exciter1 =
+      Signal::ExciterDC1Simp::make("Gen1_Exciter", CPS::Logger::Level::off);
+  exciter1->setParameters(exciter1Params);
+  gen1SP->addExciter(exciter1);
+
+  CPS::Real T4 = 1.0;
+  CPS::Real T5 = 1.0;
+
+  std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernor1 =
+      Signal::TurbineGovernorType1::make("Gen1_TurbineGovernor",
+                                         CPS::Logger::Level::off);
+
+  turbineGovernor1->setParameters(ieee9.gov1.T2, T4, T5, ieee9.gov1.T3,
+                                  ieee9.gov1.T1, ieee9.gov1.R, ieee9.gov1.Vmin,
+                                  ieee9.gov1.Vmax, 1.0);
+
+  gen1SP->addGovernor(turbineGovernor1);
+
+  auto gen2SP = SP::Ph1::SynchronGenerator4OrderVBR::make(
+      ieee9.gen2.Name, CPS::Logger::Level::off);
+
+  gen2SP->setOperationalParametersPerUnit(
+      ieee9.gen2.RatedPower,   // nomPower [VA]
+      ieee9.gen2.RatedVoltage, // nomVolt [V]
+      ieee9.nomFreq,           // nomFreq [Hz]
+      ieee9.gen2.H, ieee9.gen2.Xd, ieee9.gen2.Xq, ieee9.gen2.Xa,
+      ieee9.gen2.XdPrime, ieee9.gen2.XqPrime, ieee9.gen2.TdoPrime,
+      ieee9.gen2.TqoPrime);
+
+  auto exciter2Params = std::make_shared<Signal::ExciterDC1SimpParameters>();
+  exciter2Params->Ta = ieee9.exc2.TA;
+  exciter2Params->Ka = ieee9.exc2.KA;
+  exciter2Params->Tef = ieee9.exc2.TE;
+  exciter2Params->Kef = ieee9.exc2.KE;
+  exciter2Params->Tf = ieee9.exc2.TF;
+  exciter2Params->Kf = ieee9.exc2.KF;
+  exciter2Params->Tr = 0.01;
+  exciter2Params->MaxVa = ieee9.exc2.VRmax;
+  exciter2Params->MinVa = ieee9.exc2.VRmin;
+  exciter2Params->Bef = std::log(ieee9.exc2.S_EX2 / ieee9.exc2.S_EX1) /
+                        (ieee9.exc2.EX2 - ieee9.exc2.EX1);
+  exciter2Params->Aef =
+      ieee9.exc2.S_EX1 / std::exp(exciter2Params->Bef * ieee9.exc2.EX1);
+  auto exciter2 =
+      Signal::ExciterDC1Simp::make("Gen2_Exciter", CPS::Logger::Level::off);
+  exciter2->setParameters(exciter2Params);
+  gen2SP->addExciter(exciter2);
+
+  std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernor2 =
+      Signal::TurbineGovernorType1::make("Gen2_TurbineGovernor",
+                                         CPS::Logger::Level::off);
+
+  turbineGovernor2->setParameters(ieee9.gov2.T2, T4, T5, ieee9.gov2.T3,
+                                  ieee9.gov2.T1, ieee9.gov2.R, ieee9.gov2.Vmin,
+                                  ieee9.gov2.Vmax, 1.0);
+
+  gen2SP->addGovernor(turbineGovernor2);
+
+  auto gen3SP = SP::Ph1::SynchronGenerator4OrderVBR::make(
+      ieee9.gen3.Name, CPS::Logger::Level::off);
+
+  gen3SP->setOperationalParametersPerUnit(
+      ieee9.gen3.RatedPower,   // nomPower [VA]
+      ieee9.gen3.RatedVoltage, // nomVolt [V]
+      ieee9.nomFreq,           // nomFreq [Hz]
+      ieee9.gen3.H, ieee9.gen3.Xd, ieee9.gen3.Xq, ieee9.gen3.Xa,
+      ieee9.gen3.XdPrime, ieee9.gen3.XqPrime, ieee9.gen3.TdoPrime,
+      ieee9.gen3.TqoPrime);
+
+  auto exciter3Params = std::make_shared<Signal::ExciterDC1SimpParameters>();
+  exciter3Params->Ta = ieee9.exc3.TA;
+  exciter3Params->Ka = ieee9.exc3.KA;
+  exciter3Params->Tef = ieee9.exc3.TE;
+  exciter3Params->Kef = ieee9.exc3.KE;
+  exciter3Params->Tf = ieee9.exc3.TF;
+  exciter3Params->Kf = ieee9.exc3.KF;
+  exciter3Params->Tr = 0.01;
+  exciter3Params->MaxVa = ieee9.exc3.VRmax;
+  exciter3Params->MinVa = ieee9.exc3.VRmin;
+  exciter3Params->Bef = std::log(ieee9.exc3.S_EX2 / ieee9.exc3.S_EX1) /
+                        (ieee9.exc3.EX2 - ieee9.exc3.EX1);
+  exciter3Params->Aef =
+      ieee9.exc3.S_EX1 / std::exp(exciter3Params->Bef * ieee9.exc3.EX1);
+  auto exciter3 =
+      Signal::ExciterDC1Simp::make("Gen3_Exciter", CPS::Logger::Level::off);
+  exciter3->setParameters(exciter3Params);
+  gen3SP->addExciter(exciter3);
+
+  std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernor3 =
+      Signal::TurbineGovernorType1::make("Gen3_TurbineGovernor",
+                                         CPS::Logger::Level::off);
+
+  turbineGovernor3->setParameters(ieee9.gov3.T2, T4, T5, ieee9.gov3.T3,
+                                  ieee9.gov3.T1, ieee9.gov3.R, ieee9.gov3.Vmin,
+                                  ieee9.gov3.Vmax, 1.0);
+
+  gen3SP->addGovernor(turbineGovernor3);
+
+  // Loads
+  auto load5SP = SP::Ph1::Load::make(ieee9.load5.Name, CPS::Logger::Level::off);
+  load5SP->setParameters(ieee9.load5.RealPower, ieee9.load5.ReactivePower,
+                         ieee9.load5.BaseVoltage);
+
+  auto load6SP = SP::Ph1::Load::make(ieee9.load6.Name, CPS::Logger::Level::off);
+  load6SP->setParameters(ieee9.load6.RealPower, ieee9.load6.ReactivePower,
+                         ieee9.load6.BaseVoltage);
+
+  auto load8SP = SP::Ph1::Load::make(ieee9.load8.Name, CPS::Logger::Level::off);
+  load8SP->setParameters(ieee9.load8.RealPower, ieee9.load8.ReactivePower,
+                         ieee9.load8.BaseVoltage);
+
+  // Lines
+  auto line54SP =
+      SP::Ph1::PiLine::make(ieee9.line54.Name, CPS::Logger::Level::off);
+  line54SP->setParameters(ieee9.line54.Resistance, ieee9.line54.Inductance,
+                          ieee9.line54.Capacitance, ieee9.line54.Conductance);
+
+  auto line64SP =
+      SP::Ph1::PiLine::make(ieee9.line64.Name, CPS::Logger::Level::off);
+  line64SP->setParameters(ieee9.line64.Resistance, ieee9.line64.Inductance,
+                          ieee9.line64.Capacitance, ieee9.line64.Conductance);
+
+  auto line75SP =
+      SP::Ph1::PiLine::make(ieee9.line75.Name, CPS::Logger::Level::off);
+  line75SP->setParameters(ieee9.line75.Resistance, ieee9.line75.Inductance,
+                          ieee9.line75.Capacitance, ieee9.line75.Conductance);
+
+  auto line96SP =
+      SP::Ph1::PiLine::make(ieee9.line96.Name, CPS::Logger::Level::off);
+  line96SP->setParameters(ieee9.line96.Resistance, ieee9.line96.Inductance,
+                          ieee9.line96.Capacitance, ieee9.line96.Conductance);
+
+  auto line78SP =
+      SP::Ph1::PiLine::make(ieee9.line78.Name, CPS::Logger::Level::off);
+  line78SP->setParameters(ieee9.line78.Resistance, ieee9.line78.Inductance,
+                          ieee9.line78.Capacitance, ieee9.line78.Conductance);
+
+  auto line89SP =
+      SP::Ph1::PiLine::make(ieee9.line89.Name, CPS::Logger::Level::off);
+  line89SP->setParameters(ieee9.line89.Resistance, ieee9.line89.Inductance,
+                          ieee9.line89.Capacitance, ieee9.line89.Conductance);
+
+  // Transformers
+  auto transf14SP =
+      SP::Ph1::Transformer::make(ieee9.transf14.Name, CPS::Logger::Level::off);
+  transf14SP->setParameters(
+      ieee9.transf14.VoltageLVSide, ieee9.transf14.VoltageHVSide,
+      ieee9.transf14.RatedPower, ieee9.transf14.Ratio, 0.0,
+      ieee9.transf14.Resistance, ieee9.transf14.Inductance);
+
+  auto transf27SP =
+      SP::Ph1::Transformer::make(ieee9.transf27.Name, CPS::Logger::Level::off);
+  transf27SP->setParameters(
+      ieee9.transf27.VoltageLVSide, ieee9.transf27.VoltageHVSide,
+      ieee9.transf27.RatedPower, ieee9.transf27.Ratio, 0.0,
+      ieee9.transf27.Resistance, ieee9.transf27.Inductance);
+
+  auto transf39SP =
+      SP::Ph1::Transformer::make(ieee9.transf39.Name, CPS::Logger::Level::off);
+  transf39SP->setParameters(
+      ieee9.transf39.VoltageLVSide, ieee9.transf39.VoltageHVSide,
+      ieee9.transf39.RatedPower, ieee9.transf39.Ratio, 0.0,
+      ieee9.transf39.Resistance, ieee9.transf39.Inductance);
+
+  // Connect components to nodes
+  gen1SP->connect({n1SP});
+  gen2SP->connect({n2SP});
+  gen3SP->connect({n3SP});
+
+  load5SP->connect({n5SP});
+  load6SP->connect({n6SP});
+  load8SP->connect({n8SP});
+
+  line54SP->connect({n5SP, n4SP});
+  line64SP->connect({n6SP, n4SP});
+  line75SP->connect({n7SP, n5SP});
+  line96SP->connect({n9SP, n6SP});
+  line78SP->connect({n7SP, n8SP});
+  line89SP->connect({n8SP, n9SP});
+
+  transf14SP->connect({n1SP, n4SP});
+  transf27SP->connect({n2SP, n7SP});
+  transf39SP->connect({n3SP, n9SP});
+
+  // Create system topology
+  auto systemSP = SystemTopology(
+      ieee9.nomFreq,
+      SystemNodeList{n1SP, n2SP, n3SP, n4SP, n5SP, n6SP, n7SP, n8SP, n9SP},
+      SystemComponentList{gen1SP, gen2SP, gen3SP, load5SP, load6SP, load8SP,
+                          line54SP, line64SP, line75SP, line96SP, line78SP,
+                          line89SP, transf14SP, transf27SP, transf39SP});
+
+  systemSP.initWithPowerflow(systemPF, Domain::SP);
+
+  // Logger
+  if (logger) {
+    // Logging
+    logger->logAttribute("BUS1", n1SP->attribute("v"));
+    logger->logAttribute("BUS2", n2SP->attribute("v"));
+    logger->logAttribute("BUS3", n3SP->attribute("v"));
+    logger->logAttribute("BUS4", n4SP->attribute("v"));
+    logger->logAttribute("BUS5", n5SP->attribute("v"));
+    logger->logAttribute("BUS6", n6SP->attribute("v"));
+    logger->logAttribute("BUS7", n7SP->attribute("v"));
+    logger->logAttribute("BUS8", n8SP->attribute("v"));
+    logger->logAttribute("BUS9", n9SP->attribute("v"));
+
+    // log generator's current
+    for (auto comp : systemSP.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator4OrderVBR>(
+              comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+        logger->logAttribute(comp->name() + ".omega", comp->attribute("w_r"));
+        logger->logAttribute(comp->name() + ".delta", comp->attribute("delta"));
+      }
+    }
+
+    // log transfomers voltages & currents
+    for (auto comp : systemSP.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::SP::Ph1::Transformer>(comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+      }
+    }
+
+    // log Lines voltages & currents
+    for (auto comp : systemSP.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::SP::Ph1::PiLine>(comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+      }
+    }
+  }
+
+  return systemSP;
+}
+
+int main(int argc, char *argv[]) {
+  CommandLineArgs args(argc, argv, "SP_Ph1_IEEE9_4Order", 0.00005, 0.01 * 60,
+                       60, -1, CPS::Logger::Level::info,
+                       CPS::Logger::Level::off, false, false, false,
+                       CPS::Domain::SP);
+  std::error_code ec;
+  std::filesystem::create_directories("./logs", ec);
+
+  CPS::Logger::setLogDir("./logs/" + args.name);
+  bool log = args.options.find("log") != args.options.end() &&
+             args.getOptionBool("log");
+
+  std::filesystem::path logFilename = "./logs/" + args.name + ".csv";
+  std::shared_ptr<DataLoggerInterface> logger = nullptr;
+
+  if (log) {
+    logger =
+        RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
+  }
+
+  auto sys = buildTopology(args, logger);
+
+  Simulation sim(args.name, args);
+  sim.setSystem(sys);
+  sim.setDomain(Domain::SP);
+  sim.setSolverType(Solver::Type::MNA);
+  sim.doSystemMatrixRecomputation(true);
+  if (log) {
+    sim.addLogger(logger);
+  }
+  sim.run();
+
+  CPS::Logger::get("SP-IEEE9-4Order")->info("Simulation finished.");
+}

--- a/dpsim/examples/cxx/Examples.h
+++ b/dpsim/examples/cxx/Examples.h
@@ -894,6 +894,452 @@ void logPVAttributes(DPsim::DataLogger::Ptr logger,
 }
 
 } // namespace CIGREMV
+
+namespace IEEE9 {
+struct Gen {
+  String Name;               // Name of Generator
+  Real RatedPower;           // Rated Power of Generator
+  Real RatedVoltage;         // Rated Voltage of Generator
+  Real InitialPower;         // Initial Power of Generator
+  Real InitialPowerReactive; // Initial Reactive Power of Generator
+  Real InitialVoltage;       // Initial Voltage of Generator
+  PowerflowBusType BusType;  // Bus Type of Generator
+
+  // Generator Parameters
+  Real Ra; // Armature Resistance (PU)
+  Real Xa; // Armature Reactance (PU)
+
+  Real Xd;             // Synchronous Reactance (PU)
+  Real XdPrime;        // Transient Reactance (PU)
+  Real XdDoublePrime;  // Sub-Transient Reactance (PU)
+  Real Xq;             // Quadrature-Axis Reactance (PU)
+  Real XqPrime;        // Quadrature-Axis Transient Reactance (PU)
+  Real XqDoublePrime;  // Quadrature-Axis Sub-Transient Reactance (PU)
+  Real Ld;             // Synchronous Inductance (PU)
+  Real LdPrime;        // Transient Inductance (PU)
+  Real LdDoublePrime;  // Sub-Transient Inductance (PU)
+  Real Lq;             // Quadrature-Axis Inductance (PU)
+  Real LqPrime;        // Quadrature-Axis Transient Inductance (PU)
+  Real LqDoublePrime;  // Quadrature-Axis Sub-Transient Inductance (PU)
+  Real H;              // Inertia Constant (s)
+  Real D;              // Damping Coefficient (PU/PU)
+  Real TdoPrime;       // Open-Circuit Field Time Constant (s)
+  Real TdoDoublePrime; // Sub-Transient Time Constant (s)
+  Real TqoPrime;
+  Real TqoDoublePrime;
+
+  Real Taa; // Accelerating Time Constant (s)
+  Real L0;  // Leakage Reactance (PU)
+};          // Generator Structure
+
+struct Exciter {
+  // Exciter (IEEE Type DC1A)
+  Real KA;    // Voltage regulator gain (PU)
+  Real TA;    // Voltage regulator time constant (s)
+  Real VRmin; // Minimum exciter output limit (PU)
+  Real VRmax; // Maximum exciter output limit (PU)
+  Real KE;    // Exciter field proportional constant (PU)
+  Real TE;    // Exciter field time constant (s)
+  Real KF;    // Stabilizer feedback gain (PU)
+  Real TF;    // Stabilizer feedback time constant (s)
+
+  // Exciter (IEEE Type DC1A)
+  Real EX1;   // Saturation point 1 for exciter (PU)
+  Real S_EX1; // Saturation value at EX1 (PU)
+  Real EX2;   // Saturation point 2 for exciter (PU)
+  Real S_EX2; // Saturation value at EX2 (PU)
+};            // Exciter Structure
+
+struct Governor {
+  // Governor Data (TGOV1)
+  Real R;    // Speed droop (PU/PU)
+  Real T1;   // Governor time constant (s)
+  Real Vmax; // Maximum valve position (PU)
+  Real Vmin; // Minimum valve position (PU)
+  Real T2;   // Turbine time constant (s)
+  Real T3;   // Servo time constant (s)
+  Real Dt;   // Turbine damping coefficient (PU)
+};           // Governor Structure
+
+struct Load {
+  String Name;
+  Real RealPower;
+  Real ReactivePower;
+  Real BaseVoltage;
+  Real Conductance;
+  Real Susceptance;
+}; // Load Structure
+
+struct Line {
+  String Name;
+  Real ResistancePU;  // Resistance per unit
+  Real ReactancePU;   // Reactance per unit
+  Real SusceptancePU; // Susceptance per unit
+  Real Resistance;    // Resistance
+  Real Inductance;    // Inductance
+  Real Capacitance;   // Capacitance
+  Real Conductance;   // Conductance
+  Real BaseVoltage;   // Base Voltage
+};                    // Line Structure
+
+struct Transformer {
+  String Name;            // Name of the Transformer
+  Real VoltageHVSide;     // High Voltage Side Voltage (in volts)
+  Real VoltageLVSide;     // Low Voltage Side Voltage (in volts)
+  Real RatedPower;        // Rated Power of the Transformer (in VA)
+  Real Ratio;             // Turns Ratio (unitless)
+  Real WindingConnection; // Winding Connection Type (0 for default)
+  Real ResistancePU;      // Resistance per unit
+  Real Resistance;        // Resistance (in ohms)
+  Real ReactancePU;       // Reactance  per unit
+  Real Inductance;        // Inductance (in henrys)
+};                        // Transformer Structure
+
+struct ScenarioConfig {
+  // Network parameters
+  Real Vnom = 230e3;
+  Real nomFreq;
+  Real nomOmega;
+  Real baseMVA = 100e6;
+  Real baseZ = Vnom * Vnom / baseMVA;
+
+  // Generators
+  Gen gen1;
+  Gen gen2;
+  Gen gen3;
+  // Exciters
+  Exciter exc1;
+  Exciter exc2;
+  Exciter exc3;
+  // Governors
+  Governor gov1;
+  Governor gov2;
+  Governor gov3;
+
+  // Loads
+  Load load5;
+  Load load6;
+  Load load8;
+
+  // Lines
+  Line line54;
+  Line line64;
+  Line line75;
+  Line line96;
+  Line line78;
+  Line line89;
+
+  // Transformers
+  Transformer transf14;
+  Transformer transf27;
+  Transformer transf39;
+
+  ScenarioConfig(Real nomFreq_ = 60)
+      : nomFreq(nomFreq_), nomOmega(nomFreq_ * 2 * PI) {
+    // Generator 1 (bus1)
+    gen1.Name = "GEN1";
+    gen1.RatedPower = 100e6;
+    gen1.RatedVoltage = 16.5e3;
+    gen1.InitialPower = 71.6e6;
+    gen1.InitialPowerReactive = 27e6;
+    gen1.InitialVoltage = 1.04 * gen1.RatedVoltage;
+    gen1.BusType = PowerflowBusType::VD;
+
+    gen1.Ra = 0.000125;
+    gen1.Xa = 0.01460;
+    gen1.L0 = gen1.Xa / (2 * PI * nomFreq);
+
+    gen1.Xd = 0.146;
+    gen1.XdPrime = 0.0608;
+    gen1.XdDoublePrime = 0.06;
+
+    gen1.Ld = gen1.Xd / (2 * PI * nomFreq);
+    gen1.LdPrime = gen1.XdPrime / (2 * PI * nomFreq);
+    gen1.LdDoublePrime = gen1.XdDoublePrime / (2 * PI * nomFreq);
+
+    gen1.Xq = 0.1;
+    gen1.XqPrime = 0.0969;
+    gen1.XqDoublePrime = 0.06;
+
+    gen1.Lq = gen1.Xq / (2 * PI * nomFreq);
+    gen1.LqPrime = gen1.XqPrime / (2 * PI * nomFreq);
+    gen1.LqDoublePrime = gen1.XqDoublePrime / (2 * PI * nomFreq);
+
+    gen1.H = 23.64;
+    gen1.D = 0.0;
+    gen1.TdoPrime = 8.96;
+    gen1.TdoDoublePrime = 0.01;
+    gen1.TqoPrime = 0.310;
+    gen1.TqoDoublePrime = 0.01;
+    gen1.Taa = 0.0;
+
+    // Exciter (IEEE Type DC1A)
+    exc1.KA = 20.0;
+    exc1.TA = 0.2;
+    exc1.VRmin = -5.0;
+    exc1.VRmax = 5.0;
+    exc1.KE = 1.0;
+    exc1.TE = 0.314;
+    exc1.KF = 0.063;
+    exc1.TF = 0.35;
+
+    // Exciter (IEEE Type DC1A)
+    exc1.EX1 = 3.3;
+    exc1.S_EX1 = 0.6602;
+    exc1.EX2 = 4.5;
+    exc1.S_EX2 = 4.2662;
+
+    // Governor Data (TGOV1)
+    gov1.R = 0.05;
+    gov1.T1 = 0.05;
+    gov1.Vmax = 5.00;
+    gov1.Vmin = -5.00;
+    gov1.T2 = 2.1;
+    gov1.T3 = 7.0;
+    gov1.Dt = 0.0;
+
+    // Generator 2 (bus2)
+    gen2.Name = "GEN2";
+    gen2.RatedPower = 100e6; //163e6;
+    gen2.RatedVoltage = 18e3;
+    gen2.InitialPower = 163e6;
+    gen2.InitialPowerReactive = 6.7e6;
+    gen2.InitialVoltage = 1.025 * gen2.RatedVoltage;
+    gen2.BusType = PowerflowBusType::PV;
+
+    gen2.Ra = 0.000125;
+    gen2.Xa = 0.08958;
+    gen2.L0 = gen2.Xa / (2 * PI * nomFreq);
+
+    gen2.Xd = 0.8958;
+    gen2.XdPrime = 0.1198;
+    gen2.XdDoublePrime = 0.11;
+
+    gen2.Ld = gen2.Xd / (2 * PI * nomFreq);
+    gen2.LdPrime = gen2.XdPrime / (2 * PI * nomFreq);
+    gen2.LdDoublePrime = gen2.XdDoublePrime / (2 * PI * nomFreq);
+
+    gen2.Xq = 0.8645;
+    gen2.XqPrime = 0.1969;
+    gen2.XqDoublePrime = 0.11;
+
+    gen2.Lq = gen2.Xq / (2 * PI * nomFreq);
+    gen2.LqPrime = gen2.XqPrime / (2 * PI * nomFreq);
+    gen2.LqDoublePrime = gen2.XqDoublePrime / (2 * PI * nomFreq);
+
+    gen2.H = 6.40;
+    gen2.D = 0.0;
+    gen2.TdoPrime = 6.00;
+    gen2.TdoDoublePrime = 0.01;
+    gen2.TqoPrime = 0.535;
+    gen2.TqoDoublePrime = 0.01;
+    gen2.Taa = 0.0;
+
+    // Exciter (IEEE Type DC1A)
+    exc2.KA = 20.0;
+    exc2.TA = 0.2;
+    exc2.VRmin = -5.0;
+    exc2.VRmax = 5.0;
+    exc2.KE = 1.0;
+    exc2.TE = 0.314;
+    exc2.KF = 0.063;
+    exc2.TF = 0.35;
+
+    // Exciter (IEEE Type DC1A)
+    exc2.EX1 = 3.3;
+    exc2.S_EX1 = 0.6602;
+    exc2.EX2 = 4.5;
+    exc2.S_EX2 = 4.2662;
+
+    // Governor Data (TGOV1)
+    gov2.R = 0.05;
+    gov2.T1 = 0.05;
+    gov2.Vmax = 5.00;
+    gov2.Vmin = -5.00;
+    gov2.T2 = 2.1;
+    gov2.T3 = 7.0;
+    gov2.Dt = 0.0;
+
+    // Generator 3 (bus3)
+    gen3.Name = "GEN3";
+    gen3.RatedPower = 100e6; //85e6;
+    gen3.RatedVoltage = 13.8e3;
+    gen3.InitialPower = 85e6;
+    gen3.InitialPowerReactive = -10.9e6;
+    gen3.InitialVoltage = 1.025 * gen3.RatedVoltage;
+    gen3.BusType = PowerflowBusType::PV;
+    gen3.Ra = 0.000125;
+    gen3.Xa = 0.13125;
+    gen3.L0 = gen3.Xa / (2 * PI * nomFreq);
+
+    gen3.Xd = 1.3125;
+    gen3.XdPrime = 0.1813;
+    gen3.XdDoublePrime = 0.18;
+
+    gen3.Ld = gen3.Xd / (2 * PI * nomFreq);
+    gen3.LdPrime = gen3.XdPrime / (2 * PI * nomFreq);
+    gen3.LdDoublePrime = gen3.XdDoublePrime / (2 * PI * nomFreq);
+
+    gen3.Xq = 1.2578;
+    gen3.XqPrime = 0.25;
+    gen3.XqDoublePrime = 0.18;
+
+    gen3.Lq = gen3.Xq / (2 * PI * nomFreq);
+    gen3.LqPrime = gen3.XqPrime / (2 * PI * nomFreq);
+    gen3.LqDoublePrime = gen3.XqDoublePrime / (2 * PI * nomFreq);
+
+    gen3.H = 3.01;
+    gen3.D = 0.0;
+    gen3.TdoPrime = 5.89;
+    gen3.TdoDoublePrime = 0.01;
+    gen3.TqoPrime = 0.600;
+    gen3.TqoDoublePrime = 0.01;
+    gen3.Taa = 0.0;
+
+    // Exciter (IEEE Type DC1A)
+    exc3.KA = 20.0;
+    exc3.TA = 0.2;
+    exc3.VRmin = -5.0;
+    exc3.VRmax = 5.0;
+    exc3.KE = 1.0;
+    exc3.TE = 0.314;
+    exc3.KF = 0.063;
+    exc3.TF = 0.35;
+
+    // Exciter (IEEE Type DC1A)
+    exc3.EX1 = 3.3;
+    exc3.S_EX1 = 0.6602;
+    exc3.EX2 = 4.5;
+    exc3.S_EX2 = 4.2662;
+
+    // Governor Data (TGOV1)
+    gov3.R = 0.05;
+    gov3.T1 = 0.05;
+    gov3.Vmax = 5.00;
+    gov3.Vmin = -5.00;
+    gov3.T2 = 2.1;
+    gov3.T3 = 7.0;
+    gov3.Dt = 0.0;
+
+    load5.Name = "LOAD5";
+    load5.RealPower = 125e6;
+    load5.ReactivePower = 50e6;
+    load5.BaseVoltage = 230e3;
+    load5.Conductance = load5.RealPower / std::pow(load5.BaseVoltage, 2);
+    load5.Susceptance = -load5.ReactivePower / std::pow(load5.BaseVoltage, 2);
+
+    load6.Name = "LOAD6";
+    load6.RealPower = 90e6;
+    load6.ReactivePower = 30e6;
+    load6.BaseVoltage = 230e3;
+    load6.Conductance = load6.RealPower / std::pow(load6.BaseVoltage, 2);
+    load6.Susceptance = -load6.ReactivePower / std::pow(load6.BaseVoltage, 2);
+
+    load8.Name = "LOAD8";
+    load8.RealPower = 100e6;
+    load8.ReactivePower = 35e6;
+    load8.BaseVoltage = 230e3;
+    load8.Conductance = load8.RealPower / std::pow(load8.BaseVoltage, 2);
+    load8.Susceptance = -load8.ReactivePower / std::pow(load8.BaseVoltage, 2);
+
+    line54.Name = "LINE54";
+    line54.ResistancePU = 0.01005;
+    line54.ReactancePU = 0.08521;
+    line54.SusceptancePU = 1.0 / 5.688921;
+    line54.Conductance = 0.0;
+    line54.Resistance = line54.ResistancePU * baseZ;
+    line54.Inductance = line54.ReactancePU * baseZ / nomOmega;
+    line54.Capacitance = line54.SusceptancePU / baseZ / nomOmega;
+    line54.BaseVoltage = 230e3;
+
+    line64.Name = "LINE64";
+    line64.ResistancePU = 0.017083;
+    line64.ReactancePU = 0.092216;
+    line64.SusceptancePU = 1.0 / 6.336801;
+    line64.Conductance = 0.0;
+    line64.Resistance = line64.ResistancePU * baseZ;
+    line64.Inductance = line64.ReactancePU * baseZ / nomOmega;
+    line64.Capacitance = line64.SusceptancePU / baseZ / nomOmega;
+    line64.BaseVoltage = 230e3;
+
+    line75.Name = "LINE75";
+    line75.ResistancePU = 0.032533;
+    line75.ReactancePU = 0.162281;
+    line75.SusceptancePU = 1.0 / 3.28151;
+    line75.Conductance = 0.0;
+    line75.Resistance = line75.ResistancePU * baseZ;
+    line75.Inductance = line75.ReactancePU * baseZ / nomOmega;
+    line75.Capacitance = line75.SusceptancePU / baseZ / nomOmega;
+    line75.BaseVoltage = 230e3;
+
+    line96.Name = "LINE96";
+    line96.ResistancePU = 0.039806;
+    line96.ReactancePU = 0.171651;
+    line96.SusceptancePU = 1.0 / 2.807618;
+    line96.Conductance = 0.0;
+    line96.Resistance = line96.ResistancePU * baseZ;
+    line96.Inductance = line96.ReactancePU * baseZ / nomOmega;
+    line96.Capacitance = line96.SusceptancePU / baseZ / nomOmega;
+    line96.BaseVoltage = 230e3;
+
+    line78.Name = "LINE78";
+    line78.ResistancePU = 0.00853;
+    line78.ReactancePU = 0.072127;
+    line78.SusceptancePU = 1.0 / 6.717421;
+    line78.Conductance = 0.0;
+    line78.Resistance = line78.ResistancePU * baseZ;
+    line78.Inductance = line78.ReactancePU * baseZ / nomOmega;
+    line78.Capacitance = line78.SusceptancePU / baseZ / nomOmega;
+    line78.BaseVoltage = 230e3;
+
+    line89.Name = "LINE89";
+    line89.ResistancePU = 0.011984;
+    line89.ReactancePU = 0.10115;
+    line89.SusceptancePU = 1.0 / 4.793121;
+    line89.Conductance = 0.0;
+    line89.Resistance = line89.ResistancePU * baseZ;
+    line89.Inductance = line89.ReactancePU * baseZ / nomOmega;
+    line89.Capacitance = line89.SusceptancePU / baseZ / nomOmega;
+    line89.BaseVoltage = 230e3;
+
+    transf14.Name = "TR14";
+    transf14.VoltageLVSide = 16.5e3;
+    transf14.VoltageHVSide = 230e3;
+    transf14.RatedPower = 100e6;
+    transf14.Ratio = transf14.VoltageLVSide / transf14.VoltageHVSide;
+    transf14.WindingConnection = 0;
+    transf14.ResistancePU = 0;
+    transf14.Resistance = transf14.ResistancePU * baseZ;
+    transf14.ReactancePU = 0.0576;
+    transf14.Inductance = transf14.ReactancePU * baseZ / nomOmega;
+
+    transf27.Name = "TR27";
+    transf27.VoltageLVSide = 18e3;
+    transf27.VoltageHVSide = 230e3;
+    transf27.RatedPower = 100e6;
+    transf27.Ratio = transf27.VoltageLVSide / transf27.VoltageHVSide;
+    transf27.WindingConnection = 0;
+    transf27.ResistancePU = 0;
+    transf27.Resistance = transf27.ResistancePU * baseZ;
+    transf27.ReactancePU = 0.0625;
+    transf27.Inductance = transf27.ReactancePU * baseZ / nomOmega;
+    ;
+
+    transf39.Name = "TR39";
+    transf39.VoltageLVSide = 13.8e3;
+    transf39.VoltageHVSide = 230e3;
+    transf39.RatedPower = 100e6;
+    transf39.Ratio = transf39.VoltageLVSide / transf39.VoltageHVSide;
+    transf39.WindingConnection = 0;
+    transf39.ResistancePU = 0;
+    transf39.Resistance = transf39.ResistancePU * baseZ;
+    transf39.ReactancePU = 0.0586;
+    transf39.Inductance = transf39.ReactancePU * baseZ / nomOmega;
+    ;
+  }
+};
+} // namespace IEEE9
+
 } // namespace Grids
 
 namespace Events {

--- a/examples/Notebooks/Circuits/IEEE9_4Order_SP_DP_EMT.ipynb
+++ b/examples/Notebooks/Circuits/IEEE9_4Order_SP_DP_EMT.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# IEEE 9-bus, 4th-order generators: SP vs DP vs EMT\n",
+    "\n",
+    "Runs the same IEEE 9-bus system (three 4th-order synchronous machines with AVR and governor, power-flow initialized) in the SP, DP and EMT domains and compares bus voltages and generator behaviour.\n",
+    "\n",
+    "The system frequency is selectable with the `-f` argument of each example (default 60 Hz, matching the RTDS source). Set `frequency` below to 50 for the European variant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from villas.dataprocessing.readtools import read_timeseries_csv\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import glob\n",
+    "import os\n",
+    "import subprocess\n",
+    "import dpsimpy\n",
+    "\n",
+    "frequency = 60\n",
+    "\n",
+    "root_path = (\n",
+    "    subprocess.Popen([\"git\", \"rev-parse\", \"--show-toplevel\"], stdout=subprocess.PIPE)\n",
+    "    .communicate()[0]\n",
+    "    .rstrip()\n",
+    "    .decode(\"utf-8\")\n",
+    ")\n",
+    "\n",
+    "candidates = [os.path.join(root_path, \"build\", \"dpsim\", \"examples\", \"cxx\")]\n",
+    "candidates += glob.glob(\n",
+    "    os.path.join(root_path, \"build\", \"*\", \"dpsim\", \"examples\", \"cxx\")\n",
+    ")\n",
+    "path_exec = next(\n",
+    "    p for p in candidates if os.path.isfile(os.path.join(p, \"DP_Ph1_IEEE9_4Order\"))\n",
+    ")\n",
+    "print(\"binaries:\", path_exec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "names = [\"SP_Ph1_IEEE9_4Order\", \"DP_Ph1_IEEE9_4Order\", \"EMT_Ph3_IEEE9_4Order\"]\n",
+    "for name in names:\n",
+    "    sim = subprocess.Popen(\n",
+    "        [os.path.join(path_exec, name), \"-f\", str(frequency), \"--option\", \"log=true\"],\n",
+    "        stdout=subprocess.PIPE,\n",
+    "        stderr=subprocess.STDOUT,\n",
+    "    )\n",
+    "    sim.communicate()\n",
+    "    print(name, \"done\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load(name):\n",
+    "    flat = \"logs/\" + name + \".csv\"\n",
+    "    nested = \"logs/\" + name + \"/\" + name + \".csv\"\n",
+    "    return read_timeseries_csv(flat if os.path.isfile(flat) else nested)\n",
+    "\n",
+    "\n",
+    "ts_sp = load(\"SP_Ph1_IEEE9_4Order\")\n",
+    "ts_dp = load(\"DP_Ph1_IEEE9_4Order\")\n",
+    "ts_emt = load(\"EMT_Ph3_IEEE9_4Order\")\n",
+    "\n",
+    "\n",
+    "# Three-phase magnitude comparable to the SP/DP phasor magnitude:\n",
+    "# for a balanced set sqrt(a^2 + b^2 + c^2) equals the phasor magnitude.\n",
+    "def emt_magnitude(ts, key):\n",
+    "    a, b, c = ts[key + \"_0\"], ts[key + \"_1\"], ts[key + \"_2\"]\n",
+    "    return np.sqrt(a.values**2 + b.values**2 + c.values**2), a.time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bus voltages\n",
+    "\n",
+    "Voltage magnitude at the 230 kV network buses. The SP and DP phasor magnitudes and the EMT three-phase magnitude coincide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 7))\n",
+    "for bus in [\"BUS5\", \"BUS6\", \"BUS8\"]:\n",
+    "    plt.plot(ts_sp[bus].time, ts_sp[bus].abs().values / 1e3, label=bus + \" SP\")\n",
+    "    plt.plot(ts_dp[bus].time, ts_dp[bus].abs().values / 1e3, \"--\", label=bus + \" DP\")\n",
+    "    mag, t = emt_magnitude(ts_emt, bus)\n",
+    "    plt.plot(t, mag / 1e3, \":\", label=bus + \" EMT\")\n",
+    "plt.xlabel(\"time [s]\")\n",
+    "plt.ylabel(\"|V| [kV]\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "EMT resolves the instantaneous waveform while SP and DP carry the envelope. Phase a of BUS5 with the DP envelope (phase peak) overlaid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 7))\n",
+    "plt.plot(\n",
+    "    ts_emt[\"BUS5_0\"].time, ts_emt[\"BUS5_0\"].values / 1e3, label=\"BUS5 phase a (EMT)\"\n",
+    ")\n",
+    "plt.plot(\n",
+    "    ts_dp[\"BUS5\"].time,\n",
+    "    dpsimpy.RMS3PH_TO_PEAK1PH * ts_dp[\"BUS5\"].abs().values / 1e3,\n",
+    "    \"--\",\n",
+    "    label=\"BUS5 envelope (DP)\",\n",
+    ")\n",
+    "plt.xlim(0.0, 0.1)\n",
+    "plt.xlabel(\"time [s]\")\n",
+    "plt.ylabel(\"v [kV]\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generator behaviour\n",
+    "\n",
+    "Rotor speed, rotor angle and terminal current magnitude of the three machines across the three domains. The mechanical states (speed, angle) are domain independent and coincide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gens = [\"GEN1\", \"GEN2\", \"GEN3\"]\n",
+    "\n",
+    "plt.figure(figsize=(12, 7))\n",
+    "for gen in gens:\n",
+    "    plt.plot(\n",
+    "        ts_sp[gen + \".omega\"].time, ts_sp[gen + \".omega\"].values, label=gen + \" SP\"\n",
+    "    )\n",
+    "    plt.plot(\n",
+    "        ts_dp[gen + \".omega\"].time,\n",
+    "        ts_dp[gen + \".omega\"].values,\n",
+    "        \"--\",\n",
+    "        label=gen + \" DP\",\n",
+    "    )\n",
+    "    plt.plot(\n",
+    "        ts_emt[gen + \".omega\"].time,\n",
+    "        ts_emt[gen + \".omega\"].values,\n",
+    "        \":\",\n",
+    "        label=gen + \" EMT\",\n",
+    "    )\n",
+    "plt.xlabel(\"time [s]\")\n",
+    "plt.ylabel(\"rotor speed [pu]\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 7))\n",
+    "for gen in gens:\n",
+    "    plt.plot(\n",
+    "        ts_sp[gen + \".delta\"].time, ts_sp[gen + \".delta\"].values, label=gen + \" SP\"\n",
+    "    )\n",
+    "    plt.plot(\n",
+    "        ts_dp[gen + \".delta\"].time,\n",
+    "        ts_dp[gen + \".delta\"].values,\n",
+    "        \"--\",\n",
+    "        label=gen + \" DP\",\n",
+    "    )\n",
+    "    plt.plot(\n",
+    "        ts_emt[gen + \".delta\"].time,\n",
+    "        ts_emt[gen + \".delta\"].values,\n",
+    "        \":\",\n",
+    "        label=gen + \" EMT\",\n",
+    "    )\n",
+    "plt.xlabel(\"time [s]\")\n",
+    "plt.ylabel(\"rotor angle [rad]\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 7))\n",
+    "for gen in gens:\n",
+    "    plt.plot(ts_sp[gen + \".I\"].time, ts_sp[gen + \".I\"].abs().values, label=gen + \" SP\")\n",
+    "    plt.plot(\n",
+    "        ts_dp[gen + \".I\"].time, ts_dp[gen + \".I\"].abs().values, \"--\", label=gen + \" DP\"\n",
+    "    )\n",
+    "    mag, t = emt_magnitude(ts_emt, gen + \".I\")\n",
+    "    plt.plot(t, mag, \":\", label=gen + \" EMT\")\n",
+    "plt.xlabel(\"time [s]\")\n",
+    "plt.ylabel(\"terminal current |I| [A]\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for bus in [\"BUS5\", \"BUS6\", \"BUS8\"]:\n",
+    "    sp = ts_sp[bus].abs().values.mean()\n",
+    "    dp = ts_dp[bus].abs().values.mean()\n",
+    "    emt = emt_magnitude(ts_emt, bus)[0].mean()\n",
+    "    print(f\"{bus}: SP {sp/1e3:.2f} kV  DP {dp/1e3:.2f} kV  EMT {emt/1e3:.2f} kV\")\n",
+    "    assert abs(sp - dp) / sp < 0.02\n",
+    "    assert abs(emt - dp) / dp < 0.02"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Power-flow-initialized IEEE 9-bus dynamic simulations in the SP, DP and EMT domains, with the same generator models (4th-order `SynchronGenerator4OrderVBR`, `ExciterDC1Simp` AVR, `TurbineGovernorType1`) so the domains are comparable.

- Three examples under `dpsim/examples/cxx/Circuits/`, shared parameters in `Examples.h` (`Grids::IEEE9`)
- Notebook `examples/Notebooks/Circuits/IEEE9_4Order_SP_DP_EMT.ipynb` comparing bus voltages and generator behaviour across the domains
- System frequency selectable via `-f` (default 60 Hz); per-unit data reused for a 50 Hz variant

_Note:_ work for dynamic simulations supported for EMT 3ph and DP 1ph by @denibeleri1 during his time at ACS. Adaptations by me, including addition of SP domain.