### PR TITLE
Add DP::Ph3 mixed variable-SSN base

### DIFF
--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -93,6 +93,7 @@
 #include <dpsim-models/DP/DP_Ph3_GenericTwoTerminalITypeSSN.h>
 #include <dpsim-models/DP/DP_Ph3_GenericTwoTerminalVTypeSSN.h>
 #include <dpsim-models/DP/DP_Ph3_Inductor.h>
+#include <dpsim-models/DP/DP_Ph3_MixedVTypeVariableSSNComp.h>
 #include <dpsim-models/DP/DP_Ph3_PiLine.h>
 #include <dpsim-models/DP/DP_Ph3_Resistor.h>
 #include <dpsim-models/DP/DP_Ph3_SSN_Full_Serial_RLC.h>

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_MixedVTypeVariableSSNComp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_MixedVTypeVariableSSNComp.h
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Solver/MNAInterface.h>
+#include <dpsim-models/Solver/MNAVariableCompInterface.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph3 {
+
+/// Three-phase, two-terminal, variable V-type SSN base with a mixed
+/// real + per-phase complex-envelope state, packed as one real vector.
+///
+/// Ph3 analogue of DP::Ph1::MixedVTypeVariableSSNComp: the input/output are
+/// three complex phase envelopes (not one), so mW is a 3x3 complex Norton
+/// admittance and mYHist a 3x1 history current, stamped with
+/// MNAStampUtils::stampAdmittanceMatrix exactly as the fixed-parameter
+/// DP::Ph3::TwoTerminalVTypeSSNComp does. Each phase's complex self term is
+/// shifted by the same single carrier (A - jw_N I per phase); the per-phase
+/// coupling and any envelope shift are the derived component's own A/B, baked
+/// in pre-shifted (do not double-shift, [[reference-mixedvtype-ssn-preshifted-a]]).
+class MixedVTypeVariableSSNComp : public MNASimPowerComp<Complex>,
+                                  public MNAVariableCompInterface {
+private:
+  Bool mParameterChanged;
+
+protected:
+  static constexpr Int mInitializationMaxIterations = 10;
+  static constexpr Real mInitializationTolerance = 1e-9;
+
+  /// Number of complex network channels (phases) this base folds to/from.
+  static constexpr Int mPhaseCount = 3;
+
+  const Int mRealStateCount;
+  const Int mComplexStateCount;
+
+  Real mTimeStep;
+
+  /// Continuous-time real model over the packed state and packed [Re,Im] input/output.
+  Matrix mA, mB, mC, mD, mE, mF;
+  /// Discretized (trapezoidal) real operators.
+  Matrix mdA, mdB, mdE;
+
+  /// Complex Norton admittance / history current stamped into the network.
+  MatrixComp mW;
+  MatrixComp mYHist;
+
+  /// Packed real state: [realStates..., Re(cplxState0), Im(cplxState0), ...].
+  const Attribute<Matrix>::Ptr mX;
+
+  MixedVTypeVariableSSNComp(String uid, String name, Int realStateCount,
+                            Int complexStateCount,
+                            Logger::Level logLevel = Logger::Level::off);
+
+  /// Total packed real state size: realStateCount + 2*complexStateCount.
+  Int stateSize() const;
+
+  /// Pack an m-vector of complex into a 2m real vector [Re0,Im0,Re1,Im1,...].
+  static Matrix packComplex(const MatrixComp &c);
+  /// Inverse of packComplex.
+  static MatrixComp unpackComplex(const Matrix &v);
+  /// Fold a 2m x 2m real block-[[a,-b],[b,a]] matrix into an m x m complex map.
+  static MatrixComp foldComplexMatrix(const Matrix &real);
+
+  Attribute<MatrixComp>::Ptr inputAttribute() const;
+  Attribute<MatrixComp>::Ptr outputAttribute() const;
+
+  /// Default: balanced envelope from v_terminal1 - v_terminal0.
+  virtual MatrixComp buildInitialInputFromNodes(Real frequency);
+
+  void setParameters(const Matrix &A, const Matrix &B, const Matrix &C,
+                     const Matrix &D);
+  void setParameters(const Matrix &A, const Matrix &B, const Matrix &C,
+                     const Matrix &D, const Matrix &E, const Matrix &F);
+
+  const Matrix &stateOffset() const;
+  const Matrix &outputOffset() const;
+  void setStateOffset(const Matrix &E);
+  void setOutputOffset(const Matrix &F);
+
+  virtual Matrix calculateHistoryVectorReal() const;
+  virtual void updateState(const MatrixComp &uOld, const MatrixComp &uNew);
+  virtual void recomputeDiscreteModel();
+
+  /// Update derived attributes used for logging/inspection; called once per
+  /// step after the state update. Empty by default, override in derived
+  /// components (mirrors EMT::SSNComp::updateLogAttributes).
+  virtual void updateLogAttributes(const Matrix &u) const;
+
+  /// Rebuild A/B/C/D/E/F from the current state/input; returns true if the stamp changed.
+  virtual Bool updateComponentParameters() = 0;
+  void updateStateSpaceModel();
+
+public:
+  UInt getStateCount() const;
+  const Matrix &getDiscreteA() const;
+  const Matrix &getDiscreteB() const;
+  const Matrix &getC() const;
+
+  Bool hasParameterChanged() override final;
+
+  /// Fixed-point steady-state init; valid only when mRealStateCount == 0, override otherwise.
+  void initializeFromNodesAndTerminals(Real frequency) override;
+
+  void mnaCompInitialize(Real omega, Real timeStep,
+                         Attribute<Matrix>::Ptr leftVector) override final;
+  void mnaCompAddPreStepDependencies(
+      AttributeBase::List &prevStepDependencies,
+      AttributeBase::List &attributeDependencies,
+      AttributeBase::List &modifiedAttributes) override final;
+  void mnaCompPreStep(Real time, Int timeStepCount) override final;
+  void mnaCompAddPostStepDependencies(
+      AttributeBase::List &prevStepDependencies,
+      AttributeBase::List &attributeDependencies,
+      AttributeBase::List &modifiedAttributes,
+      Attribute<Matrix>::Ptr &leftVector) override final;
+
+  void
+  mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override final;
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override final;
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override final;
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override final;
+  void mnaCompPostStep(Real time, Int timeStepCount,
+                       Attribute<Matrix>::Ptr &leftVector) override final;
+};
+
+} // namespace Ph3
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -80,6 +80,7 @@ list(APPEND MODELS_SOURCES
 	# DP/DP_Ph3_SynchronGeneratorVBRStandalone.cpp
 
 	DP/DP_Ph3_TwoTerminalVTypeSSNComp.cpp
+	DP/DP_Ph3_MixedVTypeVariableSSNComp.cpp
 	DP/DP_Ph3_TwoTerminalITypeSSNComp.cpp
 	DP/DP_Ph3_SSN_Full_Serial_RLC.cpp
 	DP/DP_Ph3_GenericTwoTerminalVTypeSSN.cpp

--- a/dpsim-models/src/DP/DP_Ph3_MixedVTypeVariableSSNComp.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_MixedVTypeVariableSSNComp.cpp
@@ -1,0 +1,356 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph3_MixedVTypeVariableSSNComp.h>
+#include <dpsim-models/MNAStampUtils.h>
+#include <dpsim-models/MathUtils.h>
+
+using namespace CPS;
+
+DP::Ph3::MixedVTypeVariableSSNComp::MixedVTypeVariableSSNComp(
+    String uid, String name, Int realStateCount, Int complexStateCount,
+    Logger::Level logLevel)
+    : MNASimPowerComp<Complex>(uid, name, true, true, logLevel),
+      mParameterChanged(false), mRealStateCount(realStateCount),
+      mComplexStateCount(complexStateCount), mTimeStep(0.0),
+      mW(MatrixComp::Zero(mPhaseCount, mPhaseCount)),
+      mYHist(MatrixComp::Zero(mPhaseCount, 1)),
+      mX(mAttributes->create<Matrix>("x")) {
+  mPhaseType = PhaseType::ABC;
+  setTerminalNumber(2);
+
+  **mIntfVoltage = MatrixComp::Zero(mPhaseCount, 1);
+  **mIntfCurrent = MatrixComp::Zero(mPhaseCount, 1);
+
+  mParametersSet = false;
+}
+
+Int DP::Ph3::MixedVTypeVariableSSNComp::stateSize() const {
+  return mRealStateCount + 2 * mComplexStateCount;
+}
+
+UInt DP::Ph3::MixedVTypeVariableSSNComp::getStateCount() const {
+  return static_cast<UInt>(stateSize());
+}
+
+const Matrix &DP::Ph3::MixedVTypeVariableSSNComp::getDiscreteA() const {
+  return mdA;
+}
+
+const Matrix &DP::Ph3::MixedVTypeVariableSSNComp::getDiscreteB() const {
+  return mdB;
+}
+
+const Matrix &DP::Ph3::MixedVTypeVariableSSNComp::getC() const { return mC; }
+
+Matrix DP::Ph3::MixedVTypeVariableSSNComp::packComplex(const MatrixComp &c) {
+  const Matrix::Index m = c.rows();
+  Matrix v(2 * m, 1);
+  for (Matrix::Index i = 0; i < m; ++i) {
+    v(2 * i, 0) = c(i, 0).real();
+    v(2 * i + 1, 0) = c(i, 0).imag();
+  }
+  return v;
+}
+
+MatrixComp DP::Ph3::MixedVTypeVariableSSNComp::unpackComplex(const Matrix &v) {
+  const Matrix::Index m = v.rows() / 2;
+  MatrixComp c(m, 1);
+  for (Matrix::Index i = 0; i < m; ++i)
+    c(i, 0) = Complex(v(2 * i, 0), v(2 * i + 1, 0));
+  return c;
+}
+
+MatrixComp
+DP::Ph3::MixedVTypeVariableSSNComp::foldComplexMatrix(const Matrix &real) {
+  const Matrix::Index m = real.rows() / 2;
+  MatrixComp c(m, real.cols() / 2);
+  for (Matrix::Index i = 0; i < m; ++i)
+    for (Matrix::Index j = 0; j < real.cols() / 2; ++j)
+      // Trust the [[a,-b],[b,a]] complex-multiplication structure of each
+      // 2x2 block (Irc = (U - Vc)/Rc is an exact real-scalar per-phase
+      // relation), as DP::SSNComp does; not re-checked at runtime.
+      c(i, j) = Complex(real(2 * i, 2 * j), real(2 * i + 1, 2 * j));
+  return c;
+}
+
+Attribute<MatrixComp>::Ptr
+DP::Ph3::MixedVTypeVariableSSNComp::inputAttribute() const {
+  return mIntfVoltage;
+}
+
+Attribute<MatrixComp>::Ptr
+DP::Ph3::MixedVTypeVariableSSNComp::outputAttribute() const {
+  return mIntfCurrent;
+}
+
+MatrixComp
+DP::Ph3::MixedVTypeVariableSSNComp::buildInitialInputFromNodes(Real) {
+  MatrixComp vInit = MatrixComp::Zero(mPhaseCount, 1);
+  vInit(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
+  vInit(1, 0) = vInit(0, 0) * SHIFT_TO_PHASE_B;
+  vInit(2, 0) = vInit(0, 0) * SHIFT_TO_PHASE_C;
+  return vInit;
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::setParameters(const Matrix &A,
+                                                       const Matrix &B,
+                                                       const Matrix &C,
+                                                       const Matrix &D) {
+  setParameters(A, B, C, D, Matrix::Zero(A.rows(), 1),
+                Matrix::Zero(2 * mPhaseCount, 1));
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::setParameters(
+    const Matrix &A, const Matrix &B, const Matrix &C, const Matrix &D,
+    const Matrix &E, const Matrix &F) {
+  mParametersSet = false;
+
+  const Matrix::Index n = stateSize();
+  const Matrix::Index m = 2 * mPhaseCount;
+
+  if (A.rows() != n || A.cols() != n)
+    throw std::invalid_argument("A has invalid dimensions.");
+
+  if (B.rows() != n || B.cols() != m)
+    throw std::invalid_argument("B has invalid dimensions.");
+
+  if (C.rows() != m || C.cols() != n)
+    throw std::invalid_argument("C has invalid dimensions.");
+
+  if (D.rows() != m || D.cols() != m)
+    throw std::invalid_argument("D has invalid dimensions.");
+
+  if (E.rows() != n || E.cols() != 1)
+    throw std::invalid_argument("E has invalid dimensions.");
+
+  if (F.rows() != m || F.cols() != 1)
+    throw std::invalid_argument("F has invalid dimensions.");
+
+  mA = A;
+  mB = B;
+  mC = C;
+  mD = D;
+  mE = E;
+  mF = F;
+
+  **mX = Matrix::Zero(n, 1);
+
+  mdA = Matrix::Zero(n, n);
+  mdB = Matrix::Zero(n, m);
+  mdE = Matrix::Zero(n, 1);
+
+  mW = MatrixComp::Zero(mPhaseCount, mPhaseCount);
+  mYHist = MatrixComp::Zero(mPhaseCount, 1);
+
+  mParametersSet = true;
+}
+
+const Matrix &DP::Ph3::MixedVTypeVariableSSNComp::stateOffset() const {
+  return mE;
+}
+
+const Matrix &DP::Ph3::MixedVTypeVariableSSNComp::outputOffset() const {
+  return mF;
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::setStateOffset(const Matrix &E) {
+  if (E.rows() != stateSize() || E.cols() != 1)
+    throw std::invalid_argument("State offset vector has invalid dimensions.");
+
+  mE = E;
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::setOutputOffset(const Matrix &F) {
+  if (F.rows() != 2 * mPhaseCount || F.cols() != 1)
+    throw std::invalid_argument("Output offset vector has invalid dimensions.");
+
+  mF = F;
+}
+
+Matrix DP::Ph3::MixedVTypeVariableSSNComp::calculateHistoryVectorReal() const {
+  const Matrix u = packComplex(**inputAttribute());
+  return mC * (mdA * (**mX) + mdB * u + mdE) + mF;
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::updateState(const MatrixComp &uOld,
+                                                     const MatrixComp &uNew) {
+  const Matrix uOldReal = packComplex(uOld);
+  const Matrix uNewReal = packComplex(uNew);
+  **mX = mdA * (**mX) + mdB * (uNewReal + uOldReal) + mdE;
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::recomputeDiscreteModel() {
+  Math::calculateStateSpaceTrapezoidalMatrices(mA, mB, mE, mTimeStep, mdA, mdB,
+                                               mdE);
+
+  // Fold the 2m x 2m real u->y block into a 3x3 complex admittance; each 2x2
+  // block is required to have the [[a,-b],[b,a]] complex-multiplication form.
+  mW = foldComplexMatrix(mC * mdB + mD);
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::updateStateSpaceModel() {
+  mParameterChanged = updateComponentParameters();
+
+  if (mParameterChanged)
+    recomputeDiscreteModel();
+}
+
+Bool DP::Ph3::MixedVTypeVariableSSNComp::hasParameterChanged() {
+  return mParameterChanged;
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::updateLogAttributes(
+    const Matrix &) const {}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::initializeFromNodesAndTerminals(
+    Real frequency) {
+  if (!mParametersSet)
+    throw std::logic_error("setParameters() must be called before "
+                           "initializeFromNodesAndTerminals().");
+
+  if (mRealStateCount != 0)
+    throw std::logic_error(
+        "The default initializeFromNodesAndTerminals() only supports a "
+        "purely complex-envelope state (realStateCount() == 0); components "
+        "with real control states must override it.");
+
+  const MatrixComp uInit = buildInitialInputFromNodes(frequency);
+
+  **mIntfVoltage = uInit;
+  **mX = Matrix::Zero(stateSize(), 1);
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- Initialization from nodes and terminals ---");
+
+  Bool converged = false;
+
+  const Matrix uColumn = packComplex(uInit);
+
+  for (Int iter = 0; iter < mInitializationMaxIterations; ++iter) {
+    const Matrix xPrev = **mX;
+
+    updateComponentParameters();
+
+    // mA is already carrier-shifted, so steady state is 0 = mA*x + mB*u + mE.
+    **mX = -mA.inverse() * (mB * uColumn + mE);
+
+    if ((**mX).isApprox(xPrev, mInitializationTolerance)) {
+      converged = true;
+      break;
+    }
+  }
+
+  if (!converged) {
+    SPDLOG_LOGGER_WARN(
+        mSLog,
+        "Fixed-point initialization did not converge within {} iterations.",
+        mInitializationMaxIterations);
+  }
+
+  updateComponentParameters();
+
+  const Matrix yReal = mC * (**mX) + mD * uColumn + mF;
+  **mIntfCurrent = unpackComplex(yReal);
+
+  mParameterChanged = false;
+
+  SPDLOG_LOGGER_INFO(
+      mSLog,
+      "\nInput u: {:s}"
+      "\nOutput y: {:s}"
+      "\nState x: {:s}"
+      "\n--- Initialization from nodes and terminals finished ---",
+      Logger::matrixCompToString(**mIntfVoltage),
+      Logger::matrixCompToString(**mIntfCurrent), Logger::matrixToString(**mX));
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::mnaCompInitialize(
+    Real, Real timeStep, Attribute<Matrix>::Ptr) {
+  if (!mParametersSet)
+    throw std::logic_error(
+        "setParameters() must be called before initialization.");
+
+  mTimeStep = timeStep;
+  updateMatrixNodeIndices();
+
+  updateComponentParameters();
+  recomputeDiscreteModel();
+  mYHist = unpackComplex(calculateHistoryVectorReal());
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::mnaCompAddPreStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes) {
+  modifiedAttributes.push_back(mRightVector);
+  prevStepDependencies.push_back(mX);
+  prevStepDependencies.push_back(inputAttribute());
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::mnaCompPreStep(Real, Int) {
+  updateStateSpaceModel();
+  mYHist = unpackComplex(calculateHistoryVectorReal());
+  mnaCompApplyRightSideVectorStamp(**mRightVector);
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::mnaCompAddPostStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes,
+    Attribute<Matrix>::Ptr &leftVector) {
+  attributeDependencies.push_back(leftVector);
+  modifiedAttributes.push_back(inputAttribute());
+  modifiedAttributes.push_back(outputAttribute());
+  modifiedAttributes.push_back(mX);
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::mnaCompApplySystemMatrixStamp(
+    SparseMatrixRow &systemMatrix) {
+  MNAStampUtils::stampAdmittanceMatrix(
+      mW, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
+      terminalNotGrounded(0), terminalNotGrounded(1), mSLog);
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::mnaCompApplyRightSideVectorStamp(
+    Matrix &rightVector) {
+  if (terminalNotGrounded(0)) {
+    for (Int phase = 0; phase < mPhaseCount; ++phase)
+      Math::setVectorElement(rightVector, matrixNodeIndex(0, phase),
+                             mYHist(phase, 0));
+  }
+  if (terminalNotGrounded(1)) {
+    for (Int phase = 0; phase < mPhaseCount; ++phase)
+      Math::setVectorElement(rightVector, matrixNodeIndex(1, phase),
+                             -mYHist(phase, 0));
+  }
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::mnaCompUpdateVoltage(
+    const Matrix &leftVector) {
+  **mIntfVoltage = MatrixComp::Zero(mPhaseCount, 1);
+
+  if (terminalNotGrounded(1)) {
+    for (Int phase = 0; phase < mPhaseCount; ++phase)
+      (**mIntfVoltage)(phase, 0) =
+          Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, phase));
+  }
+  if (terminalNotGrounded(0)) {
+    for (Int phase = 0; phase < mPhaseCount; ++phase)
+      (**mIntfVoltage)(phase, 0) -=
+          Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, phase));
+  }
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::mnaCompUpdateCurrent(const Matrix &) {
+  **mIntfCurrent = mW * (**mIntfVoltage) + mYHist;
+}
+
+void DP::Ph3::MixedVTypeVariableSSNComp::mnaCompPostStep(
+    Real, Int, Attribute<Matrix>::Ptr &leftVector) {
+  const MatrixComp uOld = **mIntfVoltage;
+  mnaCompUpdateVoltage(**leftVector);
+  mnaCompUpdateCurrent(**leftVector);
+  updateState(uOld, **mIntfVoltage);
+  updateLogAttributes(packComplex(**mIntfVoltage));
+}


### PR DESCRIPTION

Adds `DP::Ph3::MixedVTypeVariableSSNComp`, a three-phase, two-terminal variable V-type SSN base carrying a mixed state: real control states plus per-phase complex envelope states, packed into one real vector. It is the Ph3 analogue of the merged `DP::Ph1::MixedVTypeVariableSSNComp` and the base that an averaged grid-forming inverter component will build on.

Abstract base only, no concrete component or example in this PR.