### PR TITLE
docs: add copy buttons to code blocks and compact the sidebar

### DIFF
--- a/docs/hugo/config.toml
+++ b/docs/hugo/config.toml
@@ -131,7 +131,7 @@ algolia_docsearch = false
 offlineSearch = true
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
-prism_syntax_highlighting = false
+prism_syntax_highlighting = true
 
 # User interface configuration
 [params.ui]
@@ -144,7 +144,7 @@ navbar_logo = false
 # Set to true if you don't want the top navbar to be translucent when over a `block/cover`, like on the homepage.
 navbar_translucent_over_cover_disable = false
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+sidebar_menu_compact = true
 # Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
 sidebar_search_disable = false
 


### PR DESCRIPTION
The docs are full of shell commands readers are meant to run, with no way to copy them. Docsy ships this already through Prism, but prism_syntax_highlighting was set to false. The sidebar is also switched to compact so it opens to the current section rather than the whole tree.

Verified against the pinned Hugo version: the Prism assets are linked, the bundled prism.js already carries the copy-to-clipboard plugin so no new dependency is needed, and the KaTeX formulas on the model and concept pages still render.