### PR TITLE
matpower reader: map generators on PQ-labeled and multi-generator buses

### DIFF
--- a/examples/Notebooks/matpower-multi-generator.ipynb
+++ b/examples/Notebooks/matpower-multi-generator.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generators sharing a bus in the MATPOWER reader\n",
+    "\n",
+    "A MATPOWER case may put several generators on one bus, may label a\n",
+    "generator's bus PQ, and may carry generators that are switched off. This\n",
+    "notebook builds such a case from the public case9 reference and checks that\n",
+    "the reader maps every online generator to its own component.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetching a reference case\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request\n",
+    "\n",
+    "import numpy as np\n",
+    "import scipy.io\n",
+    "\n",
+    "import dpsim\n",
+    "\n",
+    "base_url = \"https://raw.githubusercontent.com/dpsim-simulator/reference-results/master/Matpower/\"\n",
+    "urllib.request.urlretrieve(base_url + \"case9results.mat\", \"case9results.mat\")\n",
+    "\n",
+    "mpc = scipy.io.loadmat(\"case9results.mat\", simplify_cells=True)[\"case9results\"]\n",
+    "gen = np.atleast_2d(np.array(mpc[\"gen\"], dtype=float))\n",
+    "bus = np.atleast_2d(np.array(mpc[\"bus\"], dtype=float))\n",
+    "print(\"buses\", bus.shape[0], \"generators\", gen.shape[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adding more units to the case\n",
+    "\n",
+    "The MATPOWER generator columns used below are bus, Pg, Qg, Qmax, Qmin, Vg,\n",
+    "mBase and status. Bus 2 gets three units instead of one, bus 5 is labelled PQ\n",
+    "but is given two units, and one unit at bus 2 is switched off. The second unit\n",
+    "at bus 5 is left with an mBase of 0, which MATPOWER reads as the system base.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "units = [\n",
+    "    # bus,   Pg,   Qg, Qmax,  Qmin,     Vg, mBase, status\n",
+    "    (2.0, 60.0, 5.0, 40.0, -10.0, 1.025, 100.0, 1.0),\n",
+    "    (2.0, 55.0, 7.0, 35.0, -12.0, 1.025, 150.0, 1.0),\n",
+    "    (2.0, 48.0, 9.0, 30.0, -14.0, 1.025, 200.0, 1.0),\n",
+    "    (5.0, 12.0, 3.0, 20.0, -20.0, 1.000, 0.0, 1.0),\n",
+    "    (5.0, 8.0, 2.0, 15.0, -15.0, 1.000, 250.0, 1.0),\n",
+    "    (2.0, 999.0, 99.0, 99.0, -99.0, 1.025, 100.0, 0.0),\n",
+    "]\n",
+    "\n",
+    "rows = [row for row in gen if row[0] != 2.0]\n",
+    "for unit in units:\n",
+    "    row = gen[0].copy()\n",
+    "    row[:8] = unit\n",
+    "    rows.append(row)\n",
+    "\n",
+    "mpc[\"gen\"] = np.vstack(rows)\n",
+    "scipy.io.savemat(\"multigen.mat\", {\"multigen\": mpc})\n",
+    "print(\"generator rows now\", mpc[\"gen\"].shape[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Every online generator becomes its own component\n",
+    "\n",
+    "The first generator at a bus keeps the unsuffixed name it always had, so cases\n",
+    "with one generator per bus are unaffected. Further units are suffixed.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reader = dpsim.matpower.Reader(\"multigen.mat\", \"multigen\")\n",
+    "system = reader.load_mpc()\n",
+    "\n",
+    "generators = sorted(c.name() for c in system.components if c.name().startswith(\"Gen_N\"))\n",
+    "print(generators)\n",
+    "\n",
+    "assert generators == [\n",
+    "    \"Gen_N2\",\n",
+    "    \"Gen_N2_1\",\n",
+    "    \"Gen_N2_2\",\n",
+    "    \"Gen_N3\",\n",
+    "    \"Gen_N5\",\n",
+    "    \"Gen_N5_1\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Each component carries its own row\n",
+    "\n",
+    "A generator must not inherit the set points of the first machine at its bus.\n",
+    "The unit with an mBase of 0 falls back to the system base power.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mw_w = 1e6\n",
+    "expected = {\n",
+    "    \"Gen_N2\": (60.0, 5.0, 40.0, -10.0),\n",
+    "    \"Gen_N2_1\": (55.0, 7.0, 35.0, -12.0),\n",
+    "    \"Gen_N2_2\": (48.0, 9.0, 30.0, -14.0),\n",
+    "    \"Gen_N5\": (12.0, 3.0, 20.0, -20.0),\n",
+    "    \"Gen_N5_1\": (8.0, 2.0, 15.0, -15.0),\n",
+    "}\n",
+    "\n",
+    "for name, (p, q, q_max, q_min) in expected.items():\n",
+    "    component = system.component(name)\n",
+    "    assert np.isclose(component.attr(\"P_set\").get(), p * mw_w)\n",
+    "    assert np.isclose(component.attr(\"Q_set\").get(), q * mw_w)\n",
+    "    assert np.isclose(component.attr(\"Q_max\").get(), q_max * mw_w)\n",
+    "    assert np.isclose(component.attr(\"Q_min\").get(), q_min * mw_w)\n",
+    "\n",
+    "print(\"every generator kept its own set points\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Offline generators are dropped\n",
+    "\n",
+    "The switched-off unit at bus 2 would inject 999 MW if it were mapped, so it\n",
+    "must not appear as a component and must not reach the reference table.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert \"Gen_N2_3\" not in generators\n",
+    "assert (reader.mpc_gen_data[\"status\"] == 1).all()\n",
+    "print(\"offline generators are absent\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generators on a PQ-labelled bus\n",
+    "\n",
+    "Bus 5 is labelled PQ but carries generation. Mapping it is the default and can\n",
+    "be turned off to recover the previous behaviour.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reader_pq_off = dpsim.matpower.Reader(\"multigen.mat\", \"multigen\")\n",
+    "system_pq_off = reader_pq_off.load_mpc(map_pq_bus_generators=False)\n",
+    "\n",
+    "without_pq = sorted(\n",
+    "    c.name() for c in system_pq_off.components if c.name().startswith(\"Gen_N\")\n",
+    ")\n",
+    "print(without_pq)\n",
+    "\n",
+    "assert without_pq == [\"Gen_N2\", \"Gen_N2_1\", \"Gen_N2_2\", \"Gen_N3\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The reference table sums co-located generation\n",
+    "\n",
+    "Bus 2 carries three units, so its reported generation is their sum rather than\n",
+    "the first unit's contribution alone.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = reader.get_pf_results()\n",
+    "print(results.to_string())\n",
+    "\n",
+    "bus2 = results.loc[results[\"Bus\"] == \"N2\"].iloc[0]\n",
+    "assert np.isclose(bus2[\"P [MW]\"], 60.0 + 55.0 + 48.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialising from the power flow results\n",
+    "\n",
+    "Each generator row must find the component it was mapped to, otherwise units\n",
+    "sharing a bus overwrite one another.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "counter = {}\n",
+    "names = []\n",
+    "for index, _ in reader.mpc_gen_data.iterrows():\n",
+    "    bus_number = reader.mpc_gen_data.at[index, \"bus\"]\n",
+    "    gen_i = counter.get(bus_number, 0)\n",
+    "    counter[bus_number] = gen_i + 1\n",
+    "    names.append(reader.gen_component_name(bus_number, gen_i))\n",
+    "\n",
+    "assert len(set(names)) == len(names)\n",
+    "assert sorted(n for n in names if system.component(n) is not None) == generators\n",
+    "\n",
+    "reader.init_from_pf_results()\n",
+    "print(\"initialised\", len(generators), \"generators from\", len(names), \"rows\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/Notebooks/matpower-multi-generator.ipynb
+++ b/examples/Notebooks/matpower-multi-generator.ipynb
@@ -69,7 +69,7 @@
     "    (2.0, 999.0, 99.0, 99.0, -99.0, 1.025, 100.0, 0.0),\n",
     "]\n",
     "\n",
-    "rows = [row for row in gen if row[0] != 2.0]\n",
+    "rows = [row for row in gen if int(row[0]) != 2]\n",
     "for unit in units:\n",
     "    row = gen[0].copy()\n",
     "    row[:8] = unit\n",

--- a/python/src/dpsim/matpower.py
+++ b/python/src/dpsim/matpower.py
@@ -732,9 +732,6 @@ class Reader:
                 q_limit_min=gen_q_min,
             )
             gen.set_base_voltage(gen_baseV)
-            # modifyPowerFlowBusType throws for PQ, set_parameters already stored it
-            if bus_type != dpsimpy.PowerflowBusType.PQ:
-                gen.modify_power_flow_bus_type(bus_type)
         else:
             # get dynamic data of the generator
             gen_dyn_row_idx = self.mpc_dyn_gen_data.index[

--- a/python/src/dpsim/matpower.py
+++ b/python/src/dpsim/matpower.py
@@ -674,6 +674,11 @@ class Reader:
             self.mpc_gen_data["bus"] == self.mpc_bus_data.at[index, "bus_i"]
         ]
 
+    @staticmethod
+    def gen_component_name(bus_index, gen_i):
+        # the first generator keeps its unsuffixed name, so single-gen grids are unaffected
+        return "Gen_N" + str(bus_index) + ("" if gen_i == 0 else "_" + str(gen_i))
+
     def map_generators_at_bus(self, index, bus_index, **kwargs):
         # the PF solver sums P/Q and the Q limits over all components at a node
         for gen_i in range(self.gen_data_at_bus(index).shape[0]):
@@ -690,8 +695,7 @@ class Reader:
         gen_model=None,
         gen_i=0,
     ):
-        # the first generator keeps its unsuffixed name, so single-gen grids are unaffected
-        gen_name = "Gen_N" + str(bus_index) + ("" if gen_i == 0 else "_" + str(gen_i))
+        gen_name = self.gen_component_name(bus_index, gen_i)
 
         # relevant data from self.mpc_gen_data. Identification with bus number available in mpc_bus_data and mpc_gen_data
         gen_data = self.gen_data_at_bus(index).iloc[[gen_i]]
@@ -1249,21 +1253,27 @@ class Reader:
             dpsim_node.set_initial_voltage(voltage_complex)
 
         # initialize SG
+        gen_count_at_bus = {}
         for index, gen in self.mpc_gen_data.iterrows():
-            # get generator name in dpsim
+            # get generator name in dpsim, counting per bus as the mapping did
             bus_index = self.mpc_gen_data.at[index, "bus"]
-            gen_name = "Gen_N" + str(bus_index)
+            gen_i = gen_count_at_bus.get(bus_index, 0)
+            gen_count_at_bus[bus_index] = gen_i + 1
+            gen_name = self.gen_component_name(bus_index, gen_i)
 
             # get active and reactive power
             active_power = self.mpc_gen_data.at[index, "Pg"]
             reactive_power = self.mpc_gen_data.at[index, "Qg"]
-            base_power = self.mpc_gen_data.at[index, "BaseS"]
             complex_power = mw_w * complex(active_power, reactive_power)
 
+            # a slack bus is mapped as a network injection, and PQ-bus generators
+            # are absent when map_pq_bus_generators is off, so both have no component
+            gen_component = self.system.component(gen_name)
+            if gen_component is None:
+                continue
+
             # set terminal power of generator in dpsim
-            self.system.component(gen_name).get_terminal(index=0).set_power(
-                -complex_power
-            )
+            gen_component.get_terminal(index=0).set_power(-complex_power)
 
     def get_pf_results(self, decimals=5):
         pf_results = pd.DataFrame(

--- a/python/src/dpsim/matpower.py
+++ b/python/src/dpsim/matpower.py
@@ -123,6 +123,9 @@ class Reader:
         self.mpc_gen_data["bus"] = self.mpc_gen_data["bus"].astype(int)
         self.mpc_gen_data["status"] = self.mpc_gen_data["status"].astype(int)
 
+        # offline generators must not inject power, dropped regardless of filter_out_of_service
+        self.mpc_gen_data = self.mpc_gen_data[self.mpc_gen_data["status"] == 1]
+
         #### Branches #####
         # extract only first 13 columns since following columns include results
         mpc_branch_raw = self.mpc_raw[self.mpc_name]["branch"][:, :13]
@@ -300,6 +303,7 @@ class Reader:
         with_tg=True,
         filter_out_of_service=False,
         generator_model=None,
+        map_pq_bus_generators=True,
     ):
         """
         Create dpsim objects with the data contained in the mpc files.
@@ -315,6 +319,8 @@ class Reader:
         @param generator_model: explicit generator model to use for dynamic
                                 simulations. Use `GenModel` values or raw integer
                                 values 1, 3, 4, 5, 6.
+        @param map_pq_bus_generators: if True, also map generators sitting on a bus
+                                      labelled PQ, as some MATPOWER exports do
         """
         self.log_level = log_level
         self.domain = domain
@@ -414,12 +420,25 @@ class Reader:
                 # shunts
                 self.map_shunt(index, bus_index)
 
+                # some exports put generators on a bus labelled PQ
+                if map_pq_bus_generators:
+                    self.map_generators_at_bus(
+                        index,
+                        bus_index,
+                        bus_type=dpsimpy.PowerflowBusType.PQ,
+                        with_pss=with_pss,
+                        with_tg=with_tg,
+                        with_avr=with_avr,
+                        gen_model=generator_model,
+                    )
+
             # Generators
             elif bus_type == 2:
                 # map SG
-                self.map_synchronous_machine(
+                self.map_generators_at_bus(
                     index,
                     bus_index,
+                    bus_type=dpsimpy.PowerflowBusType.PV,
                     with_pss=with_pss,
                     with_tg=with_tg,
                     with_avr=with_avr,
@@ -650,6 +669,16 @@ class Reader:
 
         return bus_name
 
+    def gen_data_at_bus(self, index):
+        return self.mpc_gen_data.loc[
+            self.mpc_gen_data["bus"] == self.mpc_bus_data.at[index, "bus_i"]
+        ]
+
+    def map_generators_at_bus(self, index, bus_index, **kwargs):
+        # the PF solver sums P/Q and the Q limits over all components at a node
+        for gen_i in range(self.gen_data_at_bus(index).shape[0]):
+            self.map_synchronous_machine(index, bus_index, gen_i=gen_i, **kwargs)
+
     def map_synchronous_machine(
         self,
         index,
@@ -659,16 +688,18 @@ class Reader:
         with_tg=True,
         with_avr=True,
         gen_model=None,
+        gen_i=0,
     ):
-        #
-        gen_name = "Gen_N" + str(bus_index)
+        # the first generator keeps its unsuffixed name, so single-gen grids are unaffected
+        gen_name = "Gen_N" + str(bus_index) + ("" if gen_i == 0 else "_" + str(gen_i))
 
         # relevant data from self.mpc_gen_data. Identification with bus number available in mpc_bus_data and mpc_gen_data
-        gen_data = self.mpc_gen_data.loc[
-            self.mpc_gen_data["bus"] == self.mpc_bus_data.at[index, "bus_i"]
-        ]
+        gen_data = self.gen_data_at_bus(index).iloc[[gen_i]]
+        # a MATPOWER mBase of 0 means "use the system baseMVA"
         gen_baseS = (
             gen_data["mBase"].values[0] * mw_w
+            if gen_data["mBase"].values[0] > 0
+            else self.mpc_base_power_MVA
         )  # gen base MVA default is mpc.baseMVA
         gen_baseV = self.mpc_bus_data.at[index, "baseKV"] * kv_v  # gen base kV
         gen_v = (
@@ -701,7 +732,9 @@ class Reader:
                 q_limit_min=gen_q_min,
             )
             gen.set_base_voltage(gen_baseV)
-            gen.modify_power_flow_bus_type(bus_type)
+            # modifyPowerFlowBusType throws for PQ, set_parameters already stored it
+            if bus_type != dpsimpy.PowerflowBusType.PQ:
+                gen.modify_power_flow_bus_type(bus_type)
         else:
             # get dynamic data of the generator
             gen_dyn_row_idx = self.mpc_dyn_gen_data.index[
@@ -1166,6 +1199,7 @@ class Reader:
         with_avr=True,
         with_tg=True,
         filter_out_of_service=False,
+        map_pq_bus_generators=True,
     ):
         """
         Read mpc files and create DPsim topology
@@ -1175,6 +1209,7 @@ class Reader:
         @param filter_out_of_service: if True, exclude out-of-service
                                       generators/branches and isolated buses
                                       instead of instantiating them
+        @param map_pq_bus_generators: see create_dpsim_objects
         """
         self.create_dpsim_objects(
             domain=domain,
@@ -1183,6 +1218,7 @@ class Reader:
             with_avr=with_avr,
             with_tg=with_tg,
             filter_out_of_service=filter_out_of_service,
+            map_pq_bus_generators=map_pq_bus_generators,
         )
         self.create_dpsim_topology()
 
@@ -1242,12 +1278,10 @@ class Reader:
             p_gen = 0
             q_gen = 0
             # if PV or Slack bus --> add gen power
-            gen_data = self.mpc_gen_data.loc[
-                self.mpc_gen_data["bus"] == self.mpc_bus_data.at[i, "bus_i"]
-            ]
+            gen_data = self.gen_data_at_bus(i)
             if gen_data.shape[0] > 0:
-                p_gen = gen_data["Pg"].values[0]
-                q_gen = gen_data["Qg"].values[0]
+                p_gen = gen_data["Pg"].sum()
+                q_gen = gen_data["Qg"].sum()
 
             pf_results.loc[i] = (
                 [node_name]

--- a/python/src/dpsim/matpower.py
+++ b/python/src/dpsim/matpower.py
@@ -1266,8 +1266,7 @@ class Reader:
             reactive_power = self.mpc_gen_data.at[index, "Qg"]
             complex_power = mw_w * complex(active_power, reactive_power)
 
-            # a slack bus is mapped as a network injection, and PQ-bus generators
-            # are absent when map_pq_bus_generators is off, so both have no component
+            # a slack bus maps to a network injection, so it has no generator component
             gen_component = self.system.component(gen_name)
             if gen_component is None:
                 continue


### PR DESCRIPTION
The matpower reader dropped generation in three cases:

1. Generators on a bus labeled type 1 (PQ) were never mapped, so their generation silently disappeared. Some exports label a generator's bus PQ even when it carries real generation.
2. Multiple generators sharing a bus collapsed into a single `SynchronGenerator`, keeping only the first generator's rating.
3. Offline generators (`status == 0`) were still instantiated and injected power as if online.