### PR TITLE
docs: add AI-assisted contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,22 @@ Thanks for your interest in contributing! Below are the essentials to get a pull
 - **No saved notebook outputs**: strip outputs from `.ipynb` files before committing; pre-commit and CI both enforce this.
 - **Contributions in forks only**: do not push feature branches to the main repository.
 
+## AI-assisted contributions
+
+AI assistants are welcome here, and some of us use them. On licensing, DPsim follows the Linux Foundation [policy guidance on generative AI tools](https://www.linuxfoundation.org/legal/generative-ai): the tool's terms must not restrict its output in ways that conflict with the [MPL-2.0](https://mozilla.org/MPL/2.0/), and where the output carries pre-existing third-party material you need permission to contribute it and must supply the corresponding notice and attribution. That guidance invites projects to add their own, and the rest is ours. None of it is peculiar to AI: code adapted from a forum answer or another project has always carried the same obligations.
+
+- **You are the author**: open a pull request only for code you can explain. Read it, build it, run the tests. The sign-off is already a [DCO](https://developercertificate.org/) claim that you have the right to submit the work.
+- **Say which AI tools touched which parts**: in the pull request description. No need for a long explanation, but "I used AI" is not enough. No AI co-author trailers, the sign-off already names the author.
+- **We care about correct results**: a curve that looks right is not a validated result. Compare against a reference case before you claim it works, whether you wrote the code or an assistant did.
+- **Keep changes reviewable in one sitting**: split them when possible, and answer what reviewers actually asked.
+- **Write your text yourself**: pull request descriptions, comments and issues, explaining the process in your words. Only people can be accountable for what is posted under their name.
+- **We judge engagement, never writing style**: unpolished English is fine and we will not guess which words a model wrote. We may close a thread when we cannot tell what is being claimed, when the author goes quiet, or when the author is only passing our questions to an assistant. Closing is not personal, come back when you can talk it through yourself.
+- **Report bugs you have seen**: if an assistant hands you a list of suspected bugs, do not open an issue for each one. Report the ones you reproduced, one per issue, with the steps to reproduce.
+- **Our own LLM reviewer is disclaimed**: it posts under a bot identity, nobody checks what it writes before it appears, it cannot block a merge, and humans decide. Take what is useful and ignore the rest.
+- **Keep private material out of assistants**: no unpublished research, no confidential data, no code you do not own.
+
+This applies to pull requests and issues opened after it was merged, not retroactively.
+
 ## License
 
 By contributing you agree your work is released under the [Mozilla Public License 2.0](https://mozilla.org/MPL/2.0/).


### PR DESCRIPTION
Contributors already use AI assistants and the project says nothing about it, so this closes the gap. 

Adds a section to CONTRIBUTING.md. Licensing defers to the Linux Foundation guidance, and we also add:
- Only open a pull request only for code you can explain. The sign-off is already a DCO claim.
- Say which AI tools touched which parts, no need a multi-line explanation, but "I used AI" is not enough. No AI co-author trailers.
- We care about correct results from the simulations, both code and results.
- Keep changes reviewable in one sitting, split changes when possible.
- Preferably write pull request text, comments and issues yourself, explain the process with your words.
- Do not open issues just because an AI model said there is a bug, first verify yourself. Is useful for us if you can describe the process and the problem, and can tell us why you think is wrong (or even suggest solutions).
- We judge engagement, never writing style. Reply when needed, do not just use directly the output of an LLM model as reply.
- Our own LLM reviewer is disclaimed: bot identity, unvetted, non-blocking, humans decide.
- Nothing unpublished or confidential should be pushed.
- Applies going forward, not retroactively.
