### PR TITLE
ci: enforce conventional commits for commit messages

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+# SPDX-License-Identifier: MPL-2.0
+
+# A type missing from changelog-sections in release-please-config.json is dropped from the changelog.
+extends:
+  - "@commitlint/config-conventional"
+rules:
+  type-enum:
+    - 2
+    - always
+    - [build, chore, ci, docs, feat, fix, perf, refactor, revert, security, style, test]
+  # Component names such as DP::Ph3::Switch must survive in the subject.
+  subject-case: [0]
+  header-max-length: [2, always, 120]

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -32,6 +32,41 @@ jobs:
           python-version: '3.x'
       - uses: pre-commit/action@v3.0.1
 
+  conventional-commits:
+    name: Commit messages are conventional commits
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli @commitlint/config-conventional@19.8.1
+
+      - name: Fail if a commit in this pull request is not a conventional commit
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if ! npx commitlint --from "$BASE_SHA" --to "$HEAD_SHA" --verbose; then
+            echo ""
+            echo "Rewrite the offending commit messages, then force-push:"
+            echo ""
+            echo "  git rebase -i $BASE_SHA"
+            echo "  git push --force-with-lease"
+            echo ""
+            echo "Or install the pre-commit hooks (see CONTRIBUTING.md) to catch this locally."
+            exit 1
+          fi
+
   clean-notebook-outputs:
     name: Notebooks have no saved outputs
     if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -61,3 +61,48 @@ jobs:
               print("Or install the pre-commit hooks, see the Quick start section of CONTRIBUTING.md.")
               sys.exit(1)
           PY
+
+  conventional-commits:
+    name: Conventional commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli @commitlint/config-conventional
+
+      # The merge commit takes the PR title, so that is what Release Please reads.
+      - name: Fail if the pull request title is not a conventional commit
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if ! printf '%s\n' "$PR_TITLE" | npx commitlint --verbose; then
+            echo ""
+            echo "The pull request title becomes the merge commit subject on master."
+            echo "Use a conventional commit subject, for example:"
+            echo ""
+            echo "  fix: correct node voltage initialization in DiakopticsSolver"
+            echo ""
+            exit 1
+          fi
+
+      - name: Fail if a commit in this branch is not a conventional commit
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          if ! npx commitlint --from "$BASE" --to "$HEAD" --verbose; then
+            echo ""
+            echo "Rewrite the offending commit messages, then force-push:"
+            echo ""
+            echo "  git rebase -i $BASE"
+            echo "  git push --force-with-lease"
+            echo ""
+            echo "Or install the pre-commit hooks (see CONTRIBUTING.md) to catch this locally."
+            exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,9 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+
+# commitlint runs at commit-msg, so plain `pre-commit install` must wire that stage too.
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -56,6 +60,13 @@ repos:
         args: [-r, "~MD013,~MD033,~MD024,~MD002"]
         files: ^docs/hugo/content/.*\.md$
         types: [markdown]
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: "v9.26.0"
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional@19.8.1"]
 
   - repo: local
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thanks for your interest in contributing! Below are the essentials to get a pull
 ## Quick start
 
 1. Fork the repository and clone your fork.
-1. Run `pre-commit install` to activate automated checks (formatting, notebook output stripping).
+1. Run `pre-commit install` to activate automated checks (formatting, commit message style, notebook output stripping).
 1. Create a branch with a descriptive prefix (`feature/`, `fix/`, `docs/`).
 1. Make your changes and commit using the conventional commit style (`feat:`, `fix:`, `docs:`, ...) with a sign-off:
 
@@ -26,10 +26,11 @@ Thanks for your interest in contributing! Below are the essentials to get a pull
    git push --force-with-lease
    ```
 
-1. Open a pull request against `sogno-platform/dpsim:master`.
+1. Open a pull request against `sogno-platform/dpsim:master`, giving it a conventional commit title.
 
 ## Key requirements
 
+- **Conventional commits**: every commit message and every pull request title must follow [Conventional Commits](https://www.conventionalcommits.org/); both are checked by CI and by a `commit-msg` hook. The release version and the changelog are derived from them, so a message that does not parse is left out of both. The pull request title matters because it becomes the merge commit subject on `master`.
 - **Linear history**: never merge the target branch into your feature branch; rebase instead.
 - **Sign-off**: every commit must include `Signed-off-by` via `git commit -s` ([DCO](https://developercertificate.org/)).
 - **Formatting**: clang-format 17 for C++, black for Python, markdownlint for Markdown; all enforced by pre-commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thanks for your interest in contributing! Below are the essentials to get a pull
 ## Quick start
 
 1. Fork the repository and clone your fork.
-1. Run `pre-commit install` to activate automated checks (formatting, notebook output stripping).
+1. Run `pre-commit install` to activate automated checks (formatting, commit message style, notebook output stripping).
 1. Create a branch with a descriptive prefix (`feature/`, `fix/`, `docs/`).
 1. Make your changes and commit using the conventional commit style (`feat:`, `fix:`, `docs:`, ...) with a sign-off:
 
@@ -30,6 +30,7 @@ Thanks for your interest in contributing! Below are the essentials to get a pull
 
 ## Key requirements
 
+- **Conventional commits**: every commit message must follow [Conventional Commits](https://www.conventionalcommits.org/); this is checked by CI and by a `commit-msg` hook. The release version and the changelog are derived from the commit messages, so a message that does not parse is left out of both.
 - **Linear history**: never merge the target branch into your feature branch; rebase instead.
 - **Sign-off**: every commit must include `Signed-off-by` via `git commit -s` ([DCO](https://developercertificate.org/)).
 - **Formatting**: clang-format 17 for C++, black for Python, markdownlint for Markdown; all enforced by pre-commit.


### PR DESCRIPTION
Adds a commitlint config, a `commit-msg` hook and a CI check over every commit in a pull request. Pull request titles are not linted; linting both is what produced the duplicate changelog entries in the #608 dry run.

217 of the 326 commits since v1.2.1 do not parse today. This is a prerequisite for #608, which derives the version and the changelog from these messages.

The check is a job in `checks.yaml`, so it runs through the entry point from #661 and the fork pipeline from #674.
