### PR TITLE
Add InterfaceCosimSync for real-time DPsim co-simulation start-time synchronization

### DIFF
--- a/docs/hugo/content/en/docs/User Guide/real-time.md
+++ b/docs/hugo/content/en/docs/User Guide/real-time.md
@@ -20,6 +20,9 @@ simulation has to move with them. If nothing outside is waiting, running in real
 study slower.
 
 This is why [co-simulation]({{< ref "co-simulation.md" >}}) and real-time usually appear together.
+When the coupled processes are launched separately, they also have to be made to begin at the same
+instant, which is covered under
+[starting together]({{< ref "start-synchronization.md" >}}).
 
 ## What it changes
 

--- a/docs/hugo/content/en/docs/User Guide/start-synchronization.md
+++ b/docs/hugo/content/en/docs/User Guide/start-synchronization.md
@@ -1,0 +1,119 @@
+---
+title: "Starting Together"
+linkTitle: "Starting Together"
+date: 2026-08-05
+description: >
+  Getting separately launched real-time processes to begin the same run at the same instant.
+weight: 7
+---
+
+A co-simulation is usually more than one process, and they are started by hand, by a script or by a
+scheduler that offers no guarantee about ordering. Whichever starts first sits there stepping
+against a partner that does not exist yet. In a
+[real-time]({{< ref "real-time.md" >}}) run that is not a startup nuisance to be waited out: the
+early process has already consumed wall-clock time its partner never simulated, and the two are
+offset by that amount for the rest of the run.
+
+`InterfaceCosimSync` removes the question of who was launched first. One process is the leader; the
+others are followers. The leader decides an absolute start instant, in the future, and hands it to
+everyone. Each process then passes that instant to its real-time simulation, and they all begin
+together regardless of the order they were started in.
+
+## The handshake
+
+The leader listens on a TCP port. Every follower connects to it, receives the start instant together
+with the time step and duration, and acknowledges what it received. Only once **all** the expected
+followers have acknowledged does the leader release them, and only then does a follower return
+successfully.
+
+That second phase is what makes the group atomic. A follower that has connected and acknowledged is
+not yet free to run; it is waiting to be released. If any other follower fails to appear, the leader
+never sends the release, and every follower that did appear fails too.
+
+{{% alert title="An incomplete group starts nobody" color="warning" %}}
+This is the property worth relying on. A partial co-simulation is worse than a failed one: the
+processes that did start produce output that looks entirely normal while being coupled to nothing.
+Because the release is withheld from everyone unless the whole group is ready, that outcome cannot
+arise from a missing peer.
+{{% /alert %}}
+
+Neither side blocks forever by default. Both calls take a timeout in milliseconds, defaulting to
+60 s, and report failure rather than hanging when a peer never arrives, which is the appropriate
+behaviour for an unattended run. Passing `0` restores indefinite waiting if you want it.
+
+## Using it
+
+The leader publishes; the followers wait. `expected_followers` is how many the leader will hold out
+for.
+
+```python
+import time
+import dpsimpy
+
+leader = dpsimpy.InterfaceCosimSync("leader", "", 47129, "leader")
+leader.open()
+
+start_time_ns = time.time_ns() + 1_000_000_000
+ok = leader.publish_config(
+    start_time_ns,
+    time_step_ns=1_000_000,
+    duration_ns=1_000_000_000,
+    expected_followers=3,
+    timeout_ms=10000,
+)
+leader.close()
+```
+
+```python
+follower = dpsimpy.InterfaceCosimSync("follower", "10.0.0.1", 47129, "follower")
+follower.open()
+ok, start_time_ns, time_step_ns, duration_ns = follower.wait_for_config(timeout_ms=10000)
+follower.close()
+```
+
+Both report a boolean. Nothing should start unless it is true, on either side. The start instant is
+nanoseconds since the `system_clock` epoch, which is what `time.time_ns()` returns, and it crosses
+the wire as an exact integer so that no rounding creeps in between the processes.
+
+The role is `"leader"` or `"follower"`; anything else raises. A misspelled role would otherwise
+leave the group with no leader, and the run would fail later as a timeout with nothing pointing at
+the cause.
+
+The host argument is where the follower reaches the leader; the leader ignores it and binds on all
+interfaces. Addressing is IPv4 only. The transport is TCP, so the processes may sit on separate
+hosts, and an external real-time target can join the same rendezvous.
+
+Both calls release the Python GIL while they block, so a leader and its followers can be driven from
+threads of one interpreter, and unrelated Python threads keep running through the wait.
+
+## On the wire
+
+The exchange is three fixed-size messages, so a peer that is not DPsim can implement it. All fields
+are big-endian, and the config is packed field by field, so layout, padding and endianness stay
+host-independent.
+
+| Step | Direction | Bytes | Contents |
+| --- | --- | --- | --- |
+| 1 | leader → follower | 32 | `magic` (u32, `DPSS`), `version` (u32, currently 1), `start_time_ns` (u64), `time_step_ns` (u64), `duration_ns` (u64) |
+| 2 | follower → leader | 4 | `DACK`, sent only after the header and the config validate |
+| 3 | leader → follower | 4 | `DGO!`, sent only after every follower has acknowledged |
+
+A follower rejects a mismatched magic or version, a zero `time_step_ns`, and a `start_time_ns` above
+`INT64_MAX`, which would otherwise wrap to a time in the past. The leader rejects a zero time step
+or zero expected followers before it opens the exchange. Step 3 is the release: a connection that
+closes before it arrives means the group was incomplete.
+
+{{% alert title="Clocks are only as good as the hosts they run on" color="info" %}}
+Agreeing on an instant is not the same as agreeing on the time. The processes now hold an identical
+target, but each waits for it on its own `system_clock`. Across hosts those clocks agree only to
+whatever your time synchronization provides, and any offset between them appears directly as an
+offset between the runs. On one machine this does not arise; across machines it becomes the
+accuracy limit, and PTP rather than NTP is what closes it.
+{{% /alert %}}
+
+This is a Linux-only feature, built when `WITH_RT` is enabled, and it coordinates the start only.
+Exchanging data during the run is a separate concern, covered under
+[co-simulation]({{< ref "co-simulation.md" >}}).
+
+A worked example with one leader and three followers, including the case where a follower is
+missing, is in `examples/Notebooks/Features/CosimStartSync.ipynb`.

--- a/docs/hugo/content/en/docs/User Guide/start-synchronization.md
+++ b/docs/hugo/content/en/docs/User Guide/start-synchronization.md
@@ -86,6 +86,23 @@ hosts, and an external real-time target can join the same rendezvous.
 Both calls release the Python GIL while they block, so a leader and its followers can be driven from
 threads of one interpreter, and unrelated Python threads keep running through the wait.
 
+## Starting the simulation on it
+
+`RealTimeSimulation.run_at` takes the instant the rendezvous produced and blocks until it arrives
+before stepping:
+
+```python
+sim = dpsimpy.RealTimeSimulation("follower")
+sim.set_system(system)
+sim.set_time_step(time_step_ns / 1e9)
+sim.set_final_time(duration_ns / 1e9)
+sim.run_at(start_time_ns)
+```
+
+It takes nanoseconds rather than a `datetime`, which is only microsecond-resolution and would
+discard the precision the exchange was built to preserve. `run` remains the relative form: it starts
+a given number of seconds from now, which is per-process and therefore not a rendezvous.
+
 ## On the wire
 
 The exchange is three fixed-size messages, so a peer that is not DPsim can implement it. All fields

--- a/dpsim/include/DPsim.h
+++ b/dpsim/include/DPsim.h
@@ -16,6 +16,10 @@
 #include <dpsim/RealTimeSimulation.h>
 #endif
 
+#ifdef WITH_RT
+#include <dpsim/InterfaceCosimSync.h>
+#endif
+
 #include <dpsim-models/Components.h>
 #include <dpsim-models/Logger.h>
 

--- a/dpsim/include/dpsim/InterfaceCosimSync.h
+++ b/dpsim/include/dpsim/InterfaceCosimSync.h
@@ -28,13 +28,17 @@ public:
 
   ~InterfaceCosimSync() override {
     if (mOpened)
-      close();
+      InterfaceCosimSync::close();
   }
 
   void open() override;
   void close() override;
-  void syncExports() override {}
-  void syncImports() override {}
+  void syncExports() override {
+    // one-shot start rendezvous only, the per-step data plane runs over VILLAS
+  }
+  void syncImports() override {
+    // one-shot start rendezvous only, the per-step data plane runs over VILLAS
+  }
   CPS::Task::List getTasks() override { return CPS::Task::List(); }
 
   static constexpr uint64_t DEFAULT_TIMEOUT_MS = 60000;
@@ -64,11 +68,12 @@ private:
   static constexpr uint32_t GO = 0x44474F21;
 
   void openListener();
+  int connectOnce(uint64_t deadlineMs, bool forever);
   int connectToLeader(uint64_t timeoutMs);
-  int acceptFollower(uint64_t deadlineMs, bool forever);
+  int acceptFollower(uint64_t deadlineMs, bool forever) const;
   static bool armRecvTimeout(int fd, uint64_t deadlineMs, bool forever);
-  static bool sendAll(int fd, const void *buf, size_t len);
-  static bool recvAll(int fd, void *buf, size_t len);
+  static bool sendAll(int fd, const uint8_t *buf, size_t len);
+  static bool recvAll(int fd, uint8_t *buf, size_t len);
 };
 
 } // namespace DPsim

--- a/dpsim/include/dpsim/InterfaceCosimSync.h
+++ b/dpsim/include/dpsim/InterfaceCosimSync.h
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+#include <dpsim/Interface.h>
+
+namespace DPsim {
+
+class InterfaceCosimSync : public Interface,
+                           public SharedFactory<InterfaceCosimSync> {
+public:
+  enum class Role { Leader, Follower };
+
+  struct ConfigNs {
+    uint64_t start_time_ns;
+    uint64_t time_step_ns;
+    uint64_t duration_ns;
+  };
+
+  InterfaceCosimSync(const String &name, const String &host, uint16_t port,
+                     Role role)
+      : Interface(name), mHost(host), mPort(port), mRole(role) {}
+
+  ~InterfaceCosimSync() override {
+    if (mOpened)
+      close();
+  }
+
+  void open() override;
+  void close() override;
+  void syncExports() override {}
+  void syncImports() override {}
+  CPS::Task::List getTasks() override { return CPS::Task::List(); }
+
+  static constexpr uint64_t DEFAULT_TIMEOUT_MS = 60000;
+
+  bool publishConfig(const std::chrono::system_clock::time_point &startAt,
+                     uint64_t timeStepNs, uint64_t durationNs,
+                     uint32_t expectedFollowers = 1,
+                     uint64_t timeoutMs = DEFAULT_TIMEOUT_MS);
+
+  bool waitForConfig(ConfigNs &outCfg, uint64_t timeoutMs = DEFAULT_TIMEOUT_MS);
+
+  static std::chrono::system_clock::time_point
+  toTimePoint(uint64_t nsSinceEpoch);
+  static uint64_t toEpochNs(const std::chrono::system_clock::time_point &tp);
+
+private:
+  String mHost;
+  uint16_t mPort;
+  Role mRole;
+
+  int mListenFd = -1;
+
+  static constexpr size_t WIRE_SIZE = 32;
+  static constexpr uint32_t MAGIC = 0x44505353;
+  static constexpr uint32_t VERSION = 1;
+  static constexpr uint32_t ACK = 0x4441434B;
+  static constexpr uint32_t GO = 0x44474F21;
+
+  void openListener();
+  int connectToLeader(uint64_t timeoutMs);
+  int acceptFollower(uint64_t deadlineMs, bool forever);
+  static bool armRecvTimeout(int fd, uint64_t deadlineMs, bool forever);
+  static bool sendAll(int fd, const void *buf, size_t len);
+  static bool recvAll(int fd, void *buf, size_t len);
+};
+
+} // namespace DPsim

--- a/dpsim/src/CMakeLists.txt
+++ b/dpsim/src/CMakeLists.txt
@@ -39,6 +39,7 @@ if (WITH_RT)
 	list(APPEND DPSIM_SOURCES
 		RealTimeSimulation.cpp
 		RealTimeDataLogger.cpp
+		InterfaceCosimSync.cpp
 	)
 endif()
 

--- a/dpsim/src/InterfaceCosimSync.cpp
+++ b/dpsim/src/InterfaceCosimSync.cpp
@@ -1,0 +1,448 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+#include <arpa/inet.h>
+#include <endian.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <dpsim/InterfaceCosimSync.h>
+
+using namespace DPsim;
+using namespace CPS;
+
+namespace {
+void packU32(uint8_t *p, uint32_t v) {
+  v = htobe32(v);
+  std::memcpy(p, &v, 4);
+}
+void packU64(uint8_t *p, uint64_t v) {
+  v = htobe64(v);
+  std::memcpy(p, &v, 8);
+}
+uint32_t unpackU32(const uint8_t *p) {
+  uint32_t v;
+  std::memcpy(&v, p, 4);
+  return be32toh(v);
+}
+uint64_t unpackU64(const uint8_t *p) {
+  uint64_t v;
+  std::memcpy(&v, p, 8);
+  return be64toh(v);
+}
+
+uint64_t nowMs() {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+void setNonBlocking(int fd, bool nb) {
+  int flags = ::fcntl(fd, F_GETFL, 0);
+  if (flags < 0)
+    return;
+  if (nb)
+    flags |= O_NONBLOCK;
+  else
+    flags &= ~O_NONBLOCK;
+  ::fcntl(fd, F_SETFL, flags);
+}
+
+bool remainingTv(uint64_t deadlineMs, timeval &tv) {
+  uint64_t now = nowMs();
+  if (now >= deadlineMs)
+    return false;
+  uint64_t rem = deadlineMs - now;
+  tv.tv_sec = static_cast<time_t>(rem / 1000);
+  tv.tv_usec = static_cast<suseconds_t>((rem % 1000) * 1000);
+  return true;
+}
+} // namespace
+
+void InterfaceCosimSync::open() {
+  if (mOpened)
+    return;
+
+  if (mRole == Role::Leader)
+    openListener();
+
+  mOpened = true;
+}
+
+void InterfaceCosimSync::close() {
+  if (!mOpened)
+    return;
+
+  if (mListenFd >= 0) {
+    ::close(mListenFd);
+    mListenFd = -1;
+  }
+  mOpened = false;
+}
+
+void InterfaceCosimSync::openListener() {
+  int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    SPDLOG_LOGGER_ERROR(mLog, "CosimSync: socket failed: {}",
+                        std::strerror(errno));
+    throw SystemError("CosimSync: socket failed");
+  }
+
+  int one = 1;
+  ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+  setNonBlocking(fd, true);
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(mPort);
+
+  if (::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
+    SPDLOG_LOGGER_ERROR(mLog, "CosimSync: bind to port {} failed: {}", mPort,
+                        std::strerror(errno));
+    ::close(fd);
+    throw SystemError("CosimSync: bind failed");
+  }
+  if (::listen(fd, SOMAXCONN) < 0) {
+    SPDLOG_LOGGER_ERROR(mLog, "CosimSync: listen failed: {}",
+                        std::strerror(errno));
+    ::close(fd);
+    throw SystemError("CosimSync: listen failed");
+  }
+
+  mListenFd = fd;
+}
+
+int InterfaceCosimSync::connectToLeader(uint64_t timeoutMs) {
+  bool forever = (timeoutMs == 0);
+  uint64_t deadline = forever ? 0 : nowMs() + timeoutMs;
+
+  addrinfo hints{};
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_STREAM;
+  std::string portStr = std::to_string(mPort);
+
+  for (;;) {
+    addrinfo *res = nullptr;
+    int gai = ::getaddrinfo(mHost.c_str(), portStr.c_str(), &hints, &res);
+    if (gai == 0) {
+      for (addrinfo *ai = res; ai != nullptr; ai = ai->ai_next) {
+        int fd = ::socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (fd < 0)
+          continue;
+        setNonBlocking(fd, true);
+
+        int rc = ::connect(fd, ai->ai_addr, ai->ai_addrlen);
+        if (rc == 0) {
+          setNonBlocking(fd, false);
+          ::freeaddrinfo(res);
+          return fd;
+        }
+        if (errno == EINPROGRESS) {
+          timeval tv{};
+          timeval *ptv = nullptr;
+          if (!forever) {
+            if (!remainingTv(deadline, tv)) {
+              ::close(fd);
+              ::freeaddrinfo(res);
+              return -1;
+            }
+            ptv = &tv;
+          }
+          fd_set wfds;
+          FD_ZERO(&wfds);
+          FD_SET(fd, &wfds);
+          int r = ::select(fd + 1, nullptr, &wfds, nullptr, ptv);
+          if (r > 0) {
+            int soErr = 0;
+            socklen_t len = sizeof(soErr);
+            if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &soErr, &len) == 0 &&
+                soErr == 0) {
+              setNonBlocking(fd, false);
+              ::freeaddrinfo(res);
+              return fd;
+            }
+          }
+        }
+        ::close(fd);
+      }
+      ::freeaddrinfo(res);
+    } else {
+      SPDLOG_LOGGER_WARN(mLog, "CosimSync: getaddrinfo({}) failed: {}", mHost,
+                         ::gai_strerror(gai));
+    }
+
+    if (!forever) {
+      uint64_t now = nowMs();
+      if (now >= deadline)
+        return -1;
+      uint64_t rem = deadline - now;
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(rem < 50 ? rem : 50));
+    } else {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+  }
+}
+
+int InterfaceCosimSync::acceptFollower(uint64_t deadlineMs, bool forever) {
+  for (;;) {
+    timeval tv{};
+    timeval *ptv = nullptr;
+    if (!forever) {
+      if (!remainingTv(deadlineMs, tv))
+        return -1;
+      ptv = &tv;
+    }
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(mListenFd, &rfds);
+    int r = ::select(mListenFd + 1, &rfds, nullptr, nullptr, ptv);
+    if (r < 0) {
+      if (errno == EINTR)
+        continue;
+      SPDLOG_LOGGER_WARN(mLog, "CosimSync: select failed: {}",
+                         std::strerror(errno));
+      return -1;
+    }
+    if (r == 0)
+      return -1;
+
+    int cfd = ::accept(mListenFd, nullptr, nullptr);
+    if (cfd >= 0)
+      return cfd;
+    if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK ||
+        errno == ECONNABORTED)
+      continue;
+    SPDLOG_LOGGER_WARN(mLog, "CosimSync: accept failed: {}",
+                       std::strerror(errno));
+    return -1;
+  }
+}
+
+bool InterfaceCosimSync::armRecvTimeout(int fd, uint64_t deadlineMs,
+                                        bool forever) {
+  if (forever)
+    return true;
+  timeval tv{};
+  if (!remainingTv(deadlineMs, tv))
+    return false;
+  ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+  return true;
+}
+
+bool InterfaceCosimSync::sendAll(int fd, const void *buf, size_t len) {
+  const uint8_t *p = static_cast<const uint8_t *>(buf);
+  size_t sent = 0;
+  while (sent < len) {
+    ssize_t n = ::send(fd, p + sent, len - sent, MSG_NOSIGNAL);
+    if (n < 0) {
+      if (errno == EINTR)
+        continue;
+      return false;
+    }
+    sent += static_cast<size_t>(n);
+  }
+  return true;
+}
+
+bool InterfaceCosimSync::recvAll(int fd, void *buf, size_t len) {
+  uint8_t *p = static_cast<uint8_t *>(buf);
+  size_t got = 0;
+  while (got < len) {
+    ssize_t n = ::recv(fd, p + got, len - got, 0);
+    if (n == 0)
+      return false;
+    if (n < 0) {
+      if (errno == EINTR)
+        continue;
+      return false;
+    }
+    got += static_cast<size_t>(n);
+  }
+  return true;
+}
+
+bool InterfaceCosimSync::publishConfig(
+    const std::chrono::system_clock::time_point &startAt, uint64_t timeStepNs,
+    uint64_t durationNs, uint32_t expectedFollowers, uint64_t timeoutMs) {
+  if (!mOpened || mRole != Role::Leader)
+    throw SystemError("CosimSync: publishConfig called in wrong state");
+  if (timeStepNs == 0)
+    throw SystemError("CosimSync: time step must be greater than zero");
+  if (expectedFollowers == 0)
+    throw SystemError("CosimSync: at least one follower is required");
+
+  auto delta = startAt - std::chrono::system_clock::now();
+  if (delta > std::chrono::hours(1) || delta < -std::chrono::hours(1)) {
+    double secs =
+        std::chrono::duration_cast<std::chrono::duration<double>>(delta)
+            .count();
+    SPDLOG_LOGGER_WARN(
+        mLog, "CosimSync: start time is more than 1 hour away ({} s).", secs);
+  }
+
+  static_assert(WIRE_SIZE == 32, "wire layout is 4+4+8+8+8 bytes");
+  uint8_t wire[WIRE_SIZE];
+  packU32(wire + 0, MAGIC);
+  packU32(wire + 4, VERSION);
+  packU64(wire + 8, toEpochNs(startAt));
+  packU64(wire + 16, timeStepNs);
+  packU64(wire + 24, durationNs);
+
+  bool forever = (timeoutMs == 0);
+  uint64_t deadline = forever ? 0 : nowMs() + timeoutMs;
+
+  std::vector<int> followerFds;
+  followerFds.reserve(expectedFollowers);
+  bool ok = true;
+
+  for (uint32_t i = 0; i < expectedFollowers && ok; i++) {
+    int cfd = acceptFollower(deadline, forever);
+    if (cfd < 0) {
+      SPDLOG_LOGGER_WARN(mLog, "CosimSync: follower {} did not connect.", i);
+      ok = false;
+      break;
+    }
+    followerFds.push_back(cfd);
+
+    int one = 1;
+    ::setsockopt(cfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
+    uint8_t ack[4];
+    ok = armRecvTimeout(cfd, deadline, forever) &&
+         sendAll(cfd, wire, WIRE_SIZE) && recvAll(cfd, ack, sizeof(ack)) &&
+         unpackU32(ack) == ACK;
+    if (!ok)
+      SPDLOG_LOGGER_WARN(
+          mLog, "CosimSync: follower {} did not acknowledge the config.", i);
+  }
+
+  if (ok) {
+    uint8_t go[4];
+    packU32(go, GO);
+    for (size_t i = 0; i < followerFds.size(); i++) {
+      if (!sendAll(followerFds[i], go, sizeof(go))) {
+        SPDLOG_LOGGER_WARN(mLog, "CosimSync: failed to release follower {}.",
+                           i);
+        ok = false;
+      }
+    }
+  }
+
+  for (int fd : followerFds)
+    ::close(fd);
+  return ok;
+}
+
+bool InterfaceCosimSync::waitForConfig(ConfigNs &outCfg, uint64_t timeoutMs) {
+  if (!mOpened || mRole != Role::Follower)
+    throw SystemError("CosimSync: waitForConfig called in wrong state");
+
+  bool forever = (timeoutMs == 0);
+  uint64_t deadline = forever ? 0 : nowMs() + timeoutMs;
+
+  uint64_t connectBudget = timeoutMs;
+  if (!forever) {
+    timeval tmp{};
+    if (!remainingTv(deadline, tmp))
+      return false;
+    connectBudget =
+        static_cast<uint64_t>(tmp.tv_sec) * 1000 + tmp.tv_usec / 1000;
+    if (connectBudget == 0)
+      connectBudget = 1;
+  }
+
+  int fd = connectToLeader(connectBudget);
+  if (fd < 0)
+    return false;
+
+  if (!armRecvTimeout(fd, deadline, forever)) {
+    ::close(fd);
+    return false;
+  }
+
+  uint8_t wire[WIRE_SIZE];
+  if (!recvAll(fd, wire, WIRE_SIZE)) {
+    ::close(fd);
+    SPDLOG_LOGGER_ERROR(mLog, "CosimSync: incomplete config from leader.");
+    return false;
+  }
+
+  uint32_t magic = unpackU32(wire + 0);
+  uint32_t version = unpackU32(wire + 4);
+  if (magic != MAGIC || version != VERSION) {
+    ::close(fd);
+    SPDLOG_LOGGER_ERROR(mLog,
+                        "CosimSync: invalid header (magic=0x{:x}, version={}).",
+                        magic, version);
+    return false;
+  }
+  outCfg.start_time_ns = unpackU64(wire + 8);
+  outCfg.time_step_ns = unpackU64(wire + 16);
+  outCfg.duration_ns = unpackU64(wire + 24);
+
+  if (outCfg.time_step_ns == 0 ||
+      outCfg.start_time_ns > static_cast<uint64_t>(INT64_MAX)) {
+    ::close(fd);
+    SPDLOG_LOGGER_ERROR(mLog,
+                        "CosimSync: implausible config (start_time_ns={}, "
+                        "time_step_ns={}).",
+                        outCfg.start_time_ns, outCfg.time_step_ns);
+    return false;
+  }
+
+  uint8_t ack[4];
+  packU32(ack, ACK);
+  if (!sendAll(fd, ack, sizeof(ack))) {
+    ::close(fd);
+    SPDLOG_LOGGER_ERROR(mLog, "CosimSync: failed to acknowledge config.");
+    return false;
+  }
+
+  uint8_t go[4];
+  bool released = armRecvTimeout(fd, deadline, forever) &&
+                  recvAll(fd, go, sizeof(go)) && unpackU32(go) == GO;
+  ::close(fd);
+  if (!released) {
+    SPDLOG_LOGGER_ERROR(mLog, "CosimSync: leader did not release the group.");
+    return false;
+  }
+
+  auto delta =
+      toTimePoint(outCfg.start_time_ns) - std::chrono::system_clock::now();
+  if (delta > std::chrono::hours(1) || delta < -std::chrono::hours(1)) {
+    double secs =
+        std::chrono::duration_cast<std::chrono::duration<double>>(delta)
+            .count();
+    SPDLOG_LOGGER_WARN(
+        mLog, "CosimSync: received start time is more than 1 hour away ({} s).",
+        secs);
+  }
+  return true;
+}
+
+std::chrono::system_clock::time_point
+InterfaceCosimSync::toTimePoint(uint64_t nsSinceEpoch) {
+  using TP = std::chrono::time_point<std::chrono::system_clock,
+                                     std::chrono::nanoseconds>;
+  return TP(std::chrono::nanoseconds(nsSinceEpoch));
+}
+
+uint64_t
+InterfaceCosimSync::toEpochNs(const std::chrono::system_clock::time_point &tp) {
+  auto ns = std::chrono::time_point_cast<std::chrono::nanoseconds>(tp)
+                .time_since_epoch()
+                .count();
+  return static_cast<uint64_t>(ns);
+}

--- a/dpsim/src/InterfaceCosimSync.cpp
+++ b/dpsim/src/InterfaceCosimSync.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
 // SPDX-License-Identifier: MPL-2.0
 
+#include <array>
 #include <cerrno>
 #include <cstdint>
 #include <cstring>
@@ -67,6 +68,46 @@ bool remainingTv(uint64_t deadlineMs, timeval &tv) {
   tv.tv_usec = static_cast<suseconds_t>((rem % 1000) * 1000);
   return true;
 }
+
+int connectOne(const addrinfo *ai, uint64_t deadlineMs, bool forever) {
+  int fd = ::socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+  if (fd < 0)
+    return -1;
+  setNonBlocking(fd, true);
+
+  if (::connect(fd, ai->ai_addr, ai->ai_addrlen) == 0) {
+    setNonBlocking(fd, false);
+    return fd;
+  }
+  if (errno != EINPROGRESS) {
+    ::close(fd);
+    return -1;
+  }
+
+  timeval tv{};
+  timeval *ptv = nullptr;
+  if (!forever) {
+    if (!remainingTv(deadlineMs, tv)) {
+      ::close(fd);
+      return -1;
+    }
+    ptv = &tv;
+  }
+
+  fd_set wfds;
+  FD_ZERO(&wfds);
+  FD_SET(fd, &wfds);
+  int soErr = 0;
+  socklen_t len = sizeof(soErr);
+  if (::select(fd + 1, nullptr, &wfds, nullptr, ptv) > 0 &&
+      ::getsockopt(fd, SOL_SOCKET, SO_ERROR, &soErr, &len) == 0 && soErr == 0) {
+    setNonBlocking(fd, false);
+    return fd;
+  }
+
+  ::close(fd);
+  return -1;
+}
 } // namespace
 
 void InterfaceCosimSync::open() {
@@ -123,79 +164,55 @@ void InterfaceCosimSync::openListener() {
   mListenFd = fd;
 }
 
-int InterfaceCosimSync::connectToLeader(uint64_t timeoutMs) {
-  bool forever = (timeoutMs == 0);
-  uint64_t deadline = forever ? 0 : nowMs() + timeoutMs;
-
+int InterfaceCosimSync::connectOnce(uint64_t deadlineMs, bool forever) {
   addrinfo hints{};
   hints.ai_family = AF_INET;
   hints.ai_socktype = SOCK_STREAM;
-  std::string portStr = std::to_string(mPort);
+
+  addrinfo *res = nullptr;
+  const std::string portStr = std::to_string(mPort);
+  if (int gai = ::getaddrinfo(mHost.c_str(), portStr.c_str(), &hints, &res);
+      gai != 0) {
+    SPDLOG_LOGGER_WARN(mLog, "CosimSync: getaddrinfo({}) failed: {}", mHost,
+                       ::gai_strerror(gai));
+    return -1;
+  }
+
+  int fd = -1;
+  for (const addrinfo *ai = res; ai != nullptr; ai = ai->ai_next) {
+    fd = connectOne(ai, deadlineMs, forever);
+    if (fd >= 0)
+      break;
+  }
+
+  ::freeaddrinfo(res);
+  return fd;
+}
+
+int InterfaceCosimSync::connectToLeader(uint64_t timeoutMs) {
+  const bool forever = (timeoutMs == 0);
+  const uint64_t deadline = forever ? 0 : nowMs() + timeoutMs;
 
   for (;;) {
-    addrinfo *res = nullptr;
-    int gai = ::getaddrinfo(mHost.c_str(), portStr.c_str(), &hints, &res);
-    if (gai == 0) {
-      for (addrinfo *ai = res; ai != nullptr; ai = ai->ai_next) {
-        int fd = ::socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-        if (fd < 0)
-          continue;
-        setNonBlocking(fd, true);
+    int fd = connectOnce(deadline, forever);
+    if (fd >= 0)
+      return fd;
 
-        int rc = ::connect(fd, ai->ai_addr, ai->ai_addrlen);
-        if (rc == 0) {
-          setNonBlocking(fd, false);
-          ::freeaddrinfo(res);
-          return fd;
-        }
-        if (errno == EINPROGRESS) {
-          timeval tv{};
-          timeval *ptv = nullptr;
-          if (!forever) {
-            if (!remainingTv(deadline, tv)) {
-              ::close(fd);
-              ::freeaddrinfo(res);
-              return -1;
-            }
-            ptv = &tv;
-          }
-          fd_set wfds;
-          FD_ZERO(&wfds);
-          FD_SET(fd, &wfds);
-          int r = ::select(fd + 1, nullptr, &wfds, nullptr, ptv);
-          if (r > 0) {
-            int soErr = 0;
-            socklen_t len = sizeof(soErr);
-            if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &soErr, &len) == 0 &&
-                soErr == 0) {
-              setNonBlocking(fd, false);
-              ::freeaddrinfo(res);
-              return fd;
-            }
-          }
-        }
-        ::close(fd);
-      }
-      ::freeaddrinfo(res);
-    } else {
-      SPDLOG_LOGGER_WARN(mLog, "CosimSync: getaddrinfo({}) failed: {}", mHost,
-                         ::gai_strerror(gai));
-    }
-
-    if (!forever) {
-      uint64_t now = nowMs();
-      if (now >= deadline)
-        return -1;
-      uint64_t rem = deadline - now;
-      std::this_thread::sleep_for(
-          std::chrono::milliseconds(rem < 50 ? rem : 50));
-    } else {
+    if (forever) {
       std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      continue;
     }
+
+    uint64_t now = nowMs();
+    if (now >= deadline)
+      return -1;
+    uint64_t rem = deadline - now;
+    std::this_thread::sleep_for(std::chrono::milliseconds(rem < 50 ? rem : 50));
   }
 }
 
-int InterfaceCosimSync::acceptFollower(uint64_t deadlineMs, bool forever) {
+int InterfaceCosimSync::acceptFollower(uint64_t deadlineMs,
+                                       bool forever) const {
   for (;;) {
     timeval tv{};
     timeval *ptv = nullptr;
@@ -218,8 +235,7 @@ int InterfaceCosimSync::acceptFollower(uint64_t deadlineMs, bool forever) {
     if (r == 0)
       return -1;
 
-    int cfd = ::accept(mListenFd, nullptr, nullptr);
-    if (cfd >= 0)
+    if (int cfd = ::accept(mListenFd, nullptr, nullptr); cfd >= 0)
       return cfd;
     if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK ||
         errno == ECONNABORTED)
@@ -241,11 +257,10 @@ bool InterfaceCosimSync::armRecvTimeout(int fd, uint64_t deadlineMs,
   return true;
 }
 
-bool InterfaceCosimSync::sendAll(int fd, const void *buf, size_t len) {
-  const uint8_t *p = static_cast<const uint8_t *>(buf);
+bool InterfaceCosimSync::sendAll(int fd, const uint8_t *buf, size_t len) {
   size_t sent = 0;
   while (sent < len) {
-    ssize_t n = ::send(fd, p + sent, len - sent, MSG_NOSIGNAL);
+    ssize_t n = ::send(fd, buf + sent, len - sent, MSG_NOSIGNAL);
     if (n < 0) {
       if (errno == EINTR)
         continue;
@@ -256,11 +271,10 @@ bool InterfaceCosimSync::sendAll(int fd, const void *buf, size_t len) {
   return true;
 }
 
-bool InterfaceCosimSync::recvAll(int fd, void *buf, size_t len) {
-  uint8_t *p = static_cast<uint8_t *>(buf);
+bool InterfaceCosimSync::recvAll(int fd, uint8_t *buf, size_t len) {
   size_t got = 0;
   while (got < len) {
-    ssize_t n = ::recv(fd, p + got, len - got, 0);
+    ssize_t n = ::recv(fd, buf + got, len - got, 0);
     if (n == 0)
       return false;
     if (n < 0) {
@@ -283,8 +297,8 @@ bool InterfaceCosimSync::publishConfig(
   if (expectedFollowers == 0)
     throw SystemError("CosimSync: at least one follower is required");
 
-  auto delta = startAt - std::chrono::system_clock::now();
-  if (delta > std::chrono::hours(1) || delta < -std::chrono::hours(1)) {
+  if (auto delta = startAt - std::chrono::system_clock::now();
+      delta > std::chrono::hours(1) || delta < -std::chrono::hours(1)) {
     double secs =
         std::chrono::duration_cast<std::chrono::duration<double>>(delta)
             .count();
@@ -293,12 +307,12 @@ bool InterfaceCosimSync::publishConfig(
   }
 
   static_assert(WIRE_SIZE == 32, "wire layout is 4+4+8+8+8 bytes");
-  uint8_t wire[WIRE_SIZE];
-  packU32(wire + 0, MAGIC);
-  packU32(wire + 4, VERSION);
-  packU64(wire + 8, toEpochNs(startAt));
-  packU64(wire + 16, timeStepNs);
-  packU64(wire + 24, durationNs);
+  std::array<uint8_t, WIRE_SIZE> wire{};
+  packU32(wire.data() + 0, MAGIC);
+  packU32(wire.data() + 4, VERSION);
+  packU64(wire.data() + 8, toEpochNs(startAt));
+  packU64(wire.data() + 16, timeStepNs);
+  packU64(wire.data() + 24, durationNs);
 
   bool forever = (timeoutMs == 0);
   uint64_t deadline = forever ? 0 : nowMs() + timeoutMs;
@@ -307,7 +321,7 @@ bool InterfaceCosimSync::publishConfig(
   followerFds.reserve(expectedFollowers);
   bool ok = true;
 
-  for (uint32_t i = 0; i < expectedFollowers && ok; i++) {
+  for (uint32_t i = 0; i < expectedFollowers; i++) {
     int cfd = acceptFollower(deadline, forever);
     if (cfd < 0) {
       SPDLOG_LOGGER_WARN(mLog, "CosimSync: follower {} did not connect.", i);
@@ -319,20 +333,22 @@ bool InterfaceCosimSync::publishConfig(
     int one = 1;
     ::setsockopt(cfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
 
-    uint8_t ack[4];
+    std::array<uint8_t, 4> ack{};
     ok = armRecvTimeout(cfd, deadline, forever) &&
-         sendAll(cfd, wire, WIRE_SIZE) && recvAll(cfd, ack, sizeof(ack)) &&
-         unpackU32(ack) == ACK;
-    if (!ok)
+         sendAll(cfd, wire.data(), wire.size()) &&
+         recvAll(cfd, ack.data(), ack.size()) && unpackU32(ack.data()) == ACK;
+    if (!ok) {
       SPDLOG_LOGGER_WARN(
           mLog, "CosimSync: follower {} did not acknowledge the config.", i);
+      break;
+    }
   }
 
   if (ok) {
-    uint8_t go[4];
-    packU32(go, GO);
+    std::array<uint8_t, 4> go{};
+    packU32(go.data(), GO);
     for (size_t i = 0; i < followerFds.size(); i++) {
-      if (!sendAll(followerFds[i], go, sizeof(go))) {
+      if (!sendAll(followerFds[i], go.data(), go.size())) {
         SPDLOG_LOGGER_WARN(mLog, "CosimSync: failed to release follower {}.",
                            i);
         ok = false;
@@ -372,25 +388,25 @@ bool InterfaceCosimSync::waitForConfig(ConfigNs &outCfg, uint64_t timeoutMs) {
     return false;
   }
 
-  uint8_t wire[WIRE_SIZE];
-  if (!recvAll(fd, wire, WIRE_SIZE)) {
+  std::array<uint8_t, WIRE_SIZE> wire{};
+  if (!recvAll(fd, wire.data(), wire.size())) {
     ::close(fd);
     SPDLOG_LOGGER_ERROR(mLog, "CosimSync: incomplete config from leader.");
     return false;
   }
 
-  uint32_t magic = unpackU32(wire + 0);
-  uint32_t version = unpackU32(wire + 4);
-  if (magic != MAGIC || version != VERSION) {
+  if (uint32_t magic = unpackU32(wire.data() + 0),
+      version = unpackU32(wire.data() + 4);
+      magic != MAGIC || version != VERSION) {
     ::close(fd);
     SPDLOG_LOGGER_ERROR(mLog,
                         "CosimSync: invalid header (magic=0x{:x}, version={}).",
                         magic, version);
     return false;
   }
-  outCfg.start_time_ns = unpackU64(wire + 8);
-  outCfg.time_step_ns = unpackU64(wire + 16);
-  outCfg.duration_ns = unpackU64(wire + 24);
+  outCfg.start_time_ns = unpackU64(wire.data() + 8);
+  outCfg.time_step_ns = unpackU64(wire.data() + 16);
+  outCfg.duration_ns = unpackU64(wire.data() + 24);
 
   if (outCfg.time_step_ns == 0 ||
       outCfg.start_time_ns > static_cast<uint64_t>(INT64_MAX)) {
@@ -402,26 +418,27 @@ bool InterfaceCosimSync::waitForConfig(ConfigNs &outCfg, uint64_t timeoutMs) {
     return false;
   }
 
-  uint8_t ack[4];
-  packU32(ack, ACK);
-  if (!sendAll(fd, ack, sizeof(ack))) {
+  std::array<uint8_t, 4> ack{};
+  packU32(ack.data(), ACK);
+  if (!sendAll(fd, ack.data(), ack.size())) {
     ::close(fd);
     SPDLOG_LOGGER_ERROR(mLog, "CosimSync: failed to acknowledge config.");
     return false;
   }
 
-  uint8_t go[4];
+  std::array<uint8_t, 4> go{};
   bool released = armRecvTimeout(fd, deadline, forever) &&
-                  recvAll(fd, go, sizeof(go)) && unpackU32(go) == GO;
+                  recvAll(fd, go.data(), go.size()) &&
+                  unpackU32(go.data()) == GO;
   ::close(fd);
   if (!released) {
     SPDLOG_LOGGER_ERROR(mLog, "CosimSync: leader did not release the group.");
     return false;
   }
 
-  auto delta =
-      toTimePoint(outCfg.start_time_ns) - std::chrono::system_clock::now();
-  if (delta > std::chrono::hours(1) || delta < -std::chrono::hours(1)) {
+  if (auto delta =
+          toTimePoint(outCfg.start_time_ns) - std::chrono::system_clock::now();
+      delta > std::chrono::hours(1) || delta < -std::chrono::hours(1)) {
     double secs =
         std::chrono::duration_cast<std::chrono::duration<double>>(delta)
             .count();

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -321,7 +321,7 @@ PYBIND11_MODULE(dpsimpy, m) {
                        uint16_t port, const std::string &role) {
              if (role != "leader" && role != "follower")
                throw std::invalid_argument(
-                   "role must be \"leader\" or \"follower\", got \"" + role +
+                   R"(role must be "leader" or "follower", got ")" + role +
                    "\"");
              auto r = (role == "leader")
                           ? DPsim::InterfaceCosimSync::Role::Leader

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -313,6 +313,54 @@ PYBIND11_MODULE(dpsimpy, m) {
                &DPsim::RealTimeSimulation::run))
       .def("set_solver", &DPsim::RealTimeSimulation::setSolverType)
       .def("set_domain", &DPsim::RealTimeSimulation::setDomain);
+
+  py::class_<DPsim::InterfaceCosimSync,
+             std::shared_ptr<DPsim::InterfaceCosimSync>>(m,
+                                                         "InterfaceCosimSync")
+      .def(py::init([](const std::string &name, const std::string &host,
+                       uint16_t port, const std::string &role) {
+             if (role != "leader" && role != "follower")
+               throw std::invalid_argument(
+                   "role must be \"leader\" or \"follower\", got \"" + role +
+                   "\"");
+             auto r = (role == "leader")
+                          ? DPsim::InterfaceCosimSync::Role::Leader
+                          : DPsim::InterfaceCosimSync::Role::Follower;
+             return std::make_shared<DPsim::InterfaceCosimSync>(name, host,
+                                                                port, r);
+           }),
+           "name"_a, "host"_a, "port"_a, "role"_a)
+      .def("open", &DPsim::InterfaceCosimSync::open)
+      .def("close", &DPsim::InterfaceCosimSync::close)
+      .def(
+          "publish_config",
+          [](DPsim::InterfaceCosimSync &self, uint64_t start_time_ns,
+             uint64_t dt_ns, uint64_t duration_ns, uint32_t expected_followers,
+             uint64_t timeout_ms) {
+            if (start_time_ns > static_cast<uint64_t>(INT64_MAX))
+              throw std::invalid_argument(
+                  "start_time_ns is too large to represent as a time point");
+            auto tp = DPsim::InterfaceCosimSync::toTimePoint(start_time_ns);
+            py::gil_scoped_release unlock;
+            return self.publishConfig(tp, dt_ns, duration_ns,
+                                      expected_followers, timeout_ms);
+          },
+          "start_time_ns"_a, "time_step_ns"_a, "duration_ns"_a,
+          "expected_followers"_a = 1,
+          "timeout_ms"_a = DPsim::InterfaceCosimSync::DEFAULT_TIMEOUT_MS)
+      .def(
+          "wait_for_config",
+          [](DPsim::InterfaceCosimSync &self, uint64_t timeout_ms) {
+            DPsim::InterfaceCosimSync::ConfigNs cfg{};
+            bool ok;
+            {
+              py::gil_scoped_release unlock;
+              ok = self.waitForConfig(cfg, timeout_ms);
+            }
+            return py::make_tuple(ok, cfg.start_time_ns, cfg.time_step_ns,
+                                  cfg.duration_ns);
+          },
+          "timeout_ms"_a = DPsim::InterfaceCosimSync::DEFAULT_TIMEOUT_MS);
 #endif
 
   py::class_<CPS::SystemTopology, std::shared_ptr<CPS::SystemTopology>>(

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -311,6 +311,20 @@ PYBIND11_MODULE(dpsimpy, m) {
       .def("run",
            static_cast<void (DPsim::RealTimeSimulation::*)(CPS::Int startIn)>(
                &DPsim::RealTimeSimulation::run))
+      .def(
+          "run_at",
+          [](DPsim::RealTimeSimulation &self, uint64_t start_time_ns) {
+            if (start_time_ns > static_cast<uint64_t>(INT64_MAX))
+              throw std::invalid_argument(
+                  "start_time_ns is too large to represent as a time point");
+            auto startAt = std::chrono::time_point_cast<
+                DPsim::Timer::StartClock::duration>(
+                DPsim::Timer::StartTimePoint(
+                    std::chrono::nanoseconds(start_time_ns)));
+            py::gil_scoped_release unlock;
+            self.run(startAt);
+          },
+          "start_time_ns"_a)
       .def("set_solver", &DPsim::RealTimeSimulation::setSolverType)
       .def("set_domain", &DPsim::RealTimeSimulation::setDomain);
 

--- a/examples/Notebooks/Features/CosimStartSync.ipynb
+++ b/examples/Notebooks/Features/CosimStartSync.ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Co-simulation start-time synchronization\n",
+    "\n",
+    "Two or more DPsim processes running in real time need to start their loops at the same wall-clock instant. `InterfaceCosimSync` handles that rendezvous over TCP: one leader listens, every follower connects, and the leader broadcasts an absolute start time together with the timestep and duration.\n",
+    "\n",
+    "The handshake is two-phase. Every follower must receive the config and acknowledge it before the leader releases any of them, so the group either starts together or not at all. A follower whose peers never arrived is failed rather than left to simulate on its own.\n",
+    "\n",
+    "This example runs one leader and three followers as separate processes on the local machine.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import multiprocessing as mp\n",
+    "import time\n",
+    "\n",
+    "import dpsimpy\n",
+    "\n",
+    "host = \"127.0.0.1\"\n",
+    "port = 47129\n",
+    "num_followers = 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The follower connects to the leader, receives the configuration, and reports the start time it was handed. The timeout keeps it from waiting forever if no leader appears."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_follower(index, follower_port, result_queue, timeout_ms=15000):\n",
+    "    follower = dpsimpy.InterfaceCosimSync(\n",
+    "        f\"follower{index}\", host, follower_port, \"follower\"\n",
+    "    )\n",
+    "    follower.open()\n",
+    "    ok, start_time_ns, time_step_ns, duration_ns = follower.wait_for_config(timeout_ms)\n",
+    "    follower.close()\n",
+    "    result_queue.put((index, ok, start_time_ns, time_step_ns, duration_ns))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The leader opens its listening socket first, then the followers are started. `expected_followers=3` makes the leader wait until all three have acknowledged the config before it releases them, and it reports success only once the whole group is ready."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctx = mp.get_context(\"fork\")\n",
+    "result_queue = ctx.Queue()\n",
+    "\n",
+    "leader = dpsimpy.InterfaceCosimSync(\"leader\", \"\", port, \"leader\")\n",
+    "leader.open()\n",
+    "\n",
+    "followers = [\n",
+    "    ctx.Process(target=run_follower, args=(i, port, result_queue))\n",
+    "    for i in range(num_followers)\n",
+    "]\n",
+    "for process in followers:\n",
+    "    process.start()\n",
+    "\n",
+    "start_time_ns = time.time_ns() + 1_000_000_000\n",
+    "time_step_ns = 1_000_000\n",
+    "duration_ns = 1_000_000_000\n",
+    "published = leader.publish_config(\n",
+    "    start_time_ns,\n",
+    "    time_step_ns,\n",
+    "    duration_ns,\n",
+    "    expected_followers=num_followers,\n",
+    "    timeout_ms=10000,\n",
+    ")\n",
+    "leader.close()\n",
+    "\n",
+    "results = sorted(result_queue.get() for _ in followers)\n",
+    "for process in followers:\n",
+    "    process.join()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Both followers received the exact start time the leader published, to the nanosecond. In a real setup each side would now pass that instant to `RealTimeSimulation.run(start_at)` so their loops step in lockstep."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "leader_start_ns = start_time_ns\n",
+    "print(f\"leader published: {published}, start_time_ns: {leader_start_ns}\")\n",
+    "for index, ok, start_time_ns, step_ns, dur_ns in results:\n",
+    "    print(\n",
+    "        f\"follower{index}: ok={ok} start_time_ns={start_time_ns} time_step_ns={step_ns} duration_ns={dur_ns}\"\n",
+    "    )\n",
+    "\n",
+    "follower_starts = {start_time_ns for _, _, start_time_ns, _, _ in results}\n",
+    "assert published\n",
+    "assert all(ok for _, ok, _, _, _ in results)\n",
+    "assert follower_starts == {leader_start_ns}\n",
+    "print(\"all processes agree on the start instant\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## An incomplete group starts nobody\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "short_port = port + 1\n",
+    "short_queue = ctx.Queue()\n",
+    "\n",
+    "leader_short = dpsimpy.InterfaceCosimSync(\"leader-short\", \"\", short_port, \"leader\")\n",
+    "leader_short.open()\n",
+    "\n",
+    "present = [\n",
+    "    ctx.Process(target=run_follower, args=(i, short_port, short_queue))\n",
+    "    for i in range(num_followers - 1)\n",
+    "]\n",
+    "for process in present:\n",
+    "    process.start()\n",
+    "\n",
+    "published_short = leader_short.publish_config(\n",
+    "    time.time_ns() + 1_000_000_000,\n",
+    "    time_step_ns,\n",
+    "    duration_ns,\n",
+    "    expected_followers=num_followers,\n",
+    "    timeout_ms=3000,\n",
+    ")\n",
+    "leader_short.close()\n",
+    "\n",
+    "short_results = sorted(short_queue.get() for _ in present)\n",
+    "for process in present:\n",
+    "    process.join()\n",
+    "\n",
+    "print(f\"leader published: {published_short}\")\n",
+    "for index, ok, *_ in short_results:\n",
+    "    print(f\"follower{index}: ok={ok}\")\n",
+    "\n",
+    "assert not published_short\n",
+    "assert not any(ok for _, ok, *_ in short_results)\n",
+    "print(\"no process started from an incomplete group\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/Notebooks/Features/CosimStartSync.ipynb
+++ b/examples/Notebooks/Features/CosimStartSync.ipynb
@@ -6,11 +6,11 @@
    "source": [
     "# Co-simulation start-time synchronization\n",
     "\n",
-    "Two or more DPsim processes running in real time need to start their loops at the same wall-clock instant. `InterfaceCosimSync` handles that rendezvous over TCP: one leader listens, every follower connects, and the leader broadcasts an absolute start time together with the timestep and duration.\n",
+    "Two or more DPsim processes running in real time have to start their loops at the same wall-clock instant. `InterfaceCosimSync` performs that rendezvous over TCP: one leader listens, every follower connects, and the leader broadcasts an absolute start time together with the timestep and duration.\n",
     "\n",
     "The handshake is two-phase. Every follower must receive the config and acknowledge it before the leader releases any of them, so the group either starts together or not at all. A follower whose peers never arrived is failed rather than left to simulate on its own.\n",
     "\n",
-    "This example runs one leader and three followers as separate processes on the local machine.\n"
+    "This is only the start rendezvous. Exchanging values between the running simulations is a separate concern, handled by VILLAS; nothing here couples the three circuits to each other. What the example demonstrates is that three independent real-time simulations begin stepping at the same instant."
    ]
   },
   {
@@ -19,6 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import math\n",
     "import multiprocessing as mp\n",
     "import time\n",
     "\n",
@@ -26,14 +27,26 @@
     "\n",
     "host = \"127.0.0.1\"\n",
     "port = 47129\n",
-    "num_followers = 3"
+    "num_followers = 3\n",
+    "\n",
+    "system_frequency = 50\n",
+    "source_voltage = 10.0\n",
+    "resistance = 1.0\n",
+    "inductance = 0.01\n",
+    "\n",
+    "time_step = 1e-3\n",
+    "duration = 1.0\n",
+    "lead_time = 3.0\n",
+    "stagger = 0.3"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The follower connects to the leader, receives the configuration, and reports the start time it was handed. The timeout keeps it from waiting forever if no leader appears."
+    "## The circuit each process simulates\n",
+    "\n",
+    "Every follower builds the same dynamic-phasor circuit: an ideal voltage source feeding a series resistor into a shunt inductor. The voltage at `n2` is the reactive half of a divider, so its steady-state magnitude follows in closed form and gives each process a result that can be checked rather than merely printed."
    ]
   },
   {
@@ -42,21 +55,84 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def run_follower(index, follower_port, result_queue, timeout_ms=15000):\n",
-    "    follower = dpsimpy.InterfaceCosimSync(\n",
-    "        f\"follower{index}\", host, follower_port, \"follower\"\n",
-    "    )\n",
-    "    follower.open()\n",
-    "    ok, start_time_ns, time_step_ns, duration_ns = follower.wait_for_config(timeout_ms)\n",
-    "    follower.close()\n",
-    "    result_queue.put((index, ok, start_time_ns, time_step_ns, duration_ns))"
+    "def build_simulation(name):\n",
+    "    gnd = dpsimpy.dp.SimNode.gnd\n",
+    "    n1 = dpsimpy.dp.SimNode(\"n1\")\n",
+    "    n2 = dpsimpy.dp.SimNode(\"n2\")\n",
+    "\n",
+    "    vs = dpsimpy.dp.ph1.VoltageSource(\"vs\")\n",
+    "    vs.set_parameters(complex(source_voltage, 0))\n",
+    "    r = dpsimpy.dp.ph1.Resistor(\"r\")\n",
+    "    r.set_parameters(resistance)\n",
+    "    l = dpsimpy.dp.ph1.Inductor(\"l\")\n",
+    "    l.set_parameters(inductance)\n",
+    "\n",
+    "    vs.connect([gnd, n1])\n",
+    "    r.connect([n1, n2])\n",
+    "    l.connect([n2, gnd])\n",
+    "\n",
+    "    system = dpsimpy.SystemTopology(system_frequency, [gnd, n1, n2], [vs, r, l])\n",
+    "\n",
+    "    sim = dpsimpy.RealTimeSimulation(name, dpsimpy.LogLevel.off)\n",
+    "    sim.set_system(system)\n",
+    "    sim.set_time_step(time_step)\n",
+    "    sim.set_final_time(duration)\n",
+    "    return sim, n2\n",
+    "\n",
+    "\n",
+    "reactance = 2 * math.pi * system_frequency * inductance\n",
+    "expected_magnitude = source_voltage * reactance / math.hypot(resistance, reactance)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The leader opens its listening socket first, then the followers are started. `expected_followers=3` makes the leader wait until all three have acknowledged the config before it releases them, and it reports success only once the whole group is ready."
+    "## The follower\n",
+    "\n",
+    "A follower waits for the config, builds its circuit, and hands the start time straight to `RealTimeSimulation.run_at`, which blocks until that absolute instant before taking its first step.\n",
+    "\n",
+    "The `time.sleep(index * stagger)` is deliberate. Without it the three processes are already aligned by the handshake itself, and finishing together would prove nothing. The sleep pushes them apart *after* the rendezvous, so the only thing that can bring them back together is `run_at` honouring the shared start time.\n",
+    "\n",
+    "A follower that was not released simulates nothing at all."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_follower(index, follower_port, result_queue, timeout_ms=30000):\n",
+    "    follower = dpsimpy.InterfaceCosimSync(\n",
+    "        f\"follower{index}\", host, follower_port, \"follower\"\n",
+    "    )\n",
+    "    follower.open()\n",
+    "    ok, start_time_ns, time_step_ns, duration_ns = follower.wait_for_config(timeout_ms)\n",
+    "    follower.close()\n",
+    "\n",
+    "    if not ok:\n",
+    "        result_queue.put((index, ok, start_time_ns, 0, 0, None))\n",
+    "        return\n",
+    "\n",
+    "    sim, node = build_simulation(f\"follower{index}\")\n",
+    "    time.sleep(index * stagger)\n",
+    "\n",
+    "    entered_ns = time.time_ns()\n",
+    "    sim.run_at(start_time_ns)\n",
+    "    finished_ns = time.time_ns()\n",
+    "\n",
+    "    magnitude = abs(node.attr(\"v\").get()[0][0])\n",
+    "    result_queue.put((index, ok, start_time_ns, entered_ns, finished_ns, magnitude))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The leader\n",
+    "\n",
+    "The leader opens its listening socket first, then the followers are started. `expected_followers=3` makes it wait until all three have acknowledged the config before releasing any of them, and it reports success only once the whole group is ready."
    ]
   },
   {
@@ -78,15 +154,13 @@
     "for process in followers:\n",
     "    process.start()\n",
     "\n",
-    "start_time_ns = time.time_ns() + 1_000_000_000\n",
-    "time_step_ns = 1_000_000\n",
-    "duration_ns = 1_000_000_000\n",
+    "start_time_ns = time.time_ns() + int(lead_time * 1e9)\n",
     "published = leader.publish_config(\n",
     "    start_time_ns,\n",
-    "    time_step_ns,\n",
-    "    duration_ns,\n",
+    "    int(time_step * 1e9),\n",
+    "    int(duration * 1e9),\n",
     "    expected_followers=num_followers,\n",
-    "    timeout_ms=10000,\n",
+    "    timeout_ms=30000,\n",
     ")\n",
     "leader.close()\n",
     "\n",
@@ -99,7 +173,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Both followers received the exact start time the leader published, to the nanosecond. In a real setup each side would now pass that instant to `RealTimeSimulation.run(start_at)` so their loops step in lockstep."
+    "## Reading the result\n",
+    "\n",
+    "Two windows are worth comparing. The first is how far apart the processes *entered* `run_at`, which the stagger forces to be at least `stagger` seconds wide. The second is how far apart they *finished*. Since all three run for the same duration, a finish window narrower than the entry window can only come from a common start instant.\n",
+    "\n",
+    "If `run_at` ignored the start time the two windows would match, and the assertion below would fail."
    ]
   },
   {
@@ -108,18 +186,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "leader_start_ns = start_time_ns\n",
-    "print(f\"leader published: {published}, start_time_ns: {leader_start_ns}\")\n",
-    "for index, ok, start_time_ns, step_ns, dur_ns in results:\n",
-    "    print(\n",
-    "        f\"follower{index}: ok={ok} start_time_ns={start_time_ns} time_step_ns={step_ns} duration_ns={dur_ns}\"\n",
-    "    )\n",
+    "entry_spread = (max(r[3] for r in results) - min(r[3] for r in results)) / 1e9\n",
+    "finish_spread = (max(r[4] for r in results) - min(r[4] for r in results)) / 1e9\n",
     "\n",
-    "follower_starts = {start_time_ns for _, _, start_time_ns, _, _ in results}\n",
+    "print(f\"leader published: {published}, start_time_ns: {start_time_ns}\")\n",
+    "for index, ok, follower_start_ns, _, _, magnitude in results:\n",
+    "    print(\n",
+    "        f\"follower{index}: ok={ok} start_time_ns={follower_start_ns} \"\n",
+    "        f\"|v_n2|={magnitude:.6f}\"\n",
+    "    )\n",
+    "print(f\"entered run_at over a window of {entry_spread:.3f} s\")\n",
+    "print(f\"finished within a window of {finish_spread:.3f} s\")\n",
+    "\n",
     "assert published\n",
-    "assert all(ok for _, ok, _, _, _ in results)\n",
-    "assert follower_starts == {leader_start_ns}\n",
-    "print(\"all processes agree on the start instant\")"
+    "assert all(ok for _, ok, *_ in results)\n",
+    "assert {r[2] for r in results} == {start_time_ns}\n",
+    "assert entry_spread > stagger\n",
+    "assert finish_spread < stagger\n",
+    "for *_, magnitude in results:\n",
+    "    assert abs(magnitude - expected_magnitude) < 1e-6\n",
+    "print(\"all three simulations ran the same circuit and started together\")"
    ]
   },
   {
@@ -127,7 +213,8 @@
    "metadata": {},
    "source": [
     "## An incomplete group starts nobody\n",
-    "\n"
+    "\n",
+    "The same leader now expects three followers but only two arrive. Nobody is released, so no simulation runs at all."
    ]
   },
   {
@@ -150,9 +237,9 @@
     "    process.start()\n",
     "\n",
     "published_short = leader_short.publish_config(\n",
-    "    time.time_ns() + 1_000_000_000,\n",
-    "    time_step_ns,\n",
-    "    duration_ns,\n",
+    "    time.time_ns() + int(lead_time * 1e9),\n",
+    "    int(time_step * 1e9),\n",
+    "    int(duration * 1e9),\n",
     "    expected_followers=num_followers,\n",
     "    timeout_ms=3000,\n",
     ")\n",
@@ -168,6 +255,7 @@
     "\n",
     "assert not published_short\n",
     "assert not any(ok for _, ok, *_ in short_results)\n",
+    "assert all(magnitude is None for *_, magnitude in short_results)\n",
     "print(\"no process started from an incomplete group\")"
    ]
   }


### PR DESCRIPTION
## What

`InterfaceCosimSync` coordinates the start of separately-launched real-time simulation processes so they begin at the same wall-clock instant.

## Why

Running a co-simulation split across two or more independently-started processes, potentially on different hosts, requires all of them to enter their `RealTimeSimulation` loop at the same absolute time. There was no built-in way to agree on that instant across processes.

## Obs

- Linux only
