### PR TITLE
grid-connected grid-forming SSN inverter + IEEE 9-bus mixed example

### DIFF
--- a/docs/hugo/content/en/docs/Models/power-electronics.md
+++ b/docs/hugo/content/en/docs/Models/power-electronics.md
@@ -603,3 +603,257 @@ Because the controller operates in a single positive-sequence $dq$ frame, only t
 - Source code: [header](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/include/dpsim-models/DP/DP_Ph3_AvVoltSourceInverterStateSpace.h), [implementation](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/src/DP/DP_Ph3_AvVoltSourceInverterStateSpace.cpp)
 - [C++ example](https://github.com/sogno-platform/dpsim/blob/master/dpsim/examples/cxx/Components/DP_Ph3_AvVoltSourceInverterStateSpace.cpp)
 - [Python notebook](https://github.com/sogno-platform/dpsim/blob/master/examples/Notebooks/Components/DP_Ph3_AvVoltSourceInverterStateSpace.ipynb)
+
+# Three-Phase Averaged Grid-Forming Inverter with State-Space Nodal Interface
+
+The `EMT::Ph3::SSN_GFM` model represents a grid-forming averaged voltage source inverter in the EMT domain.
+The control structure follows the state-space grid-forming converter of [Gao2022](https://ieeexplore.ieee.org/document/9806927) (VSG algorithm loop, voltage loop, current loop with active damping), whose grid-following counterpart in the same paper is the basis for the averaged inverter above; the inner voltage/current control and LC filter modeling follow [Yazdani2010](https://ieeexplore.ieee.org/book/5237659).
+Like the grid-following inverter above it is a variable state-space nodal component stamped directly into the MNA system, but instead of a PLL that locks to the grid it carries its own virtual synchronous machine (VSG): the internal angle and voltage magnitude are states driven by active- and reactive-power balance, so the inverter imposes a voltage and can run islanded.
+The model includes the VSG swing dynamics, a reactive-power/voltage excitation loop, filtered active/reactive power measurement, a cascaded voltage and current controller, a first-order converter/digital-delay approximation, and an LC filter with coupling resistance to the grid node.
+
+The terminal input is the PCC voltage vector
+
+```math
+\mathbf{u} =
+\begin{bmatrix}
+u_a & u_b & u_c
+\end{bmatrix}^\top ,
+```
+
+and the 17-element state vector is
+
+```math
+\mathbf{x} =
+\begin{bmatrix}
+P & Q & \omega & \theta & E &
+\xi_{v,d} & \xi_{v,q} &
+\xi_{i,d} & \xi_{i,q} &
+v_{\mathrm{del},d} & v_{\mathrm{del},q} &
+v_{c,a} & v_{c,b} & v_{c,c} &
+i_{f,a} & i_{f,b} & i_{f,c}
+\end{bmatrix}^\top ,
+```
+
+where $\theta$ is the VSG angle (there is no PLL), $E$ is the excitation-controlled voltage magnitude, $\xi_{v}$, $\xi_{i}$ are the voltage- and current-loop integrators, and $v_{\mathrm{del}}$ are the two delay states.
+
+The model output is the interface current injected into the MNA system,
+
+```math
+\mathbf{y} =
+\frac{\mathbf{u} - \mathbf{v}_c}{R_c}.
+```
+
+## Control structure
+
+{{< mermaid >}}
+graph LR
+  U["PCC voltage u"] --> FILT["LC filter<br/>vc, if"]
+  FILT --> MEAS["Power measurement<br/>p, q"]
+  MEAS --> PF["Measurement filters<br/>P, Q"]
+  PF -->|P| SWING["VSG swing<br/>omega, theta"]
+  PF -->|Q| EXC["Excitation /<br/>Q-V droop -> E"]
+  EXC --> VZ["Virtual impedance<br/>E - Zv*if"]
+  VZ --> VCTRL["Voltage controller<br/>-> i_ref"]
+  VCTRL --> ICTRL["Current controller<br/>-> v_conv"]
+  ICTRL --> DELAY["Converter delay"]
+  DELAY --> FILT
+  SWING -->|theta| VCTRL
+  FILT --> Y["Interface current y"]
+{{< /mermaid >}}
+
+The virtual synchronous machine sets the internal angle from the active-power balance and the internal magnitude from the reactive-power/voltage loop; the cascaded voltage and current controllers then track that internal reference through the LC filter. The dashed grid-connected extensions (virtual impedance, feed-forward scaling, Q-V droop) are described below.
+
+## Model equations
+
+The physical grid current, positive for injection into the grid, is
+
+```math
+\mathbf{i}_g = \frac{\mathbf{v}_c - \mathbf{u}}{R_c}.
+```
+
+All dq quantities use the VSG angle $\theta$ (amplitude-invariant Park transform $\mathbf{T}(\theta)$),
+
+```math
+\mathbf{v}_{c,dq} = \mathbf{T}(\theta)\mathbf{v}_c, \qquad
+\mathbf{i}_{f,dq} = \mathbf{T}(\theta)\mathbf{i}_f, \qquad
+\mathbf{i}_{g,dq} = \mathbf{T}(\theta)\mathbf{i}_g,
+```
+
+and the capacitor current is $\mathbf{i}_{\mathrm{cap},dq} = \mathbf{i}_{f,dq} - \mathbf{i}_{g,dq}$.
+Because the Park transform is amplitude invariant, three-phase instantaneous power carries the factor $3/2$,
+
+```math
+p = \tfrac{3}{2}\,(v_{c,d} i_{g,d} + v_{c,q} i_{g,q}),
+\qquad
+q = \tfrac{3}{2}\,(v_{c,q} i_{g,d} - v_{c,d} i_{g,q}),
+```
+
+and the PCC voltage magnitude is $U_{\mathrm{pcc}} = \sqrt{v_{c,d}^2 + v_{c,q}^2}$.
+
+The measurement filters are first-order lags,
+
+```math
+\dot{P} = \omega_c(p - P),
+\qquad
+\dot{Q} = \omega_c(q - Q).
+```
+
+The VSG swing equation sets the angle from the active-power balance,
+
+```math
+J\dot{\omega} = \frac{P_{\mathrm{ref}} - P}{\omega} - D(\omega - \omega_n),
+\qquad
+\dot{\theta} = \omega,
+```
+
+with virtual inertia $J$ and damping $D$.
+The reactive-power/voltage excitation controller sets the internal magnitude,
+
+```math
+\dot{E} = K_q(Q_{\mathrm{ref}} - Q) + K_u(U_n - U_{\mathrm{pcc}}),
+```
+
+an integral law on the reactive error with a voltage-droop term.
+The excitation defines the dq voltage reference; in the islanded model it is aligned with the d-axis,
+
+```math
+v_{d,\mathrm{ref}} = E, \qquad v_{q,\mathrm{ref}} = 0 .
+```
+
+The voltage controller integrates the voltage error and forms the current reference with the capacitor-current feed-forward and dq decoupling,
+
+```math
+\dot{\xi}_{v,d} = v_{d,\mathrm{ref}} - v_{c,d},
+\qquad
+\dot{\xi}_{v,q} = v_{q,\mathrm{ref}} - v_{c,q},
+```
+
+```math
+i_{d,\mathrm{ref}} = i_{g,d} - \omega C_f v_{c,q}
++ K_{p,V}(v_{d,\mathrm{ref}} - v_{c,d}) + K_{i,V}\xi_{v,d},
+```
+
+```math
+i_{q,\mathrm{ref}} = i_{g,q} + \omega C_f v_{c,d}
++ K_{p,V}(v_{q,\mathrm{ref}} - v_{c,q}) + K_{i,V}\xi_{v,q}.
+```
+
+The current controller integrates the current error and forms the converter voltage reference, with inductor decoupling and optional active damping on the capacitor current,
+
+```math
+\dot{\xi}_{i,d} = i_{d,\mathrm{ref}} - i_{f,d},
+\qquad
+\dot{\xi}_{i,q} = i_{q,\mathrm{ref}} - i_{f,q},
+```
+
+```math
+v_{d,\mathrm{conv}} = v_{c,d} - \omega L_f i_{f,q}
++ K_{p,I}(i_{d,\mathrm{ref}} - i_{f,d}) + K_{i,I}\xi_{i,d} - K_{ad} i_{\mathrm{cap},d},
+```
+
+```math
+v_{q,\mathrm{conv}} = v_{c,q} + \omega L_f i_{f,d}
++ K_{p,I}(i_{q,\mathrm{ref}} - i_{f,q}) + K_{i,I}\xi_{i,q} - K_{ad} i_{\mathrm{cap},q}.
+```
+
+A first-order lag approximates the converter/digital delay,
+
+```math
+\dot{v}_{\mathrm{del},d} = \omega_d(v_{d,\mathrm{conv}} - v_{\mathrm{del},d}),
+\qquad
+\dot{v}_{\mathrm{del},q} = \omega_d(v_{q,\mathrm{conv}} - v_{\mathrm{del},q}),
+```
+
+and its output, transformed back to abc as $\mathbf{v}_{\mathrm{inv}} = \mathbf{T}^{-1}(\theta)\,[v_{\mathrm{del},d}\ v_{\mathrm{del},q}]^\top$, drives the LC filter,
+
+```math
+\dot{\mathbf{v}}_c = \frac{1}{C_f}\left(\mathbf{i}_f + \frac{\mathbf{u} - \mathbf{v}_c}{R_c}\right),
+\qquad
+\dot{\mathbf{i}}_f = \frac{1}{L_f}\left(\mathbf{v}_{\mathrm{inv}} - \mathbf{v}_c - R_f\mathbf{i}_f\right).
+```
+
+## Grid-connected control extensions
+
+The equations above describe the islanded inverter. Three opt-in extensions adapt it to a stiff grid; each defaults to the value that recovers the islanded model exactly, so the eigenstructure is unchanged unless a setter is called.
+
+**Virtual output impedance.** A virtual impedance $Z_v = R_v + jX_v$ is subtracted from the excitation to form the voltage reference, using the filter current $\mathbf{i}_{f,dq}$,
+
+```math
+v_{d,\mathrm{ref}} + j v_{q,\mathrm{ref}}
+= E - Z_v\,(i_{f,d} + j i_{f,q}),
+```
+
+i.e.
+
+```math
+v_{d,\mathrm{ref}} = E - (R_v i_{f,d} - X_v i_{f,q}),
+\qquad
+v_{q,\mathrm{ref}} = -(R_v i_{f,q} + X_v i_{f,d}).
+```
+
+$Z_v = 0$ recovers $v_{d,\mathrm{ref}} = E,\ v_{q,\mathrm{ref}} = 0$.
+A finite $R_v$ adds a current-proportional term opposing motion, damping the power-synchronization loop on a stiff grid at the electrical timescale, an alternative to raising the mechanical damping $D$.
+The drop is taken off the filter-current *state* $\mathbf{i}_f$ rather than the algebraically reconstructed grid current $\mathbf{i}_g = (\mathbf{v}_c-\mathbf{u})/R_c$; the latter would multiply the reference by a factor $\propto 1/R_c$, amplifying state and linearization error.
+
+**Grid-current feed-forward scale.** A scalar $\kappa$ scales the grid-current feed-forward in the current reference,
+
+```math
+i_{d,\mathrm{ref}} = \kappa\, i_{g,d} - \omega C_f v_{c,q} + \dots,
+\qquad
+i_{q,\mathrm{ref}} = \kappa\, i_{g,q} + \omega C_f v_{c,d} + \dots,
+```
+
+with $\kappa = 1$ the default full feed-forward.
+
+**Proportional reactive-power droop.** When a cutoff $\omega_q > 0$ is set, the integral excitation is replaced by a proportional Q-V droop,
+
+```math
+\dot{E} = \omega_q\big(E_{\mathrm{set}} + D_q(Q_{\mathrm{ref}} - Q) - E\big),
+```
+
+a first-order lag with a stable fixed point $E^* = E_{\mathrm{set}} + D_q(Q_{\mathrm{ref}} - Q)$ and pole at $-\omega_q$.
+On a stiff grid the network fixes $U_{\mathrm{pcc}}$, so the reactive error $Q_{\mathrm{ref}} - Q$ cannot be driven to zero and the integral law $\dot E = K_q(Q_{\mathrm{ref}} - Q) + K_u(U_n - U_{\mathrm{pcc}})$ has no reachable equilibrium (reactive windup); the proportional droop always has one.
+The setpoint $E_{\mathrm{set}}$ is captured at initialization as the operating magnitude, so $\dot{E} = 0$ when $Q = Q_{\mathrm{ref}}$ at $t = 0$.
+
+## Linearization and stamping
+
+The model is nonlinear (Park transforms with the moving angle $\theta$, the $1/\omega$ swing term, the power products). It is not linearized by hand; at each simulation step the state and output Jacobians are computed by central finite differences of the nonlinear functions $\mathbf{f}(\mathbf{x},\mathbf{u}) = \dot{\mathbf{x}}$ and $\mathbf{g}(\mathbf{x},\mathbf{u}) = \mathbf{y}$,
+
+```math
+\mathbf{A} = \frac{\partial \mathbf{f}}{\partial \mathbf{x}},\quad
+\mathbf{B} = \frac{\partial \mathbf{f}}{\partial \mathbf{u}},\quad
+\mathbf{C} = \frac{\partial \mathbf{g}}{\partial \mathbf{x}},\quad
+\mathbf{D} = \frac{\partial \mathbf{g}}{\partial \mathbf{u}},
+```
+
+each column $j$ evaluated as $[\mathbf{f}(\mathbf{x}+\delta_j\mathbf{e}_j,\mathbf{u}) - \mathbf{f}(\mathbf{x}-\delta_j\mathbf{e}_j,\mathbf{u})]/(2\delta_j)$ with a mixed relative/absolute step $\delta_j$.
+Because the grid-connected extensions above all enter through $\mathbf{f}$, they are captured in $\mathbf{A}$, $\mathbf{B}$, $\mathbf{C}$, $\mathbf{D}$ automatically, with no separate matrix code.
+The affine offsets fix the model to the current operating point,
+
+```math
+\mathbf{E} = \mathbf{f}(\mathbf{x}_0,\mathbf{u}_0) - \mathbf{A}\mathbf{x}_0 - \mathbf{B}\mathbf{u}_0,
+\qquad
+\mathbf{F} = \mathbf{g}(\mathbf{x}_0,\mathbf{u}_0) - \mathbf{C}\mathbf{x}_0 - \mathbf{D}\mathbf{u}_0,
+```
+
+giving the affine state-space form
+
+```math
+\dot{\mathbf{x}} \approx \mathbf{A}\mathbf{x} + \mathbf{B}\mathbf{u} + \mathbf{E},
+\qquad
+\mathbf{y} \approx \mathbf{C}\mathbf{x} + \mathbf{D}\mathbf{u} + \mathbf{F},
+```
+
+which is discretized and stamped into the EMT MNA system.
+The dq/abc transformations and the nonlinear controls make the local model time varying, so the SSN equivalent is recomputed every simulation step.
+
+## Source code and examples
+
+- Source code: [header](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_GFM.h), [implementation](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/src/EMT/EMT_Ph3_SSN_GFM.cpp)
+- [C++ example (IEEE 9-bus mixed SG/GFM/GFL)](https://github.com/sogno-platform/dpsim/blob/master/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp)
+- [Python notebook](https://github.com/sogno-platform/dpsim/blob/master/examples/Notebooks/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.ipynb)
+
+## References
+
+- <a name="Gao2022"></a>[Gao2022] X. Gao, D. Zhou, A. Anvari-Moghaddam, and F. Blaabjerg, "Stability Analysis of Grid-Following and Grid-Forming Converters Based on State-Space Model," in *2022 International Power Electronics Conference (IPEC-Himeji 2022 - ECCE Asia)*, 2022, pp. 422-428. Source of both the grid-following and grid-forming state-space control structures. Its eigenvalue analysis finds grid-following control better suited to a stiff grid and grid-forming control to a weak grid; the grid-connected extensions above (virtual impedance, Q-V droop) are what let the grid-forming model stay stable when connected to a stiff grid.
+- <a name="Yazdani2010"></a>[Yazdani2010] A. Yazdani and R. Iravani, *Voltage-Sourced Converters in Power Systems: Modeling, Control, and Applications*. Hoboken, NJ: Wiley-IEEE Press, 2010. Basis for the inner voltage/current control and LC-filter modeling of both inverters.

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_GFM.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_GFM.h
@@ -181,9 +181,10 @@ public:
 
   /// \brief Configure the GFM model.
   ///
-  /// nominalVoltage is the nominal line-to-line RMS voltage. With the
-  /// power-invariant Park transformation used here, a balanced system's
-  /// dq voltage magnitude equals the line-to-line RMS voltage.
+  /// nominalVoltage is the nominal peak phase voltage. With the
+  /// amplitude-invariant (2/3) Park transformation used here, a balanced
+  /// system's dq voltage magnitude equals the peak phase voltage; pass
+  /// RMS3PH_TO_PEAK1PH * (line-to-line RMS voltage), as the example does.
   ///
   /// omegaN is the nominal angular frequency in rad/s.
   void setParameters(Real lf, Real cf, Real rf, Real rc, Real nominalVoltage,

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_GFM.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_GFM.h
@@ -99,6 +99,19 @@ private:
   Real mPowerFilterCutoff;
   Real mDelayBandwidth;
 
+  // Virtual output impedance (opt-in). Zero recovers the islanded model.
+  Real mVirtualResistance;
+  Real mVirtualReactance;
+
+  // Scale on the grid-current feedforward in the voltage loop (1 = islanded).
+  Real mGridCurrentFeedforward;
+
+  // Proportional Q-V droop (opt-in). Cutoff > 0 selects droop over the integral
+  // excitation. Setpoint is captured at initialization.
+  Real mReactivePowerDroop;
+  Real mReactiveDroopCutoff;
+  Real mVoltageSetpoint;
+
   // Numerical linearization settings
   Real mJacobianRelativeStep;
   Real mJacobianAbsoluteStep;
@@ -183,6 +196,18 @@ public:
   /// \brief Configure finite-difference steps for local linearization.
   void setNumericalLinearizationParameters(Real relativeStep,
                                            Real absoluteStep);
+
+  /// \brief Opt-in virtual output impedance Zv = Rv + jXv, subtracted from the
+  /// EMF reference across the grid current. Zero (default) is the islanded
+  /// model; a finite Rv/Xv damps the power-synchronization loop on a grid.
+  void setVirtualImpedance(Real virtualResistance, Real virtualReactance = 0.0);
+
+  /// \brief Scale on the voltage-loop grid-current feedforward (default 1).
+  void setGridCurrentFeedforward(Real scale);
+
+  /// \brief Opt-in proportional Q-V droop replacing the integral excitation.
+  /// droopGain is Dq [V/var]; cutoff [rad/s] > 0 enables it.
+  void setReactivePowerDroop(Real droopGain, Real cutoff);
 
   void initializeFromNodesAndTerminals(Real frequency) override final;
 };

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_GFM.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_GFM.h
@@ -198,7 +198,7 @@ public:
                                            Real absoluteStep);
 
   /// \brief Opt-in virtual output impedance Zv = Rv + jXv, subtracted from the
-  /// EMF reference across the grid current. Zero (default) is the islanded
+  /// EMF reference across the filter current. Zero (default) is the islanded
   /// model; a finite Rv/Xv damps the power-synchronization loop on a grid.
   void setVirtualImpedance(Real virtualResistance, Real virtualReactance = 0.0);
 

--- a/dpsim-models/include/dpsim-models/MathUtils.h
+++ b/dpsim-models/include/dpsim-models/MathUtils.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include <dpsim-models/Definitions.h>
 
 namespace CPS {
@@ -155,6 +157,12 @@ public:
 
   /// To convert single phase power to symmetrical three phase
   static Matrix singlePhasePowerToThreePhase(Real power);
+
+  /// PCC-side injected power from an averaged-VSI filter-side power reference,
+  /// correcting the loss across the coupling resistance rc (S = 1.5*Vpeak*I*).
+  static std::pair<Real, Real>
+  pccPowerFromFilterPowerReference(Real pFilterRef, Real qFilterRef, Real rc,
+                                   Real vGridRmsLL);
 
   // #### Reference Frame Transformations ####
 

--- a/dpsim-models/src/EMT/EMT_Ph3_SSN_GFM.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SSN_GFM.cpp
@@ -208,6 +208,8 @@ void EMT::Ph3::SSN_GFM::setGridCurrentFeedforward(Real scale) {
 }
 
 void EMT::Ph3::SSN_GFM::setReactivePowerDroop(Real droopGain, Real cutoff) {
+  if (droopGain < 0.0)
+    throw std::invalid_argument("Reactive-droop gain must be non-negative.");
   if (cutoff < 0.0)
     throw std::invalid_argument("Reactive-droop cutoff must be non-negative.");
 

--- a/dpsim-models/src/EMT/EMT_Ph3_SSN_GFM.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SSN_GFM.cpp
@@ -16,6 +16,9 @@ EMT::Ph3::SSN_GFM::SSN_GFM(String uid, String name, Logger::Level logLevel)
       mVoltageDroopGain(0.0), mReactiveIntegralGain(0.0), mKpVoltage(0.0),
       mKiVoltage(0.0), mKpCurrent(0.0), mKiCurrent(0.0),
       mActiveDampingGain(0.0), mPowerFilterCutoff(0.0), mDelayBandwidth(0.0),
+      mVirtualResistance(0.0), mVirtualReactance(0.0),
+      mGridCurrentFeedforward(1.0), mReactivePowerDroop(0.0),
+      mReactiveDroopCutoff(0.0), mVoltageSetpoint(0.0),
       mJacobianRelativeStep(1e-6), mJacobianAbsoluteStep(1e-8),
       mPInst(mAttributes->create<Real>("p_inst")),
       mQInst(mAttributes->create<Real>("q_inst")),
@@ -191,6 +194,27 @@ void EMT::Ph3::SSN_GFM::setNumericalLinearizationParameters(Real relativeStep,
   mJacobianAbsoluteStep = absoluteStep;
 }
 
+void EMT::Ph3::SSN_GFM::setVirtualImpedance(Real virtualResistance,
+                                            Real virtualReactance) {
+  if (virtualResistance < 0.0)
+    throw std::invalid_argument("Virtual resistance must be non-negative.");
+
+  mVirtualResistance = virtualResistance;
+  mVirtualReactance = virtualReactance;
+}
+
+void EMT::Ph3::SSN_GFM::setGridCurrentFeedforward(Real scale) {
+  mGridCurrentFeedforward = scale;
+}
+
+void EMT::Ph3::SSN_GFM::setReactivePowerDroop(Real droopGain, Real cutoff) {
+  if (cutoff < 0.0)
+    throw std::invalid_argument("Reactive-droop cutoff must be non-negative.");
+
+  mReactivePowerDroop = droopGain;
+  mReactiveDroopCutoff = cutoff;
+}
+
 Matrix EMT::Ph3::SSN_GFM::getParkTransformMatrix(Real theta) const {
 
   theta = std::remainder(theta, 2.0 * PI);
@@ -329,12 +353,26 @@ void EMT::Ph3::SSN_GFM::evaluateStateDerivative(const Matrix &x,
   //     + Ku * (U_n - U_pcc)
   // ----------------------------------------------------------------------
 
-  stateDerivative(VoltageMagnitude, 0) =
-      mReactiveIntegralGain * (mQRef - qFiltered) +
-      mVoltageDroopGain * (mNominalVoltage - pccVoltageMagnitude);
+  if (mReactiveDroopCutoff > 0.0) {
+    // Proportional Q-V droop (opt-in, grid-connected): E lags a droop target
+    // E_set + Dq*(Qref-Qf). No integral, so no reactive windup on a stiff grid.
+    const Real droopTarget =
+        mVoltageSetpoint + mReactivePowerDroop * (mQRef - qFiltered);
+    stateDerivative(VoltageMagnitude, 0) =
+        mReactiveDroopCutoff * (droopTarget - voltageMagnitude);
+  } else {
+    // Integral excitation (default, islanded).
+    stateDerivative(VoltageMagnitude, 0) =
+        mReactiveIntegralGain * (mQRef - qFiltered) +
+        mVoltageDroopGain * (mNominalVoltage - pccVoltageMagnitude);
+  }
 
-  const Real voltageReferenceD = voltageMagnitude;
-  constexpr Real voltageReferenceQ = 0.0;
+  // EMF minus virtual-impedance drop Zv * if (Zv = Rv + jXv; zero = islanded).
+  // if (a filter-current state) avoids the 1/Rc sensitivity of iGrid.
+  const Real voltageReferenceD =
+      voltageMagnitude - (mVirtualResistance * ifD - mVirtualReactance * ifQ);
+  const Real voltageReferenceQ =
+      -(mVirtualResistance * ifQ + mVirtualReactance * ifD);
 
   const Real voltageErrorD = voltageReferenceD - vcD;
   const Real voltageErrorQ = voltageReferenceQ - vcQ;
@@ -351,13 +389,13 @@ void EMT::Ph3::SSN_GFM::evaluateStateDerivative(const Matrix &x,
   // Cf * dv_q/dt = if_q - ig_q - omega * Cf * v_d
   // ----------------------------------------------------------------------
 
-  const Real currentReferenceD = iGridD - omega * mCf * vcQ +
-                                 mKpVoltage * voltageErrorD +
-                                 mKiVoltage * voltageIntegratorD;
+  const Real currentReferenceD =
+      mGridCurrentFeedforward * iGridD - omega * mCf * vcQ +
+      mKpVoltage * voltageErrorD + mKiVoltage * voltageIntegratorD;
 
-  const Real currentReferenceQ = iGridQ + omega * mCf * vcD +
-                                 mKpVoltage * voltageErrorQ +
-                                 mKiVoltage * voltageIntegratorQ;
+  const Real currentReferenceQ =
+      mGridCurrentFeedforward * iGridQ + omega * mCf * vcD +
+      mKpVoltage * voltageErrorQ + mKiVoltage * voltageIntegratorQ;
 
   const Real currentErrorD = currentReferenceD - ifD;
   const Real currentErrorQ = currentReferenceQ - ifQ;
@@ -686,9 +724,16 @@ void EMT::Ph3::SSN_GFM::initializeFromNodesAndTerminals(Real frequency) {
   x0(Omega, 0) = omegaInitialization;
   x0(Theta, 0) = theta0;
 
-  // At a balanced steady operating point, the d-axis reference is the
-  // capacitor-voltage magnitude.
-  x0(VoltageMagnitude, 0) = voltageMagnitudeInitial;
+  // EMF carries the virtual-impedance drop so vc stays at the target.
+  const Real virtualDropD0 =
+      mVirtualResistance * iGridD0 - mVirtualReactance * iGridQ0;
+  const Real virtualReferenceQ0 =
+      -(mVirtualResistance * iGridQ0 + mVirtualReactance * iGridD0);
+  x0(VoltageMagnitude, 0) = voltageMagnitudeInitial + virtualDropD0;
+
+  // Proportional-droop setpoint: the operating EMF, so the droop is centered at
+  // the initial point (E_dot = 0 when Qf = Qref at t = 0).
+  mVoltageSetpoint = x0(VoltageMagnitude, 0);
 
   // Voltage controller:
   //
@@ -698,10 +743,10 @@ void EMT::Ph3::SSN_GFM::initializeFromNodesAndTerminals(Real frequency) {
   //     + KiV*xiVd
   //
   // Set iRefD = ifD and solve for xiVd.
-  x0(VoltageIntegratorD, 0) =
-      (ifD0 - iGridD0 + omegaInitialization * mCf * vcQ0 -
-       mKpVoltage * (voltageMagnitudeInitial - vcD0)) /
-      mKiVoltage;
+  x0(VoltageIntegratorD, 0) = (ifD0 - mGridCurrentFeedforward * iGridD0 +
+                               omegaInitialization * mCf * vcQ0 -
+                               mKpVoltage * (voltageMagnitudeInitial - vcD0)) /
+                              mKiVoltage;
 
   // iRefQ =
   //     iGridQ + omega*Cf*vcD
@@ -709,10 +754,10 @@ void EMT::Ph3::SSN_GFM::initializeFromNodesAndTerminals(Real frequency) {
   //     + KiV*xiVq
   //
   // Set iRefQ = ifQ and solve for xiVq.
-  x0(VoltageIntegratorQ, 0) =
-      (ifQ0 - iGridQ0 - omegaInitialization * mCf * vcD0 -
-       mKpVoltage * (0.0 - vcQ0)) /
-      mKiVoltage;
+  x0(VoltageIntegratorQ, 0) = (ifQ0 - mGridCurrentFeedforward * iGridQ0 -
+                               omegaInitialization * mCf * vcD0 -
+                               mKpVoltage * (virtualReferenceQ0 - vcQ0)) /
+                              mKiVoltage;
 
   // Current controller steady-state integrators.
   //

--- a/dpsim-models/src/EMT/EMT_Ph3_SSN_GFM.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SSN_GFM.cpp
@@ -596,14 +596,17 @@ void EMT::Ph3::SSN_GFM::updateLogAttributes(const Matrix &u) const {
   const Real iGridD = iGridDq(0, 0);
   const Real iGridQ = iGridDq(1, 0);
 
+  const Real ifD = ifDq(0, 0);
+  const Real ifQ = ifDq(1, 0);
+
   **mVcD = vcD;
   **mVcQ = vcQ;
 
   **mIGridD = iGridD;
   **mIGridQ = iGridQ;
 
-  **mIfD = ifDq(0, 0);
-  **mIfQ = ifDq(1, 0);
+  **mIfD = ifD;
+  **mIfQ = ifQ;
 
   **mPInst = 1.5 * (vcD * iGridD + vcQ * iGridQ);
   **mQInst = 1.5 * (vcQ * iGridD - vcD * iGridQ);
@@ -612,8 +615,10 @@ void EMT::Ph3::SSN_GFM::updateLogAttributes(const Matrix &u) const {
   **mThetaGFM = theta;
   **mVoltageMagnitudeGFM = x(VoltageMagnitude, 0);
 
-  **mVoltageReferenceD = x(VoltageMagnitude, 0);
-  **mVoltageReferenceQ = 0.0;
+  // Reference the controller tracks, including the virtual-impedance drop.
+  **mVoltageReferenceD = x(VoltageMagnitude, 0) -
+                         (mVirtualResistance * ifD - mVirtualReactance * ifQ);
+  **mVoltageReferenceQ = -(mVirtualResistance * ifQ + mVirtualReactance * ifD);
 }
 
 void EMT::Ph3::SSN_GFM::initializeFromNodesAndTerminals(Real frequency) {
@@ -724,11 +729,11 @@ void EMT::Ph3::SSN_GFM::initializeFromNodesAndTerminals(Real frequency) {
   x0(Omega, 0) = omegaInitialization;
   x0(Theta, 0) = theta0;
 
-  // EMF carries the virtual-impedance drop so vc stays at the target.
+  // Virtual-impedance drop off filter current if (as at runtime), not iGrid.
   const Real virtualDropD0 =
-      mVirtualResistance * iGridD0 - mVirtualReactance * iGridQ0;
+      mVirtualResistance * ifD0 - mVirtualReactance * ifQ0;
   const Real virtualReferenceQ0 =
-      -(mVirtualResistance * iGridQ0 + mVirtualReactance * iGridD0);
+      -(mVirtualResistance * ifQ0 + mVirtualReactance * ifD0);
   x0(VoltageMagnitude, 0) = voltageMagnitudeInitial + virtualDropD0;
 
   // Proportional-droop setpoint: the operating EMF, so the droop is centered at

--- a/dpsim-models/src/EMT/EMT_Ph3_SSN_GFM.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SSN_GFM.cpp
@@ -694,7 +694,13 @@ void EMT::Ph3::SSN_GFM::initializeFromNodesAndTerminals(Real frequency) {
   const Matrix iGridAbc0 = iInjectionPhasor.real();
   const Matrix converterVoltageAbc0 = converterVoltagePhasor.real();
 
-  const Real theta0 = std::arg(vcPhasor(0, 0));
+  // Align the dq frame with the internal EMF behind the virtual impedance,
+  // E0 = vc + (Rv + jXv)*if. At the operating point the voltage-loop reference
+  // is E0 in dq, so aligning to it makes both loop errors vanish (true
+  // equilibrium) even for nonzero Zv. Zv = 0 reduces to aligning with vc.
+  const Complex virtualImpedance(mVirtualResistance, mVirtualReactance);
+  const MatrixComp emfPhasor = vcPhasor + virtualImpedance * ifPhasor;
+  const Real theta0 = std::arg(emfPhasor(0, 0));
 
   const Matrix parkTransform = getParkTransformMatrix(theta0);
 
@@ -716,8 +722,6 @@ void EMT::Ph3::SSN_GFM::initializeFromNodesAndTerminals(Real frequency) {
 
   const Real qInitial = 1.5 * (vcQ0 * iGridD0 - vcD0 * iGridQ0);
 
-  const Real voltageMagnitudeInitial = std::sqrt(vcD0 * vcD0 + vcQ0 * vcQ0);
-
   const Real iCapD0 = ifD0 - iGridD0;
   const Real iCapQ0 = ifQ0 - iGridQ0;
 
@@ -729,16 +733,22 @@ void EMT::Ph3::SSN_GFM::initializeFromNodesAndTerminals(Real frequency) {
   x0(Omega, 0) = omegaInitialization;
   x0(Theta, 0) = theta0;
 
-  // Virtual-impedance drop off filter current if (as at runtime), not iGrid.
-  const Real virtualDropD0 =
-      mVirtualResistance * ifD0 - mVirtualReactance * ifQ0;
-  const Real virtualReferenceQ0 =
-      -(mVirtualResistance * ifQ0 + mVirtualReactance * ifD0);
-  x0(VoltageMagnitude, 0) = voltageMagnitudeInitial + virtualDropD0;
+  // Internal EMF magnitude behind the virtual impedance (d-axis aligned).
+  x0(VoltageMagnitude, 0) = std::abs(emfPhasor(0, 0));
 
   // Proportional-droop setpoint: the operating EMF, so the droop is centered at
   // the initial point (E_dot = 0 when Qf = Qref at t = 0).
   mVoltageSetpoint = x0(VoltageMagnitude, 0);
+
+  // Voltage-loop references at the operating point, same form as
+  // evaluateStateDerivative(). With the E0-aligned frame both errors are ~0.
+  const Real voltageReferenceD0 =
+      x0(VoltageMagnitude, 0) -
+      (mVirtualResistance * ifD0 - mVirtualReactance * ifQ0);
+  const Real voltageReferenceQ0 =
+      -(mVirtualResistance * ifQ0 + mVirtualReactance * ifD0);
+  const Real voltageErrorD0 = voltageReferenceD0 - vcD0;
+  const Real voltageErrorQ0 = voltageReferenceQ0 - vcQ0;
 
   // Voltage controller:
   //
@@ -748,10 +758,10 @@ void EMT::Ph3::SSN_GFM::initializeFromNodesAndTerminals(Real frequency) {
   //     + KiV*xiVd
   //
   // Set iRefD = ifD and solve for xiVd.
-  x0(VoltageIntegratorD, 0) = (ifD0 - mGridCurrentFeedforward * iGridD0 +
-                               omegaInitialization * mCf * vcQ0 -
-                               mKpVoltage * (voltageMagnitudeInitial - vcD0)) /
-                              mKiVoltage;
+  x0(VoltageIntegratorD, 0) =
+      (ifD0 - mGridCurrentFeedforward * iGridD0 +
+       omegaInitialization * mCf * vcQ0 - mKpVoltage * voltageErrorD0) /
+      mKiVoltage;
 
   // iRefQ =
   //     iGridQ + omega*Cf*vcD
@@ -759,10 +769,10 @@ void EMT::Ph3::SSN_GFM::initializeFromNodesAndTerminals(Real frequency) {
   //     + KiV*xiVq
   //
   // Set iRefQ = ifQ and solve for xiVq.
-  x0(VoltageIntegratorQ, 0) = (ifQ0 - mGridCurrentFeedforward * iGridQ0 -
-                               omegaInitialization * mCf * vcD0 -
-                               mKpVoltage * (virtualReferenceQ0 - vcQ0)) /
-                              mKiVoltage;
+  x0(VoltageIntegratorQ, 0) =
+      (ifQ0 - mGridCurrentFeedforward * iGridQ0 -
+       omegaInitialization * mCf * vcD0 - mKpVoltage * voltageErrorQ0) /
+      mKiVoltage;
 
   // Current controller steady-state integrators.
   //

--- a/dpsim-models/src/MathUtils.cpp
+++ b/dpsim-models/src/MathUtils.cpp
@@ -8,8 +8,10 @@
 
 #include <dpsim-models/MathUtils.h>
 
+#include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <stdexcept>
 
 using namespace CPS;
 
@@ -231,6 +233,30 @@ Matrix Math::singlePhasePowerToThreePhase(Real power) {
   Matrix power_3ph = Matrix::Zero(3, 3);
   power_3ph << power / 3., 0., 0., 0., power / 3., 0., 0, 0., power / 3.;
   return power_3ph;
+}
+
+std::pair<Real, Real> Math::pccPowerFromFilterPowerReference(Real pFilterRef,
+                                                             Real qFilterRef,
+                                                             Real rc,
+                                                             Real vGridRmsLL) {
+  const Real vPccPeakPhase = RMS3PH_TO_PEAK1PH * vGridRmsLL;
+  if (std::abs(rc) < 1e-12 || vPccPeakPhase < 1e-9)
+    return {pFilterRef, qFilterRef};
+
+  const Real qPccRef = qFilterRef;
+  const Real a = rc / (1.5 * vPccPeakPhase * vPccPeakPhase);
+  const Real discriminant =
+      1.0 + 4.0 * a * (pFilterRef - a * qPccRef * qPccRef);
+  if (discriminant < 0.0)
+    throw std::runtime_error("No feasible PCC power for the given filter-side "
+                             "power reference, rc, and PCC voltage estimate.");
+
+  const Real sqrtDisc = std::sqrt(discriminant);
+  const Real p1 = (-1.0 + sqrtDisc) / (2.0 * a);
+  const Real p2 = (-1.0 - sqrtDisc) / (2.0 * a);
+  const Real pPccRef =
+      std::abs(p1 - pFilterRef) < std::abs(p2 - pFilterRef) ? p1 : p2;
+  return {pPccRef, qPccRef};
 }
 
 Matrix Math::StateSpaceTrapezoidal(Matrix states, Matrix A, Matrix B, Real dt,

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -76,6 +76,7 @@ set(CIRCUIT_SOURCES
 	Circuits/SP_Ph1_IEEE9_4Order.cpp
 	Circuits/DP_Ph1_IEEE9_4Order.cpp
 	Circuits/EMT_Ph3_IEEE9_4Order.cpp
+	Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
 
 	#SMIB
 	Circuits/SP_SynGenTrStab_SMIB_SteadyState.cpp

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -167,6 +167,7 @@ list(APPEND TEST_SOURCES
 	Circuits/SP_Ph1_IEEE9_4Order.cpp
 	Circuits/DP_Ph1_IEEE9_4Order.cpp
 	Circuits/EMT_Ph3_IEEE9_4Order.cpp
+	Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
 	Circuits/SP_ReducedOrderSG_SMIB_Fault.cpp
 	Circuits/DP_ReducedOrderSG_SMIB_Fault.cpp
 	Circuits/EMT_ReducedOrderSG_SMIB_Fault.cpp

--- a/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
@@ -10,48 +10,9 @@ using namespace DPsim;
 using namespace CPS;
 
 namespace {
-// GFL avg-VSI filter and gains: the 400 V/10 kVA reference design rebased to
-// the BUS3 base (13.8 kV, 100 MVA, 60 Hz), preserving the per-unit values.
-struct GflParams {
-  Real lf = 1.98375e-4; // H
-  Real cf = 7.00133e-5; // F
-  Real rf = 2.38050e-2; // Ohm
-  Real rc = 2.38050e-2; // Ohm
-  Real kpPLL = 7.246377e-3;
-  Real kiPLL = 5.797101e-3;
-  Real kpPowerCtrl = 1.449275e-3;
-  Real kiPowerCtrl = 5.797101e-3;
-  Real kpCurrCtrl = 2.975625e-2;
-  Real kiCurrCtrl = 1.190250e-1;
-};
-
-// GFM SSN filter/VSG rebased from the PR #570 reference (220 V/12 kVA/50 Hz) to
-// the BUS2 base (18 kV, 100 MVA, 60 Hz), with grid-connected control tuning.
-struct GfmParams {
-  Real lf = 6.694215e-4; // H
-  Real cf = 6.224280e-5; // F
-  Real rf = 1.338843e-2; // Ohm
-  Real rc = 1.338843e-2; // Ohm
-
-  Real virtualInertia = 1157.407407;
-  Real dampingCoefficient = 3.0e6; // raised for stiff-grid stability
-
-  // Superseded by the proportional Q-V droop below.
-  Real voltageDroopGain = 1.0 / 15.0;
-  Real reactiveIntegralGain = 1.700559e-3;
-
-  Real kpVoltage = 5.8e-3; // lowered for stiff-grid stability
-  Real kiVoltage = 2.7e-1;
-  Real kpCurrent = 1.126636e0;
-  Real kiCurrent = 2.253273e1;
-
-  Real activeDampingGain = 0.0;
-  Real powerFilterCutoff = 100.0;
-  Real delayBandwidth = 20e3 / 1.5;
-
-  Real reactivePowerDroop = 1.0e-5; // proportional Q-V droop
-  Real reactiveDroopCutoff = 100.0;
-};
+// Controller parameters and their equation-based derivation live in Examples.h.
+using GfmParams = CPS::CIM::Examples::Components::GFM::Ieee9SsnGridForming;
+using GflParams = CPS::CIM::Examples::Components::GFL::Ieee9AvVsi;
 } // namespace
 
 SystemTopology buildTopology(CommandLineArgs &args,
@@ -96,7 +57,7 @@ SystemTopology buildTopology(CommandLineArgs &args,
   // rc-corrected filter reference).
   const GflParams gfl;
   const auto [gfl3PPcc, gfl3QPcc] = Math::pccPowerFromFilterPowerReference(
-      ieee9.gen3.InitialPower, ieee9.gen3.InitialPowerReactive, gfl.rc,
+      ieee9.gen3.InitialPower, ieee9.gen3.InitialPowerReactive, gfl.Rc,
       ieee9.gen3.RatedVoltage);
   auto gfl3PF = SP::Ph1::Load::make(ieee9.gen3.Name, CPS::Logger::Level::off);
   gfl3PF->setParameters(-gfl3PPcc, -gfl3QPcc, ieee9.gen3.RatedVoltage);
@@ -335,22 +296,22 @@ SystemTopology buildTopology(CommandLineArgs &args,
                : def;
   };
   gfm.dampingCoefficient = opt("gfm_d", gfm.dampingCoefficient);
-  gfm.kpVoltage = opt("gfm_kpv", gfm.kpVoltage);
-  gfm.kiVoltage = opt("gfm_kiv", gfm.kiVoltage);
+  gfm.KpVoltage = opt("gfm_kpv", gfm.KpVoltage);
+  gfm.KiVoltage = opt("gfm_kiv", gfm.KiVoltage);
   gfm.reactivePowerDroop = opt("gfm_dq", gfm.reactivePowerDroop);
   gfm.reactiveDroopCutoff = opt("gfm_dqc", gfm.reactiveDroopCutoff);
-  const Real gfmFeedforward = opt("gfm_ff", 0.0);
+  const Real gfmFeedforward = opt("gfm_ff", gfm.gridCurrentFeedforward);
   const Real gfmVirtualResistance = opt("gfm_rv", 0.0);
 
   auto gen2EMT = EMT::Ph3::SSN_GFM::make(ieee9.gen2.Name, ieee9.gen2.Name,
                                          CPS::Logger::Level::off);
   gen2EMT->setNumericalLinearizationParameters(1e-6, 1e-8);
-  gen2EMT->setParameters(gfm.lf, gfm.cf, gfm.rf, gfm.rc, gfmNominalVoltage,
+  gen2EMT->setParameters(gfm.Lf, gfm.Cf, gfm.Rf, gfm.Rc, gfmNominalVoltage,
                          omegaN, ieee9.gen2.InitialPower,
                          ieee9.gen2.InitialPowerReactive, gfm.virtualInertia,
                          gfm.dampingCoefficient, gfm.voltageDroopGain,
-                         gfm.reactiveIntegralGain, gfm.kpVoltage, gfm.kiVoltage,
-                         gfm.kpCurrent, gfm.kiCurrent, gfm.activeDampingGain,
+                         gfm.reactiveIntegralGain, gfm.KpVoltage, gfm.KiVoltage,
+                         gfm.KpCurrent, gfm.KiCurrent, gfm.activeDampingGain,
                          gfm.powerFilterCutoff, gfm.delayBandwidth);
   // Grid-connected control: no grid-current feedforward, proportional Q-V droop.
   gen2EMT->setGridCurrentFeedforward(gfmFeedforward);
@@ -364,11 +325,11 @@ SystemTopology buildTopology(CommandLineArgs &args,
       ieee9.gen3.Name, CPS::Logger::Level::off);
   // Optional overrides for studying the grid-following tuning from a notebook.
   gen3EMT->setParameters(
-      gfl.lf, gfl.cf, gfl.rf, gfl.rc, omegaN, opt("gfl_kppll", gfl.kpPLL),
-      opt("gfl_kipll", gfl.kiPLL), omegaN, ieee9.gen3.InitialPower,
-      ieee9.gen3.InitialPowerReactive, opt("gfl_kpp", gfl.kpPowerCtrl),
-      opt("gfl_kip", gfl.kiPowerCtrl), opt("gfl_kpi", gfl.kpCurrCtrl),
-      opt("gfl_kii", gfl.kiCurrCtrl));
+      gfl.Lf, gfl.Cf, gfl.Rf, gfl.Rc, omegaN, opt("gfl_kppll", gfl.KpPLL),
+      opt("gfl_kipll", gfl.KiPLL), omegaN, ieee9.gen3.InitialPower,
+      ieee9.gen3.InitialPowerReactive, opt("gfl_kpp", gfl.KpPowerCtrl),
+      opt("gfl_kip", gfl.KiPowerCtrl), opt("gfl_kpi", gfl.KpCurrCtrl),
+      opt("gfl_kii", gfl.KiCurrCtrl));
 
   // Loads
   auto load5EMT =

--- a/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
@@ -52,30 +52,6 @@ struct GfmParams {
   Real reactivePowerDroop = 1.0e-5; // proportional Q-V droop
   Real reactiveDroopCutoff = 100.0;
 };
-
-// Filter-side power reference to PCC-side injection, correcting the rc loss.
-std::pair<Real, Real> pccPowerFromFilterPowerReference(Real pFilterRef,
-                                                       Real qFilterRef, Real rc,
-                                                       Real vGridRmsLL) {
-  const Real vPccPeakPhase = RMS3PH_TO_PEAK1PH * vGridRmsLL;
-  if (std::abs(rc) < 1e-12 || vPccPeakPhase < 1e-9)
-    return {pFilterRef, qFilterRef};
-
-  const Real qPccRef = qFilterRef;
-  const Real a = rc / (1.5 * vPccPeakPhase * vPccPeakPhase);
-  const Real discriminant =
-      1.0 + 4.0 * a * (pFilterRef - a * qPccRef * qPccRef);
-  if (discriminant < 0.0)
-    throw std::runtime_error("No feasible PCC power for the GFL filter-side "
-                             "power reference, rc, and PCC voltage estimate.");
-
-  const Real sqrtDisc = std::sqrt(discriminant);
-  const Real p1 = (-1.0 + sqrtDisc) / (2.0 * a);
-  const Real p2 = (-1.0 - sqrtDisc) / (2.0 * a);
-  const Real pPccRef =
-      std::abs(p1 - pFilterRef) < std::abs(p2 - pFilterRef) ? p1 : p2;
-  return {pPccRef, qPccRef};
-}
 } // namespace
 
 SystemTopology buildTopology(CommandLineArgs &args,
@@ -119,7 +95,7 @@ SystemTopology buildTopology(CommandLineArgs &args,
   // gen3's PF image: a negative PQ load injecting the PCC-side power (the
   // rc-corrected filter reference).
   const GflParams gfl;
-  const auto [gfl3PPcc, gfl3QPcc] = pccPowerFromFilterPowerReference(
+  const auto [gfl3PPcc, gfl3QPcc] = Math::pccPowerFromFilterPowerReference(
       ieee9.gen3.InitialPower, ieee9.gen3.InitialPowerReactive, gfl.rc,
       ieee9.gen3.RatedVoltage);
   auto gfl3PF = SP::Ph1::Load::make(ieee9.gen3.Name, CPS::Logger::Level::off);
@@ -351,7 +327,21 @@ SystemTopology buildTopology(CommandLineArgs &args,
   // gen2 replaced by a grid-forming SSN inverter, keeping the GEN2 identity.
   // nominalVoltage is the peak phase target at the 1.025 pu PV setpoint.
   const Real gfmNominalVoltage = RMS3PH_TO_PEAK1PH * ieee9.gen2.InitialVoltage;
-  const GfmParams gfm;
+  GfmParams gfm;
+  // Optional overrides for studying the grid-forming tuning from a notebook.
+  auto opt = [&](const String &key, Real def) {
+    return args.options.find(key) != args.options.end()
+               ? args.getOptionReal(key)
+               : def;
+  };
+  gfm.dampingCoefficient = opt("gfm_d", gfm.dampingCoefficient);
+  gfm.kpVoltage = opt("gfm_kpv", gfm.kpVoltage);
+  gfm.kiVoltage = opt("gfm_kiv", gfm.kiVoltage);
+  gfm.reactivePowerDroop = opt("gfm_dq", gfm.reactivePowerDroop);
+  gfm.reactiveDroopCutoff = opt("gfm_dqc", gfm.reactiveDroopCutoff);
+  const Real gfmFeedforward = opt("gfm_ff", 0.0);
+  const Real gfmVirtualResistance = opt("gfm_rv", 0.0);
+
   auto gen2EMT = EMT::Ph3::SSN_GFM::make(ieee9.gen2.Name, ieee9.gen2.Name,
                                          CPS::Logger::Level::off);
   gen2EMT->setNumericalLinearizationParameters(1e-6, 1e-8);
@@ -363,7 +353,8 @@ SystemTopology buildTopology(CommandLineArgs &args,
                          gfm.kpCurrent, gfm.kiCurrent, gfm.activeDampingGain,
                          gfm.powerFilterCutoff, gfm.delayBandwidth);
   // Grid-connected control: no grid-current feedforward, proportional Q-V droop.
-  gen2EMT->setGridCurrentFeedforward(0.0);
+  gen2EMT->setGridCurrentFeedforward(gfmFeedforward);
+  gen2EMT->setVirtualImpedance(gfmVirtualResistance, 0.0);
   gen2EMT->setReactivePowerDroop(gfm.reactivePowerDroop,
                                  gfm.reactiveDroopCutoff);
 
@@ -371,10 +362,13 @@ SystemTopology buildTopology(CommandLineArgs &args,
   // identity so the topology wiring is unchanged.
   auto gen3EMT = EMT::Ph3::AvVoltSourceInverterStateSpace::make(
       ieee9.gen3.Name, CPS::Logger::Level::off);
-  gen3EMT->setParameters(gfl.lf, gfl.cf, gfl.rf, gfl.rc, omegaN, gfl.kpPLL,
-                         gfl.kiPLL, omegaN, ieee9.gen3.InitialPower,
-                         ieee9.gen3.InitialPowerReactive, gfl.kpPowerCtrl,
-                         gfl.kiPowerCtrl, gfl.kpCurrCtrl, gfl.kiCurrCtrl);
+  // Optional overrides for studying the grid-following tuning from a notebook.
+  gen3EMT->setParameters(
+      gfl.lf, gfl.cf, gfl.rf, gfl.rc, omegaN, opt("gfl_kppll", gfl.kpPLL),
+      opt("gfl_kipll", gfl.kiPLL), omegaN, ieee9.gen3.InitialPower,
+      ieee9.gen3.InitialPowerReactive, opt("gfl_kpp", gfl.kpPowerCtrl),
+      opt("gfl_kip", gfl.kiPowerCtrl), opt("gfl_kpi", gfl.kpCurrCtrl),
+      opt("gfl_kii", gfl.kiCurrCtrl));
 
   // Loads
   auto load5EMT =

--- a/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
@@ -1,0 +1,602 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include "../Examples.h"
+#include "../GeneratorFactory.h"
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS;
+
+namespace {
+// GFL avg-VSI filter and gains: the 400 V/10 kVA reference design rebased to
+// the BUS3 base (13.8 kV, 100 MVA, 60 Hz), preserving the per-unit values.
+struct GflParams {
+  Real lf = 1.98375e-4; // H
+  Real cf = 7.00133e-5; // F
+  Real rf = 2.38050e-2; // Ohm
+  Real rc = 2.38050e-2; // Ohm
+  Real kpPLL = 7.246377e-3;
+  Real kiPLL = 5.797101e-3;
+  Real kpPowerCtrl = 1.449275e-3;
+  Real kiPowerCtrl = 5.797101e-3;
+  Real kpCurrCtrl = 2.975625e-2;
+  Real kiCurrCtrl = 1.190250e-1;
+};
+
+// GFM SSN filter/VSG rebased from the PR #570 reference (220 V/12 kVA/50 Hz) to
+// the BUS2 base (18 kV, 100 MVA, 60 Hz), with grid-connected control tuning.
+struct GfmParams {
+  Real lf = 6.694215e-4; // H
+  Real cf = 6.224280e-5; // F
+  Real rf = 1.338843e-2; // Ohm
+  Real rc = 1.338843e-2; // Ohm
+
+  Real virtualInertia = 1157.407407;
+  Real dampingCoefficient = 3.0e6; // raised for stiff-grid stability
+
+  // Superseded by the proportional Q-V droop below.
+  Real voltageDroopGain = 1.0 / 15.0;
+  Real reactiveIntegralGain = 1.700559e-3;
+
+  Real kpVoltage = 5.8e-3; // lowered for stiff-grid stability
+  Real kiVoltage = 2.7e-1;
+  Real kpCurrent = 1.126636e0;
+  Real kiCurrent = 2.253273e1;
+
+  Real activeDampingGain = 0.0;
+  Real powerFilterCutoff = 100.0;
+  Real delayBandwidth = 20e3 / 1.5;
+
+  Real reactivePowerDroop = 1.0e-5; // proportional Q-V droop
+  Real reactiveDroopCutoff = 100.0;
+};
+
+// Filter-side power reference to PCC-side injection, correcting the rc loss.
+std::pair<Real, Real> pccPowerFromFilterPowerReference(Real pFilterRef,
+                                                       Real qFilterRef, Real rc,
+                                                       Real vGridRmsLL) {
+  const Real vPccPeakPhase = RMS3PH_TO_PEAK1PH * vGridRmsLL;
+  if (std::abs(rc) < 1e-12 || vPccPeakPhase < 1e-9)
+    return {pFilterRef, qFilterRef};
+
+  const Real qPccRef = qFilterRef;
+  const Real a = rc / (1.5 * vPccPeakPhase * vPccPeakPhase);
+  const Real discriminant =
+      1.0 + 4.0 * a * (pFilterRef - a * qPccRef * qPccRef);
+  if (discriminant < 0.0)
+    throw std::runtime_error("No feasible PCC power for the GFL filter-side "
+                             "power reference, rc, and PCC voltage estimate.");
+
+  const Real sqrtDisc = std::sqrt(discriminant);
+  const Real p1 = (-1.0 + sqrtDisc) / (2.0 * a);
+  const Real p2 = (-1.0 - sqrtDisc) / (2.0 * a);
+  const Real pPccRef =
+      std::abs(p1 - pFilterRef) < std::abs(p2 - pFilterRef) ? p1 : p2;
+  return {pPccRef, qPccRef};
+}
+} // namespace
+
+SystemTopology buildTopology(CommandLineArgs &args,
+                             std::shared_ptr<DataLoggerInterface> logger) {
+
+  String simName = args.name;
+
+  CPS::CIM::Examples::Grids::IEEE9::ScenarioConfig ieee9(args.sysFreq);
+
+  // POWER FLOW FOR INITIALIZATION
+  CPS::Logger::get(args.name)->info("Creating power flow initialization.");
+
+  String simNamePF = simName + "_PF";
+  CPS::Logger::setLogDir("logs/" + simNamePF);
+
+  // Nodes
+  auto n1PF = SimNode<Complex>::make("BUS1", PhaseType::Single);
+  auto n2PF = SimNode<Complex>::make("BUS2", PhaseType::Single);
+  auto n3PF = SimNode<Complex>::make("BUS3", PhaseType::Single);
+  auto n4PF = SimNode<Complex>::make("BUS4", PhaseType::Single);
+  auto n5PF = SimNode<Complex>::make("BUS5", PhaseType::Single);
+  auto n6PF = SimNode<Complex>::make("BUS6", PhaseType::Single);
+  auto n7PF = SimNode<Complex>::make("BUS7", PhaseType::Single);
+  auto n8PF = SimNode<Complex>::make("BUS8", PhaseType::Single);
+  auto n9PF = SimNode<Complex>::make("BUS9", PhaseType::Single);
+
+  auto gen1PF = SP::Ph1::SynchronGenerator::make(ieee9.gen1.Name,
+                                                 CPS::Logger::Level::off);
+  gen1PF->setParameters(ieee9.gen1.RatedPower, ieee9.gen1.RatedVoltage,
+                        ieee9.gen1.InitialPower, ieee9.gen1.InitialVoltage,
+                        ieee9.gen1.BusType);
+  gen1PF->setBaseVoltage(ieee9.gen1.RatedVoltage);
+
+  auto gen2PF = SP::Ph1::SynchronGenerator::make(ieee9.gen2.Name,
+                                                 CPS::Logger::Level::off);
+  gen2PF->setParameters(ieee9.gen2.RatedPower, ieee9.gen2.RatedVoltage,
+                        ieee9.gen2.InitialPower, ieee9.gen2.InitialVoltage,
+                        ieee9.gen2.BusType);
+  gen2PF->setBaseVoltage(ieee9.gen2.RatedVoltage);
+
+  // gen3's PF image: a negative PQ load injecting the PCC-side power (the
+  // rc-corrected filter reference).
+  const GflParams gfl;
+  const auto [gfl3PPcc, gfl3QPcc] = pccPowerFromFilterPowerReference(
+      ieee9.gen3.InitialPower, ieee9.gen3.InitialPowerReactive, gfl.rc,
+      ieee9.gen3.RatedVoltage);
+  auto gfl3PF = SP::Ph1::Load::make(ieee9.gen3.Name, CPS::Logger::Level::off);
+  gfl3PF->setParameters(-gfl3PPcc, -gfl3QPcc, ieee9.gen3.RatedVoltage);
+  gfl3PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  // Loads
+  auto load5PF = SP::Ph1::Load::make(ieee9.load5.Name, CPS::Logger::Level::off);
+  load5PF->setParameters(ieee9.load5.RealPower, ieee9.load5.ReactivePower,
+                         ieee9.load5.BaseVoltage);
+  load5PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  auto load6PF = SP::Ph1::Load::make(ieee9.load6.Name, CPS::Logger::Level::off);
+  load6PF->setParameters(ieee9.load6.RealPower, ieee9.load6.ReactivePower,
+                         ieee9.load6.BaseVoltage);
+  load6PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  auto load8PF = SP::Ph1::Load::make(ieee9.load8.Name, CPS::Logger::Level::off);
+  load8PF->setParameters(ieee9.load8.RealPower, ieee9.load8.ReactivePower,
+                         ieee9.load8.BaseVoltage);
+  load8PF->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+  // Transmission Lines
+
+  auto line54PF =
+      SP::Ph1::PiLine::make(ieee9.line54.Name, CPS::Logger::Level::off);
+  line54PF->setParameters(ieee9.line54.Resistance, ieee9.line54.Inductance,
+                          ieee9.line54.Capacitance, ieee9.line54.Conductance);
+  line54PF->setBaseVoltage(ieee9.line54.BaseVoltage);
+
+  auto line64PF =
+      SP::Ph1::PiLine::make(ieee9.line64.Name, CPS::Logger::Level::off);
+  line64PF->setParameters(ieee9.line64.Resistance, ieee9.line64.Inductance,
+                          ieee9.line64.Capacitance, ieee9.line64.Conductance);
+  line64PF->setBaseVoltage(ieee9.line64.BaseVoltage);
+
+  auto line75PF =
+      SP::Ph1::PiLine::make(ieee9.line75.Name, CPS::Logger::Level::off);
+  line75PF->setParameters(ieee9.line75.Resistance, ieee9.line75.Inductance,
+                          ieee9.line75.Capacitance, ieee9.line75.Conductance);
+  line75PF->setBaseVoltage(ieee9.line75.BaseVoltage);
+
+  auto line96PF =
+      SP::Ph1::PiLine::make(ieee9.line96.Name, CPS::Logger::Level::off);
+  line96PF->setParameters(ieee9.line96.Resistance, ieee9.line96.Inductance,
+                          ieee9.line96.Capacitance, ieee9.line96.Conductance);
+  line96PF->setBaseVoltage(ieee9.line96.BaseVoltage);
+
+  auto line78PF =
+      SP::Ph1::PiLine::make(ieee9.line78.Name, CPS::Logger::Level::off);
+  line78PF->setParameters(ieee9.line78.Resistance, ieee9.line78.Inductance,
+                          ieee9.line78.Capacitance, ieee9.line78.Conductance);
+  line78PF->setBaseVoltage(ieee9.line78.BaseVoltage);
+
+  auto line89PF =
+      SP::Ph1::PiLine::make(ieee9.line89.Name, CPS::Logger::Level::off);
+  line89PF->setParameters(ieee9.line89.Resistance, ieee9.line89.Inductance,
+                          ieee9.line89.Capacitance, ieee9.line89.Conductance);
+  line89PF->setBaseVoltage(ieee9.line89.BaseVoltage);
+
+  // Transformers
+
+  auto transf14PF =
+      SP::Ph1::Transformer::make(ieee9.transf14.Name, CPS::Logger::Level::off);
+  transf14PF->setParameters(
+      ieee9.transf14.VoltageLVSide, ieee9.transf14.VoltageHVSide,
+      ieee9.transf14.Ratio, 0.0, // No phase shift (ratioPhase = 0.0)
+      ieee9.transf14.Resistance, ieee9.transf14.Inductance);
+  transf14PF->setBaseVoltage(ieee9.transf14.VoltageHVSide);
+
+  auto transf27PF =
+      SP::Ph1::Transformer::make(ieee9.transf27.Name, CPS::Logger::Level::off);
+  transf27PF->setParameters(ieee9.transf27.VoltageLVSide,
+                            ieee9.transf27.VoltageHVSide, ieee9.transf27.Ratio,
+                            0.0, ieee9.transf27.Resistance,
+                            ieee9.transf27.Inductance);
+  transf27PF->setBaseVoltage(ieee9.transf27.VoltageHVSide);
+
+  auto transf39PF =
+      SP::Ph1::Transformer::make(ieee9.transf39.Name, CPS::Logger::Level::off);
+  transf39PF->setParameters(ieee9.transf39.VoltageLVSide,
+                            ieee9.transf39.VoltageHVSide, ieee9.transf39.Ratio,
+                            0.0, ieee9.transf39.Resistance,
+                            ieee9.transf39.Inductance);
+  transf39PF->setBaseVoltage(ieee9.transf39.VoltageHVSide);
+
+  // Connect components
+  gen1PF->connect({n1PF});
+  gen2PF->connect({n2PF});
+  gfl3PF->connect({n3PF});
+
+  load5PF->connect({n5PF});
+  load6PF->connect({n6PF});
+  load8PF->connect({n8PF});
+
+  line54PF->connect({n5PF, n4PF});
+  line64PF->connect({n6PF, n4PF});
+  line75PF->connect({n7PF, n5PF});
+  line96PF->connect({n9PF, n6PF});
+  line78PF->connect({n7PF, n8PF});
+  line89PF->connect({n8PF, n9PF});
+
+  transf14PF->connect({n1PF, n4PF});
+  transf27PF->connect({n2PF, n7PF});
+  transf39PF->connect({n3PF, n9PF});
+
+  // Create system topology
+  auto systemPF = SystemTopology(
+      ieee9.nomFreq,
+      SystemNodeList{n1PF, n2PF, n3PF, n4PF, n5PF, n6PF, n7PF, n8PF, n9PF},
+      SystemComponentList{gen1PF, gen2PF, gfl3PF, load5PF, load6PF, load8PF,
+                          line54PF, line64PF, line75PF, line96PF, line78PF,
+                          line89PF, transf14PF, transf27PF, transf39PF});
+
+  // Logger
+  auto loggerPF = DataLogger::make(simNamePF, CPS::Logger::Level::off);
+  // Log node voltages
+  loggerPF->logAttribute("v_bus1", n1PF->attribute("v"));
+  loggerPF->logAttribute("v_bus2", n2PF->attribute("v"));
+  loggerPF->logAttribute("v_bus3", n3PF->attribute("v"));
+  loggerPF->logAttribute("v_bus4", n4PF->attribute("v"));
+  loggerPF->logAttribute("v_bus5", n5PF->attribute("v"));
+  loggerPF->logAttribute("v_bus6", n6PF->attribute("v"));
+  loggerPF->logAttribute("v_bus7", n7PF->attribute("v"));
+  loggerPF->logAttribute("v_bus8", n8PF->attribute("v"));
+  loggerPF->logAttribute("v_bus9", n9PF->attribute("v"));
+  // Log node powers
+  loggerPF->logAttribute("s_bus1", n1PF->attribute("s"));
+  loggerPF->logAttribute("s_bus2", n2PF->attribute("s"));
+  loggerPF->logAttribute("s_bus3", n3PF->attribute("s"));
+  loggerPF->logAttribute("s_bus4", n4PF->attribute("s"));
+  loggerPF->logAttribute("s_bus5", n5PF->attribute("s"));
+  loggerPF->logAttribute("s_bus6", n6PF->attribute("s"));
+  loggerPF->logAttribute("s_bus7", n7PF->attribute("s"));
+  loggerPF->logAttribute("s_bus8", n8PF->attribute("s"));
+  loggerPF->logAttribute("s_bus9", n9PF->attribute("s"));
+
+  // Run power flow simulation
+  Simulation simPF(simNamePF, CPS::Logger::Level::off);
+  simPF.setSystem(systemPF);
+  simPF.setTimeStep(args.timeStep);
+  simPF.setFinalTime(1 * args.timeStep);
+  simPF.setDomain(Domain::SP);
+  simPF.setSolverType(Solver::Type::NRP);
+  simPF.setSolverAndComponentBehaviour(Solver::Behaviour::Simulation);
+  simPF.addLogger(loggerPF);
+  simPF.run();
+  CPS::Logger::get(args.name)->info("Power flow simulation finished.");
+
+  // Seed voltages for the step-2 inverters: converged n2 (GFM PCC) and
+  // n3 (GFL PCC) node voltages, magnitude [kV] and angle [deg]. Dedicated
+  // console-enabled logger so the seeds survive the setLogDir churn.
+  Complex v2PF = n2PF->singleVoltage();
+  Complex v3PF = n3PF->singleVoltage();
+  auto seedLog = CPS::Logger::get(simNamePF + "_seed", CPS::Logger::Level::info,
+                                  CPS::Logger::Level::info);
+  seedLog->info(
+      "PF seed n2 (BUS2): |V| = {:.4f} kV ({:.4f} pu), angle = {:.4f} deg",
+      std::abs(v2PF) / 1e3, std::abs(v2PF) / ieee9.gen2.RatedVoltage,
+      std::arg(v2PF) * 180.0 / PI);
+  seedLog->info(
+      "PF seed n3 (BUS3): |V| = {:.4f} kV ({:.4f} pu), angle = {:.4f} deg",
+      std::abs(v3PF) / 1e3, std::abs(v3PF) / ieee9.gen3.RatedVoltage,
+      std::arg(v3PF) * 180.0 / PI);
+
+  // DYNAMIC SIMULATION - EMT
+  CPS::Logger::get(args.name)->info("Dynamic simulation initialization.");
+  String simNameEMT = simName + "_EMT";
+  CPS::Logger::setLogDir("logs/" + simNameEMT);
+
+  // Nodes
+  auto n1EMT = SimNode<Real>::make("BUS1", PhaseType::ABC);
+  auto n2EMT = SimNode<Real>::make("BUS2", PhaseType::ABC);
+  auto n3EMT = SimNode<Real>::make("BUS3", PhaseType::ABC);
+  auto n4EMT = SimNode<Real>::make("BUS4", PhaseType::ABC);
+  auto n5EMT = SimNode<Real>::make("BUS5", PhaseType::ABC);
+  auto n6EMT = SimNode<Real>::make("BUS6", PhaseType::ABC);
+  auto n7EMT = SimNode<Real>::make("BUS7", PhaseType::ABC);
+  auto n8EMT = SimNode<Real>::make("BUS8", PhaseType::ABC);
+  auto n9EMT = SimNode<Real>::make("BUS9", PhaseType::ABC);
+
+  // Generators
+  auto gen1EMT = EMT::Ph3::SynchronGenerator4OrderVBR::make(
+      ieee9.gen1.Name, CPS::Logger::Level::off);
+
+  gen1EMT->setOperationalParametersPerUnit(
+      ieee9.gen1.RatedPower,   // nomPower [VA]
+      ieee9.gen1.RatedVoltage, // nomVolt [V]
+      ieee9.nomFreq,           // nomFreq [Hz]
+      ieee9.gen1.H, ieee9.gen1.Xd, ieee9.gen1.Xq, ieee9.gen1.Xa,
+      ieee9.gen1.XdPrime, ieee9.gen1.XqPrime, ieee9.gen1.TdoPrime,
+      ieee9.gen1.TqoPrime);
+
+  auto exciter1Params = std::make_shared<Signal::ExciterDC1SimpParameters>();
+  exciter1Params->Ta = ieee9.exc1.TA;
+  exciter1Params->Ka = ieee9.exc1.KA;
+  exciter1Params->Tef = ieee9.exc1.TE;
+  exciter1Params->Kef = ieee9.exc1.KE;
+  exciter1Params->Tf = ieee9.exc1.TF;
+  exciter1Params->Kf = ieee9.exc1.KF;
+  exciter1Params->Tr = 0.01;
+  exciter1Params->MaxVa = ieee9.exc1.VRmax;
+  exciter1Params->MinVa = ieee9.exc1.VRmin;
+  exciter1Params->Bef = std::log(ieee9.exc1.S_EX2 / ieee9.exc1.S_EX1) /
+                        (ieee9.exc1.EX2 - ieee9.exc1.EX1);
+  exciter1Params->Aef =
+      ieee9.exc1.S_EX1 / std::exp(exciter1Params->Bef * ieee9.exc1.EX1);
+  auto exciter1 =
+      Signal::ExciterDC1Simp::make("Gen1_Exciter", CPS::Logger::Level::off);
+  exciter1->setParameters(exciter1Params);
+  gen1EMT->addExciter(exciter1);
+
+  // Adaptation of the governor model parameters to the dpsim implementation
+  CPS::Real T4 = 1.0;
+  CPS::Real T5 = 1.0;
+
+  std::shared_ptr<Signal::TurbineGovernorType1> turbineGovernor1 =
+      Signal::TurbineGovernorType1::make("Gen1_TurbineGovernor",
+                                         CPS::Logger::Level::off);
+
+  turbineGovernor1->setParameters(ieee9.gov1.T2, T4, T5, ieee9.gov1.T3,
+                                  ieee9.gov1.T1, ieee9.gov1.R, ieee9.gov1.Vmin,
+                                  ieee9.gov1.Vmax, 1.0);
+
+  gen1EMT->addGovernor(turbineGovernor1);
+
+  const Real omegaN = 2.0 * PI * ieee9.nomFreq;
+
+  // gen2 replaced by a grid-forming SSN inverter, keeping the GEN2 identity.
+  // nominalVoltage is the peak phase target at the 1.025 pu PV setpoint.
+  const Real gfmNominalVoltage = RMS3PH_TO_PEAK1PH * ieee9.gen2.InitialVoltage;
+  const GfmParams gfm;
+  auto gen2EMT = EMT::Ph3::SSN_GFM::make(ieee9.gen2.Name, ieee9.gen2.Name,
+                                         CPS::Logger::Level::off);
+  gen2EMT->setNumericalLinearizationParameters(1e-6, 1e-8);
+  gen2EMT->setParameters(gfm.lf, gfm.cf, gfm.rf, gfm.rc, gfmNominalVoltage,
+                         omegaN, ieee9.gen2.InitialPower,
+                         ieee9.gen2.InitialPowerReactive, gfm.virtualInertia,
+                         gfm.dampingCoefficient, gfm.voltageDroopGain,
+                         gfm.reactiveIntegralGain, gfm.kpVoltage, gfm.kiVoltage,
+                         gfm.kpCurrent, gfm.kiCurrent, gfm.activeDampingGain,
+                         gfm.powerFilterCutoff, gfm.delayBandwidth);
+  // Grid-connected control: no grid-current feedforward, proportional Q-V droop.
+  gen2EMT->setGridCurrentFeedforward(0.0);
+  gen2EMT->setReactivePowerDroop(gfm.reactivePowerDroop,
+                                 gfm.reactiveDroopCutoff);
+
+  // gen3 replaced by a grid-following averaged VSI (SSN), keeping the GEN3
+  // identity so the topology wiring is unchanged.
+  auto gen3EMT = EMT::Ph3::AvVoltSourceInverterStateSpace::make(
+      ieee9.gen3.Name, CPS::Logger::Level::off);
+  gen3EMT->setParameters(gfl.lf, gfl.cf, gfl.rf, gfl.rc, omegaN, gfl.kpPLL,
+                         gfl.kiPLL, omegaN, ieee9.gen3.InitialPower,
+                         ieee9.gen3.InitialPowerReactive, gfl.kpPowerCtrl,
+                         gfl.kiPowerCtrl, gfl.kpCurrCtrl, gfl.kiCurrCtrl);
+
+  // Loads
+  auto load5EMT =
+      EMT::Ph3::RXLoad::make(ieee9.load5.Name, CPS::Logger::Level::off);
+  load5EMT->setParameters(
+      Math::singlePhasePowerToThreePhase(ieee9.load5.RealPower),
+      Math::singlePhasePowerToThreePhase(ieee9.load5.ReactivePower),
+      ieee9.load5.BaseVoltage);
+
+  auto load6EMT =
+      EMT::Ph3::RXLoad::make(ieee9.load6.Name, CPS::Logger::Level::off);
+  load6EMT->setParameters(
+      Math::singlePhasePowerToThreePhase(ieee9.load6.RealPower),
+      Math::singlePhasePowerToThreePhase(ieee9.load6.ReactivePower),
+      ieee9.load6.BaseVoltage);
+
+  auto load8EMT =
+      EMT::Ph3::RXLoad::make(ieee9.load8.Name, CPS::Logger::Level::off);
+  load8EMT->setParameters(
+      Math::singlePhasePowerToThreePhase(ieee9.load8.RealPower),
+      Math::singlePhasePowerToThreePhase(ieee9.load8.ReactivePower),
+      ieee9.load8.BaseVoltage);
+
+  // Lines
+  auto line54EMT =
+      EMT::Ph3::PiLine::make(ieee9.line54.Name, CPS::Logger::Level::off);
+  line54EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line54.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line54.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line54.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line54.Conductance));
+
+  auto line64EMT =
+      EMT::Ph3::PiLine::make(ieee9.line64.Name, CPS::Logger::Level::off);
+  line64EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line64.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line64.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line64.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line64.Conductance));
+
+  auto line75EMT =
+      EMT::Ph3::PiLine::make(ieee9.line75.Name, CPS::Logger::Level::off);
+  line75EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line75.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line75.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line75.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line75.Conductance));
+
+  auto line96EMT =
+      EMT::Ph3::PiLine::make(ieee9.line96.Name, CPS::Logger::Level::off);
+  line96EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line96.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line96.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line96.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line96.Conductance));
+
+  auto line78EMT =
+      EMT::Ph3::PiLine::make(ieee9.line78.Name, CPS::Logger::Level::off);
+  line78EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line78.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line78.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line78.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line78.Conductance));
+
+  auto line89EMT =
+      EMT::Ph3::PiLine::make(ieee9.line89.Name, CPS::Logger::Level::off);
+  line89EMT->setParameters(
+      Math::singlePhaseParameterToThreePhase(ieee9.line89.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line89.Inductance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line89.Capacitance),
+      Math::singlePhaseParameterToThreePhase(ieee9.line89.Conductance));
+
+  // Transformers
+  auto transf14EMT =
+      EMT::Ph3::Transformer::make(ieee9.transf14.Name, CPS::Logger::Level::off);
+  transf14EMT->setParameters(
+      ieee9.transf14.VoltageLVSide, ieee9.transf14.VoltageHVSide,
+      ieee9.transf14.RatedPower, ieee9.transf14.Ratio, 0.0,
+      Math::singlePhaseParameterToThreePhase(ieee9.transf14.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.transf14.Inductance));
+
+  auto transf27EMT =
+      EMT::Ph3::Transformer::make(ieee9.transf27.Name, CPS::Logger::Level::off);
+  transf27EMT->setParameters(
+      ieee9.transf27.VoltageLVSide, ieee9.transf27.VoltageHVSide,
+      ieee9.transf27.RatedPower, ieee9.transf27.Ratio, 0.0,
+      Math::singlePhaseParameterToThreePhase(ieee9.transf27.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.transf27.Inductance));
+
+  auto transf39EMT =
+      EMT::Ph3::Transformer::make(ieee9.transf39.Name, CPS::Logger::Level::off);
+  transf39EMT->setParameters(
+      ieee9.transf39.VoltageLVSide, ieee9.transf39.VoltageHVSide,
+      ieee9.transf39.RatedPower, ieee9.transf39.Ratio, 0.0,
+      Math::singlePhaseParameterToThreePhase(ieee9.transf39.Resistance),
+      Math::singlePhaseParameterToThreePhase(ieee9.transf39.Inductance));
+
+  // Connect components to nodes
+  gen1EMT->connect({n1EMT});
+  // Inverter terminals: 0 = GND, 1 = PCC.
+  gen2EMT->connect({SimNode<Real>::GND, n2EMT});
+  gen3EMT->connect({SimNode<Real>::GND, n3EMT});
+
+  load5EMT->connect({n5EMT});
+  load6EMT->connect({n6EMT});
+  load8EMT->connect({n8EMT});
+
+  line54EMT->connect({n5EMT, n4EMT});
+  line64EMT->connect({n6EMT, n4EMT});
+  line75EMT->connect({n7EMT, n5EMT});
+  line96EMT->connect({n9EMT, n6EMT});
+  line78EMT->connect({n7EMT, n8EMT});
+  line89EMT->connect({n8EMT, n9EMT});
+
+  transf14EMT->connect({n1EMT, n4EMT});
+  transf27EMT->connect({n2EMT, n7EMT});
+  transf39EMT->connect({n3EMT, n9EMT});
+
+  // Create system topology
+  auto systemEMT = SystemTopology(
+      ieee9.nomFreq,
+      SystemNodeList{n1EMT, n2EMT, n3EMT, n4EMT, n5EMT, n6EMT, n7EMT, n8EMT,
+                     n9EMT},
+      SystemComponentList{gen1EMT, gen2EMT, gen3EMT, load5EMT, load6EMT,
+                          load8EMT, line54EMT, line64EMT, line75EMT, line96EMT,
+                          line78EMT, line89EMT, transf14EMT, transf27EMT,
+                          transf39EMT});
+
+  systemEMT.initWithPowerflow(systemPF, Domain::EMT);
+
+  // Logger
+  if (logger) {
+    // Logging
+    logger->logAttribute("BUS1", n1EMT->attribute("v"));
+    logger->logAttribute("BUS2", n2EMT->attribute("v"));
+    logger->logAttribute("BUS3", n3EMT->attribute("v"));
+    logger->logAttribute("BUS4", n4EMT->attribute("v"));
+    logger->logAttribute("BUS5", n5EMT->attribute("v"));
+    logger->logAttribute("BUS6", n6EMT->attribute("v"));
+    logger->logAttribute("BUS7", n7EMT->attribute("v"));
+    logger->logAttribute("BUS8", n8EMT->attribute("v"));
+    logger->logAttribute("BUS9", n9EMT->attribute("v"));
+
+    // GFM inverter (gen2) signals
+    logger->logAttribute("GEN2.I", gen2EMT->attribute("i_intf"));
+    logger->logAttribute("GEN2.V", gen2EMT->attribute("v_intf"));
+    logger->logAttribute("GEN2.p_inst", gen2EMT->attribute("p_inst"));
+    logger->logAttribute("GEN2.q_inst", gen2EMT->attribute("q_inst"));
+    logger->logAttribute("GEN2.omega", gen2EMT->attribute("omega_gfm"));
+    logger->logAttribute("GEN2.vc_d", gen2EMT->attribute("vc_d"));
+    logger->logAttribute("GEN2.vc_q", gen2EMT->attribute("vc_q"));
+
+    // GFL inverter (gen3) signals
+    logger->logAttribute("GEN3.I", gen3EMT->attribute("i_intf"));
+    logger->logAttribute("GEN3.V", gen3EMT->attribute("v_intf"));
+    logger->logAttribute("GEN3.p_inst", gen3EMT->attribute("p_inst"));
+    logger->logAttribute("GEN3.q_inst", gen3EMT->attribute("q_inst"));
+    logger->logAttribute("GEN3.omega_pll", gen3EMT->attribute("omega_pll"));
+    logger->logAttribute("GEN3.vc_d", gen3EMT->attribute("vc_d"));
+    logger->logAttribute("GEN3.vc_q", gen3EMT->attribute("vc_q"));
+
+    // log generator's current
+    for (auto comp : systemEMT.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::EMT::Ph3::SynchronGenerator4OrderVBR>(
+              comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+        logger->logAttribute(comp->name() + ".omega", comp->attribute("w_r"));
+        logger->logAttribute(comp->name() + ".delta", comp->attribute("delta"));
+      }
+    }
+
+    // log transfomers voltages & currents
+    for (auto comp : systemEMT.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::EMT::Ph3::Transformer>(comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+      }
+    }
+
+    // log Lines voltages & currents
+    for (auto comp : systemEMT.mComponents) {
+      if (std::dynamic_pointer_cast<CPS::EMT::Ph3::PiLine>(comp)) {
+        logger->logAttribute(comp->name() + ".I", comp->attribute("i_intf"));
+        logger->logAttribute(comp->name() + ".V", comp->attribute("v_intf"));
+      }
+    }
+  }
+
+  return systemEMT;
+}
+
+int main(int argc, char *argv[]) {
+
+  CommandLineArgs args(argc, argv, "EMT_Ph3_IEEE9_SSN_InverterMix", 0.00005,
+                       0.01 * 60, 60, -1, CPS::Logger::Level::info,
+                       CPS::Logger::Level::off, false, false, false,
+                       CPS::Domain::EMT);
+
+  CPS::Logger::setLogDir("./logs/" + args.name);
+  bool log = args.options.find("log") != args.options.end() &&
+             args.getOptionBool("log");
+
+  std::filesystem::path logFilename =
+      "./logs/" + args.name + "/" + args.name + ".csv";
+  std::shared_ptr<DataLoggerInterface> logger = nullptr;
+
+  if (log) {
+    logger =
+        RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
+  }
+
+  auto sys = buildTopology(args, logger);
+
+  Simulation sim(args.name, args);
+  sim.setSystem(sys);
+  sim.setDomain(Domain::EMT);
+  sim.doSystemMatrixRecomputation(true);
+  if (log) {
+    sim.addLogger(logger);
+  }
+  sim.run();
+
+  CPS::Logger::get(args.name)->info("Simulation finished.");
+}

--- a/dpsim/examples/cxx/Examples.h
+++ b/dpsim/examples/cxx/Examples.h
@@ -328,7 +328,100 @@ struct Derived {
   Real Ind2 = 68e-6;
   Real Cap2 = 13.55e-3;
 };
+
+struct Ieee9SsnGridForming {
+  // Parameters for the EMT::Ph3::SSN_GFM grid-forming inverter at BUS2 of the
+  // IEEE 9-bus mixed-inverter example. Control structure (VSG loop + cascaded
+  // voltage/current control + active damping) follows
+  //   X. Gao, D. Zhou, A. Anvari-Moghaddam, F. Blaabjerg, "Stability Analysis
+  //   of Grid-Following and Grid-Forming Converters Based on State-Space
+  //   Model", IPEC-Himeji 2022 (ECCE Asia), pp. 422-428.
+  // The LC filter is the PR-#570 reference design (220 V / 12 kVA / 50 Hz)
+  // rebased to the BUS2 base, per-unit preserved. The cascaded-loop gains are
+  // computed from design bandwidths, not hand-set.
+
+  // BUS2 base
+  Real ratedVoltage = 18e3;    // V line-to-line RMS
+  Real ratedPower = 100e6;     // VA
+  Real systemFrequency = 60.0; // Hz
+  Real OmegaNull = 2.0 * M_PI * systemFrequency;
+
+  // LC filter and coupling resistance (BUS2 base)
+  Real Lf = 6.694215e-4; // H
+  Real Cf = 6.224280e-5; // F
+  Real Rf = 1.338843e-2; // Ohm
+  Real Rc = 1.338843e-2; // Ohm
+
+  // Inner current loop: PI cancels the filter pole, so the closed loop is a
+  // first-order lag of bandwidth currentCtrlBandwidth (Kp = Lf*w, Ki = Rf*w).
+  Real currentCtrlBandwidth = 1683.03;        // rad/s
+  Real KpCurrent = Lf * currentCtrlBandwidth; // = 1.126636
+  Real KiCurrent = Rf * currentCtrlBandwidth; // = 22.53273
+
+  // Outer voltage loop: second-order shaping on Cf. The natural frequency is
+  // kept low for stiff-grid stability (Kp = 2*zeta*wn*Cf, Ki = wn^2*Cf).
+  Real voltageCtrlNaturalFrequency = 65.865; // rad/s
+  Real voltageCtrlDamping = 1.0 / sqrt(2.0);
+  Real KpVoltage =
+      2.0 * voltageCtrlDamping * voltageCtrlNaturalFrequency * Cf; // = 5.8e-3
+  Real KiVoltage =
+      voltageCtrlNaturalFrequency * voltageCtrlNaturalFrequency * Cf; // = 0.27
+
+  // VSG swing: virtual inertia J and damping D. D is raised well above the
+  // islanded value for stiff-grid stability.
+  Real virtualInertia = 1157.407407;
+  Real dampingCoefficient = 3.0e6;
+
+  // Integral excitation (superseded by the proportional Q-V droop below, but
+  // still passed to setParameters for the islanded fallback).
+  Real voltageDroopGain = 1.0 / 15.0;
+  Real reactiveIntegralGain = 1.700559e-3;
+
+  // Active damping off (the converter delay makes its sign uncertain here),
+  // power-measurement filter cutoff, and switching/delay bandwidth.
+  Real activeDampingGain = 0.0;
+  Real powerFilterCutoff = 100.0; // rad/s
+  Real switchingFrequency = 20e3; // Hz
+  Real delayBandwidth = switchingFrequency / 1.5;
+
+  // Grid-connected control extensions (opt-in on the model). Feedforward is
+  // turned off and the integral excitation replaced by a proportional Q-V
+  // droop, both for stiff-grid stability.
+  Real gridCurrentFeedforward = 0.0; // 1 = full islanded feedforward
+  Real reactivePowerDroop = 1.0e-5;  // Dq [V/var]
+  Real reactiveDroopCutoff = 100.0;  // rad/s
+};
 } // namespace GFM
+
+namespace GFL {
+struct Ieee9AvVsi {
+  // Parameters for the EMT::Ph3::AvVoltSourceInverterStateSpace grid-following
+  // inverter at BUS3. The 400 V / 10 kVA reference design is rebased to the
+  // BUS3 base (13.8 kV, 100 MVA, 60 Hz): PLL and power-loop gains scale by the
+  // inverse voltage ratio, current-loop gains by the impedance ratio, so the
+  // per-unit control is preserved.
+  Real ratedVoltage = 13.8e3; // V line-to-line RMS
+  Real ratedPower = 100e6;    // VA
+  Real systemFrequency = 60.0;
+  Real OmegaNull = 2.0 * M_PI * systemFrequency;
+
+  // LC filter and coupling resistance (BUS3 base)
+  Real Lf = 1.98375e-4; // H
+  Real Cf = 7.00133e-5; // F
+  Real Rf = 2.38050e-2; // Ohm
+  Real Rc = 2.38050e-2; // Ohm
+
+  // PLL and power loop (rebased by 1/voltageRatio, voltageRatio = 13.8kV/400V)
+  Real KpPLL = 7.246377e-3;
+  Real KiPLL = 5.797101e-3;
+  Real KpPowerCtrl = 1.449275e-3;
+  Real KiPowerCtrl = 5.797101e-3;
+
+  // Current loop (rebased by the impedance ratio)
+  Real KpCurrCtrl = 2.975625e-2;
+  Real KiCurrCtrl = 1.190250e-1;
+};
+} // namespace GFL
 } // namespace Components
 
 namespace Grids {

--- a/dpsim/src/pybind/EMTComponents.cpp
+++ b/dpsim/src/pybind/EMTComponents.cpp
@@ -684,6 +684,14 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
       .def("set_numerical_linearization_parameters",
            &CPS::EMT::Ph3::SSN_GFM::setNumericalLinearizationParameters,
            "relative_step"_a = 1e-6, "absolute_step"_a = 1e-8)
+      .def("set_virtual_impedance",
+           &CPS::EMT::Ph3::SSN_GFM::setVirtualImpedance, "virtual_resistance"_a,
+           "virtual_reactance"_a = 0.0)
+      .def("set_grid_current_feedforward",
+           &CPS::EMT::Ph3::SSN_GFM::setGridCurrentFeedforward, "scale"_a)
+      .def("set_reactive_power_droop",
+           &CPS::EMT::Ph3::SSN_GFM::setReactivePowerDroop, "droop_gain"_a,
+           "cutoff"_a)
       .def("connect", &CPS::EMT::Ph3::SSN_GFM::connect)
       .def("get_state_names", &CPS::EMT::Ph3::SSN_GFM::getLocalStateNames)
       .def("get_state", &CPS::EMT::Ph3::SSN_GFM::getState)

--- a/examples/Notebooks/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.ipynb
+++ b/examples/Notebooks/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.ipynb
@@ -1,0 +1,251 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "10b78129",
+   "metadata": {},
+   "source": [
+    "# IEEE 9-bus with mixed synchronous, grid-forming and grid-following sources\n",
+    "\n",
+    "IEEE 9-bus in EMT, power-flow initialized. gen1 is a 4th-order synchronous machine, gen2 a grid-forming SSN inverter, gen3 a grid-following averaged VSI. The notebook runs the compiled example and plots the shared behaviour. The grid-forming tuning is exposed through `gfm_*` options and can be swept."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28898c96",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:10:10.259744Z",
+     "iopub.status.busy": "2026-07-19T00:10:10.259499Z",
+     "iopub.status.idle": "2026-07-19T00:10:31.438390Z",
+     "shell.execute_reply": "2026-07-19T00:10:31.437003Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from villas.dataprocessing.readtools import read_timeseries_csv\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import glob\n",
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "duration = 2.0\n",
+    "\n",
+    "root_path = (\n",
+    "    subprocess.Popen([\"git\", \"rev-parse\", \"--show-toplevel\"], stdout=subprocess.PIPE)\n",
+    "    .communicate()[0]\n",
+    "    .rstrip()\n",
+    "    .decode(\"utf-8\")\n",
+    ")\n",
+    "\n",
+    "name = \"EMT_Ph3_IEEE9_SSN_InverterMix\"\n",
+    "candidates = [os.path.join(root_path, \"build\", \"dpsim\", \"examples\", \"cxx\")]\n",
+    "candidates += glob.glob(\n",
+    "    os.path.join(root_path, \"build\", \"*\", \"dpsim\", \"examples\", \"cxx\")\n",
+    ")\n",
+    "path_exec = next(p for p in candidates if os.path.isfile(os.path.join(p, name)))\n",
+    "print(\"binary:\", path_exec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f890382",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:10:31.440655Z",
+     "iopub.status.busy": "2026-07-19T00:10:31.440365Z",
+     "iopub.status.idle": "2026-07-19T00:10:40.186323Z",
+     "shell.execute_reply": "2026-07-19T00:10:40.184852Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Run the example, optionally overriding the grid-forming tuning, and return\n",
+    "# the logged time series (the single trailing preallocated sample is dropped).\n",
+    "def run(**gfm_options):\n",
+    "    cmd = [os.path.join(path_exec, name), \"-d\", str(duration), \"--option\", \"log=true\"]\n",
+    "    for key, value in gfm_options.items():\n",
+    "        cmd += [\"--option\", f\"{key}={value}\"]\n",
+    "    subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, check=True)\n",
+    "    return read_timeseries_csv(\"logs/\" + name + \"/\" + name + \".csv\")\n",
+    "\n",
+    "\n",
+    "def xy(ts, key):\n",
+    "    m = ts[key].time > 1e-9\n",
+    "    return ts[key].time[m], ts[key].values[m]\n",
+    "\n",
+    "\n",
+    "# For a balanced set sqrt(a^2 + b^2 + c^2) of the phase voltages equals the\n",
+    "# line-to-line RMS magnitude.\n",
+    "def bus_ll_rms(ts, bus):\n",
+    "    t, a = xy(ts, bus + \"_0\")\n",
+    "    _, b = xy(ts, bus + \"_1\")\n",
+    "    _, c = xy(ts, bus + \"_2\")\n",
+    "    return t, np.sqrt(a**2 + b**2 + c**2)\n",
+    "\n",
+    "\n",
+    "ts = run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78aed836",
+   "metadata": {},
+   "source": [
+    "Bus voltages at the grid-forming (BUS2) and grid-following (BUS3) points of connection, and the anchoring machine bus (BUS1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cc0fcac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:10:40.188861Z",
+     "iopub.status.busy": "2026-07-19T00:10:40.188649Z",
+     "iopub.status.idle": "2026-07-19T00:10:41.097741Z",
+     "shell.execute_reply": "2026-07-19T00:10:41.096497Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 6))\n",
+    "for bus in [\"BUS1\", \"BUS2\", \"BUS3\"]:\n",
+    "    t, v = bus_ll_rms(ts, bus)\n",
+    "    plt.plot(t, v / 1e3, label=bus)\n",
+    "plt.xlabel(\"time [s]\")\n",
+    "plt.ylabel(\"|V| line-to-line RMS [kV]\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04facb2c",
+   "metadata": {},
+   "source": [
+    "Active and reactive power of the two inverters. The grid-forming gen2 holds its dispatch while forming the voltage; the grid-following gen3 tracks its power reference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a7b7672",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:10:41.100318Z",
+     "iopub.status.busy": "2026-07-19T00:10:41.100065Z",
+     "iopub.status.idle": "2026-07-19T00:10:41.649997Z",
+     "shell.execute_reply": "2026-07-19T00:10:41.648817Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fig, (axp, axq) = plt.subplots(2, 1, figsize=(12, 8), sharex=True)\n",
+    "for gen in [\"GEN2\", \"GEN3\"]:\n",
+    "    t, p = xy(ts, gen + \".p_inst\")\n",
+    "    _, q = xy(ts, gen + \".q_inst\")\n",
+    "    axp.plot(t, p / 1e6, label=gen)\n",
+    "    axq.plot(t, q / 1e6, label=gen)\n",
+    "axp.set_ylabel(\"P [MW]\")\n",
+    "axq.set_ylabel(\"Q [MVAr]\")\n",
+    "axq.set_xlabel(\"time [s]\")\n",
+    "axp.legend()\n",
+    "axq.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0a03d90",
+   "metadata": {},
+   "source": [
+    "Grid-forming frequency (gen2) against the synchronous machine speed (gen1), both in Hz. They stay synchronised."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddd0e9d1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:10:41.652519Z",
+     "iopub.status.busy": "2026-07-19T00:10:41.652303Z",
+     "iopub.status.idle": "2026-07-19T00:10:41.883940Z",
+     "shell.execute_reply": "2026-07-19T00:10:41.882791Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 6))\n",
+    "t, w_gfm = xy(ts, \"GEN2.omega\")\n",
+    "plt.plot(t, w_gfm / (2 * np.pi), label=\"GEN2 grid-forming\")\n",
+    "t, w_sg = xy(ts, \"GEN1.omega\")\n",
+    "plt.plot(t, w_sg * 60.0, label=\"GEN1 synchronous\")\n",
+    "plt.xlabel(\"time [s]\")\n",
+    "plt.ylabel(\"frequency [Hz]\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c17d30da",
+   "metadata": {},
+   "source": [
+    "Sweeping the tuning. On a stiff grid the grid-forming source needs enough damping; here the swing-damping `gfm_d` is swept and the gen2 active power is compared.\n",
+    "\n",
+    "Grid-forming knobs: `gfm_d`, `gfm_dq`, `gfm_dqc`, `gfm_kpv`, `gfm_kiv`, `gfm_ff`, `gfm_rv`. Grid-following knobs (gen3): `gfl_kppll`, `gfl_kipll`, `gfl_kpp`, `gfl_kip`, `gfl_kpi`, `gfl_kii`. Pass any of them to `run(...)`, e.g. `run(gfl_kppll=0.02)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d122bb2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:10:41.886932Z",
+     "iopub.status.busy": "2026-07-19T00:10:41.886660Z",
+     "iopub.status.idle": "2026-07-19T00:11:08.439166Z",
+     "shell.execute_reply": "2026-07-19T00:11:08.438322Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 6))\n",
+    "for damping in [3.0e5, 1.0e6, 3.0e6]:\n",
+    "    ts_d = run(gfm_d=damping)\n",
+    "    t, p = xy(ts_d, \"GEN2.p_inst\")\n",
+    "    plt.plot(t, p / 1e6, label=f\"gfm_d = {damping:.0e}\")\n",
+    "plt.xlabel(\"time [s]\")\n",
+    "plt.ylabel(\"GEN2 P [MW]\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/Notebooks/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.ipynb
+++ b/examples/Notebooks/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.ipynb
@@ -225,6 +225,37 @@
     "plt.legend()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abde2b26",
+   "metadata": {},
+   "source": [
+    "Virtual resistance as a substitute for a large swing-damping coefficient. The baseline holds the swing with a large `gfm_d`. Lowering `gfm_d` leaves the grid-forming frequency oscillating; adding a virtual output resistance `gfm_rv` damps it back down through a physical output-impedance path rather than the artificial swing-damping term. It recovers most, though not all, of the sustained swing damping."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b488b6bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 6))\n",
+    "cases = [\n",
+    "    (\"gfm_d = 3e6, gfm_rv = 0\", dict(gfm_d=3.0e6, gfm_rv=0.0)),\n",
+    "    (\"gfm_d = 3e5, gfm_rv = 0\", dict(gfm_d=3.0e5, gfm_rv=0.0)),\n",
+    "    (\"gfm_d = 3e5, gfm_rv = 8\", dict(gfm_d=3.0e5, gfm_rv=8.0)),\n",
+    "]\n",
+    "for label, opts in cases:\n",
+    "    ts_c = run(**opts)\n",
+    "    t, w = xy(ts_c, \"GEN2.omega\")\n",
+    "    plt.plot(t, (w / (2 * np.pi) - 60.0) * 1e3, label=label)\n",
+    "plt.xlabel(\"time [s]\")\n",
+    "plt.ylabel(\"GEN2 frequency deviation [mHz]\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
- Opt-in grid-forming control extensions to `EMT::Ph3::SSN_GFM` (3 setters, all default to a no-op so the islanded model is unchanged):
  - `setGridCurrentFeedforward(scale)`: scale/disable the voltage-loop grid-current feedforward.
  - `setVirtualImpedance(Rv, Xv)`: virtual output impedance off the filter current.
  - `setReactivePowerDroop(Dq, cutoff)`: proportional Q-V droop replacing the integral excitation.
- New example `EMT_Ph3_IEEE9_SSN_InverterMix.cpp`: IEEE 9-bus with gen1 SG, gen2 to SSN_GFM (grid-forming), gen3 to averaged VSI (grid-following).