### PR TITLE
PFSolver: SVC voltage-control outer loop

### DIFF
--- a/docs/hugo/content/en/docs/Concepts/Models/network-injection-and-compensation.md
+++ b/docs/hugo/content/en/docs/Concepts/Models/network-injection-and-compensation.md
@@ -58,6 +58,31 @@ merely a smoothing of the reported value; making it small to track faster couple
 noise, and making it large delays the response into a range where it can interact with nearby
 machine controls.
 
+## Compensation in the power flow
+
+Before any of that runs, the compensator has to appear in the power flow that sets the operating
+point. There it is not a differential equation but a boundary condition, and since the device
+exchanges no active power, the only question is what the reactive half of that condition states.
+
+Two statements are available. Fixing the voltage and letting the solution supply whatever reactive
+power holds it is the familiar voltage-controlled bus. It says what the compensator is for, but it
+says it without bound: the reactive power that comes out is whatever the network needs, and nothing
+in the formulation knows the device is rated. Where the requirement exceeds the rating, the result is
+a converged case that could not be built.
+
+Fixing the reactive power instead keeps the constant-power equations the rest of the network already
+uses, and moves the regulation outside the Newton iteration. An outer loop adjusts the injection
+until the bus reaches its reference, clamped to the installed band, and the clamped case is the same
+one the dynamic model reaches: the device sits at its limit and the voltage error persists. The
+inner solve stays a problem the solver is already good at, and the rating enters where it can be
+enforced.
+
+One property of the physical device does not survive the substitution. A susceptance delivers
+reactive power in proportion to $V^2$, while a specified injection does not vary with voltage at all.
+The two agree at the regulated voltage and diverge away from it, so a compensator that reached its
+reference hands over an operating point the time domain will recognise, and one pinned at a limit
+does not.
+
 ## Discrete compensation
 
 Where the compensation is switched rather than continuous, the control is a different kind. The

--- a/docs/hugo/content/en/docs/Developer Guide/Model Implementations/network-injection-and-compensation.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Model Implementations/network-injection-and-compensation.md
@@ -26,11 +26,11 @@ modulation frequency for a modulated one. Which overload is called determines wh
 Because the source is ideal, adding an impedance to represent a finite short circuit level is the
 caller's job. Nothing in the component does it.
 
-## `SVC`
+## `SVC` in the time domain
 
-Not composite. It computes a susceptance each step and realises it by reconfiguring an internal
-reactive element, so it implements the variable-component interface and forces a refactorisation
-whenever the value changes.
+`DP::Ph1::SVC` is the dynamic model. Not composite. It computes a susceptance each step and realises
+it by reconfiguring an internal reactive element, so it implements the variable-component interface
+and forces a refactorisation whenever the value changes.
 
 `updateSusceptance` performs both lags with the trapezoidal rule, using precomputed constants
 `Fac1 = dt / (2 Tr)`, `Fac2 = dt Kr / (2 Tr)` and `Fac3 = dt / (2 Tm)`. The measurement lag is
@@ -55,6 +55,38 @@ magnitude of the complex envelope. For a dynamic phasor quantity those differ, a
 not negligible when the envelope has a significant imaginary part.
 {{% /alert %}}
 
+## `SVC` in the power flow
+
+`SP::Ph1::SVC` is a separate class with no code in common with the dynamic one. It is a
+`SimPowerComp<Complex>` and a `PFSolverInterfaceBus` with one terminal and no MNA interface, so it
+exists only for a power flow and takes no part in a time-domain solve.
+
+It stamps nothing into the admittance matrix. `setParameters(ratedApparentPower, ratedVoltage,
+setPointVoltage, qLimMax, qLimMin)` records the voltage set point and the reactive band and fixes
+`mPowerflowBusType` to `PQ`; the active power is identically zero. What the solver sees is therefore
+a reactive injection `Q_set` and a set point `V_set`, and `updateReactivePowerInjection` is the
+setter that moves the injection. Attribute names follow `SynchronGenerator`: `V_set`, `V_set_pu`,
+`Q_set`, `Q_set_pu`, `Q_max`, `Q_min` and their per-unit counterparts.
+
+`calculatePerUnitParameters(baseApparentPower, baseOmega)` divides the set point by the base voltage
+and the band by the base apparent power. Unset limits are $\pm\infty$ and stay $\pm\infty$ in per
+unit. The method throws `std::invalid_argument` if either base is still zero, rather than dividing
+and producing an infinite or undefined set point.
+
+{{% alert title="Watch out: the base voltage comes from the solver, not from the caller" color="warning" %}}
+`ratedVoltage` in `setParameters` is logged and otherwise unused. A compensator is not a voltage
+source and must not seed a zone's voltage level, so `PFSolver::propagateAndVerifyBaseVoltage`
+resolves the zone first and only then calls `setBaseVoltage` with the node's resolved value. A
+standalone `SVC` that never went through a solver has no base voltage, which is what the guard in
+`calculatePerUnitParameters` catches.
+{{% /alert %}}
+
+The regulation itself lives in the solver rather than in the component: something has to call
+`updateReactivePowerInjection` between Newton solves for the set point to be held. Until that outer
+loop exists, an `SVC` in a system is inert. `PFSolver::initialize` does not collect it into any of
+its component lists, `determinePFBusType` does not read its bus type, and its `Q_set` stays at zero,
+which is the same case as a node with nothing attached.
+
 ## `SolidStateTransformer`
 
 A `CompositePowerComp` that represents each side as a current source rather than as a coupled
@@ -70,6 +102,7 @@ representation the concept page describes and not an omission.
 
 - [`DP_Ph1_NetworkInjection`](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/src/DP/DP_Ph1_NetworkInjection.cpp), and the SP and EMT variants alongside it
 - [`DP_Ph1_SVC`](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/src/DP/DP_Ph1_SVC.cpp)
+- [`SP_Ph1_SVC`](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/src/SP/SP_Ph1_SVC.cpp)
 - [`SP_Ph1_SolidStateTransformer`](https://github.com/sogno-platform/dpsim/blob/master/dpsim-models/src/SP/SP_Ph1_SolidStateTransformer.cpp)
 
 Availability per domain is in

--- a/docs/hugo/content/en/docs/Reference/model-availability.md
+++ b/docs/hugo/content/en/docs/Reference/model-availability.md
@@ -58,7 +58,7 @@ model, so the table cannot fall behind the code. For the equations behind a mode
 | PQLoadCS | &ndash; | &ndash; | &check; | &ndash; | &ndash; | &ndash; |
 | Load | &check; | &ndash; | &ndash; | &ndash; | &ndash; | &ndash; |
 | Shunt | &check; | &ndash; | &check; | &ndash; | &ndash; | &check; |
-| SVC | &ndash; | &ndash; | &check; | &ndash; | &ndash; | &ndash; |
+| SVC | &check; | &ndash; | &check; | &ndash; | &ndash; | &ndash; |
 
 ## Synchronous generators
 

--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -22,6 +22,7 @@
 #include <dpsim-models/SP/SP_Ph1_ReducedOrderSynchronGeneratorVBR.h>
 #include <dpsim-models/SP/SP_Ph1_SSNTypeI2T.h>
 #include <dpsim-models/SP/SP_Ph1_SSNTypeV2T.h>
+#include <dpsim-models/SP/SP_Ph1_SVC.h>
 #include <dpsim-models/SP/SP_Ph1_Shunt.h>
 #include <dpsim-models/SP/SP_Ph1_SolidStateTransformer.h>
 #include <dpsim-models/SP/SP_Ph1_Switch.h>

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <limits>
+
+#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Solver/PFSolverInterfaceBus.h>
+
+namespace CPS {
+namespace SP {
+namespace Ph1 {
+
+/// \brief Static VAR compensator (SVC) power-flow model.
+///
+/// Voltage-controlling shunt reactive device. Modelled as a PQ bus whose
+/// reactive injection Q_set is driven by the solver's SVC outer control loop
+/// until the bus voltage reaches V_set (clamped to [Q_min, Q_max]). This
+/// sidesteps the ill-conditioned derived-Q of the ordinary PV-bus formulation
+/// at electrically stiff, near-zero-P buses. No active power (always 0) and no
+/// admittance stamp: it participates purely through bus classification + the
+/// reactive setpoint the outer loop maintains.
+class SVC : public SimPowerComp<Complex>,
+            public SharedFactory<SVC>,
+            public PFSolverInterfaceBus {
+private:
+  /// Base voltage [V]
+  Real mBaseVoltage;
+  /// Base apparent power [VA]
+  Real mBaseApparentPower;
+
+public:
+  /// Voltage set point [V]
+  const Attribute<Real>::Ptr mSetPointVoltage;
+  /// Voltage set point [pu]
+  const Attribute<Real>::Ptr mSetPointVoltagePerUnit;
+  /// Reactive power injection [VAr] (maintained by the SVC outer loop)
+  const Attribute<Real>::Ptr mSetPointReactivePower;
+  /// Reactive power injection [pu]
+  const Attribute<Real>::Ptr mSetPointReactivePowerPerUnit;
+  /// Maximum reactive power limit [VAr] (default +inf = unlimited)
+  const Attribute<Real>::Ptr mReactivePowerMax;
+  /// Minimum reactive power limit [VAr] (default -inf = unlimited)
+  const Attribute<Real>::Ptr mReactivePowerMin;
+  /// Maximum reactive power limit [pu]
+  const Attribute<Real>::Ptr mReactivePowerMaxPerUnit;
+  /// Minimum reactive power limit [pu]
+  const Attribute<Real>::Ptr mReactivePowerMinPerUnit;
+
+  /// Defines UID, name and logging level
+  SVC(String uid, String name, Logger::Level logLevel = Logger::Level::off);
+  /// Defines name and logging level
+  SVC(String name, Logger::Level logLevel = Logger::Level::off)
+      : SVC(name, name, logLevel) {}
+  /// Setter for SVC parameters. setPointVoltage is the controlled voltage [V];
+  /// qLimMax/qLimMin are the reactive-power band [VAr] the outer control loop
+  /// respects. The device holds no active power (always 0).
+  void setParameters(Real ratedApparentPower, Real ratedVoltage,
+                     Real setPointVoltage,
+                     Real qLimMax = std::numeric_limits<Real>::infinity(),
+                     Real qLimMin = -std::numeric_limits<Real>::infinity());
+  // #### Powerflow section ####
+  Real getBaseVoltage() const;
+  /// Set base voltage
+  void setBaseVoltage(Real baseVoltage);
+  /// Initializes component from power flow data
+  void calculatePerUnitParameters(Real baseApparentPower, Real baseOmega);
+  /// Modify powerflow bus type
+  void modifyPowerFlowBusType(PowerflowBusType powerflowBusType) override;
+  /// Update reactive power injection (driven by the SVC outer control loop)
+  void updateReactivePowerInjection(Complex powerInj);
+  /// Get apparent power of the power-flow solution (P is always 0)
+  Complex getApparentPower() const;
+};
+} // namespace Ph1
+} // namespace SP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
@@ -25,10 +25,10 @@ class SVC : public SimPowerComp<Complex>,
             public SharedFactory<SVC>,
             public PFSolverInterfaceBus {
 private:
-  /// Base voltage [V]
-  Real mBaseVoltage;
+  /// Base voltage [V], set via setBaseVoltage() before power-flow init
+  Real mBaseVoltage = 0;
   /// Base apparent power [VA]
-  Real mBaseApparentPower;
+  Real mBaseApparentPower = 0;
 
 public:
   /// Voltage set point [V]

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
@@ -45,7 +45,7 @@ public:
   /// Defines name and logging level
   SVC(String name, Logger::Level logLevel = Logger::Level::off)
       : SVC(name, name, logLevel) {}
-  /// Set SVC specific parameters
+  /// Set SVC specific parameters; the rated values are logged only
   void setParameters(Real ratedApparentPower, Real ratedVoltage,
                      Real setPointVoltage,
                      Real qLimMax = std::numeric_limits<Real>::infinity(),
@@ -57,7 +57,7 @@ public:
   void setBaseVoltage(Real baseVoltage);
   /// Initializes component from power flow data
   void calculatePerUnitParameters(Real baseApparentPower, Real baseOmega);
-  /// Modify powerflow bus type
+  /// Modify powerflow bus type; only PQ is valid for an SVC
   void modifyPowerFlowBusType(PowerflowBusType powerflowBusType) override;
   /// Update reactive power injection (driven by the SVC outer control loop)
   void updateReactivePowerInjection(Complex powerInj);

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SVC.h
@@ -12,15 +12,7 @@ namespace CPS {
 namespace SP {
 namespace Ph1 {
 
-/// \brief Static VAR compensator (SVC) power-flow model.
-///
-/// Voltage-controlling shunt reactive device. Modelled as a PQ bus whose
-/// reactive injection Q_set is driven by the solver's SVC outer control loop
-/// until the bus voltage reaches V_set (clamped to [Q_min, Q_max]). This
-/// sidesteps the ill-conditioned derived-Q of the ordinary PV-bus formulation
-/// at electrically stiff, near-zero-P buses. No active power (always 0) and no
-/// admittance stamp: it participates purely through bus classification + the
-/// reactive setpoint the outer loop maintains.
+/// Static VAR compensator for power flow: PQ bus, no active power, no admittance stamp
 class SVC : public SimPowerComp<Complex>,
             public SharedFactory<SVC>,
             public PFSolverInterfaceBus {
@@ -53,14 +45,13 @@ public:
   /// Defines name and logging level
   SVC(String name, Logger::Level logLevel = Logger::Level::off)
       : SVC(name, name, logLevel) {}
-  /// Setter for SVC parameters. setPointVoltage is the controlled voltage [V];
-  /// qLimMax/qLimMin are the reactive-power band [VAr] the outer control loop
-  /// respects. The device holds no active power (always 0).
+  /// Set SVC specific parameters
   void setParameters(Real ratedApparentPower, Real ratedVoltage,
                      Real setPointVoltage,
                      Real qLimMax = std::numeric_limits<Real>::infinity(),
                      Real qLimMin = -std::numeric_limits<Real>::infinity());
   // #### Powerflow section ####
+  /// Get base voltage
   Real getBaseVoltage() const;
   /// Set base voltage
   void setBaseVoltage(Real baseVoltage);

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -179,6 +179,7 @@ list(APPEND MODELS_SOURCES
 	SP/SP_Ph1_Transformer.cpp
 	SP/SP_Ph1_SolidStateTransformer.cpp
 	SP/SP_Ph1_Shunt.cpp
+	SP/SP_Ph1_SVC.cpp
 	SP/SP_Ph1_SynchronGenerator.cpp
 	SP/SP_Ph1_ReducedOrderSynchronGeneratorVBR.cpp
 	SP/SP_Ph1_SynchronGenerator3OrderVBR.cpp

--- a/dpsim-models/src/SP/SP_Ph1_SVC.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SVC.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/SP/SP_Ph1_SVC.h>
+
+using namespace CPS;
+
+SP::Ph1::SVC::SVC(String uid, String name, Logger::Level logLevel)
+    : SimPowerComp<Complex>(uid, name, logLevel),
+      mSetPointVoltage(mAttributes->create<Real>("V_set")),
+      mSetPointVoltagePerUnit(mAttributes->create<Real>("V_set_pu")),
+      mSetPointReactivePower(mAttributes->create<Real>("Q_set")),
+      mSetPointReactivePowerPerUnit(mAttributes->create<Real>("Q_set_pu")),
+      mReactivePowerMax(mAttributes->create<Real>(
+          "Q_max", std::numeric_limits<Real>::infinity())),
+      mReactivePowerMin(mAttributes->create<Real>(
+          "Q_min", -std::numeric_limits<Real>::infinity())),
+      mReactivePowerMaxPerUnit(mAttributes->create<Real>(
+          "Q_max_pu", std::numeric_limits<Real>::infinity())),
+      mReactivePowerMinPerUnit(mAttributes->create<Real>(
+          "Q_min_pu", -std::numeric_limits<Real>::infinity())) {
+
+  SPDLOG_LOGGER_INFO(mSLog, "Create {} of type {}", name, this->type());
+  mSLog->flush();
+
+  setTerminalNumber(1);
+};
+
+void SP::Ph1::SVC::setParameters(Real ratedApparentPower, Real ratedVoltage,
+                                 Real setPointVoltage, Real qLimMax,
+                                 Real qLimMin) {
+  **mSetPointVoltage = setPointVoltage;
+  **mReactivePowerMax = qLimMax;
+  **mReactivePowerMin = qLimMin;
+  // The SVC always presents as a PQ bus; the outer control loop moves Q_set
+  // within [Q_min, Q_max] to hold V at V_set.
+  mPowerflowBusType = PowerflowBusType::PQ;
+
+  SPDLOG_LOGGER_INFO(mSLog, "Rated Apparent Power={} [VA] Rated Voltage={} [V]",
+                     ratedApparentPower, ratedVoltage);
+  SPDLOG_LOGGER_INFO(mSLog, "Voltage Set Point={} [V]", **mSetPointVoltage);
+  SPDLOG_LOGGER_INFO(mSLog, "Reactive Power Limits Qmin={} Qmax={} [VAr]",
+                     **mReactivePowerMin, **mReactivePowerMax);
+  mSLog->flush();
+}
+
+// #### Powerflow section ####
+
+Real SP::Ph1::SVC::getBaseVoltage() const { return mBaseVoltage; }
+
+void SP::Ph1::SVC::setBaseVoltage(Real baseVoltage) {
+  mBaseVoltage = baseVoltage;
+}
+
+void SP::Ph1::SVC::calculatePerUnitParameters(Real baseApparentPower,
+                                              Real baseOmega) {
+  SPDLOG_LOGGER_INFO(mSLog, "#### Calculate Per Unit Parameters for {}",
+                     **mName);
+  mBaseApparentPower = baseApparentPower;
+  SPDLOG_LOGGER_INFO(mSLog, "Base Power={} [VA]  Base Omega={} [1/s]",
+                     mBaseApparentPower, baseOmega);
+
+  **mSetPointVoltagePerUnit = **mSetPointVoltage / mBaseVoltage;
+  **mSetPointReactivePowerPerUnit =
+      **mSetPointReactivePower / mBaseApparentPower;
+  // +/-inf limits divide to +/-inf in pu (still "unlimited"); finite limits scale.
+  **mReactivePowerMaxPerUnit = **mReactivePowerMax / mBaseApparentPower;
+  **mReactivePowerMinPerUnit = **mReactivePowerMin / mBaseApparentPower;
+  SPDLOG_LOGGER_INFO(mSLog, "Voltage Set Point={} [pu]",
+                     **mSetPointVoltagePerUnit);
+  mSLog->flush();
+}
+
+void SP::Ph1::SVC::modifyPowerFlowBusType(PowerflowBusType powerflowBusType) {
+  switch (powerflowBusType) {
+  case CPS::PowerflowBusType::PV:
+    mPowerflowBusType = powerflowBusType;
+    break;
+  case CPS::PowerflowBusType::PQ:
+    mPowerflowBusType = powerflowBusType;
+    break;
+  case CPS::PowerflowBusType::VD:
+    mPowerflowBusType = powerflowBusType;
+    break;
+  case CPS::PowerflowBusType::None:
+    break;
+  default:
+    throw std::invalid_argument(" Invalid power flow bus type ");
+    break;
+  }
+}
+
+// Method used by the SVC outer control loop to update the reactive injection
+void SP::Ph1::SVC::updateReactivePowerInjection(Complex powerInj) {
+  **mSetPointReactivePower = powerInj.imag();
+  **mSetPointReactivePowerPerUnit =
+      **mSetPointReactivePower / mBaseApparentPower;
+}
+
+Complex SP::Ph1::SVC::getApparentPower() const {
+  return Complex(0., **mSetPointReactivePower);
+}

--- a/dpsim-models/src/SP/SP_Ph1_SVC.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SVC.cpp
@@ -60,6 +60,14 @@ void SP::Ph1::SVC::calculatePerUnitParameters(Real baseApparentPower,
   SPDLOG_LOGGER_INFO(mSLog, "Base Power={} [VA]  Base Omega={} [1/s]",
                      mBaseApparentPower, baseOmega);
 
+  // Reject unset/zero divisors before the per-unit conversion below.
+  if (mBaseVoltage <= 0)
+    throw std::invalid_argument(
+        "SVC: base voltage not set (call setBaseVoltage() before power-flow "
+        "initialization).");
+  if (mBaseApparentPower <= 0)
+    throw std::invalid_argument("SVC: base apparent power must be positive.");
+
   **mSetPointVoltagePerUnit = **mSetPointVoltage / mBaseVoltage;
   **mSetPointReactivePowerPerUnit =
       **mSetPointReactivePower / mBaseApparentPower;

--- a/dpsim-models/src/SP/SP_Ph1_SVC.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SVC.cpp
@@ -80,17 +80,14 @@ void SP::Ph1::SVC::calculatePerUnitParameters(Real baseApparentPower,
 
 void SP::Ph1::SVC::modifyPowerFlowBusType(PowerflowBusType powerflowBusType) {
   switch (powerflowBusType) {
-  case CPS::PowerflowBusType::PV:
-    mPowerflowBusType = powerflowBusType;
-    break;
   case CPS::PowerflowBusType::PQ:
-    mPowerflowBusType = powerflowBusType;
-    break;
-  case CPS::PowerflowBusType::VD:
     mPowerflowBusType = powerflowBusType;
     break;
   case CPS::PowerflowBusType::None:
     break;
+  case CPS::PowerflowBusType::PV:
+  case CPS::PowerflowBusType::VD:
+    throw std::invalid_argument("SVC: only PQ is a valid power flow bus type.");
   default:
     throw std::invalid_argument(" Invalid power flow bus type ");
     break;
@@ -99,6 +96,11 @@ void SP::Ph1::SVC::modifyPowerFlowBusType(PowerflowBusType powerflowBusType) {
 
 // Called by the SVC outer control loop
 void SP::Ph1::SVC::updateReactivePowerInjection(Complex powerInj) {
+  if (mBaseApparentPower <= 0)
+    throw std::invalid_argument(
+        "SVC: base apparent power must be positive (call "
+        "calculatePerUnitParameters() before updating the injection).");
+
   **mSetPointReactivePower = powerInj.imag();
   **mSetPointReactivePowerPerUnit =
       **mSetPointReactivePower / mBaseApparentPower;

--- a/dpsim-models/src/SP/SP_Ph1_SVC.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SVC.cpp
@@ -32,8 +32,7 @@ void SP::Ph1::SVC::setParameters(Real ratedApparentPower, Real ratedVoltage,
   **mSetPointVoltage = setPointVoltage;
   **mReactivePowerMax = qLimMax;
   **mReactivePowerMin = qLimMin;
-  // The SVC always presents as a PQ bus; the outer control loop moves Q_set
-  // within [Q_min, Q_max] to hold V at V_set.
+  // Always a PQ bus; the outer loop moves Q_set within the band to hold V_set
   mPowerflowBusType = PowerflowBusType::PQ;
 
   SPDLOG_LOGGER_INFO(mSLog, "Rated Apparent Power={} [VA] Rated Voltage={} [V]",
@@ -71,7 +70,7 @@ void SP::Ph1::SVC::calculatePerUnitParameters(Real baseApparentPower,
   **mSetPointVoltagePerUnit = **mSetPointVoltage / mBaseVoltage;
   **mSetPointReactivePowerPerUnit =
       **mSetPointReactivePower / mBaseApparentPower;
-  // +/-inf limits divide to +/-inf in pu (still "unlimited"); finite limits scale.
+  // +/-inf limits stay +/-inf in pu; finite limits scale
   **mReactivePowerMaxPerUnit = **mReactivePowerMax / mBaseApparentPower;
   **mReactivePowerMinPerUnit = **mReactivePowerMin / mBaseApparentPower;
   SPDLOG_LOGGER_INFO(mSLog, "Voltage Set Point={} [pu]",
@@ -98,7 +97,7 @@ void SP::Ph1::SVC::modifyPowerFlowBusType(PowerflowBusType powerflowBusType) {
   }
 }
 
-// Method used by the SVC outer control loop to update the reactive injection
+// Called by the SVC outer control loop
 void SP::Ph1::SVC::updateReactivePowerInjection(Complex powerInj) {
   **mSetPointReactivePower = powerInj.imag();
   **mSetPointReactivePowerPerUnit =

--- a/dpsim-models/src/SP/SP_Ph1_SVC.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SVC.cpp
@@ -60,12 +60,13 @@ void SP::Ph1::SVC::calculatePerUnitParameters(Real baseApparentPower,
                      mBaseApparentPower, baseOmega);
 
   // Reject unset/zero divisors before the per-unit conversion below.
-  if (mBaseVoltage <= 0)
+  if (!Math::isFinite(mBaseVoltage) || mBaseVoltage <= 0)
     throw std::invalid_argument(
         "SVC: base voltage not set (call setBaseVoltage() before power-flow "
         "initialization).");
-  if (mBaseApparentPower <= 0)
-    throw std::invalid_argument("SVC: base apparent power must be positive.");
+  if (!Math::isFinite(mBaseApparentPower) || mBaseApparentPower <= 0)
+    throw std::invalid_argument(
+        "SVC: base apparent power must be finite and positive.");
 
   **mSetPointVoltagePerUnit = **mSetPointVoltage / mBaseVoltage;
   **mSetPointReactivePowerPerUnit =
@@ -89,17 +90,20 @@ void SP::Ph1::SVC::modifyPowerFlowBusType(PowerflowBusType powerflowBusType) {
   case CPS::PowerflowBusType::VD:
     throw std::invalid_argument("SVC: only PQ is a valid power flow bus type.");
   default:
-    throw std::invalid_argument(" Invalid power flow bus type ");
+    throw std::invalid_argument("Invalid power flow bus type");
     break;
   }
 }
 
 // Called by the SVC outer control loop
 void SP::Ph1::SVC::updateReactivePowerInjection(Complex powerInj) {
-  if (mBaseApparentPower <= 0)
+  if (!Math::isFinite(mBaseApparentPower) || mBaseApparentPower <= 0)
     throw std::invalid_argument(
-        "SVC: base apparent power must be positive (call "
+        "SVC: base apparent power must be finite and positive (call "
         "calculatePerUnitParameters() before updating the injection).");
+  if (!Math::isFinite(powerInj.imag()))
+    throw std::invalid_argument(
+        "SVC: reactive power injection must be finite.");
 
   **mSetPointReactivePower = powerInj.imag();
   **mSetPointReactivePowerPerUnit =

--- a/dpsim/include/dpsim/PFSolver.h
+++ b/dpsim/include/dpsim/PFSolver.h
@@ -77,6 +77,8 @@ protected:
   /// Vector of average voltage source inverters
   std::vector<std::shared_ptr<CPS::SP::Ph1::AvVoltageSourceInverterDQ>>
       mAverageVoltageSourceInverters;
+  /// Vector of static VAR compensator components
+  std::vector<std::shared_ptr<CPS::SP::Ph1::SVC>> mSVCs;
   /// Map providing determined base voltages for each node
   std::map<CPS::TopologicalNode::Ptr, CPS::Real> mBaseVoltageAtNode;
 
@@ -92,6 +94,12 @@ protected:
   CPS::UInt mMaxOuterIterations = 10;
   /// Maximum number of PV<->PQ switches per bus before it is frozen (anti-oscillation)
   CPS::UInt mMaxQLimitSwitchesPerBus = 2;
+  /// Hold each SVC bus at its voltage setpoint via a reactive-injection outer loop
+  CPS::Bool mEnforceSvcControl = false;
+  /// Voltage tolerance [pu] at which an SVC bus is considered on setpoint
+  CPS::Real mSvcVoltageTolerance = 1e-7;
+  /// Damping applied to each SVC reactive-injection step (1.0 = full secant/Newton)
+  CPS::Real mSvcDamping = 1.0;
   /// Relative tolerance for non-authoritative (e.g. Load) base-voltage candidates vs. the zone's rating
   CPS::Real mBaseVoltageLooseTolerance = 0.1;
   /// Relative tolerance between authoritative base-voltage sources (generator/transformer/network-injection/VSI) within a zone
@@ -158,6 +166,8 @@ protected:
   Bool runNewtonRaphson();
   /// Switch generators violating their Q limits between PV/PQ; base impl is a no-op
   virtual CPS::Bool enforceReactiveLimits() { return false; }
+  /// Adjust SVC reactive injections to hold their voltage setpoints; base is a no-op
+  virtual CPS::Bool enforceSvcVoltageControl() { return false; }
   /// Allocate Jacobian storage; dense by default, sparse subclass overrides
   virtual void setUpJacobianStorage();
   /// Solve the linearized system mJ*mX = mF into mX; sparse subclass overrides
@@ -197,6 +207,9 @@ public:
   void setEnforceReactiveLimits(CPS::Bool value) {
     mEnforceReactiveLimits = value;
   }
+
+  /// Enable SVC voltage control (reactive-injection outer loop)
+  void setEnforceSvcControl(CPS::Bool value) { mEnforceSvcControl = value; }
 
   /// Raise for grids with legitimate large voltage drop (e.g. untapped feeders)
   void setBaseVoltageLooseTolerance(CPS::Real tolerance) {

--- a/dpsim/include/dpsim/PFSolverPowerPolar.h
+++ b/dpsim/include/dpsim/PFSolverPowerPolar.h
@@ -75,6 +75,12 @@ protected:
   CPS::Real loadReactivePowerPerUnit(CPS::TopologicalNode::Ptr node);
   /// Q-limit PV<->PQ switching pass (overrides the base no-op)
   CPS::Bool enforceReactiveLimits() override;
+  /// SVC voltage-control pass: nudge each SVC's reactive injection toward its
+  /// voltage setpoint (overrides the base no-op)
+  CPS::Bool enforceSvcVoltageControl() override;
+  /// Previous (Q_pu, V_pu) per SVC bus for the secant sensitivity estimate
+  std::map<CPS::TopologicalNode::Ptr, std::pair<CPS::Real, CPS::Real>>
+      mSvcPrevQV;
   /// Clear the Q-limit conversion bookkeeping between solves
   void clearReactiveLimitState() override;
   /// Buses switched PV->PQ by the Q-limit loop -> pinned at Qmax (true) or Qmin (false)

--- a/dpsim/include/dpsim/Simulation.h
+++ b/dpsim/include/dpsim/Simulation.h
@@ -59,6 +59,10 @@ public:
   /// switching. Default false; opt in via setPFSolverEnforceReactiveLimits(true).
   const CPS::Attribute<Bool>::Ptr mPFEnforceReactiveLimits;
 
+  /// Hold each SVC bus at its voltage setpoint in the powerflow via a reactive-
+  /// injection outer loop. Default false; opt in via setPFSolverEnforceSvcControl(true).
+  const CPS::Attribute<Bool>::Ptr mPFEnforceSvcControl;
+
   /// Loose tolerance for a zone's Load base-voltage vs. its rating; default 0.1
   const CPS::Attribute<Real>::Ptr mPFBaseVoltageLooseTolerance;
 
@@ -283,6 +287,10 @@ public:
   void setPFSolverEnforceReactiveLimits(Bool value);
 
   Bool getPFSolverEnforceReactiveLimits() const;
+
+  void setPFSolverEnforceSvcControl(Bool value);
+
+  Bool getPFSolverEnforceSvcControl() const;
 
   void setPFSolverBaseVoltageLooseTolerance(Real tolerance);
 

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -446,6 +446,17 @@ void PFSolver::propagateAndVerifyBaseVoltage() {
     }
   }
 
+  // An SVC is a compensator, not a voltage source: derive its base voltage
+  // from the node's resolved zone value so its per-unit setpoint stays consistent.
+  for (auto node : mSystem.mNodes) {
+    CPS::Real vBase = mBaseVoltageAtNode[node];
+    if (std::abs(vBase) < 1e-6)
+      continue;
+    for (auto comp : mSystem.mComponentsAtNode[node])
+      if (auto svc = std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp))
+        svc->setBaseVoltage(vBase);
+  }
+
   UInt numMissing = 0;
   UInt numZero = 0;
 

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -61,6 +61,9 @@ void PFSolver::initialize() {
   initializeComponents();
   determinePFBusType();
   propagateAndVerifyBaseVoltage();
+  // An SVC gets its base voltage from the propagation above, so convert it after
+  for (auto svc : mSVCs)
+    svc->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
   composeAdmittanceMatrix();
 
   setUpJacobianStorage();
@@ -131,9 +134,6 @@ void PFSolver::initializeComponents() {
   }
   for (auto sst : mSolidStateTransformers) {
     sst->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
-  }
-  for (auto svc : mSVCs) {
-    svc->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
   }
 }
 

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -51,7 +51,9 @@ void PFSolver::initialize() {
                  std::dynamic_pointer_cast<
                      CPS::SP::Ph1::AvVoltageSourceInverterDQ>(comp)) {
       mAverageVoltageSourceInverters.push_back(vsi);
-    }
+    } else if (std::shared_ptr<CPS::SP::Ph1::SVC> svc =
+                   std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp))
+      mSVCs.push_back(svc);
   }
 
   setBaseApparentPower();
@@ -129,6 +131,9 @@ void PFSolver::initializeComponents() {
   }
   for (auto sst : mSolidStateTransformers) {
     sst->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
+  }
+  for (auto svc : mSVCs) {
+    svc->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
   }
 }
 
@@ -628,26 +633,30 @@ Bool PFSolver::runNewtonRaphson() {
 Bool PFSolver::solvePowerflow() {
   Bool converged = runNewtonRaphson();
 
-  if (!mEnforceReactiveLimits)
+  if (!mEnforceReactiveLimits && !mEnforceSvcControl)
     return converged;
 
-  // Outer loop: switch PV<->PQ on Q-limit violations, re-solve until no bus switches.
+  // Outer loop: apply Q-limit PV<->PQ switching and/or SVC voltage control, then
+  // re-solve, until neither pass changes anything (both settled).
   Bool settled = false;
   for (CPS::UInt outer = 0; converged && outer < mMaxOuterIterations; ++outer) {
-    if (!enforceReactiveLimits()) {
+    Bool qLimitChanged = mEnforceReactiveLimits && enforceReactiveLimits();
+    Bool svcChanged = mEnforceSvcControl && enforceSvcVoltageControl();
+    if (!qLimitChanged && !svcChanged) {
       settled = true;
-      break; // all generators within their reactive limits
+      break; // all generators within limits and all SVCs on setpoint
     }
-    reclassifyBuses();
+    if (qLimitChanged)
+      reclassifyBuses();
     converged = runNewtonRaphson();
   }
 
   if (converged && !settled) {
-    // Unsettled PV/PQ classification must not look converged to setSolution().
+    // Unsettled classification/SVC control must not look converged to setSolution().
     SPDLOG_LOGGER_WARN(
         mSLog,
-        "Q-limit outer loop did not settle within {} iterations; "
-        "PV/PQ classification may still be oscillating",
+        "PF outer loop did not settle within {} iterations; Q-limit "
+        "classification or SVC control may still be oscillating",
         mMaxOuterIterations);
     isConverged = false;
     converged = false;

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -326,6 +326,10 @@ CPS::Real PFSolver::componentBaseVoltage(CPS::TopologicalPowerComp::Ptr comp,
     return extnet->getBaseVoltage();
   if (auto shunt = std::dynamic_pointer_cast<CPS::SP::Ph1::Shunt>(comp))
     return shunt->getBaseVoltage();
+  // An SVC takes its base voltage from the resolved zone instead of contributing one,
+  // so it is not a missing case and must not warn.
+  if (std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp))
+    return 0;
   SPDLOG_LOGGER_WARN(mSLog, "Unable to get base voltage at {}", node->name());
   return 0;
 }

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -57,7 +57,14 @@ void PFSolverPowerPolar::generateInitialSolution(Real time,
             std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(comp)) {
       gen->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
     }
+
+    if (auto svc = std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp)) {
+      svc->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
+    }
   }
+
+  // SVC secant history is per-solve; start each solve fresh.
+  mSvcPrevQV.clear();
 
   // PQ buses
   for (auto pq : mPQBuses) {
@@ -90,6 +97,10 @@ void PFSolverPowerPolar::generateInitialSolution(Real time,
                          comp)) {
         sol_P(idx) += gen->attributeTyped<CPS::Real>("P_set_pu")->get();
         sol_Q(idx) += gen->attributeTyped<CPS::Real>("Q_set_pu")->get();
+      } else if (auto svc =
+                     std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp)) {
+        // SVC injects reactive power only; the outer control loop moves Q_set_pu.
+        sol_Q(idx) += svc->attributeTyped<CPS::Real>("Q_set_pu")->get();
       }
     }
 
@@ -641,6 +652,69 @@ CPS::Bool PFSolverPowerPolar::enforceReactiveLimits() {
   }
 
   return !toPQ.empty() || !toPV.empty();
+}
+
+CPS::Bool PFSolverPowerPolar::enforceSvcVoltageControl() {
+  // The SVC component holding the controlled voltage/band at a node, if any.
+  auto svcAtNode = [&](CPS::TopologicalNode::Ptr node)
+      -> std::shared_ptr<CPS::SP::Ph1::SVC> {
+    for (auto comp : mSystem.mComponentsAtNode[node])
+      if (auto svc = std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp))
+        return svc;
+    return nullptr;
+  };
+
+  CPS::Bool anyChanged = false;
+  for (auto node : mPQBuses) {
+    auto svc = svcAtNode(node);
+    if (!svc)
+      continue;
+    UInt idx = node->matrixNodeIndex();
+    CPS::Real vSetPU = svc->attributeTyped<CPS::Real>("V_set_pu")->get();
+    CPS::Real qMaxPU = svc->attributeTyped<CPS::Real>("Q_max_pu")->get();
+    CPS::Real qMinPU = svc->attributeTyped<CPS::Real>("Q_min_pu")->get();
+    CPS::Real qOld = svc->attributeTyped<CPS::Real>("Q_set_pu")->get();
+    CPS::Real v = sol_V(idx);
+    CPS::Real vErr = vSetPU - v;
+
+    if (std::abs(vErr) < mSvcVoltageTolerance)
+      continue; // already on setpoint
+
+    // Reactive-injection sensitivity dQ/dV: seeded from the local diagonal
+    // susceptance |B_kk| (the decoupled Newton sensitivity, self-scaling at
+    // stiff buses) and refined by a secant estimate once a prior iterate exists.
+    CPS::Real dQdV = std::abs(B(idx, idx));
+    auto prev = mSvcPrevQV.find(node);
+    if (prev != mSvcPrevQV.end()) {
+      CPS::Real dV = v - prev->second.second;
+      CPS::Real dQ = qOld - prev->second.first;
+      if (std::abs(dV) > 1e-12 && std::abs(dQ) > 1e-15)
+        dQdV = dQ / dV;
+    }
+    if (!CPS::Math::isFinite(dQdV) || std::abs(dQdV) < 1e-9)
+      dQdV = 1.0; // degenerate sensitivity -> unit fallback
+
+    CPS::Real qNew = qOld + mSvcDamping * dQdV * vErr;
+    if (CPS::Math::isFinite(qMaxPU) && qNew > qMaxPU)
+      qNew = qMaxPU;
+    if (CPS::Math::isFinite(qMinPU) && qNew < qMinPU)
+      qNew = qMinPU;
+
+    CPS::Real dq = qNew - qOld;
+    if (std::abs(dq) < 1e-12)
+      continue; // pinned at a limit or converged -> contributes to settling
+
+    mSvcPrevQV[node] = std::make_pair(qOld, v);
+    Qesp(idx) += dq;
+    sol_Q(idx) += dq;
+    svc->updateReactivePowerInjection(
+        CPS::Complex(0., qNew * mBaseApparentPower));
+    anyChanged = true;
+    SPDLOG_LOGGER_INFO(mSLog,
+                       "SVC {}: V={:.6f} (set {:.6f}), Q {:.6f} -> {:.6f} pu",
+                       svc->name(), v, vSetPU, qOld, qNew);
+  }
+  return anyChanged;
 }
 
 void PFSolverPowerPolar::clearReactiveLimitState() {

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -664,6 +664,11 @@ CPS::Bool PFSolverPowerPolar::enforceSvcVoltageControl() {
     return nullptr;
   };
 
+  // Per-unit floors for the secant sensitivity estimate (heuristic).
+  constexpr CPS::Real svcSecantDQFloor = 1e-15; // dQ below this is noise
+  constexpr CPS::Real svcMinSensitivity =
+      1e-9; // |dQ/dV| below this is degenerate
+
   CPS::Bool anyChanged = false;
   for (auto node : mPQBuses) {
     auto svc = svcAtNode(node);
@@ -688,10 +693,10 @@ CPS::Bool PFSolverPowerPolar::enforceSvcVoltageControl() {
     if (prev != mSvcPrevQV.end()) {
       CPS::Real dV = v - prev->second.second;
       CPS::Real dQ = qOld - prev->second.first;
-      if (std::abs(dV) > 1e-12 && std::abs(dQ) > 1e-15)
+      if (std::abs(dV) > DOUBLE_EPSILON && std::abs(dQ) > svcSecantDQFloor)
         dQdV = dQ / dV;
     }
-    if (!CPS::Math::isFinite(dQdV) || std::abs(dQdV) < 1e-9)
+    if (!CPS::Math::isFinite(dQdV) || std::abs(dQdV) < svcMinSensitivity)
       dQdV = 1.0; // degenerate sensitivity -> unit fallback
 
     CPS::Real qNew = qOld + mSvcDamping * dQdV * vErr;
@@ -701,7 +706,7 @@ CPS::Bool PFSolverPowerPolar::enforceSvcVoltageControl() {
       qNew = qMinPU;
 
     CPS::Real dq = qNew - qOld;
-    if (std::abs(dq) < 1e-12)
+    if (std::abs(dq) < DOUBLE_EPSILON)
       continue; // pinned at a limit or converged -> contributes to settling
 
     mSvcPrevQV[node] = std::make_pair(qOld, v);

--- a/dpsim/src/Simulation.cpp
+++ b/dpsim/src/Simulation.cpp
@@ -40,6 +40,7 @@ Simulation::Simulation(String name, Logger::Level logLevel)
       mPFMaxIterations(CPS::AttributeStatic<CPS::UInt>::make(20)),
       mPFSolverUseSparse(CPS::AttributeStatic<Bool>::make(false)),
       mPFEnforceReactiveLimits(CPS::AttributeStatic<Bool>::make(false)),
+      mPFEnforceSvcControl(CPS::AttributeStatic<Bool>::make(false)),
       mPFBaseVoltageLooseTolerance(CPS::AttributeStatic<Real>::make(0.1)),
       mPFBaseVoltageStrictTolerance(CPS::AttributeStatic<Real>::make(0.01)),
       mSplitSubnets(AttributeStatic<Bool>::make(true)),
@@ -58,6 +59,7 @@ Simulation::Simulation(String name, CommandLineArgs &args)
       mPFMaxIterations(CPS::AttributeStatic<CPS::UInt>::make(20)),
       mPFSolverUseSparse(CPS::AttributeStatic<Bool>::make(false)),
       mPFEnforceReactiveLimits(CPS::AttributeStatic<Bool>::make(false)),
+      mPFEnforceSvcControl(CPS::AttributeStatic<Bool>::make(false)),
       mPFBaseVoltageLooseTolerance(CPS::AttributeStatic<Real>::make(0.1)),
       mPFBaseVoltageStrictTolerance(CPS::AttributeStatic<Real>::make(0.01)),
       mSplitSubnets(AttributeStatic<Bool>::make(true)),
@@ -136,6 +138,7 @@ template <typename VarType> void Simulation::createSolvers() {
     pfSolver->setBaseApparentPowerFallback(**mPFBaseApparentPowerFallback);
     pfSolver->setMaxIterations(**mPFMaxIterations);
     pfSolver->setEnforceReactiveLimits(**mPFEnforceReactiveLimits);
+    pfSolver->setEnforceSvcControl(**mPFEnforceSvcControl);
     pfSolver->setBaseVoltageLooseTolerance(**mPFBaseVoltageLooseTolerance);
     pfSolver->setBaseVoltageStrictTolerance(**mPFBaseVoltageStrictTolerance);
 
@@ -383,6 +386,14 @@ void Simulation::setPFSolverEnforceReactiveLimits(Bool value) {
 
 Bool Simulation::getPFSolverEnforceReactiveLimits() const {
   return **mPFEnforceReactiveLimits;
+}
+
+void Simulation::setPFSolverEnforceSvcControl(Bool value) {
+  **mPFEnforceSvcControl = value;
+}
+
+Bool Simulation::getPFSolverEnforceSvcControl() const {
+  return **mPFEnforceSvcControl;
 }
 
 void Simulation::setPFSolverBaseVoltageLooseTolerance(Real tolerance) {

--- a/dpsim/src/pybind/SPComponents.cpp
+++ b/dpsim/src/pybind/SPComponents.cpp
@@ -163,6 +163,22 @@ void addSPPh1Components(py::module_ mSPPh1) {
       .def("get_apparent_power",
            &CPS::SP::Ph1::SynchronGenerator::getApparentPower);
 
+  py::class_<CPS::SP::Ph1::SVC, std::shared_ptr<CPS::SP::Ph1::SVC>,
+             CPS::SimPowerComp<CPS::Complex>>(mSPPh1, "SVC",
+                                              py::multiple_inheritance())
+      .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
+           "loglevel"_a = CPS::Logger::Level::off)
+      .def("set_parameters", &CPS::SP::Ph1::SVC::setParameters,
+           "rated_apparent_power"_a, "rated_voltage"_a, "set_point_voltage"_a,
+           "q_limit_max"_a = std::numeric_limits<double>::infinity(),
+           "q_limit_min"_a = -std::numeric_limits<double>::infinity())
+      .def("set_base_voltage", &CPS::SP::Ph1::SVC::setBaseVoltage,
+           "base_voltage"_a)
+      .def("connect", &CPS::SP::Ph1::SVC::connect)
+      .def("modify_power_flow_bus_type",
+           &CPS::SP::Ph1::SVC::modifyPowerFlowBusType, "bus_type"_a)
+      .def("get_apparent_power", &CPS::SP::Ph1::SVC::getApparentPower);
+
   py::class_<CPS::SP::Ph1::varResSwitch,
              std::shared_ptr<CPS::SP::Ph1::varResSwitch>,
              CPS::SimPowerComp<CPS::Complex>, CPS::Base::Ph1::Switch>(

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -253,6 +253,10 @@ PYBIND11_MODULE(dpsimpy, m) {
            &DPsim::Simulation::setPFSolverEnforceReactiveLimits)
       .def("get_pf_solver_enforce_q_limits",
            &DPsim::Simulation::getPFSolverEnforceReactiveLimits)
+      .def("set_pf_solver_enforce_svc_control",
+           &DPsim::Simulation::setPFSolverEnforceSvcControl)
+      .def("get_pf_solver_enforce_svc_control",
+           &DPsim::Simulation::getPFSolverEnforceSvcControl)
       .def("set_pf_solver_base_voltage_loose_tolerance",
            &DPsim::Simulation::setPFSolverBaseVoltageLooseTolerance)
       .def("get_pf_solver_base_voltage_loose_tolerance",

--- a/examples/Notebooks/Grids/PF_SVC_VoltageControl.ipynb
+++ b/examples/Notebooks/Grids/PF_SVC_VoltageControl.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "svc-intro",
+   "metadata": {},
+   "source": [
+    "# Static VAR compensator (SVC) voltage control\n",
+    "\n",
+    "DPsim's Newton-Raphson powerflow can hold an `SP::Ph1::SVC` bus at a voltage setpoint by moving the device's reactive injection within its Q band, an outer loop that runs alongside the generator Q-limit switching. Enforcement is opt-in via `set_pf_solver_enforce_svc_control(True)` on the `Simulation` (default off). Inside the band the SVC holds the bus at its setpoint; at the band edge the injection pins at Qmax or Qmin and the voltage misses the setpoint.\n",
+    "\n",
+    "This notebook uses a hand-wired three-bus case (slack, two PiLines, a mid-bus load, and an SVC at the far bus) and checks the behaviour under both the dense and sparse solvers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "svc-imports",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "import dpsimpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "svc-runpf",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASE_V = 110e3\n",
+    "BASE_S = 100e6\n",
+    "\n",
+    "\n",
+    "def run_pf(\n",
+    "    v_set_pu, q_max_mvar, q_min_mvar, load_p_mw, load_q_mvar, enforce, use_sparse\n",
+    "):\n",
+    "    n1 = dpsimpy.sp.SimNode(\"n1\", dpsimpy.PhaseType.Single)\n",
+    "    n2 = dpsimpy.sp.SimNode(\"n2\", dpsimpy.PhaseType.Single)\n",
+    "    n3 = dpsimpy.sp.SimNode(\"n3\", dpsimpy.PhaseType.Single)\n",
+    "\n",
+    "    slack = dpsimpy.sp.ph1.SynchronGenerator(\"slack\")\n",
+    "    slack.set_parameters(\n",
+    "        rated_apparent_power=BASE_S,\n",
+    "        rated_voltage=BASE_V,\n",
+    "        set_point_active_power=0.0,\n",
+    "        set_point_voltage=BASE_V,\n",
+    "        powerflow_bus_type=dpsimpy.PowerflowBusType.VD,\n",
+    "    )\n",
+    "    slack.set_base_voltage(BASE_V)\n",
+    "    slack.modify_power_flow_bus_type(dpsimpy.PowerflowBusType.VD)\n",
+    "    slack.connect([n1])\n",
+    "\n",
+    "    load = dpsimpy.sp.ph1.Load(\"load\")\n",
+    "    load.set_parameters(load_p_mw * 1e6, load_q_mvar * 1e6, BASE_V)\n",
+    "    load.modify_power_flow_bus_type(dpsimpy.PowerflowBusType.PQ)\n",
+    "    load.connect([n2])\n",
+    "\n",
+    "    svc = dpsimpy.sp.ph1.SVC(\"svc\")\n",
+    "    svc.set_parameters(\n",
+    "        rated_apparent_power=BASE_S,\n",
+    "        rated_voltage=BASE_V,\n",
+    "        set_point_voltage=v_set_pu * BASE_V,\n",
+    "        q_limit_max=q_max_mvar * 1e6,\n",
+    "        q_limit_min=q_min_mvar * 1e6,\n",
+    "    )\n",
+    "    svc.set_base_voltage(BASE_V)\n",
+    "    svc.connect([n3])\n",
+    "\n",
+    "    z_base = BASE_V**2 / BASE_S\n",
+    "    line12 = dpsimpy.sp.ph1.PiLine(\"line12\")\n",
+    "    line12.set_parameters(0.02 * z_base, 0.08 * z_base / (2 * math.pi * 50), 0.0, 0.0)\n",
+    "    line12.set_base_voltage(BASE_V)\n",
+    "    line12.connect([n1, n2])\n",
+    "\n",
+    "    line23 = dpsimpy.sp.ph1.PiLine(\"line23\")\n",
+    "    line23.set_parameters(0.02 * z_base, 0.08 * z_base / (2 * math.pi * 50), 0.0, 0.0)\n",
+    "    line23.set_base_voltage(BASE_V)\n",
+    "    line23.connect([n2, n3])\n",
+    "\n",
+    "    system = dpsimpy.SystemTopology(\n",
+    "        50, [n1, n2, n3], [slack, load, svc, line12, line23]\n",
+    "    )\n",
+    "\n",
+    "    sim = dpsimpy.Simulation(\"svc_pf\", dpsimpy.LogLevel.off)\n",
+    "    sim.set_system(system)\n",
+    "    sim.set_time_step(0.1)\n",
+    "    sim.set_final_time(0.1)\n",
+    "    sim.set_domain(dpsimpy.Domain.SP)\n",
+    "    sim.set_solver(dpsimpy.Solver.NRP)\n",
+    "    sim.set_solver_component_behaviour(dpsimpy.SolverBehaviour.Simulation)\n",
+    "    sim.set_pf_solver_use_sparse(use_sparse)\n",
+    "    sim.set_pf_solver_enforce_svc_control(enforce)\n",
+    "    sim.run()\n",
+    "\n",
+    "    v_svc = abs(complex(n3.single_voltage()) / BASE_V)\n",
+    "    q_svc = svc.get_apparent_power().imag / 1e6\n",
+    "    return v_svc, q_svc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "svc-cases-md",
+   "metadata": {},
+   "source": [
+    "The load moves the far bus off nominal: an inductive load pulls it down, a capacitive load pushes it up. A wide Q band lets the SVC reach its setpoint; a tight band forces it to pin at the reactive limit and miss. With enforcement off the SVC injects nothing and the bus is left uncompensated. The cases below exercise a hold by injecting, a hold by absorbing, a pin at each limit, and the enforcement-off baseline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "svc-cases",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# label, Vset [pu], Qmax [MVAr], Qmin [MVAr], load P [MW], load Q [MVAr], enforce, expected\n",
+    "CASES = [\n",
+    "    (\"wide band, inductive load, holds\", 1.00, 1000, -1000, 30, 15, True, \"hold\"),\n",
+    "    (\"tight Qmax, inductive load, pins max\", 1.00, 5, -5, 30, 15, True, \"max\"),\n",
+    "    (\"wide band, capacitive load, holds\", 0.98, 1000, -1000, 5, -60, True, \"hold\"),\n",
+    "    (\"tight Qmin, capacitive load, pins min\", 0.98, 5, -5, 5, -60, True, \"min\"),\n",
+    "    (\"enforcement off, no support\", 1.00, 1000, -1000, 30, 15, False, \"off\"),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "svc-run",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = []\n",
+    "for use_sparse in (False, True):\n",
+    "    for label, v_set, q_max, q_min, load_p, load_q, enforce, expected in CASES:\n",
+    "        v, q = run_pf(v_set, q_max, q_min, load_p, load_q, enforce, use_sparse)\n",
+    "        rows.append(\n",
+    "            {\n",
+    "                \"case\": label,\n",
+    "                \"solver\": \"sparse\" if use_sparse else \"dense\",\n",
+    "                \"Vset [pu]\": v_set,\n",
+    "                \"Qmax [MVAr]\": q_max,\n",
+    "                \"Qmin [MVAr]\": q_min,\n",
+    "                \"expected\": expected,\n",
+    "                \"V [pu]\": v,\n",
+    "                \"SVC Q [MVAr]\": q,\n",
+    "            }\n",
+    "        )\n",
+    "results = pd.DataFrame(rows)\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "svc-assert",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for _, row in results.iterrows():\n",
+    "    if row[\"expected\"] == \"max\":\n",
+    "        assert (\n",
+    "            abs(row[\"SVC Q [MVAr]\"] - row[\"Qmax [MVAr]\"]) < 0.5\n",
+    "        ), f\"{row['solver']}/{row['case']}: SVC not pinned at Qmax\"\n",
+    "    elif row[\"expected\"] == \"min\":\n",
+    "        assert (\n",
+    "            abs(row[\"SVC Q [MVAr]\"] - row[\"Qmin [MVAr]\"]) < 0.5\n",
+    "        ), f\"{row['solver']}/{row['case']}: SVC not pinned at Qmin\"\n",
+    "    elif row[\"expected\"] == \"hold\":\n",
+    "        assert (\n",
+    "            abs(row[\"V [pu]\"] - row[\"Vset [pu]\"]) < 1e-3\n",
+    "        ), f\"{row['solver']}/{row['case']}: SVC bus not held at Vset\"\n",
+    "    else:\n",
+    "        assert (\n",
+    "            abs(row[\"SVC Q [MVAr]\"]) < 1e-6\n",
+    "        ), f\"{row['solver']}/{row['case']}: SVC injected with enforcement off\"\n",
+    "\n",
+    "print(\"all SVC voltage-control cases passed\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/Notebooks/Grids/PF_SVC_VoltageControl.ipynb
+++ b/examples/Notebooks/Grids/PF_SVC_VoltageControl.ipynb
@@ -14,8 +14,8 @@
   },
   {
    "cell_type": "code",
-   "id": "svc-imports",
    "execution_count": null,
+   "id": "svc-imports",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,8 +29,8 @@
   },
   {
    "cell_type": "code",
-   "id": "svc-runpf",
    "execution_count": null,
+   "id": "svc-runpf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,8 +114,8 @@
   },
   {
    "cell_type": "code",
-   "id": "svc-cases",
    "execution_count": null,
+   "id": "svc-cases",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,8 +131,8 @@
   },
   {
    "cell_type": "code",
-   "id": "svc-run",
    "execution_count": null,
+   "id": "svc-run",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,8 +158,8 @@
   },
   {
    "cell_type": "code",
-   "id": "svc-assert",
    "execution_count": null,
+   "id": "svc-assert",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Adds the solver-side outer loop that holds each SVC bus at its voltage setpoint. Opt in via `set_pf_solver_enforce_svc_control`.

Needs #580 