### PR TITLE
refactor: shared elementwise complex-product helper

### DIFF
--- a/dpsim-models/include/dpsim-models/MathUtils.h
+++ b/dpsim-models/include/dpsim-models/MathUtils.h
@@ -34,6 +34,13 @@ public:
   static Complex polar(Real abs, Real phase);
   static Complex polarDeg(Real abs, Real phase);
 
+  /// Elementwise product of two same-shaped Eigen expressions.
+  template <typename DerivedA, typename DerivedB>
+  static auto elementwiseProduct(const Eigen::MatrixBase<DerivedA> &a,
+                                 const Eigen::MatrixBase<DerivedB> &b) {
+    return (a.array() * b.array()).matrix();
+  }
+
   // -Ofast/-ffast-math folds std::isnan/isfinite to false; test the IEEE-754
   // exponent bits directly instead.
   static bool isFinite(Real value);

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -386,7 +386,8 @@ void PFSolverPowerPolar::calculateBranchFlow() {
     /// I = Y * V
     VectorComp current = line->Y_element() * v;
     /// pf on branch [S_01; S_10] = [V_0 * conj(I_0); V_1 * conj(I_1)]
-    VectorComp flow_on_branch = v.array() * current.conjugate().array();
+    VectorComp flow_on_branch =
+        Math::elementwiseProduct(v, current.conjugate());
     line->updateBranchFlow(current, flow_on_branch);
   }
   for (auto trafo : mTransformers) {
@@ -396,7 +397,8 @@ void PFSolverPowerPolar::calculateBranchFlow() {
     /// I = Y * V
     VectorComp current = trafo->Y_element() * v;
     /// pf on branch [S_01; S_10] = [V_0 * conj(I_0); V_1 * conj(I_1)]
-    VectorComp flow_on_branch = v.array() * current.conjugate().array();
+    VectorComp flow_on_branch =
+        Math::elementwiseProduct(v, current.conjugate());
     trafo->updateBranchFlow(current, flow_on_branch);
   }
 }

--- a/dpsim/src/StateSpaceModalAnalysis.cpp
+++ b/dpsim/src/StateSpaceModalAnalysis.cpp
@@ -4,6 +4,7 @@
 #include <Eigen/Eigenvalues>
 #include <Eigen/LU>
 
+#include <dpsim-models/MathUtils.h>
 #include <dpsim/StateSpaceModalAnalysis.h>
 
 #include <cmath>
@@ -92,15 +93,8 @@ void StateSpaceModalAnalysis::update() {
 
   mLeftEigenvectors = eigenvectorLu.inverse();
 
-  mParticipationFactors.resize(mRightEigenvectors.rows(),
-                               mRightEigenvectors.cols());
-
-  for (Eigen::Index mode = 0; mode < mRightEigenvectors.cols(); ++mode) {
-    for (Eigen::Index state = 0; state < mRightEigenvectors.rows(); ++state) {
-      mParticipationFactors(state, mode) =
-          mRightEigenvectors(state, mode) * mLeftEigenvectors(mode, state);
-    }
-  }
+  mParticipationFactors = CPS::Math::elementwiseProduct(
+      mRightEigenvectors, mLeftEigenvectors.transpose());
 }
 
 Matrix


### PR DESCRIPTION
Adds `Math::elementwiseProduct(a, b)` to `MathUtils.h` and routes existing Hadamard-product sites through it