### PR TITLE
 add DP::Ph3::Switch three-phase matrix switch

### DIFF
--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -100,6 +100,7 @@
 #include <dpsim-models/DP/DP_Ph3_SSN_Full_Serial_RLC.h>
 #include <dpsim-models/DP/DP_Ph3_SeriesResistor.h>
 #include <dpsim-models/DP/DP_Ph3_SeriesSwitch.h>
+#include <dpsim-models/DP/DP_Ph3_Switch.h>
 #include <dpsim-models/DP/DP_Ph3_SynchronGeneratorDQTrapez.h>
 #include <dpsim-models/DP/DP_Ph3_TwoTerminalITypeSSNComp.h>
 #include <dpsim-models/DP/DP_Ph3_TwoTerminalVTypeSSNComp.h>

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_Switch.h
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/Base/Base_Ph3_Switch.h>
+#include <dpsim-models/Definitions.h>
+#include <dpsim-models/Logger.h>
+#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Solver/MNASwitchInterface.h>
+#include <dpsim-models/Solver/MNAVariableCompInterface.h>
+
+namespace CPS {
+namespace DP {
+namespace Ph3 {
+/// \brief Dynamic phasor three-phase switch with per-phase resistance.
+///
+/// The switch can be opened and closed; each state has its own 3x3 resistance
+/// matrix. An asymmetric closed matrix (e.g. one low diagonal entry) models a
+/// single-phase fault. DP analogue of EMT::Ph3::Switch, driven by SwitchEvent3Ph.
+class Switch : public MNASimPowerComp<Complex>,
+               public Base::Ph3::Switch,
+               public SharedFactory<Switch>,
+               public MNAVariableCompInterface,
+               public MNASwitchInterface {
+public:
+  /// Defines UID, name, component parameters and logging level
+  Switch(String uid, String name, Logger::Level loglevel = Logger::Level::off);
+  /// Defines name, component parameters and logging level
+  Switch(String name, Logger::Level logLevel = Logger::Level::off)
+      : Switch(name, name, logLevel) {}
+
+  SimPowerComp<Complex>::Ptr clone(String name) override;
+
+  // #### General ####
+  /// Initializes component from power flow data
+  void initializeFromNodesAndTerminals(Real frequency) override;
+
+  // #### General MNA section ####
+  void mnaCompInitialize(Real omega, Real timeStep,
+                         Attribute<Matrix>::Ptr leftVector) override;
+  /// Stamps system matrix
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
+  /// Update interface voltage from MNA system result
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
+  /// Update interface current from MNA system result
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
+
+  // #### MNA section for switches ####
+  /// Check if switch is closed
+  Bool mnaIsClosed() override;
+  /// Stamps system matrix considering the defined switch position
+  void mnaCompApplySwitchSystemMatrixStamp(Bool closed,
+                                           SparseMatrixRow &systemMatrix,
+                                           Int freqIdx) override;
+
+  void mnaCompPostStep(Real time, Int timeStepCount,
+                       Attribute<Matrix>::Ptr &leftVector) override;
+
+  /// Add MNA post step dependencies
+  void
+  mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
+                                 AttributeBase::List &attributeDependencies,
+                                 AttributeBase::List &modifiedAttributes,
+                                 Attribute<Matrix>::Ptr &leftVector) override;
+
+  // #### MNA section for variable component ####
+  Bool hasParameterChanged() override;
+};
+} // namespace Ph3
+} // namespace DP
+} // namespace CPS

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -73,6 +73,7 @@ list(APPEND MODELS_SOURCES
 	DP/DP_Ph3_PiLine.cpp
 	DP/DP_Ph3_SeriesResistor.cpp
 	DP/DP_Ph3_SeriesSwitch.cpp
+	DP/DP_Ph3_Switch.cpp
 	DP/DP_Ph3_SynchronGeneratorDQ.cpp
 	DP/DP_Ph3_SynchronGeneratorDQTrapez.cpp
 	# DP/DP_Ph3_SynchronGeneratorDQSmpl.cpp

--- a/dpsim-models/src/DP/DP_Ph3_Switch.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_Switch.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/DP/DP_Ph3_Switch.h>
+
+using namespace CPS;
+
+DP::Ph3::Switch::Switch(String uid, String name, Logger::Level logLevel)
+    : MNASimPowerComp<Complex>(uid, name, false, true, logLevel),
+      Base::Ph3::Switch(mAttributes) {
+  mPhaseType = PhaseType::ABC;
+  setTerminalNumber(2);
+  **mIntfVoltage = MatrixComp::Zero(3, 1);
+  **mIntfCurrent = MatrixComp::Zero(3, 1);
+}
+
+SimPowerComp<Complex>::Ptr DP::Ph3::Switch::clone(String name) {
+  auto copy = Switch::make(name, mLogLevel);
+  copy->setParameters(**mOpenResistance, **mClosedResistance, **mIsClosed);
+  return copy;
+}
+
+void DP::Ph3::Switch::initializeFromNodesAndTerminals(Real frequency) {
+  mTerminals[0]->setPhaseType(PhaseType::ABC);
+  mTerminals[1]->setPhaseType(PhaseType::ABC);
+
+  Matrix impedance = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
+  // Voltage across component is defined as V1 - V0.
+  **mIntfVoltage = initialVoltage(1) - initialVoltage(0);
+  **mIntfCurrent = impedance.inverse() * **mIntfVoltage;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- Initialization from powerflow ---"
+                     "\nVoltage across phasor: \n{:s}"
+                     "\nCurrent phasor: \n{:s}"
+                     "\nTerminal 0 voltage phasor: \n{:s}"
+                     "\nTerminal 1 voltage phasor: \n{:s}"
+                     "\n--- Initialization from powerflow finished ---",
+                     Logger::phasorMatrixToString(**mIntfVoltage),
+                     Logger::phasorMatrixToString(**mIntfCurrent),
+                     Logger::phasorMatrixToString(initialVoltage(0)),
+                     Logger::phasorMatrixToString(initialVoltage(1)));
+}
+
+void DP::Ph3::Switch::mnaCompInitialize(Real omega, Real timeStep,
+                                        Attribute<Matrix>::Ptr leftVector) {
+  updateMatrixNodeIndices();
+  **mRightVector = Matrix::Zero(0, 0);
+}
+
+Bool DP::Ph3::Switch::mnaIsClosed() { return **mIsClosed; }
+
+void DP::Ph3::Switch::mnaCompApplySystemMatrixStamp(
+    SparseMatrixRow &systemMatrix) {
+  MatrixFixedSizeComp<3, 3> conductance = Matrix::Zero(3, 3);
+  conductance.real() = (**mIsClosed) ? (**mClosedResistance).inverse()
+                                     : (**mOpenResistance).inverse();
+
+  MNAStampUtils::stampAdmittanceMatrix(
+      conductance, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
+      terminalNotGrounded(0), terminalNotGrounded(1), mSLog);
+}
+
+void DP::Ph3::Switch::mnaCompApplySwitchSystemMatrixStamp(
+    Bool closed, SparseMatrixRow &systemMatrix, Int freqIdx) {
+  MatrixFixedSizeComp<3, 3> conductance = Matrix::Zero(3, 3);
+  conductance.real() = (closed) ? (**mClosedResistance).inverse()
+                                : (**mOpenResistance).inverse();
+
+  MNAStampUtils::stampAdmittanceMatrix(
+      conductance, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
+      terminalNotGrounded(0), terminalNotGrounded(1), mSLog);
+}
+
+void DP::Ph3::Switch::mnaCompAddPostStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes,
+    Attribute<Matrix>::Ptr &leftVector) {
+  attributeDependencies.push_back(leftVector);
+  modifiedAttributes.push_back(mIntfVoltage);
+  modifiedAttributes.push_back(mIntfCurrent);
+}
+
+void DP::Ph3::Switch::mnaCompPostStep(Real time, Int timeStepCount,
+                                      Attribute<Matrix>::Ptr &leftVector) {
+  mnaCompUpdateVoltage(**leftVector);
+  mnaCompUpdateCurrent(**leftVector);
+}
+
+void DP::Ph3::Switch::mnaCompUpdateVoltage(const Matrix &leftVector) {
+  // Voltage across component is defined as V1 - V0.
+  **mIntfVoltage = MatrixComp::Zero(3, 1);
+  if (terminalNotGrounded(1)) {
+    (**mIntfVoltage)(0, 0) =
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 0));
+    (**mIntfVoltage)(1, 0) =
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 1));
+    (**mIntfVoltage)(2, 0) =
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 2));
+  }
+  if (terminalNotGrounded(0)) {
+    (**mIntfVoltage)(0, 0) =
+        (**mIntfVoltage)(0, 0) -
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 0));
+    (**mIntfVoltage)(1, 0) =
+        (**mIntfVoltage)(1, 0) -
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 1));
+    (**mIntfVoltage)(2, 0) =
+        (**mIntfVoltage)(2, 0) -
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 2));
+  }
+}
+
+void DP::Ph3::Switch::mnaCompUpdateCurrent(const Matrix &leftVector) {
+  MatrixFixedSizeComp<3, 3> conductance = Matrix::Zero(3, 3);
+  conductance.real() = (**mIsClosed) ? (**mClosedResistance).inverse()
+                                     : (**mOpenResistance).inverse();
+
+  **mIntfCurrent = conductance * **mIntfVoltage;
+}
+
+Bool DP::Ph3::Switch::hasParameterChanged() {
+  // Recompute the system matrix only when the switch state changed.
+  if (!(mIsClosedPrev == this->mnaIsClosed())) {
+    mIsClosedPrev = this->mnaIsClosed();
+    return 1;
+  } else {
+    return 0;
+  }
+}

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -47,6 +47,7 @@ set(CIRCUIT_SOURCES
 	Circuits/DP_Ph3_RLC1VS1_RC_vs_SSN.cpp
 	Circuits/DP_Ph3_R3C1L1CS1_RC_vs_SSN.cpp
 	Circuits/DP_Ph3_R3C1L1CS1_RC_vs_SSN_Fault.cpp
+	Circuits/DP_Ph3_Switch_vs_SeriesSwitch.cpp
 	Circuits/EMT_Ph3_R3C1L1CS1_RC_vs_SSN_Fault.cpp
 
 	# EMT examples with PF initialization

--- a/dpsim/examples/cxx/Circuits/DP_Ph3_Switch_vs_SeriesSwitch.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_Ph3_Switch_vs_SeriesSwitch.cpp
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <DPsim.h>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+
+using namespace DPsim;
+using namespace CPS::DP;
+
+// Parity check: a balanced diagonal R must reproduce DP::Ph3::SeriesSwitch, and
+// an asymmetric closed matrix (phase A only) must give per-phase-diverging
+// current, the capability SeriesSwitch lacks.
+
+static const Real switchOpenR = 1e6;
+static const Real switchClosedR = 0.001;
+static const Real startTimeFault = 0.03;
+static const Real endTimeFault = 0.06;
+static const Real timeStep = 0.0001;
+static const Real finalTime = 0.1;
+
+static Matrix identity3() {
+  Matrix m = Matrix::Zero(3, 3);
+  m << 1., 0, 0, 0, 1., 0, 0, 0, 1.;
+  return m;
+}
+
+// Builds the shared R-network and returns the two nodes.
+static void buildNetwork(SimNode::Ptr &n1, SimNode::Ptr &n2,
+                         SystemComponentList &comps) {
+  const Matrix param = identity3();
+
+  auto cs0 = Ph3::CurrentSource::make("CS0");
+  cs0->setParameters(
+      CPS::Math::singlePhaseVariableToThreePhase(CPS::Math::polar(1.0, 0.0)));
+  auto r1 = Ph3::Resistor::make("R1");
+  r1->setParameters(10 * param);
+  auto r2 = Ph3::Resistor::make("R2");
+  r2->setParameters(param);
+
+  cs0->connect(SimNode::List{n1, SimNode::GND});
+  r1->connect(SimNode::List{n2, n1});
+  r2->connect(SimNode::List{n2, SimNode::GND});
+
+  comps = SystemComponentList{cs0, r1, r2};
+}
+
+static void runSeriesSwitch(const String &simName) {
+  auto n1 = SimNode::make("n1", PhaseType::ABC);
+  auto n2 = SimNode::make("n2", PhaseType::ABC);
+  SystemComponentList comps;
+  buildNetwork(n1, n2, comps);
+
+  auto fault = Ph3::SeriesSwitch::make("fault");
+  fault->setParameters(switchOpenR, switchClosedR);
+  fault->open();
+  fault->connect(SimNode::List{n2, SimNode::GND});
+  comps.push_back(fault);
+
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2}, comps);
+
+  Logger::setLogDir("logs/" + simName);
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v_n2", n2->attribute("v"));
+  logger->logAttribute("i_fault", fault->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addEvent(SwitchEvent::make(startTimeFault, fault, true));
+  sim.addEvent(SwitchEvent::make(endTimeFault, fault, false));
+  sim.run();
+}
+
+// closedR is the 3x3 closed-state resistance matrix (diagonal per phase).
+static void runNewSwitch(const String &simName, const Matrix &closedR) {
+  auto n1 = SimNode::make("n1", PhaseType::ABC);
+  auto n2 = SimNode::make("n2", PhaseType::ABC);
+  SystemComponentList comps;
+  buildNetwork(n1, n2, comps);
+
+  auto fault = Ph3::Switch::make("fault");
+  fault->setParameters(switchOpenR * identity3(), closedR);
+  fault->openSwitch();
+  fault->connect(SimNode::List{n2, SimNode::GND});
+  comps.push_back(fault);
+
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2}, comps);
+
+  Logger::setLogDir("logs/" + simName);
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v_n2", n2->attribute("v"));
+  logger->logAttribute("i_fault", fault->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::DP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addEvent(SwitchEvent3Ph::make(startTimeFault, fault, true));
+  sim.addEvent(SwitchEvent3Ph::make(endTimeFault, fault, false));
+  sim.run();
+}
+
+static String trim(const String &s) {
+  const size_t a = s.find_first_not_of(" \t\r\n");
+  if (a == String::npos)
+    return "";
+  const size_t b = s.find_last_not_of(" \t\r\n");
+  return s.substr(a, b - a + 1);
+}
+
+struct CsvData {
+  std::vector<String> names;           // column headers, trimmed
+  std::vector<std::vector<Real>> rows; // numeric rows
+  std::map<String, size_t> colByName;  // header -> column index
+
+  Real at(size_t row, const String &name) const {
+    return rows.at(row).at(colByName.at(name));
+  }
+  bool has(const String &name) const { return colByName.count(name) > 0; }
+};
+
+static CsvData readCsv(const String &simName) {
+  const String path = "logs/" + simName + "/" + simName + ".csv";
+  std::ifstream file(path);
+  if (!file.is_open())
+    throw std::runtime_error("Could not open CSV: " + path);
+
+  CsvData data;
+  String line;
+  std::getline(file, line); // header
+  {
+    std::stringstream ss(line);
+    String cell;
+    while (std::getline(ss, cell, ','))
+      data.names.push_back(trim(cell));
+  }
+  for (size_t i = 0; i < data.names.size(); ++i)
+    data.colByName[data.names[i]] = i;
+
+  while (std::getline(file, line)) {
+    if (trim(line).empty())
+      continue;
+    std::vector<Real> row;
+    std::stringstream ss(line);
+    String cell;
+    while (std::getline(ss, cell, ','))
+      row.push_back(std::stod(cell));
+    data.rows.push_back(row);
+  }
+  return data;
+}
+
+// Magnitude of a complex column pair name.re / name.im at a given row.
+static Real magAt(const CsvData &d, size_t row, const String &base) {
+  const Real re = d.at(row, base + ".re");
+  const Real im = d.at(row, base + ".im");
+  return std::sqrt(re * re + im * im);
+}
+
+int main(int argc, char *argv[]) {
+  const String nameSeries = "DP_Ph3_Switch_vs_SeriesSwitch_Series";
+  const String nameBalanced = "DP_Ph3_Switch_vs_SeriesSwitch_Balanced";
+  const String nameAsym = "DP_Ph3_Switch_vs_SeriesSwitch_Asymmetric";
+
+  runSeriesSwitch(nameSeries);
+  runNewSwitch(nameBalanced, switchClosedR * identity3());
+
+  // Asymmetric: only phase A shorts; phases B and C stay effectively open.
+  Matrix closedAsym = Matrix::Zero(3, 3);
+  closedAsym(0, 0) = switchClosedR;
+  closedAsym(1, 1) = switchOpenR;
+  closedAsym(2, 2) = switchOpenR;
+  runNewSwitch(nameAsym, closedAsym);
+
+  // Balanced parity: a balanced diagonal R must reproduce SeriesSwitch's v_n2.
+  const auto series = readCsv(nameSeries);
+  const auto balanced = readCsv(nameBalanced);
+  if (series.rows.size() != balanced.rows.size())
+    throw std::runtime_error("Row count mismatch between the two runs.");
+
+  const std::vector<String> voltageCols = {"v_n2_0.re", "v_n2_0.im",
+                                           "v_n2_1.re", "v_n2_1.im",
+                                           "v_n2_2.re", "v_n2_2.im"};
+  Real maxDiff = 0.0;
+  for (size_t i = 0; i < series.rows.size(); ++i)
+    for (const auto &c : voltageCols)
+      maxDiff =
+          std::max(maxDiff, std::abs(series.at(i, c) - balanced.at(i, c)));
+
+  std::cout << "Balanced parity max abs v_n2 diff: " << maxDiff << std::endl;
+  if (maxDiff > 1e-9)
+    throw std::runtime_error(
+        "DP::Ph3::Switch does not match DP::Ph3::SeriesSwitch in the balanced "
+        "case.");
+
+  // Asymmetric fault: phase-A current must dominate B and C.
+  const auto asym = readCsv(nameAsym);
+  Real faultPhaseA = 0.0, faultPhaseB = 0.0;
+  for (size_t i = 0; i < asym.rows.size(); ++i) {
+    const Real t = asym.at(i, "time");
+    if (t <= startTimeFault || t >= endTimeFault)
+      continue;
+    faultPhaseA = std::max(faultPhaseA, magAt(asym, i, "i_fault_0"));
+    faultPhaseB = std::max(faultPhaseB, magAt(asym, i, "i_fault_1"));
+  }
+  std::cout << "Asymmetric fault |I_A|=" << faultPhaseA
+            << "  |I_B|=" << faultPhaseB << std::endl;
+  if (!(faultPhaseA > 100.0 * faultPhaseB))
+    throw std::runtime_error(
+        "Asymmetric switch did not produce a single-phase-dominant current.");
+
+  std::cout << "DP_Ph3_Switch parity checks PASSED." << std::endl;
+  return 0;
+}

--- a/dpsim/src/pybind/DPComponents.cpp
+++ b/dpsim/src/pybind/DPComponents.cpp
@@ -612,6 +612,19 @@ void addDPPh3Components(py::module_ mDPPh3) {
       .def("close", &CPS::DP::Ph3::SeriesSwitch::close)
       .def("connect", &CPS::DP::Ph3::SeriesSwitch::connect);
 
+  py::class_<CPS::DP::Ph3::Switch, std::shared_ptr<CPS::DP::Ph3::Switch>,
+             CPS::SimPowerComp<CPS::Complex>, CPS::Base::Ph3::Switch>(
+      mDPPh3, "Switch", py::multiple_inheritance())
+      .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
+           "loglevel"_a = CPS::Logger::Level::off)
+      .def("set_parameters", &CPS::DP::Ph3::Switch::setParameters,
+           "open_resistance"_a, "closed_resistance"_a,
+           // cppcheck-suppress assignBoolToPointer
+           "closed"_a = false)
+      .def("open", &CPS::DP::Ph3::Switch::openSwitch)
+      .def("close", &CPS::DP::Ph3::Switch::closeSwitch)
+      .def("connect", &CPS::DP::Ph3::Switch::connect);
+
   py::class_<CPS::DP::Ph3::SSN::Full_Serial_RLC,
              std::shared_ptr<CPS::DP::Ph3::SSN::Full_Serial_RLC>,
              CPS::SimPowerComp<CPS::Complex>>(mDPPh3, "Full_Serial_RLC",


### PR DESCRIPTION
Adds `DP::Ph3::Switch`, a 3x3 open/closed conductance switch for the DP domain