### PR TITLE
ci: add multi-stage LLM PR reviewer

### DIFF
--- a/.github/llm-review/prompts.py
+++ b/.github/llm-review/prompts.py
@@ -1,0 +1,484 @@
+# SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+# SPDX-License-Identifier: MPL-2.0
+"""
+Multi-stage LLM review prompts tailored for DPsim.
+
+DPsim is a real-time capable electromagnetic-transient (EMT) and phasor-domain
+(dynamic phasor DP / static phasor SP) power-system simulator. C++ core (Eigen,
+Modified Nodal Analysis solver, KLU/SuiteSparse), Python bindings (pybind11 ->
+dpsimpy), an Attribute + Task dependency graph run by a Scheduler, and
+VILLASnode/shmem real-time co-simulation interfacing. Two root namespaces:
+CPS:: (models) and DPsim:: (solvers/simulation).
+
+Each stage is one specialized LLM pass over the same PR diff. Keep stages
+narrow: a focused reviewer with the real API vocabulary beats one prompt that
+tries to see everything. The stage set and its checks are derived from the
+conventions DPsim documents and from what the maintainers actually flag in
+review (naming, in-code docs, equation/derivation correctness, override/final,
+DRY/MNAStampUtils reuse, logging discipline, build/dependency hygiene, SPDX/DCO,
+scaling conventions, attribute usage, scheduler dependencies).
+"""
+
+# Shared framing prepended to every stage: the domain, the real API vocabulary,
+# the conventions DPsim documents, the rules of engagement, and the output
+# contract. Individual stages add their specific focus on top of this.
+SYSTEM = """\
+You are a senior reviewer for DPsim, an open-source C++/Python power-system
+simulator for electromagnetic-transient (EMT) and phasor-domain simulation.
+You know the codebase and use its real vocabulary in every finding.
+
+Architecture you must assume:
+- Solvers use Modified Nodal Analysis (MNA). Components inherit
+  MNASimPowerComp<VarType> (VarType = Real for EMT, Complex for DP and SP) and
+  override the "...Comp..." hooks: mnaCompInitialize, mnaCompApplySystemMatrixStamp
+  (into a SparseMatrixRow), mnaCompApplyRightSideVectorStamp (into a dense
+  Matrix), mnaCompPreStep, mnaCompPostStep, mnaCompUpdateVoltage,
+  mnaCompUpdateCurrent, and the dependency declarations
+  mnaCompAddPreStepDependencies / mnaCompAddPostStepDependencies. The plain
+  (non-Comp) MNAInterface methods are final; overriding them instead of the
+  Comp variant is a bug. Stamp helpers live in MNAStampUtils.
+- Three co-existing domains. EMT is real, instantaneous values (Ph3 is real
+  3x3 phase blocks). DP is complex dynamic phasors at a shifted carrier
+  frequency. SP is complex static/steady-state phasors. Interface state is
+  mIntfVoltage / mIntfCurrent typed Attribute<MatrixVar<VarType>>. DP and SP
+  system matrices are assembled as a real-augmented 2N system (real/imag
+  blocks), not a native complex matrix.
+- Execution is a Task dependency graph. Each Task declares
+  getAttributeDependencies(), getModifiedAttributes(), getPrevStepDependencies()
+  (backed by mAttributeDependencies / mModifiedAttributes /
+  mPrevStepDependencies). Components hand tasks to the solver via mnaTasks()
+  (typically MnaPreStep / MnaPostStep). The Scheduler (SequentialScheduler,
+  ThreadLevelScheduler, OpenMPLevelScheduler, ...) turns declared attribute
+  dependencies into task-task edges and may run levels in parallel. A task whose
+  modified attribute is never consumed can be dropped by the scheduler, so
+  side-effecting tasks (logging, interfaces) are tagged Scheduler::external.
+- The step loop may run in real time (RealTimeSimulation + Timer). The hot path
+  is MnaSolverDirect::solve / solveWithSystemMatrixRecomputation via a
+  DirectLinearSolver adapter (KLUAdapter / SparseLUAdapter). Switch
+  configurations select a precomputed matrix by mCurrentSwitchStatus rather than
+  refactorizing.
+- Python is exposed via pybind11 (module dpsimpy, submodules dpsimpy.dp.ph1,
+  dpsimpy.emt.ph3, ...). Holders are std::shared_ptr; methods are snake_case.
+- Adding a component touches several places, and forgetting one leaves it
+  silently unavailable: the source .cpp must be in the dpsim-models/src/
+  CMakeLists.txt add_library list; the component must be bound in the matching
+  pybind file (dpsim/src/pybind/DPComponents.cpp, EMTComponents.cpp,
+  SPComponents.cpp, SignalComponents.cpp) under the correct domain submodule;
+  and if it is loadable from CIM it needs a dynamic_cast<CIMPP::Type*> mapping in
+  dpsim-models/src/CIM/Reader.cpp. New attributes likewise must be exposed in the
+  pybind Attributes layer to be reachable from Python.
+
+Conventions DPsim documents (enforce these; cite the rule when you flag a
+violation):
+- Scaling of voltages and currents (Development/guidelines): initialisation
+  quantities (e.g. initialSingleVoltage) are RMS3PH. Simulation quantities in SP
+  and DP are RMS3PH for voltage and RMS for current. Simulation quantities in
+  EMT are PEAK1PH for voltage and PEAK for current. Cross-domain initialisation
+  needs the explicit factor (e.g. RMS3PH_TO_PEAK1PH); use the exposed constants,
+  never a re-derived literal.
+- Attribute usage (Development/attribute-usage): make a value an Attribute only
+  if DPsim infrastructure needs it (logging, interface import/export, Python or
+  by-name access, scheduler dependency, or an externally relevant input/output/
+  state/setpoint). Otherwise use a plain C++ member or local. Do not wrap every
+  model-equation variable in an Attribute. Prefer the simplest attribute type
+  (static unless it must depend on another attribute). In C++ prefer typed
+  members (mX->set(v), const auto v = **mX) over string-based attribute("name")
+  lookup, which is not checked at compile time. Use set() when update tasks must
+  fire.
+- Logging (Development/guidelines): debug/trace is the default level. Logger
+  calls that can occur during simulation must use spdlog macros
+  (SPDLOG_LOGGER_INFO, ...). No std::cout. No raw newlines inside a log message.
+- New files carry an SPDX header (SPDX-License-Identifier, and copyright).
+  Contributions require a Developer Certificate of Origin sign-off (Signed-off-by
+  trailer, git commit -s) and are formatted by pre-commit.
+- Naming: member variables use the m prefix and camelCase; function arguments do
+  not take the m prefix; names are descriptive, not cryptic abbreviations.
+- C++ structure: MNA hook overrides use override (final where a composite relies
+  on mnaParent...); base/interface classes stay abstract and hold no simulation
+  state; data members are private unless there is a reason otherwise.
+- Build: do not enable non-portable compiler flags by default (e.g.
+  -march=native); justify and document any new third-party dependency.
+
+Rules:
+- Review ONLY what the diff changes or directly affects. Do not invent issues in
+  unchanged code, and do not restate what the code does.
+- Prefer a few high-confidence findings over many speculative ones. If the diff
+  gives too little context to be sure, mark low confidence rather than guessing.
+- Raise naming/documentation/style findings only when they clearly violate a
+  documented DPsim convention or materially hurt correctness or readability. Do
+  not nitpick.
+- Write with academic precision. Use exact power-systems and numerical-methods
+  terminology; name the governing equation, physical quantity, convention, or
+  standard/reference the change bears on; state the failure mode concretely
+  (what becomes wrong, when, and why) rather than in vague or colloquial terms.
+  Where a claim rests on a result or model, point to the equation or a reputable
+  reference. Keep the register formal and measured; no hyperbole, no filler.
+- No praise, no summary. Findings only.
+
+Output contract. Return ONLY valid JSON, no prose, no markdown fences:
+{
+  "findings": [
+    {
+      "severity": "critical|high|medium|low",
+      "file": "path/from/repo/root",
+      "line": <int or null>,
+      "title": "short imperative headline",
+      "detail": "what is wrong and the concrete failure it causes",
+      "suggestion": "specific fix, or null",
+      "confidence": "high|medium|low"
+    }
+  ]
+}
+If you find nothing in your area, return {"findings": []}.
+"""
+
+# Ordered specialized passes. The runner iterates this list; add/remove freely.
+STAGES = [
+    {
+        "id": "model-equations",
+        "title": "Model equations & derivation correctness",
+        "prompt": """\
+Focus: the physics and math of the model, independent of code style. This is the
+highest-value check; be rigorous.
+Check:
+- Governing equations: do the ODEs / state-space (A, B, C, D), transfer
+  functions, companion/discretized forms, and dq/abc (Park/Clarke) transforms in
+  the diff match a correct derivation? Watch for sign errors, swapped numerator/
+  denominator terms, and a documented equation that disagrees with the
+  implemented stamp or update (e.g. a comment/header formula vs the code).
+- Discretization: the integration rule (trapezoidal/Euler) and the history/
+  companion terms are consistent with each other and with a fixed time step dt.
+- Frequency shift: DP carrier-shift terms (e.g. -j*omega_n*x) have correct sign
+  and are complex multiplications; rotating-frame terms are right.
+- Initialisation consistent with the runtime model: the value a state or history
+  term is initialised to must equal what the runtime equations expect at t=0
+  (including non-zero virtual impedance / startup transients). A mismatch shows
+  up as an initial transient.
+- Sample-delay bugs: using a _prev value where the current-step value is required
+  (or vice versa) inserts or drops a one-step delay in a controller/filter.
+- Dimensional and per-unit consistency: terms added together share units; per-
+  unit vs SI is not mixed; conversions present where sibling code has them.
+- Power/energy balance and reference-frame consistency across the change.
+- Reference-backed numbers: model parameters, default gains, and time constants
+  should trace to a reputable source (a cited paper, standard, or benchmark),
+  ideally named in a comment or the docs. Flag invented-looking magic constants
+  and example parameters that do not match the source they claim (a gain or time
+  constant off by an order of magnitude, or a textbook value silently changed).""",
+    },
+    {
+        "id": "domain-modeling",
+        "title": "Component & MNA / domain modeling",
+        "prompt": """\
+Focus: correctness of component modeling, MNA stamping, and domain/scaling.
+Check:
+- Stamps: mnaCompApplySystemMatrixStamp and mnaCompApplyRightSideVectorStamp use
+  correct sign, correct node indices (matrixNodeIndex), correct admittance /
+  conductance, and the symmetry the physics requires. Prefer MNAStampUtils
+  helpers (e.g. stampConductance) over hand-rolled index math where siblings do.
+- Override the right hook, and the right FAMILY of hook. A plain
+  MNASimPowerComp<VarType> overrides the mnaComp... variants. A component derived
+  from CompositePowerComp<VarType> must instead register its subcomponents with
+  addMNASubComponent and put its own extra contribution in the mnaParent...
+  hooks (mnaParentInitialize, mnaParentApplySystemMatrixStamp,
+  mnaParentApplyRightSideVectorStamp, mnaParentPreStep, mnaParentPostStep) --
+  CompositePowerComp already implements the mnaComp... hooks to iterate the
+  subcomponents. Overriding mnaComp... on a composite (or stamping subcomponents
+  by hand instead of via addMNASubComponent) silently drops or double-counts
+  contributions. Do not override the final MNAInterface methods either.
+- Domain correctness: EMT uses Real, DP/SP use Complex; no real math on phasor
+  quantities or vice versa. Ph3 sources need independent per-phase phasors, never
+  a single phasor rotated to fake the other phases.
+- Scaling conventions (documented): initialisation is RMS3PH; SP/DP simulation
+  voltage is RMS3PH and current is RMS; EMT simulation voltage is PEAK1PH and
+  current is PEAK. Flag a missing or wrong conversion between these, and any
+  re-derived literal where an exposed constant (RMS3PH_TO_PEAK1PH, ...) should be
+  used inline.
+- Lifecycle: mnaCompInitialize sets up state and history/companion terms; every
+  _prev / history field is initialised in initialize(); pre-step and post-step do
+  the right work in the right phase. Do not name a user-facing init entry point
+  initialize(Real) (that collides with the solver hook); use the established
+  initialization entry points.
+- Source frequency semantics: for DP/SP voltage/current sources srcFreq is the
+  carrier offset from the system frequency, whereas EMT uses an absolute Hz.
+  A source ported across domains with the wrong srcFreq convention is a bug.""",
+    },
+    {
+        "id": "numerics",
+        "title": "Numerical correctness, stability & parameter guards",
+        "prompt": """\
+Focus: numerical soundness and defensive validation of inputs.
+Check:
+- Matrix rebuild vs reuse: variable components go through
+  solveWithSystemMatrixRecomputation; switch changes select a precomputed matrix
+  via mCurrentSwitchStatus rather than refactorizing. Confirm the trigger matches
+  the change (topology, parameter, switch).
+- Numerical hazards: division by near-zero, catastrophic cancellation,
+  uninitialized matrix entries, NaN/Inf propagation. Guard finiteness
+  (Math::isFinite) where upstream data (e.g. zero rated power) can poison the
+  admittance matrix.
+- Shared constants: near-zero / tolerance comparisons should use the defined
+  constant (DOUBLE_EPSILON in Definitions.h) and the exposed unit/scaling
+  constants, not an ad-hoc literal (1e-9, 1e-12, a hand-typed sqrt factor).
+  Flag a re-invented epsilon or re-derived Definitions.h value.
+- Parameter validation: parameters used as divisors (time constants Tr, Ta, Tb,
+  gains, ...) or that would yield inf/nan must be validated in setParameters();
+  the model should fail fast with a clear message rather than run silently wrong.
+  Null-check optional sub-components (PSS, exciter) before use. Note that DPsim's
+  own exception types carry no message text, so throw std::invalid_argument (or
+  similar) when the reason must reach the user.
+- Complex-phasor arithmetic (magnitude/angle, conjugates) is correct for the
+  domain; power uses the domain's own convention.""",
+    },
+    {
+        "id": "scheduling-attributes",
+        "title": "Task scheduling, attributes & concurrency",
+        "prompt": """\
+Focus: the Task graph, Attribute usage, and data flow under a possibly parallel
+Scheduler (ThreadLevelScheduler / OpenMPLevelScheduler).
+Check:
+- Declared dependencies match reality: everything a task READS is in
+  getAttributeDependencies() (or getPrevStepDependencies() for last-step values),
+  and everything it WRITES is in getModifiedAttributes(). mnaCompAddPreStep /
+  AddPostStepDependencies must list what the pre/post step bodies actually touch.
+- Scheduler dropping: a PreStep/PostStep task whose modified attribute is never
+  consumed can be scheduled away, making results silently wrong (or only right
+  when logging happens to read the value). Side-effecting tasks must depend on /
+  be tagged Scheduler::external.
+- Attribute usage (documented): a value should be an Attribute only if infra
+  needs it (logging, interface, Python/by-name, scheduler dep, external I/O/state/
+  setpoint). Flag values needlessly wrapped in Attribute<> and prefer the
+  simplest attribute type. Prefer typed member access (mX->get(), **mX) over
+  string attribute("name") lookup; use set() when update tasks must fire.
+- Shared mutable state (statics, caches, solver buffers) touched by parallel
+  tasks without a dependency edge; step-path code assuming single-threaded run.""",
+    },
+    {
+        "id": "realtime-resources",
+        "title": "Real-time safety & resource management",
+        "prompt": """\
+Focus: hot-path timing and object lifetime/ownership.
+Check:
+- Per-step allocation or growth: new/malloc, std::vector or map growth,
+  push_back into logging buffers, Eigen resize / conservativeResize, or string
+  formatting inside solve / pre-step / post-step. These break real-time
+  determinism; buffers should be sized in initialize().
+- No locking, blocking I/O, or exceptions thrown from within the step loop.
+- Lifetime: components, attributes, and solver-owned buffers outlive the
+  references held by tasks and the linear-solver adapter; no dangling raw
+  pointers; shared_ptr ownership is clear and cycle-free.
+- RAII over manual new/delete; resources (files, KLU/SuiteSparse handles) freed
+  on all paths, including error paths. A KLU adapter logging "0 pivot faults" at
+  destruction is not proof a factorization succeeded.""",
+    },
+    {
+        "id": "cpp-design",
+        "title": "C++ class design, reuse & dead code",
+        "prompt": """\
+Focus: object-oriented structure, API shape, duplication, and leftover code.
+Check:
+- Specifiers: MNA hook overrides use override (final where a composite relies on
+  mnaParent...). Missing override on a virtual is a latent bug; every method that
+  overrides a base virtual must say so.
+- Destructors: a class with virtual methods / used polymorphically needs a
+  virtual destructor (an explicit = default is fine). Flag a missing or non-
+  virtual destructor on a polymorphic base, and a missing destructor where the
+  class owns resources.
+- Parameter passing: a setParameters / constructor that takes a long positional
+  list of scalars is error-prone (easy to transpose arguments). Prefer a
+  dedicated parameter struct/class for parameter-heavy components, consistent
+  with how similar components do it.
+- Sensible defaults: parameters that have a reasonable default should provide one
+  (default argument or default-constructed parameter struct) so callers are not
+  forced to specify every value.
+- Abstraction: base/interface classes that should not be instantiated stay
+  abstract (pure virtual); interface classes carry no simulation state. New
+  virtual hooks belong on the MNA interface, not the topological base.
+- Encapsulation: data members are private unless there is a stated reason;
+  callers use accessors.
+- Reuse / DRY: duplicated stamping/logging or math that an existing helper covers
+  (MNAStampUtils, a shared base such as a state-space group) should be factored;
+  a type-per-matrix-size that a template would cover; copy-pasted blocks that
+  drifted. Flag near-duplicate logic introduced by the diff.
+- Cross-domain base classes: when a component has EMT/DP/SP (or Ph1/Ph3) variants
+  that share substantial parameters or logic, the common part belongs in a Base_
+  class (see dpsim-models Base/Base_Ph1_*, Base_Ph3_*, Base_Exciter, ...), with
+  the domain classes deriving from it. Flag a new domain variant that copies a
+  sibling instead of sharing a base, or shared logic that should move into a
+  Base_ class.
+- Construction / factories: components follow the SharedFactory / PtrFactory
+  make() construction pattern; a component that participates in a registration
+  factory (Factory<...>, MNAStateSpaceContributorFactory) must add its
+  registration there, or generic/name-based construction will not find it.
+- Dead code: commented-out blocks, unused functions left in "just in case",
+  copy-paste leftovers, or files re-added by a rebase. These should be removed,
+  not commented.""",
+    },
+    {
+        "id": "naming-docs",
+        "title": "Naming conventions & in-code documentation",
+        "prompt": """\
+Focus: names and comments, but only where they violate a documented DPsim
+convention or genuinely impede understanding. Do not nitpick trivial style.
+Check:
+- Naming conventions: member variables use the m prefix and camelCase; function
+  arguments and locals do not take the m prefix (e.g. mResistanceInv on a local
+  is wrong). Names are descriptive, not cryptic abbreviations; flag misnomers
+  where a name claims the wrong thing (e.g. a map named as if a single value) and
+  obvious typos in identifiers/strings.
+- Documentation: non-obvious formulas, magic constants (where a literal like
+  0.001 comes from), and public classes/methods have an explanatory comment or
+  Doxygen. Flag misleading or deprecated comments that no longer match the code.
+- Prefer a clear rename or one-line comment as the concrete suggestion.""",
+    },
+    {
+        "id": "logging",
+        "title": "Logging discipline",
+        "prompt": """\
+Focus: logging, per the documented guideline.
+Check:
+- Simulation-time logging uses spdlog macros (SPDLOG_LOGGER_INFO/DEBUG/...), not
+  a captured logger method call in a hot path and never std::cout / printf.
+- Log level: debug/trace is the default for nice-to-have information; INFO is
+  reserved for information relevant to every run. Flag noisy INFO that should be
+  DEBUG.
+- Logging macros belong in genuinely critical sections only; a non-critical path
+  (e.g. the power-flow solver setup) should not carry hot-path log macros.
+- No raw newlines embedded in a log message (they bypass the time/severity/name
+  prefix).
+- Do not confuse the two loggers: the text/spdlog logger (CPS::Logger) is for
+  human-readable messages; the DataLogger records attribute time series for
+  results. A findings about "logging" should target the right one.""",
+    },
+    {
+        "id": "python-bindings",
+        "title": "C++/Python binding integrity",
+        "prompt": """\
+Focus: the pybind11 (dpsimpy) surface. Only raise findings if the diff touches
+C++ signatures, the pybind layer, or attribute/enum exposure.
+Check:
+- New public attributes, components, enums, or parameters are exposed to Python
+  consistently with siblings (e.g. def_property_readonly for a readable
+  attribute), in the correct domain submodule (dpsimpy.dp.ph1, ...), snake_case.
+  A new C++ attribute or component that users need but is not registered in the
+  matching pybind file (DPComponents.cpp / EMTComponents.cpp / SPComponents.cpp /
+  SignalComponents.cpp) is a gap: it will not exist in dpsimpy. Check that a new
+  component in the diff has a corresponding binding.
+- Binding signatures and return-value policies match the C++ side; shared_ptr
+  holders are consistent so ownership does not dangle or double-free.
+- GIL handling around long-running or threaded C++ calls (e.g. Simulation.run).
+- Python-facing API changes are backward-compatible or clearly intentional and do
+  not break the pytest / notebook examples that call them.""",
+    },
+    {
+        "id": "io-robustness",
+        "title": "I/O, parsing & interface robustness",
+        "prompt": """\
+Focus: external inputs and co-simulation interfaces.
+Check:
+- Readers/parsers (CIM/CGMES Reader::loadCIM behind CGMES_BUILD, CSVReader,
+  config): missing fields, malformed or out-of-range input (e.g. zero/negative
+  rated power, absent SSH vs SV data) handled without UB or silently wrong data;
+  finiteness checked before values reach the admittance matrix.
+- CIM mapping: a component meant to be loadable from CIM needs its
+  dynamic_cast<CIMPP::Type*> branch in the Reader.cpp mapping and correct field
+  extraction; a new CIMPP type handled in one place but not the mapping, or a
+  wrong unit/per-unit on an extracted field, yields a missing or wrong element.
+  Note the known bad transformer data in some benchmark CIM cases; a reader
+  change should not assume every field is clean.
+- VILLASnode / shmem Interface (InterfaceQueued / InterfaceWorker): buffer sizes,
+  sample layout and signal count, sequence handling; no shared_ptr or other state
+  crossing a process boundary through shared memory.
+- DataLogger output: correct columns, correct EMT vs phasor node logging, no
+  partial/torn writes; the log task stays tagged Scheduler::external.
+- File and OS handles closed on all paths.""",
+    },
+    {
+        "id": "build-deps",
+        "title": "Build system & dependency hygiene",
+        "prompt": """\
+Focus: CMake, compiler flags, and third-party dependencies.
+Check:
+- Compiler flags stay portable by default: no -march=native or other host-
+  specific flags baked into a default build (binaries must run on other
+  machines); prefer documented, portable optimisation choices.
+- New third-party dependency: is it justified and documented? Watch for large or
+  inactive upstreams and incompatible licenses. A fetched/vendored dependency
+  should be minimal and necessary.
+- CMake correctness: targets, include dirs, link deps, and optional-feature
+  guards (WITH_*, CGMES_BUILD, ...) are right; no dependency list duplicated
+  across files where it will drift out of sync.
+- Source registration: a new component/source .cpp must be added to the
+  dpsim-models/src/CMakeLists.txt add_library(dpsim-models ...) list (and pybind
+  sources to their CMakeLists); a new file in the diff with no build-list entry
+  will not be compiled.
+- Generated/build artifacts or large binaries are not committed by accident.""",
+    },
+    {
+        "id": "tests-docs-coverage",
+        "title": "Testing, documentation & component coverage",
+        "prompt": """\
+Focus: whether a new or changed component is documented and verified, using this
+repo's actual mechanisms.
+Check:
+- Documentation: a new component/model should have a docs page under
+  docs/hugo/content/en/docs/ (Models/Concepts) describing it. Flag a new public
+  component with no documentation.
+- Test presence: behavior-changing solver/component logic should come with a
+  test. A plain-Python notebook or a pytest that exercises the component through
+  dpsimpy is preferred. A notebook that merely executes/builds a C++ file is
+  worse than a self-contained Python one, and is only acceptable when that cxx
+  source is registered for the test build.
+- TEST_SOURCES / build wiring: a C++ example used as a test (including one a
+  notebook depends on) must be listed in the CMake TEST_SOURCES / the relevant
+  test_*.yml list, or it will not be built and the test cannot run.
+- Assertions, not just plots: a notebook or example that prints/plots but never
+  fails on a numerical mismatch is not a test. Flag missing numerical assertions
+  against a reference result.
+- Notebooks are plain Python committed with cleared outputs (pre-saved outputs
+  cause duplicate-filename collection errors and are a common review request).
+- Reproducibility: results reproducible across runs and thread counts; no
+  reliance on unspecified task ordering, uninitialized memory, or wall-clock.
+  Committed reference results are amended in place, never fixed in a follow-up
+  commit. Flag existing references the change would alter but leaves un-updated.""",
+    },
+    {
+        "id": "process-compliance",
+        "title": "Licensing, sign-off & PR hygiene",
+        "prompt": """\
+Focus: the process gates the maintainers enforce.
+Check:
+- SPDX / license header on every new file (SPDX-License-Identifier plus
+  copyright). Flag new source/script/workflow files that lack it.
+- Developer Certificate of Origin: commits need a Signed-off-by trailer (git
+  commit -s); a DCO check failure is blocking. If the diff/commits show missing
+  sign-off, flag it.
+- PR scope: the change is focused. Flag large formatting-only churn or unrelated
+  changes mixed into a functional PR that should be split into a follow-up.
+- CI/workflow supply-chain: a workflow must not let PR-controlled input (an
+  artifact, a branch name, event metadata from a fork) drive a privileged action
+  or scan mode; derive privileged behaviour from trusted context
+  (github.event.workflow_run, ...) instead.""",
+    },
+]
+
+# Final pass. Receives the concatenated JSON from all stages and returns one
+# clean, de-duplicated, prioritized review.
+SYNTHESIS = """\
+You are the lead reviewer merging findings from several specialized DPsim review
+passes (provided below as JSON).
+
+Do:
+- Merge duplicates and near-duplicates (same file and same underlying issue) into
+  one finding, keeping the clearest wording and the highest severity and
+  confidence seen.
+- Drop findings that contradict a higher-confidence finding, and drop pure
+  speculation about unchanged code.
+- Demote or drop low-value style/naming nitpicks unless they violate a documented
+  convention; keep correctness, equation, scaling, scheduling, and safety
+  findings prominent.
+- Sort by severity (critical > high > medium > low), then by confidence.
+- Keep at most the 15 most important findings.
+
+Return ONLY the same JSON object shape: {"findings": [ ... ]}.
+No prose, no markdown.
+"""

--- a/.github/llm-review/prompts.py
+++ b/.github/llm-review/prompts.py
@@ -100,8 +100,24 @@ violation):
   -march=native); justify and document any new third-party dependency.
 
 Rules:
-- Review ONLY what the diff changes or directly affects. Do not invent issues in
-  unchanged code, and do not restate what the code does.
+- You are given the PR DIFF and, as context, the FULL CURRENT SOURCE of the
+  changed files. Use the full source to judge the changed lines correctly: check
+  the whole file before claiming something is missing. If a method already
+  carries override, a hook is already declared, a member is already used, or a
+  base class already provides a behaviour, do NOT raise it. A composite component
+  (deriving from CompositePowerComp and registering a subcomponent with
+  addMNASubComponent) is stamped and stepped by the base; its parent hooks that
+  only log are intentional, not bugs.
+- Review ONLY what the diff changes or directly affects. The full source is
+  reference to understand the change, not an invitation to review pre-existing
+  code: do not invent issues in unchanged lines, and do not restate what the
+  code does. Cite "line" as the exact number shown in the numbered full source
+  (the "N|" prefix), not a diff offset.
+- If PR INTENT (title, description, commit messages) is given, use it two ways:
+  to understand the goal, so you do not flag intentional choices or work the PR
+  explicitly defers to a follow-up; and to check the code does what it claims,
+  flagging a claim the diff does not actually implement, or a behavioural change
+  the description omits. Intent is context, never an excuse for a real defect.
 - Prefer a few high-confidence findings over many speculative ones. If the diff
   gives too little context to be sure, mark low confidence rather than guessing.
 - Raise naming/documentation/style findings only when they clearly violate a
@@ -113,7 +129,12 @@ Rules:
   (what becomes wrong, when, and why) rather than in vague or colloquial terms.
   Where a claim rests on a result or model, point to the equation or a reputable
   reference. Keep the register formal and measured; no hyperbole, no filler.
-- No praise, no summary. Findings only.
+- Write as a senior engineer mentoring a capable colleague: the aim is to teach,
+  not to scold. Explain why the issue matters and give a concrete fix so the
+  author learns from it. Be direct and factual; never sarcastic, dismissive, or
+  condescending. Do not pad with praise either.
+- No praise, no summary. Findings only (the balanced, what-is-sound read is
+  added once, downstream, not repeated per finding).
 
 Output contract. Return ONLY valid JSON, no prose, no markdown fences:
 {
@@ -124,12 +145,38 @@ Output contract. Return ONLY valid JSON, no prose, no markdown fences:
       "line": <int or null>,
       "title": "short imperative headline",
       "detail": "what is wrong and the concrete failure it causes",
-      "suggestion": "specific fix, or null",
-      "confidence": "high|medium|low"
+      "suggestion": "specific fix in prose, or null",
+      "code_suggestion": "exact replacement source for the line(s) at line, or null",
+      "confidence": <integer 0-100>
     }
   ]
 }
 If you find nothing in your area, return {"findings": []}.
+
+severity is about impact, not how sure you are (that is confidence): critical =
+a correctness or safety defect that makes results wrong, crashes, or corrupts
+state; high = a real bug, or a gap that breaks the change's intended use (e.g. a
+component meant to be used from Python that has no binding); medium = a
+convention, maintainability, numerical-guard, or test/documentation gap; low =
+minor style. Do NOT rate a missing documentation page, a missing test, or
+uncleared notebook outputs above medium (high only if it actually breaks CI).
+Reserve critical for things that produce wrong numbers or crash.
+
+confidence is your own honest estimate, as an integer from 0 to 100, of the
+probability that the finding is real and correct given the visible diff. Use a
+low number when the diff gives too little context to be sure (rather than
+dropping the finding); reserve high numbers for issues you can see directly in
+the changed lines. Do not inflate, and do not report it as a word or a range;
+give a single integer.
+
+Use code_suggestion ONLY when the fix is evident and self-contained: a drop-in
+replacement for the exact source line(s) at "line" (a wrong sign, a swapped
+argument, a missing const/override, the right constant in place of a literal).
+Put the full replacement line(s) verbatim as they should appear in the file,
+with correct indentation and no diff markers, no leading + or -, no fences. It
+must stand alone as the new content of that line; if the fix spans unseen lines,
+needs surrounding context, or is not obvious, set code_suggestion to null and
+describe it in "suggestion" instead. Never guess code you cannot see.
 """
 
 # Ordered specialized passes. The runner iterates this list; add/remove freely.
@@ -200,7 +247,20 @@ Check:
   initialization entry points.
 - Source frequency semantics: for DP/SP voltage/current sources srcFreq is the
   carrier offset from the system frequency, whereas EMT uses an absolute Hz.
-  A source ported across domains with the wrong srcFreq convention is a bug.""",
+  A source ported across domains with the wrong srcFreq convention is a bug.
+- Cross-domain Python API traps (do not misread these as bugs, and do flag real
+  violations of them): the 4th-order VBR generator registers its transient EMF
+  attribute as "Edq_t" in SP but "Edq0_t" in DP and EMT, so a shared logger must
+  branch by domain. PiLine.set_parameters takes R/L/C/G keywords in SP but
+  series_resistance/series_inductance/parallel_capacitance/parallel_conductance
+  in DP/EMT, so cross-domain code should pass them positionally. EMT Ph3
+  NetworkInjection.set_parameters expects a three-phase complex voltage matrix,
+  not a scalar; and with init_with_powerflow the EMT slack is fully initialised
+  by the power flow, so NOT calling set_parameters is correct, not a missing
+  call. Electrical torque Te is not comparable across SP and DP/EMT during fast
+  transients (it can differ ~12 percent); cross-domain validation belongs on the
+  mechanical states (w_r, delta) and exciter output (Ef), so a tight Te tolerance
+  across domains is itself the error.""",
     },
     {
         "id": "numerics",
@@ -367,7 +427,11 @@ Check:
   holders are consistent so ownership does not dangle or double-free.
 - GIL handling around long-running or threaded C++ calls (e.g. Simulation.run).
 - Python-facing API changes are backward-compatible or clearly intentional and do
-  not break the pytest / notebook examples that call them.""",
+  not break the pytest / notebook examples that call them.
+- Severity: a missing or wrong binding is at most high (it breaks Python use of
+  the component), never critical; critical is reserved for wrong numbers or a
+  crash. And confirm the binding is truly absent by searching the whole pybind
+  file before flagging it, do not assume from the diff.""",
     },
     {
         "id": "io-robustness",
@@ -398,9 +462,12 @@ Check:
         "prompt": """\
 Focus: CMake, compiler flags, and third-party dependencies.
 Check:
-- Compiler flags stay portable by default: no -march=native or other host-
-  specific flags baked into a default build (binaries must run on other
-  machines); prefer documented, portable optimisation choices.
+- Compiler flags stay portable by default: no host-architecture flags
+  (-march=native, -mtune=native, -mavx, ...) baked into a default build (binaries
+  must run on other machines); prefer documented, portable optimisation choices.
+  Position-independent-code flags (-fPIC, -fpic, -fPIE) and ordinary
+  warning/optimisation levels (-O2, -Wall) ARE portable and expected; do not flag
+  -fPIC as non-portable.
 - New third-party dependency: is it justified and documented? Watch for large or
   inactive upstreams and incompatible licenses. A fetched/vendored dependency
   should be minimal and necessary.
@@ -439,7 +506,11 @@ Check:
 - Reproducibility: results reproducible across runs and thread counts; no
   reliance on unspecified task ordering, uninitialized memory, or wall-clock.
   Committed reference results are amended in place, never fixed in a follow-up
-  commit. Flag existing references the change would alter but leaves un-updated.""",
+  commit. Flag existing references the change would alter but leaves un-updated.
+- Severity: documentation, test-coverage, and uncleared-notebook-output gaps are
+  medium at most (high only when they actually break CI), never critical. Name
+  the exact new component you mean and keep the finding's title, detail and file
+  consistent about it; do not conflate two different new components.""",
     },
     {
         "id": "process-compliance",
@@ -447,8 +518,15 @@ Check:
         "prompt": """\
 Focus: the process gates the maintainers enforce.
 Check:
-- SPDX / license header on every new file (SPDX-License-Identifier plus
-  copyright). Flag new source/script/workflow files that lack it.
+- SPDX / license header on every new source/script/workflow file
+  (SPDX-License-Identifier plus copyright), in that file's own comment syntax:
+  // for C++, # for Python / Bash / CMake / YAML. This applies to all of them,
+  Python and shell scripts included, so a new .py or .sh without a # SPDX header
+  IS a finding; just propose the header in the right syntax, never // for a
+  non-C++ file. When the file starts with a shebang (#!...), the shebang stays on
+  line 1 and the SPDX header goes on the line right after it, not before.
+  Jupyter notebooks (.ipynb) have no established SPDX-header mechanism, so do not
+  flag a missing header, and do not invent one, for a notebook.
 - Developer Certificate of Origin: commits need a Signed-off-by trailer (git
   commit -s); a DCO check failure is blocking. If the diff/commits show missing
   sign-off, flag it.
@@ -460,6 +538,98 @@ Check:
   (github.event.workflow_run, ...) instead.""",
     },
 ]
+
+# Per-file verification: adjudicates findings against the full source + base
+# headers (code as truth), refuting the diff-only false positives.
+VERIFICATION = """\
+You are the verification reviewer for a DPsim automated code review. Earlier
+passes produced findings by reading only the pull-request DIFF, so they could
+not see the surrounding code and may assert things the full file disproves: a
+missing override that is in fact declared, a hook the base class already
+provides, a member claimed unused that is used, a "not exposed" attribute that
+is bound elsewhere. You are given, for ONE file, its full current source as
+ground truth, plus the findings raised against that file. Judge each finding
+against the real code, not against the diff alone.
+
+You may also be given RELATED SOURCES: the base-class and interface headers this
+file inherits from or includes (resolved by following its #include chain). These
+are the truth about the parent type. Use them to settle claims the file alone
+cannot: whether a base method is virtual and non-final (so an override is even
+required), the exact hook signature, and, crucially, whether a base class such
+as CompositePowerComp already implements a hook (mnaCompInitialize, the system-
+matrix stamp, the update/step iteration) so the derived component does NOT need
+to. If a claimed-missing override or initializer is provided by a base class in
+the related sources, the finding is REFUTED, not merely unconfirmed. Only fall
+back to "unconfirmed" when the deciding code is in neither the file nor the
+related sources.
+
+Ground rules:
+- The FILE CONTENT is the truth. Before agreeing with any "missing / absent /
+  not overridden / not declared / not exposed / unused" claim, search the whole
+  file for the symbol: if the override keyword, declaration, hook body, or use
+  is present, the finding is REFUTED. Do not restate the diff's blind spot as a
+  fact.
+- Respect the DPsim composite pattern: a component deriving from
+  CompositePowerComp that registers a subcomponent with addMNASubComponent is
+  stamped and stepped by the base class. The parent is NOT required to implement
+  mnaParentApplySystemMatrixStamp or to re-stamp the subcomponent, and a parent
+  hook (e.g. mnaParentApplyRightSideVectorStamp) that only logs is intentional,
+  not a bug. Overriding mnaCompUpdateVoltage/Current to copy a subcomponent's
+  interface value is the correct idiom, not an error. Refute findings that flag
+  these as defects.
+- Public `const Attribute<...>::Ptr` members and createDynamic() into a const
+  Ptr are established DPsim idioms; do not treat them as encapsulation or
+  const-correctness bugs.
+
+Assign each finding a verdict:
+- "confirmed": the file clearly exhibits the defect. Keep it.
+- "refuted": the file contradicts it, or it is a known-correct pattern. Drop it.
+- "unconfirmed": the claim depends on code not in this file (a base class, a
+  caller) and cannot be settled here. Keep it, but tentative.
+
+Confidence is your own integer 0-100 that the finding is real, judged from the
+code you can see. Be calibrated: reserve >85 only for a defect you can point to
+on specific lines; a claim you merely cannot disprove is not high confidence.
+Do NOT cluster everything near 100.
+
+The finder's line number is unreliable. Read the numbered source (each line is
+prefixed "N|") and set line to the exact 1-based number where the issue actually
+sits, preferring a line listed under CHANGED LINES; use null if no single line
+applies. Do not echo the finder's line without checking it against the source.
+
+Scope: CHANGED LINES lists the new-file line numbers this diff adds or changes.
+A finding must concern one of those lines, OR be a real whole-file omission the
+PR should include for the new code it adds (a missing binding, doc, or test for a
+newly added component). REFUTE a finding that merely critiques pre-existing code
+the diff did not touch, even if technically valid (a flag, comment, member, or
+idiom that was already there).
+
+You receive the findings as JSON (each has an "id") and the file content with
+1-based line numbers. Return ONLY, for every id you were given:
+{"verdicts": [
+  {"id": <int>, "verdict": "confirmed|unconfirmed|refuted",
+   "confidence": <int 0-100>, "line": <int or null>,
+   "note": "one clause of evidence from the code"}
+]}
+Include every id. No prose, no markdown.
+"""
+
+# Claim check: compares the PR's stated intent against what the diff does.
+CLAIM_CHECK = """\
+You verify a DPsim pull request against its own stated intent. You are given the
+PR INTENT (title, description, commit messages, what the author says it does) and
+the DIFF (what it actually changes). Judge only from these two.
+
+State plainly and concretely, without restating every file:
+- claimed: what the PR says it does, in one line.
+- done: what the diff actually does, in one line.
+- difference: any discrepancy that matters, a claim the diff does not implement,
+  or a behavioural or scope change the description does not mention. Use exactly
+  "none" if the code matches the description.
+
+Return ONLY JSON, no prose, no markdown:
+{"claimed": "<one line>", "done": "<one line>", "difference": "<one line or none>"}
+"""
 
 # Final pass. Receives the concatenated JSON from all stages and returns one
 # clean, de-duplicated, prioritized review.
@@ -477,8 +647,22 @@ Do:
   convention; keep correctness, equation, scaling, scheduling, and safety
   findings prominent.
 - Sort by severity (critical > high > medium > low), then by confidence.
+- Preserve each kept finding's fields as given (file, line, suggestion,
+  code_suggestion, confidence, stage, unconfirmed, verify_note); when merging
+  duplicates keep a non-null code_suggestion rather than dropping it. Do not raise
+  a finding's confidence above the value given. Keep the "unconfirmed" flag unless
+  a confirmed (not unconfirmed) duplicate covers the same issue, in which case
+  keep that confirmed one instead.
 - Keep at most the 15 most important findings.
+- Write "summary" as a single-sentence TL;DR: the bottom line a maintainer
+  needs, the must-fix items and the overall risk, not a list of every finding
+  (e.g. "Two real fixes, a missing Python binding and a dead member; the rest is
+  minor and the equation/stamping/scheduling passes flagged nothing."). You may
+  fold in, factually, what the change gets right (as areas that surfaced no
+  concerns), but keep it neutral: no praise or approving adjectives. If there are
+  no findings, say the change looks clean. One sentence, no line breaks.
 
-Return ONLY the same JSON object shape: {"findings": [ ... ]}.
+Return ONLY a JSON object of the shape:
+{"summary": "<2-3 sentence overview>", "findings": [ ... ]}.
 No prose, no markdown.
 """

--- a/.github/llm-review/review.py
+++ b/.github/llm-review/review.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+# SPDX-License-Identifier: MPL-2.0
+"""
+Multi-stage LLM PR reviewer for DPsim, driven by an OpenAI-compatible endpoint
+(KI:connect / RWTHgpt). Pure stdlib, no pip installs needed on the runner.
+
+Flow: read the base..head diff, run each stage in prompts.STAGES against the
+model, run a synthesis pass, then post one non-blocking COMMENT PR review with
+inline comments anchored only to lines present in the diff.
+
+Env:
+  LLM_BASE_URL   e.g. https://chat.kiconnect.nrw/api/v1   (trailing / ok)
+  LLM_CHAT_PATH  chat path appended to the base, default /chat/completions
+  LLM_API_KEY    Bearer API key
+  LLM_MODEL      e.g. mistral-small-4-119b-2603
+  GITHUB_TOKEN   provided by Actions
+  GITHUB_REPOSITORY  provided by Actions (owner/repo)
+  PR_NUMBER, BASE_SHA, HEAD_SHA  passed by the workflow; if absent they are read
+                 from GITHUB_EVENT_PATH (pull_request event payload)
+  MAX_DIFF_CHARS optional cap on diff sent to the model (default 60000)
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+import urllib.error
+
+# Make `import prompts` work no matter the current working directory.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import prompts  # noqa: E402
+
+SEV_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+CONF_RANK = {"high": 0, "medium": 1, "low": 2}
+
+
+def env(name, default=None, required=False):
+    v = os.environ.get(name, default)
+    if required and not v:
+        sys.exit(f"missing required env var: {name}")
+    return v
+
+
+def get_pr():
+    """Return (number, base_sha, head_sha).
+
+    Prefer the explicit env vars the workflow passes; fall back to the Actions
+    pull_request event payload so the script also works if run bare.
+    """
+    number = os.environ.get("PR_NUMBER")
+    base = os.environ.get("BASE_SHA")
+    head = os.environ.get("HEAD_SHA")
+    if number and base and head:
+        return int(number), base, head
+
+    path = os.environ.get("GITHUB_EVENT_PATH")
+    if path and os.path.exists(path):
+        with open(path) as f:
+            event = json.load(f)
+        pr = event.get("pull_request")
+        if pr:
+            return pr["number"], pr["base"]["sha"], pr["head"]["sha"]
+    sys.exit(
+        "could not determine PR (need PR_NUMBER/BASE_SHA/HEAD_SHA or a "
+        "pull_request event); nothing to review"
+    )
+
+
+def api_pr_diff(pr_number):
+    """Fetch the PR unified diff via the GitHub API.
+
+    Used in the workflow_run (fork-PR) context, where the PR head is not checked
+    out. Reads the diff as data only; it never executes PR code.
+    """
+    repo = env("GITHUB_REPOSITORY", required=True)
+    token = env("GITHUB_TOKEN", required=True)
+    url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": "Bearer " + token,
+            "Accept": "application/vnd.github.v3.diff",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return resp.read().decode(errors="replace")
+
+
+def get_diff(pr_number, base_sha, head_sha):
+    # In a workflow_run run the PR branch is not present locally, so fetch the
+    # diff via the API. Otherwise (same-repo PR, local dry-run) use git.
+    if os.environ.get("USE_API_DIFF"):
+        out = api_pr_diff(pr_number)
+    else:
+        out = subprocess.run(
+            ["git", "diff", "--unified=3", f"{base_sha}...{head_sha}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    cap = int(env("MAX_DIFF_CHARS", "60000"))
+    if len(out) > cap:
+        out = out[:cap] + "\n\n[diff truncated for length]\n"
+    return out
+
+
+def changed_files(diff):
+    # Derive the changed-file set from the diff text itself, so it works in both
+    # the git and the API path. Only files with a "+++ b/<path>" header (i.e.
+    # not pure deletions) can carry an inline comment on the RIGHT side.
+    files = set()
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[len("+++ b/") :].strip()
+            if path and path != "/dev/null":
+                files.add(path)
+    return files
+
+
+def llm(system, user):
+    """One OpenAI-compatible chat completion. Returns the assistant text."""
+    base = env("LLM_BASE_URL", required=True).rstrip("/")
+    # <base> already ends in /api/v1 for KI:connect, so the chat path is just
+    # /chat/completions. Override LLM_CHAT_PATH if the gateway differs.
+    path = env("LLM_CHAT_PATH", "/chat/completions")
+    url = base + path
+    body = json.dumps(
+        {
+            "model": env("LLM_MODEL", required=True),
+            "temperature": 0.1,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        }
+    ).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + env("LLM_API_KEY", required=True),
+        },
+    )
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        data = json.load(resp)
+    return data["choices"][0]["message"]["content"]
+
+
+def strip_reasoning(text):
+    """Remove <think>...</think> reasoning blocks (this is a reasoning model).
+
+    A trace can contain braces that would confuse the outermost-object grab, so
+    drop the reasoning before extracting JSON. Also handle an unclosed <think>
+    where only the opening tag is present.
+    """
+    t = re.sub(r"(?is)<think>.*?</think>", "", text)
+    if "<think>" in t and "</think>" not in t:
+        t = t.split("<think>", 1)[0]
+    return t
+
+
+def parse_findings(text):
+    """Tolerant JSON extraction: strip reasoning + fences, grab outermost object."""
+    t = strip_reasoning(text).strip()
+    if t.startswith("```"):
+        t = t.split("```", 2)[1]
+        if t.lstrip().lower().startswith("json"):
+            t = t.lstrip()[4:]
+    start, end = t.find("{"), t.rfind("}")
+    if start == -1 or end == -1:
+        return []
+    try:
+        obj = json.loads(t[start : end + 1])
+    except json.JSONDecodeError:
+        return []
+    findings = obj.get("findings", [])
+    return findings if isinstance(findings, list) else []
+
+
+def run_stages(diff):
+    all_findings = []
+    for stage in prompts.STAGES:
+        user = f"{stage['prompt']}\n\n=== PR DIFF (base..head) ===\n{diff}"
+        try:
+            raw = llm(prompts.SYSTEM, user)
+        except (urllib.error.URLError, KeyError, ValueError) as e:
+            # Non-blocking: one failed stage must not sink the whole review.
+            print(f"[{stage['id']}] stage failed: {e}", file=sys.stderr)
+            continue
+        found = parse_findings(raw)
+        for f in found:
+            f["stage"] = stage["id"]
+        print(f"[{stage['id']}] {len(found)} finding(s)", file=sys.stderr)
+        all_findings.extend(found)
+    return all_findings
+
+
+def synthesize(findings):
+    if not findings:
+        return []
+    try:
+        raw = llm(prompts.SYNTHESIS, json.dumps({"findings": findings}, indent=2))
+    except (urllib.error.URLError, KeyError, ValueError) as e:
+        print(f"synthesis failed, using raw union: {e}", file=sys.stderr)
+        return findings
+    merged = parse_findings(raw)
+    return merged or findings  # fall back to raw union if synthesis misbehaves
+
+
+def render_body(f):
+    sev = f.get("severity", "low").upper()
+    body = f"**[{sev}] {f.get('title', '')}**\n\n{f.get('detail', '')}"
+    if f.get("suggestion"):
+        body += f"\n\n_Suggested fix:_ {f['suggestion']}"
+    body += (
+        f"\n\n<sub>stage: {f.get('stage', '?')} · "
+        f"confidence: {f.get('confidence', '?')}</sub>"
+    )
+    return body
+
+
+def build_review(findings, head_sha, valid_files):
+    """Assemble the GitHub review payload (summary body + inline comments)."""
+    findings.sort(
+        key=lambda f: (
+            SEV_RANK.get(f.get("severity"), 9),
+            CONF_RANK.get(f.get("confidence"), 9),
+        )
+    )
+
+    inline, general = [], []
+    for f in findings:
+        body = render_body(f)
+        # Only attach inline comments to files+lines actually in the diff,
+        # otherwise the GitHub review API rejects the whole submission.
+        if f.get("file") in valid_files and isinstance(f.get("line"), int):
+            inline.append(
+                {"path": f["file"], "line": f["line"], "side": "RIGHT", "body": body}
+            )
+        else:
+            loc = f.get("file", "general")
+            line0 = body.splitlines()[0]
+            general.append(f"- {line0}  ({loc})")
+
+    counts = {}
+    for f in findings:
+        s = f.get("severity", "low")
+        counts[s] = counts.get(s, 0) + 1
+    summary = "### DPsim LLM review\n"
+    if findings:
+        summary += (
+            "Found: "
+            + ", ".join(
+                f"{n} {s}"
+                for s, n in sorted(counts.items(), key=lambda x: SEV_RANK.get(x[0], 9))
+            )
+            + ".\n"
+        )
+    else:
+        summary += "No issues surfaced by the automated passes.\n"
+    if general:
+        summary += "\n**Findings without a diff line:**\n" + "\n".join(general)
+    model = os.environ.get("LLM_MODEL", "LLM")
+    summary += (
+        "\n\n<sub>Automated, non-blocking review. May be wrong. "
+        f"Model: {model}.</sub>"
+    )
+
+    payload = {
+        "commit_id": head_sha,
+        "event": "COMMENT",
+        "body": summary,
+        "comments": inline,
+    }
+    return payload
+
+
+def gh_post_review(pr_number, payload):
+    repo = env("GITHUB_REPOSITORY", required=True)
+    token = env("GITHUB_TOKEN", required=True)
+    summary = payload["body"]
+    url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews"
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        method="POST",
+        headers={
+            "Authorization": "Bearer " + token,
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            print(f"posted review, HTTP {resp.status}", file=sys.stderr)
+    except urllib.error.HTTPError as e:
+        # Fall back to a plain issue comment if inline anchoring is rejected.
+        print(
+            f"review POST failed HTTP {e.code}: "
+            f"{e.read().decode(errors='replace')[:300]}",
+            file=sys.stderr,
+        )
+        icu = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
+        ireq = urllib.request.Request(
+            icu,
+            data=json.dumps({"body": summary}).encode(),
+            method="POST",
+            headers={
+                "Authorization": "Bearer " + token,
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+            },
+        )
+        with urllib.request.urlopen(ireq, timeout=60) as resp:
+            print(f"posted fallback issue comment, HTTP {resp.status}", file=sys.stderr)
+
+
+def main():
+    # DRY_RUN (or --dry-run) runs the full pipeline against the endpoint but
+    # prints the assembled review instead of posting it, and needs no
+    # GITHUB_TOKEN. Handy for local testing without any Actions runner.
+    dry_run = os.environ.get("DRY_RUN") or "--dry-run" in sys.argv
+
+    pr_number, base_sha, head_sha = get_pr()
+    diff = get_diff(pr_number, base_sha, head_sha)
+    if not diff.strip():
+        print("empty diff, nothing to review", file=sys.stderr)
+        return
+    valid_files = changed_files(diff)
+    findings = synthesize(run_stages(diff))
+    payload = build_review(findings, head_sha, valid_files)
+
+    if dry_run:
+        print("=== DRY RUN: review body ===\n")
+        print(payload["body"])
+        print(f"\n=== {len(payload['comments'])} inline comment(s) ===")
+        for c in payload["comments"]:
+            print(f"\n--- {c['path']}:{c['line']} ---")
+            print(c["body"])
+        return
+
+    gh_post_review(pr_number, payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/llm-review/review.py
+++ b/.github/llm-review/review.py
@@ -5,9 +5,9 @@
 Multi-stage LLM PR reviewer for DPsim, driven by an OpenAI-compatible endpoint
 (KI:connect / RWTHgpt). Pure stdlib, no pip installs needed on the runner.
 
-Flow: read the base..head diff, run each stage in prompts.STAGES against the
-model, run a synthesis pass, then post one non-blocking COMMENT PR review with
-inline comments anchored only to lines present in the diff.
+Flow: diff + full source of changed files -> STAGES (finders) -> dedup ->
+per-file verification against the real code -> synthesis -> one non-blocking
+COMMENT review with inline suggestions.
 
 Env:
   LLM_BASE_URL   e.g. https://chat.kiconnect.nrw/api/v1   (trailing / ok)
@@ -27,13 +27,49 @@ import subprocess
 import sys
 import urllib.request
 import urllib.error
+import urllib.parse
 
 # Make `import prompts` work no matter the current working directory.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import prompts  # noqa: E402
 
 SEV_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
-CONF_RANK = {"high": 0, "medium": 1, "low": 2}
+
+# Applyable ```suggestion blocks are emitted only for high-confidence, confirmed
+# findings, so a one-click "Commit suggestion" cannot apply a shaky guess; a
+# lower-confidence finding still gets its prose fix. Inline comments are capped so
+# a bad run cannot carpet a PR.
+SUGGESTION_MIN_CONF = 80
+MAX_INLINE = 8
+
+
+def confidence_display(f):
+    """What to show for a finding's confidence: "85%" when the model supplied a
+    number, the word when a stage returned one instead, or None. We never invent
+    a number from a categorical word; if there is no real value, show nothing."""
+    c = f.get("confidence")
+    if isinstance(c, (int, float)):
+        return f"{int(round(c))}%"
+    if isinstance(c, str) and c.strip():
+        return c.strip()
+    return None
+
+
+def confidence_sort_key(f):
+    """Ordering only (never shown): higher confidence first. A word maps to a
+    rough rank so mixed number/word outputs still sort sensibly."""
+    c = f.get("confidence")
+    if isinstance(c, (int, float)):
+        return -c
+    return {"high": -90, "medium": -60, "low": -30}.get(str(c).lower(), 0.0)
+
+
+def is_low_confidence(f):
+    """Whether a finding reads as tentative, from a number (<50) or the word."""
+    c = f.get("confidence")
+    if isinstance(c, (int, float)):
+        return c < 50
+    return isinstance(c, str) and c.strip().lower() == "low"
 
 
 def env(name, default=None, required=False):
@@ -163,8 +199,9 @@ def strip_reasoning(text):
     return t
 
 
-def parse_findings(text):
-    """Tolerant JSON extraction: strip reasoning + fences, grab outermost object."""
+def extract_object(text):
+    """Tolerant JSON-object extraction: strip reasoning + fences, grab the
+    outermost {...}. Returns the parsed dict, or None if nothing parseable."""
     t = strip_reasoning(text).strip()
     if t.startswith("```"):
         t = t.split("```", 2)[1]
@@ -172,19 +209,143 @@ def parse_findings(text):
             t = t.lstrip()[4:]
     start, end = t.find("{"), t.rfind("}")
     if start == -1 or end == -1:
-        return []
+        return None
     try:
         obj = json.loads(t[start : end + 1])
     except json.JSONDecodeError:
-        return []
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def extract_findings(text):
+    """Findings list on a successful parse (possibly empty, i.e. the model
+    deliberately returned none), or None when the output could not be parsed.
+
+    Callers that must tell "nothing found" apart from "parse failed" (e.g. the
+    verifier) rely on this distinction; parse_findings() collapses both to an
+    empty list for the stage path.
+    """
+    obj = extract_object(text)
+    if obj is None:
+        return None
     findings = obj.get("findings", [])
-    return findings if isinstance(findings, list) else []
+    return findings if isinstance(findings, list) else None
 
 
-def run_stages(diff):
+def parse_findings(text):
+    """Findings list, empty on either no-findings or parse failure."""
+    return extract_findings(text) or []
+
+
+def gh_get_json(url, token):
+    """GET a GitHub API endpoint as JSON."""
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": "Bearer " + token,
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.load(resp)
+
+
+def pr_context(pr_number, base_sha, head_sha):
+    """PR title, description and commit messages, so the review can understand
+    the author's intent and check that what the PR claims matches the code.
+
+    API in the fork path (USE_API_DIFF), git log locally. Best-effort: returns ""
+    on any failure. Read-only, data only.
+    """
+    lines = []
+    if os.environ.get("USE_API_DIFF"):
+        repo = os.environ.get("GITHUB_REPOSITORY")
+        token = os.environ.get("GITHUB_TOKEN")
+        if repo and token:
+            try:
+                pr = gh_get_json(
+                    f"https://api.github.com/repos/{repo}/pulls/{pr_number}", token
+                )
+                lines.append(f"PR #{pr_number}: {pr.get('title', '')}".strip())
+                body = (pr.get("body") or "").strip()
+                if body:
+                    lines.append(body)
+            except (urllib.error.URLError, ValueError, KeyError) as e:
+                print(f"pr_context: PR fetch failed: {e}", file=sys.stderr)
+            try:
+                commits = gh_get_json(
+                    f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
+                    "/commits?per_page=100",
+                    token,
+                )
+                for c in commits or []:
+                    msg = (c.get("commit", {}).get("message") or "").strip()
+                    if msg:
+                        lines.append("commit: " + msg)
+            except (urllib.error.URLError, ValueError, KeyError) as e:
+                print(f"pr_context: commits fetch failed: {e}", file=sys.stderr)
+    else:
+        r = subprocess.run(
+            ["git", "log", f"{base_sha}..{head_sha}", "--format=%B%x00"],
+            capture_output=True,
+            text=True,
+        )
+        if r.returncode == 0:
+            for msg in r.stdout.split("\x00"):
+                msg = msg.strip()
+                if msg:
+                    lines.append("commit: " + msg)
+    if not lines:
+        return ""
+    text = "\n\n".join(lines)
+    if len(text) > MAX_PR_CONTEXT_CHARS:
+        text = text[:MAX_PR_CONTEXT_CHARS] + "\n[truncated]"
+    return (
+        "\n\n=== PR INTENT (title, description, commit messages) ===\n"
+        "Use this to understand the change and to check the code does what the PR "
+        "claims; it is context, NOT a spec that excuses a real bug.\n" + text
+    )
+
+
+def changed_sources_block(diff, head_sha):
+    """Numbered full source of the changed files, as context for every stage.
+
+    Lets the finders see beyond the diff window (a present override, a base
+    method) so they stop raising "missing X". Unfetchable/oversized are omitted.
+    """
+    files = sorted(changed_files(diff))
+    cache, blocks, total, dropped = {}, [], 0, 0
+    for path in files:
+        if len(blocks) >= MAX_STAGE_SOURCE_FILES or total >= MAX_STAGE_SOURCE_CHARS:
+            dropped += 1
+            continue
+        content = fetch_file(path, head_sha)
+        if content is None:
+            continue
+        cache[path] = content
+        blocks.append(f"\n--- {path} ---\n{number_lines(content)}\n")
+        total += len(content)
+    if dropped:
+        print(
+            f"stage context: {dropped} changed file(s) omitted past the cap",
+            file=sys.stderr,
+        )
+    if not blocks:
+        return ""
+    return (
+        "\n\n=== FULL SOURCE OF CHANGED FILES (context to judge the changed "
+        "lines; do NOT raise findings about unchanged code) ===\n" + "".join(blocks)
+    )
+
+
+def run_stages(diff, head_sha, pr_ctx=""):
+    context = changed_sources_block(diff, head_sha)
     all_findings = []
     for stage in prompts.STAGES:
-        user = f"{stage['prompt']}\n\n=== PR DIFF (base..head) ===\n{diff}"
+        user = (
+            f"{stage['prompt']}\n\n=== PR DIFF (base..head) ===\n"
+            f"{diff}{context}{pr_ctx}"
+        )
         try:
             raw = llm(prompts.SYSTEM, user)
         except (urllib.error.URLError, KeyError, ValueError) as e:
@@ -199,81 +360,580 @@ def run_stages(diff):
     return all_findings
 
 
-def synthesize(findings):
+# Verification fetches+checks at most this many files (one LLM call each); the
+# rest, and unfetchable files, stay unconfirmed rather than trusted or dropped.
+MAX_VERIFY_FILES = 12
+MAX_VERIFY_FILE_CHARS = 90000
+UNCONFIRMED_CONF_CAP = 35
+# Base-class/interface headers given to the verifier, followed up the #include
+# chain (3 hops: .cpp -> .h -> base -> base's base). Bounded, cached per run.
+MAX_CONTEXT_HEADERS = 12
+MAX_CONTEXT_CHARS = 80000
+CONTEXT_HOPS = 3
+# Full source of the changed files given to the finder stages (context beyond
+# the diff, to cut "missing X" false positives). Bounded.
+MAX_STAGE_SOURCE_FILES = 15
+MAX_STAGE_SOURCE_CHARS = 160000
+# PR title/description/commit messages given as intent context. Bounded.
+MAX_PR_CONTEXT_CHARS = 8000
+
+
+def fetch_file(path, ref):
+    """Full source of `path` at `ref`, or None (read-only, never runs PR code).
+
+    Contents API in the fork path (USE_API_DIFF), git locally. Oversized -> None.
+    """
+    if os.environ.get("USE_API_DIFF"):
+        repo = env("GITHUB_REPOSITORY", required=True)
+        token = env("GITHUB_TOKEN", required=True)
+        url = (
+            f"https://api.github.com/repos/{repo}/contents/"
+            f"{urllib.parse.quote(path)}?ref={urllib.parse.quote(ref)}"
+        )
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": "Bearer " + token,
+                "Accept": "application/vnd.github.raw+json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                content = resp.read().decode(errors="replace")
+        except urllib.error.URLError as e:
+            print(f"fetch {path} failed: {e}", file=sys.stderr)
+            return None
+    else:
+        r = subprocess.run(
+            ["git", "show", f"{ref}:{path}"], capture_output=True, text=True
+        )
+        if r.returncode != 0:
+            return None
+        content = r.stdout
+    if len(content) > MAX_VERIFY_FILE_CHARS:
+        return None
+    return content
+
+
+def number_lines(content):
+    """Prefix each line with its 1-based number for the verifier to cite."""
+    return "\n".join(
+        f"{i:5d}| {ln}" for i, ln in enumerate(content.splitlines(), start=1)
+    )
+
+
+def file_hunk(diff, path):
+    """The section of the unified diff that belongs to `path` (for scope)."""
+    out, capture = [], False
+    for ln in diff.splitlines(keepends=True):
+        if ln.startswith("diff --git "):
+            capture = f" a/{path} " in ln or ln.rstrip().endswith(f" b/{path}")
+        if capture:
+            out.append(ln)
+    return "".join(out)
+
+
+def added_lines(diff, path):
+    """New-file line numbers the diff adds/changes for `path` (its scope)."""
+    added, new_ln = set(), 0
+    for ln in file_hunk(diff, path).splitlines():
+        if ln.startswith("@@"):
+            m = re.search(r"\+(\d+)", ln)
+            new_ln = int(m.group(1)) if m else 0
+        elif ln.startswith(("+++", "---")):
+            continue
+        elif ln.startswith("+"):
+            added.add(new_ln)
+            new_ln += 1
+        elif ln.startswith("-"):
+            continue
+        else:
+            new_ln += 1
+    return added
+
+
+def to_ranges(nums):
+    """Compact "1-4, 9, 20-22" rendering of a set of line numbers."""
+    nums = sorted(nums)
+    if not nums:
+        return "(none)"
+    out, start, prev = [], nums[0], nums[0]
+    for n in nums[1:]:
+        if n == prev + 1:
+            prev = n
+            continue
+        out.append(f"{start}-{prev}" if start != prev else f"{start}")
+        start = prev = n
+    out.append(f"{start}-{prev}" if start != prev else f"{start}")
+    return ", ".join(out)
+
+
+INCLUDE_RE = re.compile(r'#\s*include\s*[<"]((?:dpsim-models|dpsim)/[^">]+\.h)[>"]')
+
+
+def resolve_include(inc):
+    """DPsim #include target -> repo path, or None for externals.
+    e.g. dpsim-models/X.h -> dpsim-models/include/dpsim-models/X.h"""
+    for pkg in ("dpsim-models/", "dpsim/"):
+        if inc.startswith(pkg):
+            return pkg + "include/" + inc
+    return None
+
+
+def dpsim_includes(code):
+    """Repo paths of the DPsim (non-external) headers a source #includes."""
+    out = []
+    for m in INCLUDE_RE.finditer(code):
+        p = resolve_include(m.group(1))
+        if p:
+            out.append(p)
+    return out
+
+
+def gather_context(code, ref, cache):
+    """Base-class/interface headers this file depends on, following its #include
+    chain up to CONTEXT_HOPS hops. Bounded, cached across the run. These carry the
+    parent hook declarations that override/signature claims must be judged against."""
+    ctx, total = {}, 0
+    frontier = dpsim_includes(code)
+    for _hop in range(CONTEXT_HOPS):
+        nxt = []
+        for p in frontier:
+            if len(ctx) >= MAX_CONTEXT_HEADERS or total >= MAX_CONTEXT_CHARS:
+                break
+            if p in ctx:
+                continue
+            if p not in cache:
+                cache[p] = fetch_file(p, ref)
+            content = cache[p]
+            if content is None:
+                continue
+            ctx[p] = content
+            total += len(content)
+            nxt.extend(dpsim_includes(content))
+        frontier = nxt
+    return ctx
+
+
+def dedup_findings(findings):
+    """Collapse exact-duplicate findings (same file, line, normalized title)
+    before verification. Keeps the copy with a code_suggestion, else the first.
+    Semantic merging is synthesis's job."""
+    seen = {}
+    for f in findings:
+        key = (
+            f.get("file"),
+            f.get("line"),
+            " ".join(str(f.get("title", "")).lower().split()),
+        )
+        cur = seen.get(key)
+        if cur is None:
+            seen[key] = f
+        elif not cur.get("code_suggestion") and f.get("code_suggestion"):
+            seen[key] = f
+    return list(seen.values())
+
+
+def verify(findings, diff, head_sha):
+    """Adjudicate findings per file against the real source (code as truth):
+    confirmed -> kept, refuted -> dropped, unconfirmed -> kept tentative with
+    confidence capped. Nothing drops without a refutation; unreachable code or an
+    omitted verdict defaults to unconfirmed. Non-blocking on per-file failure.
+    Returns (kept, stats) where stats carries the raw/kept/refuted counts and a
+    sample of refuted findings with reasons, for the methodology footer."""
     if not findings:
-        return []
+        return [], {}
+    # Finders sometimes cite a wrong path (src/ vs include/). Remap to the real
+    # changed file by basename so verification fetches the true source instead of
+    # failing and defaulting everything to unconfirmed.
+    real_paths = changed_files(diff)
+    by_base = {}
+    for p in real_paths:
+        by_base.setdefault(p.rsplit("/", 1)[-1], p)
+    for f in findings:
+        fp = f.get("file")
+        if fp and fp not in real_paths:
+            real = by_base.get(fp.rsplit("/", 1)[-1])
+            if real:
+                f["file"] = real
+    before = len(findings)
+    findings = dedup_findings(findings)
+    if len(findings) < before:
+        print(
+            f"verification: deduped {before} -> {len(findings)} findings",
+            file=sys.stderr,
+        )
+    for i, f in enumerate(findings):
+        f["_id"] = i
+
+    by_file = {}
+    for f in findings:
+        by_file.setdefault(f.get("file"), []).append(f)
+
+    # Most-findings files first (the cap spends where it matters); file-less
+    # (process) findings pass through unchanged.
+    files = [p for p in by_file if p]
+    files.sort(key=lambda p: len(by_file[p]), reverse=True)
+    if len(files) > MAX_VERIFY_FILES:
+        print(
+            f"verification: {len(files)} files with findings, checking the top "
+            f"{MAX_VERIFY_FILES}; the rest are kept as unconfirmed",
+            file=sys.stderr,
+        )
+    to_check = set(files[:MAX_VERIFY_FILES])
+
+    verdicts = {}  # id -> verdict dict from the model
+    checked_ids = set()  # ids that went through a code-grounded check
+    header_cache = {}  # (path -> content|None) shared across files this run
+    for path in to_check:
+        code = fetch_file(path, head_sha)
+        if code is None:
+            print(
+                f"verification: no source for {path}, keeping unconfirmed",
+                file=sys.stderr,
+            )
+            continue
+        group = by_file[path]
+        payload = [
+            {k: f.get(k) for k in ("_id", "severity", "title", "detail", "line")}
+            for f in group
+        ]
+        # Base-class/interface headers, so override/hook/signature claims are
+        # judged against the real parent, not left unconfirmed.
+        context = gather_context(code, head_sha, header_cache)
+        related = "".join(f"\n--- {p} ---\n{c}\n" for p, c in context.items())
+        user = f"FILE: {path}\n\n=== FINDINGS (JSON) ===\n" + json.dumps(
+            {"findings": payload}, indent=2
+        ) + f"\n\n=== FULL CURRENT SOURCE OF {path} (ground truth) ===\n" + number_lines(
+            code
+        ) + (
+            "\n\n=== RELATED SOURCES (base classes / interfaces it inherits, "
+            "ground truth) ===\n" + related
+            if related
+            else ""
+        ) + f"\n\n=== CHANGED LINES in {path} (new-file line numbers, the " f"in-scope lines) ===\n" + to_ranges(
+            added_lines(diff, path)
+        ) + f"\n\n=== DIFF HUNK FOR {path} (what changed) ===\n" + file_hunk(
+            diff, path
+        )
+        if context:
+            print(
+                f"verification: {path} + {len(context)} base/interface header(s)",
+                file=sys.stderr,
+            )
+        for f in group:
+            checked_ids.add(f["_id"])
+        try:
+            raw = llm(prompts.VERIFICATION, user)
+        except (urllib.error.URLError, KeyError, ValueError) as e:
+            print(
+                f"verification of {path} failed, keeping unconfirmed: {e}",
+                file=sys.stderr,
+            )
+            continue
+        obj = extract_object(raw)
+        for v in (obj or {}).get("verdicts", []) if isinstance(obj, dict) else []:
+            if isinstance(v, dict) and isinstance(v.get("id"), int):
+                verdicts[v["id"]] = v
+
+    kept, drops, unconf, refuted_list = [], 0, 0, []
+    for f in findings:
+        v = verdicts.get(f["_id"]) or {}
+        verdict = v.get("verdict")
+        note = v.get("note") if isinstance(v.get("note"), str) else None
+        if verdict == "refuted":
+            drops += 1
+            if len(refuted_list) < 15:
+                refuted_list.append(
+                    {
+                        "title": f.get("title", ""),
+                        "file": f.get("file"),
+                        "note": note or "not supported by the code",
+                    }
+                )
+            continue
+        if verdict == "confirmed":
+            if isinstance(v.get("confidence"), (int, float)):
+                f["confidence"] = v["confidence"]
+            if isinstance(v.get("line"), int):
+                f["line"] = v["line"]
+        else:
+            # unconfirmed / omitted / unchecked: keep tentative, cap confidence.
+            f["unconfirmed"] = True
+            unconf += 1
+            base = (
+                v.get("confidence")
+                if isinstance(v.get("confidence"), (int, float))
+                else f.get("confidence")
+            )
+            f["confidence"] = (
+                min(base, UNCONFIRMED_CONF_CAP)
+                if isinstance(base, (int, float))
+                else UNCONFIRMED_CONF_CAP
+            )
+            if isinstance(v.get("line"), int):
+                f["line"] = v["line"]
+        if note:
+            f["verify_note"] = note
+        f.pop("_id", None)
+        kept.append(f)
+
+    for f in findings:
+        f.pop("_id", None)
+    print(
+        f"verification: {len(kept)} kept ({unconf} unconfirmed), {drops} refuted "
+        f"of {len(findings)}",
+        file=sys.stderr,
+    )
+    stats = {
+        "raw": before,
+        "checked": len(findings),
+        "kept": len(kept),
+        "unconfirmed": unconf,
+        "refuted": drops,
+        "refuted_list": refuted_list,
+    }
+    return kept, stats
+
+
+def synthesize(findings, pr_ctx=""):
+    """Merge/prioritize findings and produce a short overview.
+
+    Returns (overview_text, findings). On any failure fall back to the raw
+    union with an empty overview so the review still posts.
+    """
+    if not findings:
+        return "", []
     try:
-        raw = llm(prompts.SYNTHESIS, json.dumps({"findings": findings}, indent=2))
+        raw = llm(
+            prompts.SYNTHESIS,
+            json.dumps({"findings": findings}, indent=2) + pr_ctx,
+        )
     except (urllib.error.URLError, KeyError, ValueError) as e:
         print(f"synthesis failed, using raw union: {e}", file=sys.stderr)
-        return findings
-    merged = parse_findings(raw)
-    return merged or findings  # fall back to raw union if synthesis misbehaves
+        return "", findings
+    obj = extract_object(raw)
+    if obj is None:
+        return "", findings  # synthesis misbehaved; keep the raw union
+    merged = obj.get("findings")
+    if not isinstance(merged, list) or not merged:
+        merged = findings
+    overview = obj.get("summary")
+    overview = overview.strip() if isinstance(overview, str) else ""
+    return overview, merged
+
+
+def claim_check(diff, pr_ctx):
+    """Compare what the PR claims (pr_ctx) with what the diff does. Returns
+    {claimed, done, difference} or None (no intent given, or the call failed)."""
+    if not pr_ctx:
+        return None
+    user = f"{pr_ctx}\n\n=== PR DIFF (base..head) ===\n{diff}"
+    try:
+        raw = llm(prompts.CLAIM_CHECK, user)
+    except (urllib.error.URLError, KeyError, ValueError) as e:
+        print(f"claim check failed: {e}", file=sys.stderr)
+        return None
+    obj = extract_object(raw)
+    return obj if isinstance(obj, dict) else None
 
 
 def render_body(f):
-    sev = f.get("severity", "low").upper()
-    body = f"**[{sev}] {f.get('title', '')}**\n\n{f.get('detail', '')}"
+    """Inline comment body. The tag carries the severity category and the
+    model's own confidence number (a percentage), shown only when it exists."""
+    parts = [f"severity: {f.get('severity', 'low')}"]
+    cd = confidence_display(f)
+    if cd:
+        parts.append(f"confidence: {cd}")
+    tag = " · ".join(parts)
+    body = f"**{f.get('title', '')}**  \n`{tag}`\n\n{f.get('detail', '')}"
     if f.get("suggestion"):
         body += f"\n\n_Suggested fix:_ {f['suggestion']}"
-    body += (
-        f"\n\n<sub>stage: {f.get('stage', '?')} · "
-        f"confidence: {f.get('confidence', '?')}</sub>"
+    # ```suggestion renders as a one-click change; only offer it for a confirmed,
+    # high-confidence finding so an applied guess cannot be wrong code. The prose
+    # fix above stays either way.
+    code = f.get("code_suggestion")
+    conf = f.get("confidence")
+    conf_ok = (isinstance(conf, (int, float)) and conf >= SUGGESTION_MIN_CONF) or (
+        isinstance(conf, str) and conf.strip().lower() == "high"
     )
+    if isinstance(code, str) and code.strip() and conf_ok and not f.get("unconfirmed"):
+        body += "\n\n```suggestion\n" + code.rstrip("\n") + "\n```"
+    if f.get("verify_note"):
+        body += f"\n\n_Checked against the source: {f['verify_note']}_"
+    body += f"\n\n<sub>stage: {f.get('stage', '?')}</sub>"
     return body
 
 
-def build_review(findings, head_sha, valid_files):
-    """Assemble the GitHub review payload (summary body + inline comments)."""
+# Severity buckets for the summary body, in display order. Critical/high always
+# land in the top bucket regardless of confidence; among the rest, a low-
+# confidence finding is a tentative "worth a glance" rather than an action item.
+SECTIONS = [
+    ("critical", "\U0001f534 Critical & high"),
+    ("suggestion", "\U0001f7e1 Suggestions"),
+    ("optional", "\U0001f535 Optional / low-confidence"),
+]
+
+
+def bucket(f):
+    # Unconfirmed findings stay tentative, never Critical.
+    if f.get("unconfirmed"):
+        return "optional"
+    if f.get("severity") in ("critical", "high"):
+        return "critical"
+    if is_low_confidence(f):
+        return "optional"
+    return "suggestion"
+
+
+def summary_line(f, anchored, compact=False):
+    """One grouped-summary line: title, severity+confidence tag, and location.
+
+    Anchored findings point at their inline comment for the detail. Compact mode
+    (used for the collapsed low-confidence bucket) shows only that one line;
+    otherwise an unanchored finding carries its detail and fix here.
+    """
+    sev = f.get("severity", "low")
+    cd = confidence_display(f)
+    tag = sev if not cd else f"{sev} · {cd} confidence"
+    if f.get("unconfirmed"):
+        tag += " · unconfirmed"
+    where = f.get("file") or "general"
+    if isinstance(f.get("line"), int):
+        where = f"{where}:{f['line']}"
+    line = f"- **{f.get('title', '')}** `[{tag}]` in `{where}`"
+    if anchored:
+        return line + " _(details inline)_"
+    if compact:
+        return line
+    detail = " ".join((f.get("detail", "") or "").split())
+    if detail:
+        line += f"  \n  {detail}"
+    if f.get("suggestion"):
+        line += f"  \n  _Fix:_ {' '.join(f['suggestion'].split())}"
+    return line
+
+
+def methodology_block(stats, claim=None):
+    """A collapsible note on how the review was produced, with a sample of the
+    findings verification refuted (and why), so a reader can trust the culling."""
+    if not stats or not stats.get("raw"):
+        return []
+    out = []
+    if claim and (claim.get("claimed") or claim.get("done")):
+        out += [
+            "",
+            "<details><summary>Claim vs. implementation</summary>",
+            "",
+            f"- Claimed: {claim.get('claimed', '(not stated)')}",
+            f"- Done: {claim.get('done', '(unclear)')}",
+            f"- Difference: {claim.get('difference', 'none')}",
+            "</details>",
+        ]
+    out += [
+        "",
+        "<details><summary>How this review was produced</summary>",
+        "",
+        f"{len(prompts.STAGES)} specialized passes raised {stats.get('raw', 0)} "
+        "findings over the diff and the full changed sources. After "
+        f"de-duplication, {stats.get('checked', 0)} were re-checked against the "
+        "current file and the base-class / interface headers it inherits (code as "
+        f"truth): {stats.get('refuted', 0)} refuted as unsupported, "
+        f"{stats.get('kept', 0)} kept ({stats.get('unconfirmed', 0)} tentative).",
+    ]
+    refuted = stats.get("refuted_list") or []
+    if refuted:
+        out += ["", "Refuted by verification:"]
+        for r in refuted:
+            loc = f" ({r['file']})" if r.get("file") else ""
+            out.append(f"- {r.get('title', '')}{loc}: {r.get('note', '')}")
+    out.append("</details>")
+    return out
+
+
+def build_review(findings, head_sha, valid_files, overview="", stats=None, claim=None):
+    """Assemble the GitHub review payload (summary body + inline comments).
+
+    Body: a one-line TL;DR, a claim-vs-code note, a severity tally, findings
+    grouped into buckets, and a collapsible methodology note. Findings that
+    anchor to a diff line are also emitted as inline comments with the detail.
+    """
     findings.sort(
-        key=lambda f: (
-            SEV_RANK.get(f.get("severity"), 9),
-            CONF_RANK.get(f.get("confidence"), 9),
-        )
+        key=lambda f: (SEV_RANK.get(f.get("severity"), 9), confidence_sort_key(f))
     )
 
-    inline, general = [], []
+    inline = []
     for f in findings:
-        body = render_body(f)
-        # Only attach inline comments to files+lines actually in the diff,
-        # otherwise the GitHub review API rejects the whole submission.
-        if f.get("file") in valid_files and isinstance(f.get("line"), int):
+        # Inline only on diff lines (API rejects otherwise); unconfirmed stay
+        # summary-only; and stop once the inline cap is reached so a bad run
+        # cannot flood the PR. Findings past the cap keep their detail in the
+        # summary (they are not marked anchored).
+        anchorable = (
+            not f.get("unconfirmed")
+            and f.get("file") in valid_files
+            and isinstance(f.get("line"), int)
+        )
+        f["_anchored"] = anchorable and len(inline) < MAX_INLINE
+        if f["_anchored"]:
             inline.append(
-                {"path": f["file"], "line": f["line"], "side": "RIGHT", "body": body}
+                {
+                    "path": f["file"],
+                    "line": f["line"],
+                    "side": "RIGHT",
+                    "body": render_body(f),
+                }
             )
-        else:
-            loc = f.get("file", "general")
-            line0 = body.splitlines()[0]
-            general.append(f"- {line0}  ({loc})")
 
-    counts = {}
-    for f in findings:
-        s = f.get("severity", "low")
-        counts[s] = counts.get(s, 0) + 1
-    summary = "### DPsim LLM review\n"
-    if findings:
-        summary += (
-            "Found: "
-            + ", ".join(
-                f"{n} {s}"
-                for s, n in sorted(counts.items(), key=lambda x: SEV_RANK.get(x[0], 9))
-            )
-            + ".\n"
-        )
+    lines = ["### DPsim LLM review", ""]
+    if claim:
+        diff_note = (claim.get("difference") or "").strip()
+        if diff_note and diff_note.lower() != "none":
+            lines += [f"**Claim vs. code:** {diff_note}", ""]
+        else:
+            lines += ["**Claim vs. code:** matches the description.", ""]
+    if not findings:
+        lines.append("No issues surfaced by the automated passes.")
     else:
-        summary += "No issues surfaced by the automated passes.\n"
-    if general:
-        summary += "\n**Findings without a diff line:**\n" + "\n".join(general)
+        if overview:
+            lines += [f"**TL;DR:** {overview}", ""]
+        counts = {}
+        for f in findings:
+            sev = f.get("severity", "low")
+            counts[sev] = counts.get(sev, 0) + 1
+        tally = ", ".join(
+            f"{n} {s}"
+            for s, n in sorted(counts.items(), key=lambda x: SEV_RANK.get(x[0], 9))
+        )
+        lines.append(f"Found {tally} ({len(inline)} anchored to lines below).")
+        for key, header in SECTIONS:
+            items = [f for f in findings if bucket(f) == key]
+            if not items:
+                continue
+            # Collapse the tentative bucket into a compact, foldable block so it
+            # does not crowd the actionable findings.
+            if key == "optional":
+                lines += [
+                    "",
+                    f"<details><summary>{header} ({len(items)})</summary>",
+                    "",
+                ]
+                lines += [summary_line(f, f["_anchored"], compact=True) for f in items]
+                lines += ["", "</details>"]
+            else:
+                lines += ["", f"#### {header}"]
+                lines += [summary_line(f, f["_anchored"]) for f in items]
+
+    lines += methodology_block(stats, claim)
     model = os.environ.get("LLM_MODEL", "LLM")
-    summary += (
-        "\n\n<sub>Automated, non-blocking review. May be wrong. "
-        f"Model: {model}.</sub>"
-    )
+    lines += [
+        "",
+        f"<sub>Automated, non-blocking review. May be wrong. Model: {model}.</sub>",
+    ]
 
     payload = {
         "commit_id": head_sha,
         "event": "COMMENT",
-        "body": summary,
+        "body": "\n".join(lines),
         "comments": inline,
     }
     return payload
@@ -331,8 +991,11 @@ def main():
         print("empty diff, nothing to review", file=sys.stderr)
         return
     valid_files = changed_files(diff)
-    findings = synthesize(run_stages(diff))
-    payload = build_review(findings, head_sha, valid_files)
+    pr_ctx = pr_context(pr_number, base_sha, head_sha)
+    claim = claim_check(diff, pr_ctx)
+    verified, vstats = verify(run_stages(diff, head_sha, pr_ctx), diff, head_sha)
+    overview, findings = synthesize(verified, pr_ctx)
+    payload = build_review(findings, head_sha, valid_files, overview, vstats, claim)
 
     if dry_run:
         print("=== DRY RUN: review body ===\n")

--- a/.github/workflows/llm-review-collect.yml
+++ b/.github/workflows/llm-review-collect.yml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+# SPDX-License-Identifier: MPL-2.0
+#
+# Multi-stage LLM pull-request reviewer (untrusted collect stage).
+#
+# This workflow runs on pull_request, including from forks, and therefore has NO
+# access to secrets (GitHub withholds them from fork pull_request runs). It only
+# records the PR number and SHAs, from trusted GitHub context, into an artifact.
+# It checks out nothing and runs no code from the pull request, so there is
+# nothing for a malicious PR to exfiltrate here. The trusted "LLM Review"
+# workflow then consumes this artifact via workflow_run and does the actual,
+# secret-bearing review.
+
+name: LLM Review (collect)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record PR metadata
+        env:
+          # Trusted GitHub context: a numeric id and two commit SHAs.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p pr-meta
+          printf '{"pr_number":"%s","base_sha":"%s","head_sha":"%s"}\n' \
+            "$PR_NUMBER" "$BASE_SHA" "$HEAD_SHA" > pr-meta/meta.json
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: llm-review-pr-meta
+          path: pr-meta/meta.json
+          retention-days: 1

--- a/.github/workflows/llm-review.yml
+++ b/.github/workflows/llm-review.yml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+# SPDX-License-Identifier: MPL-2.0
+#
+# Multi-stage LLM pull-request reviewer (trusted stage).
+#
+# This job is triggered by workflow_run, after the untrusted "LLM Review
+# (collect)" workflow finishes on a pull request. It runs in the BASE repository
+# context with access to the secret, and reviews fork PRs safely:
+#
+#   - It checks out the base repository's own code (this workflow + review.py),
+#     never the pull request's code, so no untrusted code runs with the secret.
+#   - It reads the PR diff as DATA through the GitHub API; it never builds or
+#     executes anything from the pull request.
+#   - The API key is only ever sent as an Authorization header to the configured
+#     LLM endpoint, never placed in the model prompt, so a prompt-injection
+#     payload in the diff cannot exfiltrate it.
+#   - PR metadata comes from the untrusted collect artifact and is validated
+#     (numeric PR number, hex SHAs) before use.
+#
+# The review is a non-blocking COMMENT and cannot block a merge.
+
+name: LLM Review
+
+on:
+  workflow_run:
+    workflows: ["LLM Review (collect)"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  contents: read
+  actions: read # to download the artifact from the triggering run
+
+concurrency:
+  group: llm-review-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Only for pull_request collect runs that succeeded.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ${{ vars.LLM_REVIEW_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout base repository (trusted code only)
+        uses: actions/checkout@v4
+        # Default checkout: the base repo's default branch. The pull request's
+        # head is deliberately NOT checked out.
+
+      - name: Download PR metadata from the collect run
+        uses: actions/download-artifact@v4
+        with:
+          name: llm-review-pr-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: pr-meta
+
+      - name: Validate PR metadata (untrusted artifact)
+        run: |
+          python3 - <<'PY'
+          import json, os, re, sys
+          d = json.load(open("pr-meta/meta.json"))
+          num, base, head = (str(d.get(k, "")) for k in ("pr_number", "base_sha", "head_sha"))
+          if not re.fullmatch(r"[0-9]+", num):
+              sys.exit("invalid pr_number in artifact")
+          if not re.fullmatch(r"[0-9a-fA-F]{7,40}", base):
+              sys.exit("invalid base_sha in artifact")
+          if not re.fullmatch(r"[0-9a-fA-F]{7,40}", head):
+              sys.exit("invalid head_sha in artifact")
+          with open(os.environ["GITHUB_ENV"], "a") as f:
+              f.write(f"PR_NUMBER={num}\nBASE_SHA={base}\nHEAD_SHA={head}\n")
+          PY
+
+      - name: Run multi-stage LLM review
+        env:
+          USE_API_DIFF: "1" # fetch the diff via the API; PR head is not checked out
+          LLM_BASE_URL: ${{ vars.LLM_BASE_URL || 'https://chat.kiconnect.nrw/api/v1' }}
+          LLM_MODEL: ${{ vars.LLM_MODEL || 'mistral-small-4-119b-2603' }}
+          LLM_CHAT_PATH: ${{ vars.LLM_CHAT_PATH || '/chat/completions' }}
+          LLM_API_KEY: ${{ secrets.RWTH_LLM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 .github/llm-review/review.py

--- a/docs/hugo/content/en/docs/Development/llm-pr-review.md
+++ b/docs/hugo/content/en/docs/Development/llm-pr-review.md
@@ -1,0 +1,122 @@
+---
+title: "LLM Pull Request Review"
+linkTitle: "LLM PR Review"
+---
+
+# Overview
+
+DPsim ships an optional, non-blocking pull-request reviewer that runs a series of
+specialised passes over the diff of a pull request using a large language model
+and posts a single review comment. It is intended as an assistive first pass: it
+never requests changes and cannot block a merge, so a human review remains
+authoritative.
+
+The reviewer lives under `.github/llm-review/` (the prompts in `prompts.py` and a
+pure-standard-library runner in `review.py`) and is driven by two workflows:
+`llm-review-collect.yml`, which runs on the pull request itself, and
+`llm-review.yml`, which performs the review. The split is what makes reviewing
+pull requests from forks safe (see [Fork pull requests](#fork-pull-requests)). It
+communicates with any OpenAI-compatible chat endpoint, configured through the
+environment variables described below.
+
+# How it works
+
+For each pull request the runner reads the `base..head` diff and sends it, in
+turn, to a set of focused review stages, each with its own prompt. The stages
+cover model equations and their derivation, MNA stamping and domain modeling,
+numerical correctness, task scheduling and attribute usage, real-time safety,
+C++ class design and reuse, naming and in-code documentation, logging discipline,
+the Python bindings, input parsing, the build system and dependencies, testing
+and component coverage, and licensing and pull-request hygiene. Each stage returns
+a strict JSON list of findings. A final synthesis pass deduplicates and
+prioritises them, and the runner posts them as one review, anchoring inline
+comments only to lines present in the diff.
+
+The prompts encode DPsim's documented conventions (see
+[Guidelines]({{< ref "guidelines.md" >}})) and the recurring points raised in
+past reviews, so the feedback stays specific to this project rather than generic.
+
+# Configuration
+
+The workflow requires one repository secret:
+
+- `RWTH_LLM_TOKEN`: the bearer API key for the chat endpoint.
+
+The following repository Actions variables are optional and override the
+defaults baked into the workflow:
+
+- `LLM_BASE_URL`: the OpenAI-compatible base URL.
+- `LLM_MODEL`: the model identifier.
+- `LLM_CHAT_PATH`: the chat path appended to the base URL (default
+  `/chat/completions`).
+- `LLM_REVIEW_RUNNER`: the runner label (default `ubuntu-latest`; see
+  [Runner selection](#runner-selection)).
+
+The workflow's baked-in defaults target an OpenAI-compatible deployment; override
+`LLM_BASE_URL` and `LLM_MODEL` to point at a different endpoint or model.
+
+# Obtaining an API key
+
+Obtain a bearer API key from the chosen OpenAI-compatible provider and store it as
+the `RWTH_LLM_TOKEN` repository secret. The key is only exposed to workflow runs on
+pull requests from the repository itself, never from forks.
+
+Before storing the secret, a single request confirms that the key reaches the
+model:
+
+```bash
+curl -sS -X POST "$LLM_BASE_URL/chat/completions" \
+  -H "Authorization: Bearer $RWTH_LLM_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"model\":\"$LLM_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"ok\"}]}"
+```
+
+# Running locally
+
+The runner has a dry-run mode that executes the full pipeline and prints the
+assembled review instead of posting it. It needs no GitHub token and no Actions
+runner, only network access to the endpoint:
+
+```bash
+cd .github/llm-review
+export LLM_BASE_URL='<openai-compatible-base-url>'
+export LLM_MODEL='<model-identifier>'
+export LLM_CHAT_PATH='/chat/completions'
+export LLM_API_KEY="$RWTH_LLM_TOKEN"
+export BASE_SHA=$(git rev-parse origin/main) HEAD_SHA=$(git rev-parse HEAD) PR_NUMBER=0
+python3 review.py --dry-run
+```
+
+# Runner selection
+
+The workflow defaults to a GitHub-hosted `ubuntu-latest` runner. If the chosen
+endpoint is only reachable from within a particular network, set the
+`LLM_REVIEW_RUNNER` variable to a self-hosted runner label registered inside that
+network; no change to the workflow is required.
+
+# Fork pull requests
+
+Reviewing pull requests from forks requires care, because a fork's code is
+untrusted and must never gain access to the secret. The reviewer uses the
+`workflow_run` pattern for this, rather than `pull_request_target`, and splits the
+work into two workflows:
+
+- `llm-review-collect.yml` runs on the `pull_request` event, including from
+  forks. GitHub withholds secrets from fork `pull_request` runs, so this job has
+  no key. It checks out nothing and runs no code from the pull request; it only
+  records the PR number and commit SHAs, taken from trusted GitHub context, into
+  an artifact.
+- `llm-review.yml` runs on `workflow_run`, after the collect job completes, in
+  the base repository context where the secret is available. It checks out the
+  base repository's own code, never the pull request's, and reads the diff as
+  data through the GitHub API. It never builds or executes anything from the pull
+  request.
+
+Two properties keep the key safe. First, the key is only ever sent as an
+`Authorization` header to the configured LLM endpoint, and is never placed in the
+model prompt, so a prompt-injection payload in the diff cannot reveal it. Second,
+the privileged job runs only trusted base-repository code, so untrusted pull
+request code never executes with the secret in scope. The PR metadata read from
+the collect artifact is validated (numeric PR number, hexadecimal SHAs) before
+use. For this to operate, both the workflows and the secret must reside on the
+repository the pull requests target.


### PR DESCRIPTION
Adds an optional, non-blocking LLM reviewer that runs specialised passes over the PR diff and posts a single COMMENT review with inline notes on changed lines.

The multi-stage design is inspired by Sashiko (https://github.com/sashiko-dev/sashiko); the prompts and runner here are written from scratch and tailored to DPsim. Special thanks to @al3xa23 ( and @stv0g ) for the pointer to the inspiration.

Setup and configuration are documented under docs/hugo Development/LLM PR Review. Prompts for stages are based on a set of comments of previous PRs and my own expertise.

