### PR TITLE
Generic Ph1 two-terminal linear SSN components for SP domain

### DIFF
--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -20,6 +20,8 @@
 #include <dpsim-models/SP/SP_Ph1_PiLine.h>
 #include <dpsim-models/SP/SP_Ph1_RXLine.h>
 #include <dpsim-models/SP/SP_Ph1_ReducedOrderSynchronGeneratorVBR.h>
+#include <dpsim-models/SP/SP_Ph1_SSNTypeI2T.h>
+#include <dpsim-models/SP/SP_Ph1_SSNTypeV2T.h>
 #include <dpsim-models/SP/SP_Ph1_Shunt.h>
 #include <dpsim-models/SP/SP_Ph1_SolidStateTransformer.h>
 #include <dpsim-models/SP/SP_Ph1_Switch.h>

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SSNTypeI2T.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SSNTypeI2T.h
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Solver/MNATearInterface.h>
+#include <dpsim-models/Solver/PFSolverInterfaceBranch.h>
+
+namespace CPS {
+namespace SP {
+namespace Ph1 {
+/// \brief SSNTypeI2T
+/// Model for a one phase, two terminal I-type SSN component which can be represented using
+/// a state space equation system
+/// x' = A * x + B * u
+/// y = C * x + D * u
+/// with x: state vector, y: output vector, u: input vector,
+/// where u represents external current (mIntfCurrent),
+/// y represents external voltage (mIntfVoltage),
+/// x represents any component states.
+class SSNTypeI2T : public MNASimPowerComp<Complex>,
+                   public SharedFactory<SSNTypeI2T> {
+private:
+protected:
+  MatrixComp mA;
+  MatrixComp mB;
+  MatrixComp mC;
+  MatrixComp mD;
+
+  MatrixComp mX;
+  MatrixComp mU;
+  MatrixComp mUPrev;
+
+  Complex mAdmittance;
+
+public:
+  /// Defines UID, name, component parameters and logging level
+  SSNTypeI2T(String uid, String name,
+             Logger::Level logLevel = Logger::Level::off);
+  /// Defines name and logging level
+  SSNTypeI2T(String name, Logger::Level logLevel = Logger::Level::off)
+      : SSNTypeI2T(name, name, logLevel) {}
+
+  SimPowerComp<Complex>::Ptr clone(String name) override;
+
+  // #### General ####
+  void calculateAdmittance(Real omega);
+  void setParameters(const MatrixComp &A, const MatrixComp &B,
+                     const MatrixComp &C, const MatrixComp &D);
+
+  // #### Powerflow section ####
+  /// Initializes component from power flow data
+  void initializeFromNodesAndTerminals(Real frequency) override;
+
+  // #### MNA section ####
+  /// Initializes internal variables of the component
+  void mnaCompInitialize(Real omega, Real timeStep,
+                         Attribute<Matrix>::Ptr leftVector) override;
+  /// Stamps system matrix
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
+  /// Update interface voltage from MNA system result
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
+  /// Update interface current from MNA system result
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
+
+  void mnaCompPostStep(Real time, Int timeStepCount,
+                       Attribute<Matrix>::Ptr &leftVector) override;
+  /// Add MNA post step dependencies
+  void
+  mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
+                                 AttributeBase::List &attributeDependencies,
+                                 AttributeBase::List &modifiedAttributes,
+                                 Attribute<Matrix>::Ptr &leftVector) override;
+};
+} // namespace Ph1
+} // namespace SP
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SSNTypeV2T.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SSNTypeV2T.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/MNASimPowerComp.h>
+#include <dpsim-models/Solver/MNATearInterface.h>
+
+namespace CPS {
+namespace SP {
+namespace Ph1 {
+/// \brief SSNTypeV2T
+/// Model for a one phase, two terminal V-type SSN component which can be represented using
+/// a state space equation system
+/// x' = A * x + B * u
+/// y = C * x + D * u
+/// with x: state vector, y: output vector, u: input vector,
+/// where u represents external voltage (mIntfVoltage),
+/// y represents external current (mIntfCurrent),
+/// x represents any component states.
+class SSNTypeV2T : public MNASimPowerComp<Complex>,
+                   public SharedFactory<SSNTypeV2T> {
+private:
+protected:
+  MatrixComp mA;
+  MatrixComp mB;
+  MatrixComp mC;
+  MatrixComp mD;
+
+  MatrixComp mX;
+  MatrixComp mU;
+  MatrixComp mUPrev;
+
+  Complex mAdmittance;
+
+public:
+  /// Defines UID, name, component parameters and logging level
+  SSNTypeV2T(String uid, String name,
+             Logger::Level logLevel = Logger::Level::off);
+  /// Defines name and logging level
+  SSNTypeV2T(String name, Logger::Level logLevel = Logger::Level::off)
+      : SSNTypeV2T(name, name, logLevel) {}
+
+  SimPowerComp<Complex>::Ptr clone(String name) override;
+
+  // #### General ####
+  void calculateAdmittance(Real omega);
+  void setParameters(const MatrixComp &A, const MatrixComp &B,
+                     const MatrixComp &C, const MatrixComp &D);
+  /// Initializes component from power flow data
+  void initializeFromNodesAndTerminals(Real frequency) override;
+
+  // #### MNA section ####
+  /// Initializes internal variables of the component
+  void mnaCompInitialize(Real omega, Real timeStep,
+                         Attribute<Matrix>::Ptr leftVector) override;
+  /// Stamps system matrix
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
+  /// Update interface voltage from MNA system result
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
+  /// Update interface current from MNA system result
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
+
+  void mnaCompPostStep(Real time, Int timeStepCount,
+                       Attribute<Matrix>::Ptr &leftVector) override;
+  /// Add MNA post step dependencies
+  void
+  mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
+                                 AttributeBase::List &attributeDependencies,
+                                 AttributeBase::List &modifiedAttributes,
+                                 Attribute<Matrix>::Ptr &leftVector) override;
+};
+} // namespace Ph1
+} // namespace SP
+} // namespace CPS

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -184,6 +184,8 @@ list(APPEND MODELS_SOURCES
 	SP/SP_Ph1_NetworkInjection.cpp
 	SP/SP_Ph1_SynchronGeneratorTrStab.cpp
 	SP/SP_Ph1_varResSwitch.cpp
+	SP/SP_Ph1_SSNTypeI2T.cpp
+	SP/SP_Ph1_SSNTypeV2T.cpp
 
 	SP/SP_Ph3_Capacitor.cpp
 	SP/SP_Ph3_Inductor.cpp

--- a/dpsim-models/src/SP/SP_Ph1_SSNTypeI2T.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SSNTypeI2T.cpp
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/SP/SP_Ph1_SSNTypeI2T.h>
+
+using namespace CPS;
+
+SP::Ph1::SSNTypeI2T::SSNTypeI2T(String uid, String name, Logger::Level logLevel)
+    : MNASimPowerComp<Complex>(uid, name, false, true, logLevel) {
+  setTerminalNumber(2);
+  **mIntfVoltage = Matrix::Zero(1, 1);
+  **mIntfCurrent = Matrix::Zero(1, 1);
+  mParametersSet = false;
+}
+
+void SP::Ph1::SSNTypeI2T::setParameters(const MatrixComp &A,
+                                        const MatrixComp &B,
+                                        const MatrixComp &C,
+                                        const MatrixComp &D) {
+
+  if (A.cols() != A.rows())
+    throw std::invalid_argument("A needs to be square.");
+
+  if (B.rows() != A.cols())
+    throw std::invalid_argument(
+        "Rows of B do not match columns and rows of A.");
+
+  if (B.cols() != 1)
+    throw std::invalid_argument(
+        "Two terminal I-type SSN component only has one "
+        "external current, so column number of B must be one.");
+
+  if (C.rows() != 1)
+    throw std::invalid_argument(
+        "A two terminal I type SSN component only has"
+        "one output voltage. C must have exactly one row.");
+
+  if (C.cols() != A.rows())
+    throw std::invalid_argument("Columns of C do not match rows of A.");
+
+  if (D.rows() != 1)
+    throw std::invalid_argument(
+        "A two terminal I type SSN component only has"
+        "one output voltage. D must have exactly one row.");
+
+  if (D.cols() != B.cols())
+    throw std::invalid_argument(
+        "Columns of D do not match columns of B and rows"
+        "of input vector u, which need to be one.");
+
+  mA = A;
+  mB = B;
+  mC = C;
+  mD = D;
+
+  mX = Matrix::Zero(mA.rows(), 1);
+  mU = Matrix::Zero(mB.cols(), 1);
+  mUPrev = Matrix::Zero(mB.cols(), 1);
+
+  mParametersSet = true;
+}
+
+SimPowerComp<Complex>::Ptr SP::Ph1::SSNTypeI2T::clone(String name) {
+  auto copy = SSNTypeI2T::make(name, mLogLevel);
+  copy->setParameters(mA, mB, mC, mD);
+  return copy;
+}
+
+void SP::Ph1::SSNTypeI2T::calculateAdmittance(Real omega) {
+
+  MatrixComp H_inv =
+      omega * Complex(0, 1.) * Matrix::Identity(mA.rows(), mA.cols()) - mA;
+
+  MatrixComp H = MatrixComp(H_inv.rows(), H_inv.cols());
+
+  H = H_inv.inverse().eval();
+
+  Complex denom = ((mC.eval() * H * mB.eval() + mD.eval()).value());
+
+  if (!Math::isFinite(denom) || std::abs(denom) < DOUBLE_EPSILON)
+    throw std::invalid_argument(
+        "calculateAdmittance: denominator is near zero or infinite.");
+
+  mAdmittance =
+      1. /
+      denom; //I-type: y=V, x=I ->Matrix factor is Impedance, not Admittance
+}
+
+void SP::Ph1::SSNTypeI2T::initializeFromNodesAndTerminals(Real frequency) {
+
+  SPDLOG_LOGGER_INFO(
+      mSLog, "\n--- Initialization from node voltages and terminals ---");
+  if (!mParametersSet)
+    throw std::logic_error("Not initialized.");
+
+  Real omega = 2 * PI * frequency;
+
+  calculateAdmittance(omega);
+
+  (**mIntfVoltage)(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
+  **mIntfCurrent = mAdmittance * **mIntfVoltage;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\nImpedance [Ohm]: {:s}"
+                     "\nAdmittance [S]: {:s}",
+                     Logger::complexToString(1. / mAdmittance),
+                     Logger::complexToString(mAdmittance));
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- Initialization from powerflow ---"
+                     "\nVoltage across: {:s}"
+                     "\nCurrent: {:s}"
+                     "\nTerminal 0 voltage: {:s}"
+                     "\nTerminal 1 voltage: {:s}"
+                     "\n--- Initialization from powerflow finished ---",
+                     Logger::phasorToString((**mIntfVoltage)(0, 0)),
+                     Logger::phasorToString((**mIntfCurrent)(0, 0)),
+                     Logger::phasorToString(initialSingleVoltage(0)),
+                     Logger::phasorToString(initialSingleVoltage(1)));
+}
+
+void SP::Ph1::SSNTypeI2T::mnaCompInitialize(Real omega, Real timeStep,
+                                            Attribute<Matrix>::Ptr leftVector) {
+
+  SPDLOG_LOGGER_INFO(
+      mSLog, "\n--- Initialization from node voltages and terminals ---");
+  if (!mParametersSet)
+    throw std::logic_error("Not initialized.");
+
+  updateMatrixNodeIndices();
+
+  calculateAdmittance(omega);
+
+  SPDLOG_LOGGER_INFO(mSLog, "\nImpedance [Ohm]: {:s}",
+                     Logger::complexToString(1. / mAdmittance));
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- MNA initialization ---"
+                     "\nInitial voltage {:s}"
+                     "\nInitial current {:s}"
+                     "\n--- MNA initialization finished ---",
+                     Logger::phasorToString((**mIntfVoltage)(0, 0)),
+                     Logger::phasorToString((**mIntfCurrent)(0, 0)));
+}
+
+void SP::Ph1::SSNTypeI2T::mnaCompApplySystemMatrixStamp(
+    SparseMatrixRow &systemMatrix) {
+
+  MNAStampUtils::stampAdmittance(mAdmittance, systemMatrix, matrixNodeIndex(0),
+                                 matrixNodeIndex(1), terminalNotGrounded(0),
+                                 terminalNotGrounded(1), mSLog);
+}
+
+void SP::Ph1::SSNTypeI2T::mnaCompAddPostStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes,
+    Attribute<Matrix>::Ptr &leftVector) {
+  attributeDependencies.push_back(leftVector);
+  modifiedAttributes.push_back(mIntfVoltage);
+  modifiedAttributes.push_back(mIntfCurrent);
+}
+
+void SP::Ph1::SSNTypeI2T::mnaCompPostStep(Real time, Int timeStepCount,
+                                          Attribute<Matrix>::Ptr &leftVector) {
+  mnaCompUpdateVoltage(**leftVector);
+  mnaCompUpdateCurrent(**leftVector);
+}
+
+void SP::Ph1::SSNTypeI2T::mnaCompUpdateVoltage(const Matrix &leftVector) {
+  // v1 - v0
+  (**mIntfVoltage)(0, 0) = 0;
+  if (terminalNotGrounded(1))
+    (**mIntfVoltage)(0, 0) =
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(1));
+  if (terminalNotGrounded(0))
+    (**mIntfVoltage)(0, 0) =
+        (**mIntfVoltage)(0, 0) -
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(0));
+}
+
+void SP::Ph1::SSNTypeI2T::mnaCompUpdateCurrent(const Matrix &leftVector) {
+  **mIntfCurrent = mAdmittance * (**mIntfVoltage);
+}

--- a/dpsim-models/src/SP/SP_Ph1_SSNTypeV2T.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SSNTypeV2T.cpp
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/SP/SP_Ph1_SSNTypeV2T.h>
+
+using namespace CPS;
+
+SP::Ph1::SSNTypeV2T::SSNTypeV2T(String uid, String name, Logger::Level logLevel)
+    : MNASimPowerComp<Complex>(uid, name, false, true, logLevel) {
+  setTerminalNumber(2);
+  **mIntfVoltage = Matrix::Zero(1, 1);
+  **mIntfCurrent = Matrix::Zero(1, 1);
+  mParametersSet = false;
+}
+
+void SP::Ph1::SSNTypeV2T::setParameters(const MatrixComp &A,
+                                        const MatrixComp &B,
+                                        const MatrixComp &C,
+                                        const MatrixComp &D) {
+
+  if (A.cols() != A.rows())
+    throw std::invalid_argument("A needs to be square.");
+
+  if (B.rows() != A.cols())
+    throw std::invalid_argument(
+        "Rows of B do not match columns and rows of A.");
+
+  if (B.cols() != 1)
+    throw std::invalid_argument(
+        "Two terminal V-type SSN component only has one external voltage, so "
+        "column number of B must be one!");
+
+  if (C.rows() != 1)
+    throw std::invalid_argument(
+        "A two terminal V type SSN component only has one output current. C "
+        "must have exactly one row.");
+
+  if (C.cols() != A.rows())
+    throw std::invalid_argument("Columns of C do not match rows of A.");
+
+  if (D.rows() != 1)
+    throw std::invalid_argument(
+        "A two terminal V type SSN component only has one output current. D "
+        "must have exactly one row.");
+
+  if (D.cols() != B.cols())
+    throw std::invalid_argument(
+        "Columns of D do not match columns of B and rows of input vector u, "
+        "which need to be one.");
+
+  mA = A;
+  mB = B;
+  mC = C;
+  mD = D;
+
+  mX = Matrix::Zero(mA.rows(), 1);
+  mU = Matrix::Zero(mB.cols(), 1);
+  mUPrev = Matrix::Zero(mB.cols(), 1);
+
+  mParametersSet = true;
+}
+
+SimPowerComp<Complex>::Ptr SP::Ph1::SSNTypeV2T::clone(String name) {
+  auto copy = SSNTypeV2T::make(name, mLogLevel);
+  copy->setParameters(mA, mB, mC, mD);
+  return copy;
+}
+
+void SP::Ph1::SSNTypeV2T::calculateAdmittance(Real omega) {
+  MatrixComp H_inv =
+      omega * Complex(0, 1.) * Matrix::Identity(mA.rows(), mA.cols()) - mA;
+
+  MatrixComp H = MatrixComp(H_inv.rows(), H_inv.cols());
+
+  H = H_inv.inverse().eval();
+
+  mAdmittance = (mC.eval() * H * mB.eval() + mD.eval()).value();
+
+  if (!Math::isFinite(mAdmittance) || std::abs(mAdmittance) < DOUBLE_EPSILON)
+    throw std::invalid_argument(
+        "calculateAdmittance: Admittance is near zero or infinite.");
+}
+
+void SP::Ph1::SSNTypeV2T::initializeFromNodesAndTerminals(Real frequency) {
+
+  SPDLOG_LOGGER_INFO(
+      mSLog, "\n--- Initialization from node voltages and terminals ---");
+  if (!mParametersSet)
+    throw std::logic_error("Not initialized.");
+
+  Real omega = 2 * PI * frequency;
+
+  calculateAdmittance(omega);
+
+  (**mIntfVoltage)(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
+  **mIntfCurrent = mAdmittance * **mIntfVoltage;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\nImpedance [Ohm]: {:s}"
+                     "\nAdmittance [S]: {:s}",
+                     Logger::complexToString(1. / mAdmittance),
+                     Logger::complexToString(mAdmittance));
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- Initialization from powerflow ---"
+                     "\nVoltage across: {:s}"
+                     "\nCurrent: {:s}"
+                     "\nTerminal 0 voltage: {:s}"
+                     "\nTerminal 1 voltage: {:s}"
+                     "\n--- Initialization from powerflow finished ---",
+                     Logger::phasorToString((**mIntfVoltage)(0, 0)),
+                     Logger::phasorToString((**mIntfCurrent)(0, 0)),
+                     Logger::phasorToString(initialSingleVoltage(0)),
+                     Logger::phasorToString(initialSingleVoltage(1)));
+}
+
+void SP::Ph1::SSNTypeV2T::mnaCompInitialize(Real omega, Real timeStep,
+                                            Attribute<Matrix>::Ptr leftVector) {
+
+  SPDLOG_LOGGER_INFO(
+      mSLog, "\n--- Initialization from node voltages and terminals ---");
+  if (!mParametersSet)
+    throw std::logic_error("Not initialized.");
+
+  updateMatrixNodeIndices();
+
+  calculateAdmittance(omega);
+
+  SPDLOG_LOGGER_INFO(mSLog, "\nImpedance [Ohm]: {:s}",
+                     Logger::complexToString(1. / mAdmittance));
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "\n--- MNA initialization ---"
+                     "\nInitial voltage {:s}"
+                     "\nInitial current {:s}"
+                     "\n--- MNA initialization finished ---",
+                     Logger::phasorToString((**mIntfVoltage)(0, 0)),
+                     Logger::phasorToString((**mIntfCurrent)(0, 0)));
+}
+
+void SP::Ph1::SSNTypeV2T::mnaCompApplySystemMatrixStamp(
+    SparseMatrixRow &systemMatrix) {
+
+  MNAStampUtils::stampAdmittance(mAdmittance, systemMatrix, matrixNodeIndex(0),
+                                 matrixNodeIndex(1), terminalNotGrounded(0),
+                                 terminalNotGrounded(1), mSLog);
+}
+
+void SP::Ph1::SSNTypeV2T::mnaCompAddPostStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes,
+    Attribute<Matrix>::Ptr &leftVector) {
+  attributeDependencies.push_back(leftVector);
+  modifiedAttributes.push_back(mIntfVoltage);
+  modifiedAttributes.push_back(mIntfCurrent);
+}
+
+void SP::Ph1::SSNTypeV2T::mnaCompPostStep(Real time, Int timeStepCount,
+                                          Attribute<Matrix>::Ptr &leftVector) {
+  mnaCompUpdateVoltage(**leftVector);
+  mnaCompUpdateCurrent(**leftVector);
+}
+
+void SP::Ph1::SSNTypeV2T::mnaCompUpdateVoltage(const Matrix &leftVector) {
+  // v1 - v0
+  (**mIntfVoltage)(0, 0) = 0;
+  if (terminalNotGrounded(1))
+    (**mIntfVoltage)(0, 0) =
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(1));
+  if (terminalNotGrounded(0))
+    (**mIntfVoltage)(0, 0) =
+        (**mIntfVoltage)(0, 0) -
+        Math::complexFromVectorElement(leftVector, matrixNodeIndex(0));
+}
+
+void SP::Ph1::SSNTypeV2T::mnaCompUpdateCurrent(const Matrix &leftVector) {
+  **mIntfCurrent = mAdmittance * (**mIntfVoltage);
+}

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -63,6 +63,7 @@ set(CIRCUIT_SOURCES
 	Circuits/SP_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
 	Circuits/SP_Slack_PiLine_PQLoad_with_PF_Init.cpp
 	Circuits/SP_RC_split_decoupled_node.cpp
+	Circuits/SP_Ph1_General2TerminalSSN.cpp
 
 	# Combined EMT/DP/SP examples
 	Circuits/EMT_DP_SP_Slack.cpp
@@ -190,6 +191,7 @@ list(APPEND TEST_SOURCES
 	Circuits/EMT_Ph3_RLC1VS1_RC_vs_SSN.cpp
 	Circuits/EMT_Ph1_General2TerminalSSN.cpp
 	Circuits/SP_ITM_withPiLine_Ph1.cpp
+	Circuits/SP_Ph1_General2TerminalSSN.cpp
 )
 
 if(WITH_SUNDIALS)

--- a/dpsim/examples/cxx/Circuits/SP_Ph1_General2TerminalSSN.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_Ph1_General2TerminalSSN.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS::SP;
+
+void SP_Ph1_VS_RLC(double R, double L, double C) {
+  // Define simulation scenario
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "SP_Ph1_VS_rlc_RC";
+  Logger::setLogDir("logs/" + simName);
+
+  // Nodes
+  auto n1 = SimNode::make("n1", PhaseType::Single);
+  auto n2 = SimNode::make("n2", PhaseType::Single);
+  auto n3 = SimNode::make("n3", PhaseType::Single);
+
+  // Components
+  auto vs = Ph1::VoltageSource::make("vs");
+  vs->setParameters(Complex(1.0, 2.0));
+  auto r1 = Ph1::Resistor::make("r_1");
+  r1->setParameters(R);
+  auto l1 = Ph1::Inductor::make("l_1");
+  l1->setParameters(L);
+  auto c1 = Ph1::Capacitor::make("c_1");
+  c1->setParameters(C);
+
+  // Topology
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  r1->connect(SimNode::List{n1, n2});
+  l1->connect(SimNode::List{n2, n3});
+  c1->connect(SimNode::List{n3, SimNode::GND});
+
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2, n3},
+                            SystemComponentList{vs, r1, l1, c1});
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v1", n1->attribute("v"));
+  logger->logAttribute("v2", n2->attribute("v"));
+  logger->logAttribute("v3", n3->attribute("v"));
+  logger->logAttribute("i12", r1->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.doInitFromNodesAndTerminals(true);
+  sim.setDomain(Domain::SP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+void SP_Ph1_SSNsingleComps_VS_RLC(double R, double L, double C) {
+  // Define simulation scenario
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "SP_Ph1_VS_rlc_SSNsingleComps";
+  Logger::setLogDir("logs/" + simName);
+
+  // Nodes
+  auto n1 = SimNode::make("n1", PhaseType::Single);
+  auto n2 = SimNode::make("n2", PhaseType::Single);
+  auto n3 = SimNode::make("n3", PhaseType::Single);
+
+  // Components
+  auto vs = Ph1::VoltageSource::make("vs");
+  vs->setParameters(Complex(1.0, 2.0));
+
+  Matrix A_r1 = Matrix::Zero(1, 1);
+  Matrix B_r1 = Matrix::Zero(1, 1);
+  Matrix C_r1 = Matrix::Zero(1, 1);
+  Matrix D_r1 = Matrix::Zero(1, 1);
+  D_r1 << 1. / R;
+  auto r1 = Ph1::SSNTypeV2T::make("r_1");
+  r1->setParameters(A_r1, B_r1, C_r1, D_r1);
+
+  Matrix A_l1 = Matrix::Zero(1, 1);
+  Matrix B_l1 = Matrix::Zero(1, 1);
+  B_l1 << 1. / L;
+  Matrix C_l1 = Matrix::Zero(1, 1);
+  C_l1 << 1.;
+  Matrix D_l1 = Matrix::Zero(1, 1);
+  auto l1 = Ph1::SSNTypeV2T::make("l_1");
+  l1->setParameters(A_l1, B_l1, C_l1, D_l1); //Idot = U/L , B = 1/L, C = 1
+
+  Matrix A_c1 = Matrix::Zero(1, 1);
+  Matrix B_c1 = Matrix::Zero(1, 1);
+  B_c1 << 1. / C;
+  Matrix C_c1 = Matrix::Zero(1, 1);
+  C_c1 << 1.;
+  Matrix D_c1 = Matrix::Zero(1, 1);
+  auto c1 = Ph1::SSNTypeI2T::make("c_1");
+  c1->setParameters(A_c1, B_c1, C_c1, D_c1); //Udot = I/C, B = 1/C, C = 1
+
+  // Topology
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  r1->connect(SimNode::List{n1, n2});
+  l1->connect(SimNode::List{n2, n3});
+  c1->connect(SimNode::List{n3, SimNode::GND});
+
+  auto sys = SystemTopology(50, SystemNodeList{n1, n2, n3},
+                            SystemComponentList{vs, r1, l1, c1});
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v1", n1->attribute("v"));
+  logger->logAttribute("v2", n2->attribute("v"));
+  logger->logAttribute("v3", n3->attribute("v"));
+  logger->logAttribute("i12", r1->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.doInitFromNodesAndTerminals(true);
+  sim.setDomain(Domain::SP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+void SP_Ph1_SSNcombined_VS_RLC(double R, double L, double C) {
+  // Define simulation scenario
+  Real timeStep = 0.0001;
+  Real finalTime = 0.1;
+  String simName = "SP_Ph1_VS_rlc_genSSNcombined";
+  Logger::setLogDir("logs/" + simName);
+
+  // Nodes
+  auto n1 = SimNode::make("n1", PhaseType::Single);
+
+  // Components
+  auto vs = Ph1::VoltageSource::make("vs");
+  vs->setParameters(Complex(1.0, 2.0));
+
+  Matrix A_rlc = Matrix::Zero(2, 2);
+  A_rlc << 0, 1. / C, -1. / L, -R / L;
+  Matrix B_rlc = Matrix::Zero(2, 1);
+  B_rlc << 0, 1. / L;
+  Matrix C_rlc = Matrix::Zero(1, 2);
+  C_rlc << 0, 1.;
+  Matrix D_rlc = Matrix::Zero(1, 1);
+  auto rlc = Ph1::SSNTypeV2T::make("rlc");
+  rlc->setParameters(A_rlc, B_rlc, C_rlc, D_rlc);
+
+  // Topology
+  vs->connect(SimNode::List{SimNode::GND, n1});
+  rlc->connect(SimNode::List{n1, SimNode::GND});
+
+  auto sys =
+      SystemTopology(50, SystemNodeList{n1}, SystemComponentList{vs, rlc});
+
+  // Logging
+  auto logger = DataLogger::make(simName);
+  logger->logAttribute("v1", n1->attribute("v"));
+  logger->logAttribute("i12", rlc->attribute("i_intf"));
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.doInitFromNodesAndTerminals(true);
+  sim.setDomain(Domain::SP);
+  sim.setTimeStep(timeStep);
+  sim.setFinalTime(finalTime);
+  sim.run();
+}
+
+int main(int argc, char *argv[]) {
+  const double R = 1.5;
+  const double L = 0.02;
+  const double C = 0.08;
+
+  SP_Ph1_VS_RLC(R, L, C);
+  SP_Ph1_SSNsingleComps_VS_RLC(R, L, C);
+  SP_Ph1_SSNcombined_VS_RLC(R, L, C);
+}

--- a/examples/Notebooks/Circuits/SP_Ph1_generalizedSSN.ipynb
+++ b/examples/Notebooks/Circuits/SP_Ph1_generalizedSSN.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Comparing RC and generalized two terminal SSN linear circuit simulations in SP Ph1 domain\n",
+    "### Comparing SP domain simulations of Ph1 linear circuits built from Resistive Companion (RC) component models against the same linear circuits build from generalized two terminal SSN (State Space Nodal) component models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run C++ example: RLC circuit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "# %matplotlib widget\n",
+    "\n",
+    "name = \"SP_Ph1_General2TerminalSSN\"\n",
+    "\n",
+    "dpsim_path = (\n",
+    "    subprocess.Popen([\"git\", \"rev-parse\", \"--show-toplevel\"], stdout=subprocess.PIPE)\n",
+    "    .communicate()[0]\n",
+    "    .rstrip()\n",
+    "    .decode(\"utf-8\")\n",
+    ")\n",
+    "\n",
+    "path_exec = dpsim_path + \"/build/dpsim/examples/cxx/\"\n",
+    "sim = subprocess.Popen(\n",
+    "    [path_exec + name], stdout=subprocess.PIPE, stderr=subprocess.STDOUT\n",
+    ")\n",
+    "print(sim.communicate()[0].decode())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from villas.dataprocessing.readtools import *\n",
+    "from villas.dataprocessing.timeseries import *\n",
+    "from villas.dataprocessing.timeseries import TimeSeries as ts\n",
+    "import matplotlib.pyplot as plt\n",
+    "import re\n",
+    "import numpy as np\n",
+    "import math\n",
+    "\n",
+    "name = \"SP_Ph1_VS_rlc\"\n",
+    "\n",
+    "work_dir = os.getcwd() + \"/logs/\"\n",
+    "path_logfile_VS_rlc_RC = work_dir + name + \"_RC/\" + name + \"_RC\" + \".csv\"\n",
+    "ts_SP_Ph1_VS_rlc_RC = read_timeseries_dpsim(path_logfile_VS_rlc_RC)\n",
+    "\n",
+    "path_logfile_VS_rlc_SSNsingleComps = (\n",
+    "    work_dir + name + \"_SSNsingleComps/\" + name + \"_SSNsingleComps\" + \".csv\"\n",
+    ")\n",
+    "ts_SP_VS_rlc_SSNsingleComps = read_timeseries_dpsim(path_logfile_VS_rlc_SSNsingleComps)\n",
+    "\n",
+    "path_logfile_VS_RLC_genSSNcombined = (\n",
+    "    work_dir + name + \"_genSSNcombined/\" + name + \"_genSSNcombined\" + \".csv\"\n",
+    ")\n",
+    "ts_SP_Ph1_VS_RLC_genSSNcombined = read_timeseries_dpsim(\n",
+    "    path_logfile_VS_RLC_genSSNcombined\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.close(\"all\")\n",
+    "fig1 = plt.figure()\n",
+    "\n",
+    "plt.plot(\n",
+    "    ts_SP_Ph1_VS_rlc_RC[\"i12\"].time,\n",
+    "    np.abs(ts_SP_Ph1_VS_rlc_RC[\"i12\"].values),\n",
+    "    \"cx\",\n",
+    "    markevery=11,\n",
+    "    label=\"i_rlc_RC\",\n",
+    ")\n",
+    "plt.plot(\n",
+    "    ts_SP_VS_rlc_SSNsingleComps[\"i12\"].time,\n",
+    "    np.abs(ts_SP_VS_rlc_SSNsingleComps[\"i12\"].values),\n",
+    "    \"bx\",\n",
+    "    markevery=13,\n",
+    "    label=\"i_rlc_SSN_single\",\n",
+    ")\n",
+    "\n",
+    "plt.plot(\n",
+    "    ts_SP_Ph1_VS_RLC_genSSNcombined[\"i12\"].time,\n",
+    "    np.abs(ts_SP_Ph1_VS_RLC_genSSNcombined[\"i12\"].values),\n",
+    "    \"rx\",\n",
+    "    markevery=17,\n",
+    "    label=\"i_rlc_SSN_combined\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "plt.legend(loc=4)\n",
+    "\n",
+    "plt.title(\"RC vs. single component SSN vs. generalized SSN simulation: RLC current\")\n",
+    "plt.xlabel(\"t [s]\")\n",
+    "plt.ylabel(\"RLC Current [A]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assert"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "epsilon = 1e-12\n",
+    "\n",
+    "# compare resistive companion vs. single general SSN component modeling\n",
+    "assert (\n",
+    "    np.max(\n",
+    "        np.abs(\n",
+    "            ts_SP_Ph1_VS_rlc_RC[\"i12\"].values\n",
+    "            - ts_SP_VS_rlc_SSNsingleComps[\"i12\"].values\n",
+    "        )\n",
+    "    )\n",
+    "    < epsilon\n",
+    ")\n",
+    "\n",
+    "# compare resistive companion vs. combined general SSN component modeling\n",
+    "assert (\n",
+    "    np.max(\n",
+    "        np.abs(\n",
+    "            ts_SP_Ph1_VS_rlc_RC[\"i12\"].values\n",
+    "            - ts_SP_Ph1_VS_RLC_genSSNcombined[\"i12\"].values\n",
+    "        )\n",
+    "    )\n",
+    "    < epsilon\n",
+    ")\n",
+    "\n",
+    "# compare single general SSN component modeling vs. combined general SSN component modeling\n",
+    "assert (\n",
+    "    np.max(\n",
+    "        np.abs(\n",
+    "            ts_SP_Ph1_VS_RLC_genSSNcombined[\"i12\"].values\n",
+    "            - ts_SP_VS_rlc_SSNsingleComps[\"i12\"].values\n",
+    "        )\n",
+    "    )\n",
+    "    < epsilon\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "tests": {
+   "skip": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Adds generalized components for the Ph1 SP domain which implement the State Space Nodal approach for any linear two-terminal component which can be described by state space matrices and does not include internal injections.

"SSNTypeV2T" implements the V-type group variant while "SSNTypeI2T" implements the I-type group variant.

As of now, powerflow is not supported by these components.