### PR TITLE
PFSolver: exclude local shunt from PV/VD bus P/Q reporting

### DIFF
--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -481,6 +481,13 @@ void PFSolverPowerPolar::calculatePAndQAtSlackBus() {
       }
     }
 
+    // Exclude local shunt, matching calculatePAndQInjectionPQBuses's convention.
+    CPS::Real V = sol_V.coeff(node_idx);
+    for (auto comp : mSystem.mComponentsAtNode[topoNode])
+      if (auto shuntPtr = std::dynamic_pointer_cast<CPS::SP::Ph1::Shunt>(comp))
+        S += std::pow(V, 2) * Complex(-**(shuntPtr->mConductancePerUnit),
+                                      **(shuntPtr->mSusceptancePerUnit));
+
     // Store net nodal injection, not generator power
     sol_P(node_idx) = S.real();
     sol_Q(node_idx) = S.imag();
@@ -515,6 +522,13 @@ void PFSolverPowerPolar::calculateQAtPVBuses() {
         break;
       }
     }
+
+    // Exclude local shunt, matching calculatePAndQInjectionPQBuses's convention.
+    CPS::Real V = sol_V.coeff(node_idx);
+    for (auto comp : mSystem.mComponentsAtNode[topoNode])
+      if (auto shuntPtr = std::dynamic_pointer_cast<CPS::SP::Ph1::Shunt>(comp))
+        S += std::pow(V, 2) * Complex(-**(shuntPtr->mConductancePerUnit),
+                                      **(shuntPtr->mSusceptancePerUnit));
 
     // Store net nodal Q injection, not generator Q
     sol_Q(node_idx) = S.imag();


### PR DESCRIPTION
`calculatePAndQInjectionPQBuses` already excludes a bus's own shunt when reporting net nodal injection (flow to the rest of the network, matching the `Pgen - Pd - Gs*Vm^2` convention). The PV and VD reporting paths (`calculateQAtPVBuses`, `calculatePAndQAtSlackBus`) did not, so a PV or VD bus with a nonzero shunt reported an injection that still included the shunt's own local draw.