### PR TITLE
add power-flow static VAR compensator in SP domain

### DIFF
--- a/docs/hugo/content/en/docs/Concepts/Models/network-injection-and-compensation.md
+++ b/docs/hugo/content/en/docs/Concepts/Models/network-injection-and-compensation.md
@@ -58,6 +58,31 @@ merely a smoothing of the reported value; making it small to track faster couple
 noise, and making it large delays the response into a range where it can interact with nearby
 machine controls.
 
+## Compensation in the power flow
+
+Before any of that runs, the compensator has to appear in the power flow that sets the operating
+point. There it is not a differential equation but a boundary condition, and since the device
+exchanges no active power, the only question is what the reactive half of that condition states.
+
+Two statements are available. Fixing the voltage and letting the solution supply whatever reactive
+power holds it is the familiar voltage-controlled bus. It says what the compensator is for, but it
+says it without bound: the reactive power that comes out is whatever the network needs, and nothing
+in the formulation knows the device is rated. Where the requirement exceeds the rating, the result is
+a converged case that could not be built.
+
+Fixing the reactive power instead keeps the constant-power equations the rest of the network already
+uses, and moves the regulation outside the Newton iteration. An outer loop adjusts the injection
+until the bus reaches its reference, clamped to the installed band, and the clamped case is the same
+one the dynamic model reaches: the device sits at its limit and the voltage error persists. The
+inner solve stays a problem the solver is already good at, and the rating enters where it can be
+enforced.
+
+One property of the physical device does not survive the substitution. A susceptance delivers
+reactive power in proportion to $V^2$, while a specified injection does not vary with voltage at all.
+The two agree at the regulated voltage and diverge away from it, so a compensator that reached its
+reference hands over an operating point the time domain will recognise, and one pinned at a limit
+does not.
+
 ## Discrete compensation
 
 Where the compensation is switched rather than continuous, the control is a different kind. The

--- a/docs/hugo/content/en/docs/Developer Guide/Model Implementations/network-injection-and-compensation.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Model Implementations/network-injection-and-compensation.md
@@ -26,11 +26,11 @@ modulation frequency for a modulated one. Which overload is called determines wh
 Because the source is ideal, adding an impedance to represent a finite short circuit level is the
 caller's job. Nothing in the component does it.
 
-## `SVC`
+## `SVC` in the time domain
 
-Not composite. It computes a susceptance each step and realises it by reconfiguring an internal
-reactive element, so it implements the variable-component interface and forces a refactorisation
-whenever the value changes.
+`DP::Ph1::SVC` is the dynamic model. Not composite. It computes a susceptance each step and realises
+it by reconfiguring an internal reactive element, so it implements the variable-component interface
+and forces a refactorisation whenever the value changes.
 
 `updateSusceptance` performs both lags with the trapezoidal rule, using precomputed constants
 `Fac1 = dt / (2 Tr)`, `Fac2 = dt Kr / (2 Tr)` and `Fac3 = dt / (2 Tm)`. The measurement lag is
@@ -55,6 +55,38 @@ magnitude of the complex envelope. For a dynamic phasor quantity those differ, a
 not negligible when the envelope has a significant imaginary part.
 {{% /alert %}}
 
+## `SVC` in the power flow
+
+`SP::Ph1::SVC` is a separate class with no code in common with the dynamic one. It is a
+`SimPowerComp<Complex>` and a `PFSolverInterfaceBus` with one terminal and no MNA interface, so it
+exists only for a power flow and takes no part in a time-domain solve.
+
+It stamps nothing into the admittance matrix. `setParameters(ratedApparentPower, ratedVoltage,
+setPointVoltage, qLimMax, qLimMin)` records the voltage set point and the reactive band and fixes
+`mPowerflowBusType` to `PQ`; the active power is identically zero. What the solver sees is therefore
+a reactive injection `Q_set` and a set point `V_set`, and `updateReactivePowerInjection` is the
+setter that moves the injection. Attribute names follow `SynchronGenerator`: `V_set`, `V_set_pu`,
+`Q_set`, `Q_set_pu`, `Q_max`, `Q_min` and their per-unit counterparts.
+
+`calculatePerUnitParameters(baseApparentPower, baseOmega)` divides the set point by the base voltage
+and the band by the base apparent power. Unset limits are $\pm\infty$ and stay $\pm\infty$ in per
+unit. The method throws `std::invalid_argument` if either base is still zero, rather than dividing
+and producing an infinite or undefined set point.
+
+{{% alert title="Watch out: the base voltage comes from the solver, not from the caller" color="warning" %}}
+`ratedVoltage` in `setParameters` is logged and otherwise unused. A compensator is not a voltage
+source and must not seed a zone's voltage level, so `PFSolver::propagateAndVerifyBaseVoltage`
+resolves the zone first and only then calls `setBaseVoltage` with the node's resolved value. A
+standalone `SVC` that never went through a solver has no base voltage, which is what the guard in
+`calculatePerUnitParameters` catches.
+{{% /alert %}}
+
+The regulation itself lives in the solver rather than in the component: something has to call
+`updateReactivePowerInjection` between Newton solves for the set point to be held. Until that outer
+loop exists, an `SVC` in a system is inert. `PFSolver::initialize` does not collect it into any of
+its component lists, `determinePFBusType` does not read its bus type, and its `Q_set` stays at zero,
+which is the same case as a node with nothing attached.
+
 ## `SolidStateTransformer`
 
 A `CompositePowerComp` that represents each side as a current source rather than as a coupled
@@ -70,6 +102,7 @@ representation the concept page describes and not an omission.
 
 - [`DP_Ph1_NetworkInjection`](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp), and the SP and EMT variants alongside it
 - [`DP_Ph1_SVC`](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/src/DP/DP_Ph1_SVC.cpp)
+- [`SP_Ph1_SVC`](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/src/SP/SP_Ph1_SVC.cpp)
 - [`SP_Ph1_SolidStateTransformer`](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp)
 
 Availability per domain is in

--- a/docs/hugo/content/en/docs/Reference/model-availability.md
+++ b/docs/hugo/content/en/docs/Reference/model-availability.md
@@ -58,7 +58,7 @@ model, so the table cannot fall behind the code. For the equations behind a mode
 | PQLoadCS | &ndash; | &ndash; | &check; | &ndash; | &ndash; | &ndash; |
 | Load | &check; | &ndash; | &ndash; | &ndash; | &ndash; | &ndash; |
 | Shunt | &check; | &ndash; | &check; | &ndash; | &ndash; | &check; |
-| SVC | &ndash; | &ndash; | &check; | &ndash; | &ndash; | &ndash; |
+| SVC | &check; | &ndash; | &check; | &ndash; | &ndash; | &ndash; |
 
 ## Synchronous generators
 

--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -22,6 +22,7 @@
 #include <dpsim-models/SP/SP_Ph1_ReducedOrderSynchronGeneratorVBR.h>
 #include <dpsim-models/SP/SP_Ph1_SSNTypeI2T.h>
 #include <dpsim-models/SP/SP_Ph1_SSNTypeV2T.h>
+#include <dpsim-models/SP/SP_Ph1_SVC.h>
 #include <dpsim-models/SP/SP_Ph1_Shunt.h>
 #include <dpsim-models/SP/SP_Ph1_SolidStateTransformer.h>
 #include <dpsim-models/SP/SP_Ph1_Switch.h>

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <limits>
+
+#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Solver/PFSolverInterfaceBus.h>
+
+namespace CPS {
+namespace SP {
+namespace Ph1 {
+
+/// \brief Static VAR compensator (SVC) power-flow model.
+///
+/// Voltage-controlling shunt reactive device. Modelled as a PQ bus whose
+/// reactive injection Q_set is driven by the solver's SVC outer control loop
+/// until the bus voltage reaches V_set (clamped to [Q_min, Q_max]). This
+/// sidesteps the ill-conditioned derived-Q of the ordinary PV-bus formulation
+/// at electrically stiff, near-zero-P buses. No active power (always 0) and no
+/// admittance stamp: it participates purely through bus classification + the
+/// reactive setpoint the outer loop maintains.
+class SVC : public SimPowerComp<Complex>,
+            public SharedFactory<SVC>,
+            public PFSolverInterfaceBus {
+private:
+  /// Base voltage [V]
+  Real mBaseVoltage;
+  /// Base apparent power [VA]
+  Real mBaseApparentPower;
+
+public:
+  /// Voltage set point [V]
+  const Attribute<Real>::Ptr mSetPointVoltage;
+  /// Voltage set point [pu]
+  const Attribute<Real>::Ptr mSetPointVoltagePerUnit;
+  /// Reactive power injection [VAr] (maintained by the SVC outer loop)
+  const Attribute<Real>::Ptr mSetPointReactivePower;
+  /// Reactive power injection [pu]
+  const Attribute<Real>::Ptr mSetPointReactivePowerPerUnit;
+  /// Maximum reactive power limit [VAr] (default +inf = unlimited)
+  const Attribute<Real>::Ptr mReactivePowerMax;
+  /// Minimum reactive power limit [VAr] (default -inf = unlimited)
+  const Attribute<Real>::Ptr mReactivePowerMin;
+  /// Maximum reactive power limit [pu]
+  const Attribute<Real>::Ptr mReactivePowerMaxPerUnit;
+  /// Minimum reactive power limit [pu]
+  const Attribute<Real>::Ptr mReactivePowerMinPerUnit;
+
+  /// Defines UID, name and logging level
+  SVC(String uid, String name, Logger::Level logLevel = Logger::Level::off);
+  /// Defines name and logging level
+  SVC(String name, Logger::Level logLevel = Logger::Level::off)
+      : SVC(name, name, logLevel) {}
+  /// Setter for SVC parameters. setPointVoltage is the controlled voltage [V];
+  /// qLimMax/qLimMin are the reactive-power band [VAr] the outer control loop
+  /// respects. The device holds no active power (always 0).
+  void setParameters(Real ratedApparentPower, Real ratedVoltage,
+                     Real setPointVoltage,
+                     Real qLimMax = std::numeric_limits<Real>::infinity(),
+                     Real qLimMin = -std::numeric_limits<Real>::infinity());
+  // #### Powerflow section ####
+  Real getBaseVoltage() const;
+  /// Set base voltage
+  void setBaseVoltage(Real baseVoltage);
+  /// Initializes component from power flow data
+  void calculatePerUnitParameters(Real baseApparentPower, Real baseOmega);
+  /// Modify powerflow bus type
+  void modifyPowerFlowBusType(PowerflowBusType powerflowBusType) override;
+  /// Update reactive power injection (driven by the SVC outer control loop)
+  void updateReactivePowerInjection(Complex powerInj);
+  /// Get apparent power of the power-flow solution (P is always 0)
+  Complex getApparentPower() const;
+};
+} // namespace Ph1
+} // namespace SP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
@@ -25,10 +25,10 @@ class SVC : public SimPowerComp<Complex>,
             public SharedFactory<SVC>,
             public PFSolverInterfaceBus {
 private:
-  /// Base voltage [V]
-  Real mBaseVoltage;
+  /// Base voltage [V], set via setBaseVoltage() before power-flow init
+  Real mBaseVoltage = 0;
   /// Base apparent power [VA]
-  Real mBaseApparentPower;
+  Real mBaseApparentPower = 0;
 
 public:
   /// Voltage set point [V]

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
@@ -45,7 +45,7 @@ public:
   /// Defines name and logging level
   SVC(String name, Logger::Level logLevel = Logger::Level::off)
       : SVC(name, name, logLevel) {}
-  /// Set SVC specific parameters
+  /// Set SVC specific parameters; the rated values are logged only
   void setParameters(Real ratedApparentPower, Real ratedVoltage,
                      Real setPointVoltage,
                      Real qLimMax = std::numeric_limits<Real>::infinity(),
@@ -57,7 +57,7 @@ public:
   void setBaseVoltage(Real baseVoltage);
   /// Initializes component from power flow data
   void calculatePerUnitParameters(Real baseApparentPower, Real baseOmega);
-  /// Modify powerflow bus type
+  /// Modify powerflow bus type; only PQ is valid for an SVC
   void modifyPowerFlowBusType(PowerflowBusType powerflowBusType) override;
   /// Update reactive power injection (driven by the SVC outer control loop)
   void updateReactivePowerInjection(Complex powerInj);

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
@@ -12,15 +12,7 @@ namespace CPS {
 namespace SP {
 namespace Ph1 {
 
-/// \brief Static VAR compensator (SVC) power-flow model.
-///
-/// Voltage-controlling shunt reactive device. Modelled as a PQ bus whose
-/// reactive injection Q_set is driven by the solver's SVC outer control loop
-/// until the bus voltage reaches V_set (clamped to [Q_min, Q_max]). This
-/// sidesteps the ill-conditioned derived-Q of the ordinary PV-bus formulation
-/// at electrically stiff, near-zero-P buses. No active power (always 0) and no
-/// admittance stamp: it participates purely through bus classification + the
-/// reactive setpoint the outer loop maintains.
+/// Static VAR compensator for power flow: PQ bus, no active power, no admittance stamp
 class SVC : public SimPowerComp<Complex>,
             public SharedFactory<SVC>,
             public PFSolverInterfaceBus {
@@ -53,14 +45,13 @@ public:
   /// Defines name and logging level
   SVC(String name, Logger::Level logLevel = Logger::Level::off)
       : SVC(name, name, logLevel) {}
-  /// Setter for SVC parameters. setPointVoltage is the controlled voltage [V];
-  /// qLimMax/qLimMin are the reactive-power band [VAr] the outer control loop
-  /// respects. The device holds no active power (always 0).
+  /// Set SVC specific parameters
   void setParameters(Real ratedApparentPower, Real ratedVoltage,
                      Real setPointVoltage,
                      Real qLimMax = std::numeric_limits<Real>::infinity(),
                      Real qLimMin = -std::numeric_limits<Real>::infinity());
   // #### Powerflow section ####
+  /// Get base voltage
   Real getBaseVoltage() const;
   /// Set base voltage
   void setBaseVoltage(Real baseVoltage);

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -179,6 +179,7 @@ list(APPEND MODELS_SOURCES
 	SP/SP_Ph1_Transformer.cpp
 	SP/SP_Ph1_SolidStateTransformer.cpp
 	SP/SP_Ph1_Shunt.cpp
+	SP/SP_Ph1_SVC.cpp
 	SP/SP_Ph1_SynchronGenerator.cpp
 	SP/SP_Ph1_ReducedOrderSynchronGeneratorVBR.cpp
 	SP/SP_Ph1_SynchronGenerator3OrderVBR.cpp

--- a/dpsim-models/src/SP/SP_Ph1_SVC.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SVC.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/SP/SP_Ph1_SVC.h>
+
+using namespace CPS;
+
+SP::Ph1::SVC::SVC(String uid, String name, Logger::Level logLevel)
+    : SimPowerComp<Complex>(uid, name, logLevel),
+      mSetPointVoltage(mAttributes->create<Real>("V_set")),
+      mSetPointVoltagePerUnit(mAttributes->create<Real>("V_set_pu")),
+      mSetPointReactivePower(mAttributes->create<Real>("Q_set")),
+      mSetPointReactivePowerPerUnit(mAttributes->create<Real>("Q_set_pu")),
+      mReactivePowerMax(mAttributes->create<Real>(
+          "Q_max", std::numeric_limits<Real>::infinity())),
+      mReactivePowerMin(mAttributes->create<Real>(
+          "Q_min", -std::numeric_limits<Real>::infinity())),
+      mReactivePowerMaxPerUnit(mAttributes->create<Real>(
+          "Q_max_pu", std::numeric_limits<Real>::infinity())),
+      mReactivePowerMinPerUnit(mAttributes->create<Real>(
+          "Q_min_pu", -std::numeric_limits<Real>::infinity())) {
+
+  SPDLOG_LOGGER_INFO(mSLog, "Create {} of type {}", name, this->type());
+  mSLog->flush();
+
+  setTerminalNumber(1);
+};
+
+void SP::Ph1::SVC::setParameters(Real ratedApparentPower, Real ratedVoltage,
+                                 Real setPointVoltage, Real qLimMax,
+                                 Real qLimMin) {
+  **mSetPointVoltage = setPointVoltage;
+  **mReactivePowerMax = qLimMax;
+  **mReactivePowerMin = qLimMin;
+  // The SVC always presents as a PQ bus; the outer control loop moves Q_set
+  // within [Q_min, Q_max] to hold V at V_set.
+  mPowerflowBusType = PowerflowBusType::PQ;
+
+  SPDLOG_LOGGER_INFO(mSLog, "Rated Apparent Power={} [VA] Rated Voltage={} [V]",
+                     ratedApparentPower, ratedVoltage);
+  SPDLOG_LOGGER_INFO(mSLog, "Voltage Set Point={} [V]", **mSetPointVoltage);
+  SPDLOG_LOGGER_INFO(mSLog, "Reactive Power Limits Qmin={} Qmax={} [VAr]",
+                     **mReactivePowerMin, **mReactivePowerMax);
+  mSLog->flush();
+}
+
+// #### Powerflow section ####
+
+Real SP::Ph1::SVC::getBaseVoltage() const { return mBaseVoltage; }
+
+void SP::Ph1::SVC::setBaseVoltage(Real baseVoltage) {
+  mBaseVoltage = baseVoltage;
+}
+
+void SP::Ph1::SVC::calculatePerUnitParameters(Real baseApparentPower,
+                                              Real baseOmega) {
+  SPDLOG_LOGGER_INFO(mSLog, "#### Calculate Per Unit Parameters for {}",
+                     **mName);
+  mBaseApparentPower = baseApparentPower;
+  SPDLOG_LOGGER_INFO(mSLog, "Base Power={} [VA]  Base Omega={} [1/s]",
+                     mBaseApparentPower, baseOmega);
+
+  **mSetPointVoltagePerUnit = **mSetPointVoltage / mBaseVoltage;
+  **mSetPointReactivePowerPerUnit =
+      **mSetPointReactivePower / mBaseApparentPower;
+  // +/-inf limits divide to +/-inf in pu (still "unlimited"); finite limits scale.
+  **mReactivePowerMaxPerUnit = **mReactivePowerMax / mBaseApparentPower;
+  **mReactivePowerMinPerUnit = **mReactivePowerMin / mBaseApparentPower;
+  SPDLOG_LOGGER_INFO(mSLog, "Voltage Set Point={} [pu]",
+                     **mSetPointVoltagePerUnit);
+  mSLog->flush();
+}
+
+void SP::Ph1::SVC::modifyPowerFlowBusType(PowerflowBusType powerflowBusType) {
+  switch (powerflowBusType) {
+  case CPS::PowerflowBusType::PV:
+    mPowerflowBusType = powerflowBusType;
+    break;
+  case CPS::PowerflowBusType::PQ:
+    mPowerflowBusType = powerflowBusType;
+    break;
+  case CPS::PowerflowBusType::VD:
+    mPowerflowBusType = powerflowBusType;
+    break;
+  case CPS::PowerflowBusType::None:
+    break;
+  default:
+    throw std::invalid_argument(" Invalid power flow bus type ");
+    break;
+  }
+}
+
+// Method used by the SVC outer control loop to update the reactive injection
+void SP::Ph1::SVC::updateReactivePowerInjection(Complex powerInj) {
+  **mSetPointReactivePower = powerInj.imag();
+  **mSetPointReactivePowerPerUnit =
+      **mSetPointReactivePower / mBaseApparentPower;
+}
+
+Complex SP::Ph1::SVC::getApparentPower() const {
+  return Complex(0., **mSetPointReactivePower);
+}

--- a/dpsim-models/src/SP/SP_Ph1_SVC.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SVC.cpp
@@ -60,6 +60,14 @@ void SP::Ph1::SVC::calculatePerUnitParameters(Real baseApparentPower,
   SPDLOG_LOGGER_INFO(mSLog, "Base Power={} [VA]  Base Omega={} [1/s]",
                      mBaseApparentPower, baseOmega);
 
+  // Reject unset/zero divisors before the per-unit conversion below.
+  if (mBaseVoltage <= 0)
+    throw std::invalid_argument(
+        "SVC: base voltage not set (call setBaseVoltage() before power-flow "
+        "initialization).");
+  if (mBaseApparentPower <= 0)
+    throw std::invalid_argument("SVC: base apparent power must be positive.");
+
   **mSetPointVoltagePerUnit = **mSetPointVoltage / mBaseVoltage;
   **mSetPointReactivePowerPerUnit =
       **mSetPointReactivePower / mBaseApparentPower;

--- a/dpsim-models/src/SP/SP_Ph1_SVC.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SVC.cpp
@@ -80,17 +80,14 @@ void SP::Ph1::SVC::calculatePerUnitParameters(Real baseApparentPower,
 
 void SP::Ph1::SVC::modifyPowerFlowBusType(PowerflowBusType powerflowBusType) {
   switch (powerflowBusType) {
-  case CPS::PowerflowBusType::PV:
-    mPowerflowBusType = powerflowBusType;
-    break;
   case CPS::PowerflowBusType::PQ:
-    mPowerflowBusType = powerflowBusType;
-    break;
-  case CPS::PowerflowBusType::VD:
     mPowerflowBusType = powerflowBusType;
     break;
   case CPS::PowerflowBusType::None:
     break;
+  case CPS::PowerflowBusType::PV:
+  case CPS::PowerflowBusType::VD:
+    throw std::invalid_argument("SVC: only PQ is a valid power flow bus type.");
   default:
     throw std::invalid_argument(" Invalid power flow bus type ");
     break;
@@ -99,6 +96,11 @@ void SP::Ph1::SVC::modifyPowerFlowBusType(PowerflowBusType powerflowBusType) {
 
 // Called by the SVC outer control loop
 void SP::Ph1::SVC::updateReactivePowerInjection(Complex powerInj) {
+  if (mBaseApparentPower <= 0)
+    throw std::invalid_argument(
+        "SVC: base apparent power must be positive (call "
+        "calculatePerUnitParameters() before updating the injection).");
+
   **mSetPointReactivePower = powerInj.imag();
   **mSetPointReactivePowerPerUnit =
       **mSetPointReactivePower / mBaseApparentPower;

--- a/dpsim-models/src/SP/SP_Ph1_SVC.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SVC.cpp
@@ -32,8 +32,7 @@ void SP::Ph1::SVC::setParameters(Real ratedApparentPower, Real ratedVoltage,
   **mSetPointVoltage = setPointVoltage;
   **mReactivePowerMax = qLimMax;
   **mReactivePowerMin = qLimMin;
-  // The SVC always presents as a PQ bus; the outer control loop moves Q_set
-  // within [Q_min, Q_max] to hold V at V_set.
+  // Always a PQ bus; the outer loop moves Q_set within the band to hold V_set
   mPowerflowBusType = PowerflowBusType::PQ;
 
   SPDLOG_LOGGER_INFO(mSLog, "Rated Apparent Power={} [VA] Rated Voltage={} [V]",
@@ -71,7 +70,7 @@ void SP::Ph1::SVC::calculatePerUnitParameters(Real baseApparentPower,
   **mSetPointVoltagePerUnit = **mSetPointVoltage / mBaseVoltage;
   **mSetPointReactivePowerPerUnit =
       **mSetPointReactivePower / mBaseApparentPower;
-  // +/-inf limits divide to +/-inf in pu (still "unlimited"); finite limits scale.
+  // +/-inf limits stay +/-inf in pu; finite limits scale
   **mReactivePowerMaxPerUnit = **mReactivePowerMax / mBaseApparentPower;
   **mReactivePowerMinPerUnit = **mReactivePowerMin / mBaseApparentPower;
   SPDLOG_LOGGER_INFO(mSLog, "Voltage Set Point={} [pu]",
@@ -98,7 +97,7 @@ void SP::Ph1::SVC::modifyPowerFlowBusType(PowerflowBusType powerflowBusType) {
   }
 }
 
-// Method used by the SVC outer control loop to update the reactive injection
+// Called by the SVC outer control loop
 void SP::Ph1::SVC::updateReactivePowerInjection(Complex powerInj) {
   **mSetPointReactivePower = powerInj.imag();
   **mSetPointReactivePowerPerUnit =

--- a/dpsim-models/src/SP/SP_Ph1_SVC.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SVC.cpp
@@ -60,12 +60,13 @@ void SP::Ph1::SVC::calculatePerUnitParameters(Real baseApparentPower,
                      mBaseApparentPower, baseOmega);
 
   // Reject unset/zero divisors before the per-unit conversion below.
-  if (mBaseVoltage <= 0)
+  if (!Math::isFinite(mBaseVoltage) || mBaseVoltage <= 0)
     throw std::invalid_argument(
         "SVC: base voltage not set (call setBaseVoltage() before power-flow "
         "initialization).");
-  if (mBaseApparentPower <= 0)
-    throw std::invalid_argument("SVC: base apparent power must be positive.");
+  if (!Math::isFinite(mBaseApparentPower) || mBaseApparentPower <= 0)
+    throw std::invalid_argument(
+        "SVC: base apparent power must be finite and positive.");
 
   **mSetPointVoltagePerUnit = **mSetPointVoltage / mBaseVoltage;
   **mSetPointReactivePowerPerUnit =
@@ -89,17 +90,20 @@ void SP::Ph1::SVC::modifyPowerFlowBusType(PowerflowBusType powerflowBusType) {
   case CPS::PowerflowBusType::VD:
     throw std::invalid_argument("SVC: only PQ is a valid power flow bus type.");
   default:
-    throw std::invalid_argument(" Invalid power flow bus type ");
+    throw std::invalid_argument("Invalid power flow bus type");
     break;
   }
 }
 
 // Called by the SVC outer control loop
 void SP::Ph1::SVC::updateReactivePowerInjection(Complex powerInj) {
-  if (mBaseApparentPower <= 0)
+  if (!Math::isFinite(mBaseApparentPower) || mBaseApparentPower <= 0)
     throw std::invalid_argument(
-        "SVC: base apparent power must be positive (call "
+        "SVC: base apparent power must be finite and positive (call "
         "calculatePerUnitParameters() before updating the injection).");
+  if (!Math::isFinite(powerInj.imag()))
+    throw std::invalid_argument(
+        "SVC: reactive power injection must be finite.");
 
   **mSetPointReactivePower = powerInj.imag();
   **mSetPointReactivePowerPerUnit =

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -446,6 +446,17 @@ void PFSolver::propagateAndVerifyBaseVoltage() {
     }
   }
 
+  // An SVC is a compensator, not a voltage source: derive its base voltage
+  // from the node's resolved zone value so its per-unit setpoint stays consistent.
+  for (auto node : mSystem.mNodes) {
+    CPS::Real vBase = mBaseVoltageAtNode[node];
+    if (std::abs(vBase) < 1e-6)
+      continue;
+    for (auto comp : mSystem.mComponentsAtNode[node])
+      if (auto svc = std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp))
+        svc->setBaseVoltage(vBase);
+  }
+
   UInt numMissing = 0;
   UInt numZero = 0;
 

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -326,6 +326,10 @@ CPS::Real PFSolver::componentBaseVoltage(CPS::TopologicalPowerComp::Ptr comp,
     return extnet->getBaseVoltage();
   if (auto shunt = std::dynamic_pointer_cast<CPS::SP::Ph1::Shunt>(comp))
     return shunt->getBaseVoltage();
+  // An SVC takes its base voltage from the resolved zone instead of contributing one,
+  // so it is not a missing case and must not warn.
+  if (std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp))
+    return 0;
   SPDLOG_LOGGER_WARN(mSLog, "Unable to get base voltage at {}", node->name());
   return 0;
 }

--- a/dpsim/src/pybind/SPComponents.cpp
+++ b/dpsim/src/pybind/SPComponents.cpp
@@ -163,6 +163,22 @@ void addSPPh1Components(py::module_ mSPPh1) {
       .def("get_apparent_power",
            &CPS::SP::Ph1::SynchronGenerator::getApparentPower);
 
+  py::class_<CPS::SP::Ph1::SVC, std::shared_ptr<CPS::SP::Ph1::SVC>,
+             CPS::SimPowerComp<CPS::Complex>>(mSPPh1, "SVC",
+                                              py::multiple_inheritance())
+      .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
+           "loglevel"_a = CPS::Logger::Level::off)
+      .def("set_parameters", &CPS::SP::Ph1::SVC::setParameters,
+           "rated_apparent_power"_a, "rated_voltage"_a, "set_point_voltage"_a,
+           "q_limit_max"_a = std::numeric_limits<double>::infinity(),
+           "q_limit_min"_a = -std::numeric_limits<double>::infinity())
+      .def("set_base_voltage", &CPS::SP::Ph1::SVC::setBaseVoltage,
+           "base_voltage"_a)
+      .def("connect", &CPS::SP::Ph1::SVC::connect)
+      .def("modify_power_flow_bus_type",
+           &CPS::SP::Ph1::SVC::modifyPowerFlowBusType, "bus_type"_a)
+      .def("get_apparent_power", &CPS::SP::Ph1::SVC::getApparentPower);
+
   py::class_<CPS::SP::Ph1::varResSwitch,
              std::shared_ptr<CPS::SP::Ph1::varResSwitch>,
              CPS::SimPowerComp<CPS::Complex>, CPS::Base::Ph1::Switch>(


### PR DESCRIPTION
Voltage-controlling shunt reactive device modelled as a PQ bus, to be driven by the SVC outer control loop. No active power, no admittance stamp; participates via bus classification and reactive setpoint. Reuses the SynchronGenerator per-unit/attribute pattern (V_set_pu, Q_max_pu, Q_min_pu).

For real usage, #582 is the follow up.