### PR TITLE
Analyze fork PRs with SonarCloud without exposing secrets

### DIFF
--- a/.github/workflows/sonar_cloud.yaml
+++ b/.github/workflows/sonar_cloud.yaml
@@ -1,18 +1,23 @@
-name: Sonar Cloud Analysis
+name: Sonar Cloud Build
+
+# Untrusted stage: runs in the PR/fork context with NO secrets and a read-only
+# token. It only builds the code and uploads the build-wrapper output. The
+# privileged scan (which holds SONAR_TOKEN) happens in sonar_cloud_scan.yaml,
+# triggered by this workflow's completion, and never executes PR code.
 
 on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  sonarcloud:
-    name: Prepare and run Sonar Scan
+  build:
+    name: Build for Sonar Scan
     runs-on: ubuntu-latest
     container: sogno/dpsim:dev
     env:
@@ -23,12 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
-      - name: Setup Node 24
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v8.1.0
@@ -42,14 +42,6 @@ jobs:
           path: ${{ github.workspace }}/build
           key: wrapper-dir-cache-${{ github.ref }}
 
-      - name: Setup sonar cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            .scannerwork
-            sonar-cache
-          key: sonar-cache-${{ github.ref }}
-
       - name: Configure CMake
         shell: bash
         working-directory: ${{ github.workspace }}/build
@@ -58,12 +50,17 @@ jobs:
       - name: Run build-wrapper
         run: build-wrapper-linux-x86-64 --out-dir "${{ env.BUILD_WRAPPER_OUT_DIR }}" cmake --build build/ -j "$(nproc)"
 
-      - name: Run sonar-scanner
-        uses: SonarSource/sonarqube-scan-action@v8.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io
+      # Exclude scanner state so a fork cannot smuggle it into the privileged scan.
+      - name: Package workspace for scan
+        run: >
+          tar czf /tmp/sonar-workspace.tgz
+          --exclude=./.scannerwork
+          --exclude=./sonar-cache
+          -C "$GITHUB_WORKSPACE" .
+
+      - name: Upload workspace artifact
+        uses: actions/upload-artifact@v4
         with:
-          args: >
-            --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json
+          name: sonar-workspace
+          path: /tmp/sonar-workspace.tgz
+          retention-days: 1

--- a/.github/workflows/sonar_cloud_scan.yaml
+++ b/.github/workflows/sonar_cloud_scan.yaml
@@ -1,0 +1,115 @@
+name: Sonar Cloud Scan
+
+# Privileged stage: triggered by the completion of "Sonar Cloud Build". It runs
+# in the base-repo context with SONAR_TOKEN available, but only consumes the
+# build artifact and runs sonar-scanner (which parses sources, it does not build
+# or execute them). No untrusted PR code is executed here, so a fork PR cannot
+# reach the secret. projectKey/organization are pinned so a fork cannot redirect
+# the analysis to another project.
+
+on:
+  workflow_run:
+    workflows: ["Sonar Cloud Build"]
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Prepare and run Sonar Scan
+    runs-on: ubuntu-latest
+    container: sogno/dpsim:dev
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
+      actions: read
+    env:
+      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
+
+    steps:
+      - name: Download workspace artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sonar-workspace
+          path: /tmp/sonar-dl
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract workspace
+        run: tar xzf /tmp/sonar-dl/sonar-workspace.tgz -C "$GITHUB_WORKSPACE"
+
+      # Metadata comes from trusted workflow_run context, not the PR artifact.
+      - name: Resolve analysis metadata
+        id: meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            core.setOutput('event_name', run.event);
+            core.setOutput('head_sha', run.head_sha);
+            core.setOutput('branch_name', run.head_branch);
+            if (run.event === 'pull_request') {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: run.head_sha,
+              });
+              const pr = prs.find(p => p.state === 'open') || prs[0];
+              if (!pr) {
+                core.setFailed(`No pull request found for commit ${run.head_sha}`);
+                return;
+              }
+              core.setOutput('pr_number', pr.number);
+              core.setOutput('pr_head_ref', pr.head.ref);
+              core.setOutput('pr_base_ref', pr.base.ref);
+            }
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # Cache only on trusted push runs; a PR workspace could seed a poisoned cache.
+      - name: Setup sonar cache
+        if: steps.meta.outputs.event_name == 'push'
+        uses: actions/cache@v5
+        with:
+          path: |
+            .scannerwork
+            sonar-cache
+          key: sonar-cache-${{ steps.meta.outputs.head_sha }}
+          restore-keys: |
+            sonar-cache-
+
+      - name: Run sonar-scanner (pull request)
+        if: steps.meta.outputs.event_name == 'pull_request'
+        uses: SonarSource/sonarqube-scan-action@v8.1.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
+        with:
+          args: >
+            --define sonar.projectKey=sogno-platform_dpsim
+            --define sonar.organization=sogno-platform
+            --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json
+            --define sonar.scm.revision=${{ steps.meta.outputs.head_sha }}
+            --define sonar.pullrequest.key=${{ steps.meta.outputs.pr_number }}
+            --define sonar.pullrequest.branch=${{ steps.meta.outputs.pr_head_ref }}
+            --define sonar.pullrequest.base=${{ steps.meta.outputs.pr_base_ref }}
+
+      - name: Run sonar-scanner (branch)
+        if: steps.meta.outputs.event_name == 'push'
+        uses: SonarSource/sonarqube-scan-action@v8.1.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
+        with:
+          args: >
+            --define sonar.projectKey=sogno-platform_dpsim
+            --define sonar.organization=sogno-platform
+            --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json
+            --define sonar.scm.revision=${{ steps.meta.outputs.head_sha }}
+            --define sonar.branch.name=${{ steps.meta.outputs.branch_name }}


### PR DESCRIPTION
The SonarCloud workflow used `pull_request_target` and checked out the PR head SHA. `actions/checkout@v6` now refuses this by default (the "pwn request" guard), so the check fails on fork PRs.

Split the analysis into two stages so fork PRs are analyzed again, without running untrusted code with secrets in scope.

Need to be merged to verify if it works.