### PR TITLE
Fix EMT::Ph3 averaged VSI without a connection transformer (#604)

### DIFF
--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.h
@@ -55,6 +55,12 @@ protected:
   std::shared_ptr<EMT::Ph3::Resistor> mSubResistorC;
   /// Optional connection transformer
   std::shared_ptr<EMT::Ph3::Transformer> mConnectionTransformer;
+  /// Node the control measures: the transformer's low-voltage virtual node
+  /// when a connection transformer is present, and the component's own
+  /// terminal when it is not. Without a transformer there is no virtual node 3
+  /// -- setVirtualNodeNumber(3) leaves indices 0..2 -- so the control cannot
+  /// name it. Resolved once during initialization and used by controlStep().
+  SimNode::Ptr mControlNode;
 
   /// Flag for connection transformer usage
   Bool mWithConnectionTransformer = false;

--- a/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_AvVoltageSourceInverterDQ.cpp
@@ -265,6 +265,13 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::initializeParentFromNodesAndTerminals(
   else
     mSubResistorC->connect({mVirtualNodes[2], mTerminals[0]->node()});
 
+  // The control measures the filter interface. With a connection transformer
+  // that is virtual node 3; without one the filter interface IS the component
+  // terminal, and virtual node 3 does not exist -- setVirtualNodeNumber(3)
+  // above leaves only indices 0..2, so naming it is out-of-range access.
+  mControlNode = mWithConnectionTransformer ? mVirtualNodes[3]
+                                            : mTerminals[0]->node();
+
   // Initialize electrical subcomponents
   for (auto subcomp : mSubComponents) {
     subcomp->initialize(mFrequencies);
@@ -274,7 +281,7 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::initializeParentFromNodesAndTerminals(
   // Initialize control subcomponents
   // current and voltage inputs to PLL and power controller
   Matrix vcdq, ircdq;
-  Real theta = std::arg(mVirtualNodes[3]->initialSingleVoltage());
+  Real theta = std::arg(mControlNode->initialSingleVoltage());
   vcdq =
       parkTransformPowerInvariant(theta, filterInterfaceInitialVoltage.real());
   ircdq = parkTransformPowerInvariant(
@@ -288,8 +295,8 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::initializeParentFromNodesAndTerminals(
   // angle input
   Matrix matrixStateInit = Matrix::Zero(2, 1);
   Matrix matrixOutputInit = Matrix::Zero(2, 1);
-  matrixStateInit(0, 0) = std::arg(mVirtualNodes[3]->initialSingleVoltage());
-  matrixOutputInit(0, 0) = std::arg(mVirtualNodes[3]->initialSingleVoltage());
+  matrixStateInit(0, 0) = theta;
+  matrixOutputInit(0, 0) = theta;
   mPLL->setInitialValues(**mVcq, matrixStateInit, matrixOutputInit);
 
   SPDLOG_LOGGER_INFO(
@@ -410,7 +417,7 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::controlStep(Real time,
   // Transformation interface forward
   Matrix vcdq, ircdq;
   Real theta = mPLL->mOutputPrev->get()(0, 0);
-  vcdq = parkTransformPowerInvariant(theta, **mVirtualNodes[3]->mVoltage);
+  vcdq = parkTransformPowerInvariant(theta, **mControlNode->mVoltage);
   ircdq = parkTransformPowerInvariant(theta, -**mSubResistorC->mIntfCurrent);
 
   **mVcd = vcdq(0, 0);
@@ -470,10 +477,20 @@ void EMT::Ph3::AvVoltageSourceInverterDQ::mnaParentPostStep(
 
 void EMT::Ph3::AvVoltageSourceInverterDQ::mnaCompUpdateCurrent(
     const Matrix &leftvector) {
-  if (mWithConnectionTransformer)
+  if (mWithConnectionTransformer) {
+    // Transformer is connected {terminal 0, virtual node 3}, so its interface
+    // current already flows towards the terminal.
     **mIntfCurrent = mConnectionTransformer->mIntfCurrent->get();
-  else
-    **mIntfCurrent = mSubResistorC->mIntfCurrent->get();
+  } else {
+    // Rc is connected the other way round, {virtual node 2, terminal 0}, so its
+    // interface current points into the component and has to be negated to mean
+    // the same thing as the transformer branch. Without this the component
+    // reports an inverter at a +4 kW setpoint as ABSORBING 4 kW, while the
+    // network solution is identical -- only the published current is wrong.
+    // controlStep() already applies exactly this negation when it feeds
+    // mSubResistorC->mIntfCurrent to the Park transform.
+    **mIntfCurrent = -mSubResistorC->mIntfCurrent->get();
+  }
 }
 
 void EMT::Ph3::AvVoltageSourceInverterDQ::mnaCompUpdateVoltage(


### PR DESCRIPTION
Fixes #604.

### The segfault

`AvVoltageSourceInverterDQ` allocates three virtual nodes when `withTrafo` is false (`setVirtualNodeNumber(3)`, leaving indices 0..2) while four sites dereference `mVirtualNodes[3]` unconditionally — three in `initializeParentFromNodesAndTerminals`, one in `controlStep`.

This resolves the control's measurement node once during initialization instead: virtual node 3 with a connection transformer, `mTerminals[0]->node()` without one. Without a transformer the filter interface *is* the component terminal, which is already how `mSubResistorC` is connected a few lines above. `EMT_Ph3_VSIVoltageControlVCO` was the reference, as suggested.

### A second defect on the same branch

While confirming the fix I found that `mnaCompUpdateCurrent` publishes `mSubResistorC->mIntfCurrent` unnegated:

```cpp
if (mWithConnectionTransformer)
  **mIntfCurrent = mConnectionTransformer->mIntfCurrent->get();
else
  **mIntfCurrent = mSubResistorC->mIntfCurrent->get();
```

The transformer is connected `{terminal 0, virtual node 3}` and Rc is connected `{virtual node 2, terminal 0}` — opposite orientations — so the two branches report opposite signs for the same physical current. `controlStep()` already applies exactly this negation when it feeds the same attribute to the Park transform, which I took as the intended convention.

I've included the one-line fix here since it is the same root cause (the branch was never exercised) and within the EMT::Ph3 scope you set, but I'm happy to split it out if you'd rather review it separately.

### Verification

Both paths on the same network — 400 V, 12 kW load, inverter at a +4 kW setpoint behind a short LV feeder — run for 2000 steps at `dt = 100 us`:

| | before | after |
|---|---|---|
| `with_trafo=True` | +4472.5 W, load bus 252.2 V | unchanged |
| `with_trafo=False` | segfault | +4480.4 W, load bus 252.2 V |

The load bus voltage agreeing to within a volt across the two paths is what says the sign difference was in the published attribute and not in the network solution.

### Scope

EMT::Ph3 only, as discussed. SP and DP have the same node-count split and can follow as separate PRs — happy to do those next if this shape looks right to you.