### PR TITLE
docs: correct the model inventory and contributor pages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,11 @@ repos:
     hooks:
       - id: markdownlint
         args: [-r, "~MD013,~MD033,~MD024"]
+        exclude: ^docs/hugo/content/
+      # Hugo emits the <h1> from the page front matter, so a top level header in the
+      # body would render a second one. MD002 is therefore dropped for content pages only.
+      - id: markdownlint
+        name: Markdownlint (Hugo content)
+        args: [-r, "~MD013,~MD033,~MD024,~MD002"]
+        files: ^docs/hugo/content/.*\.md$
+        types: [markdown]

--- a/docs/hugo/content/en/docs/Concepts/_index.md
+++ b/docs/hugo/content/en/docs/Concepts/_index.md
@@ -2,11 +2,18 @@
 title: "Concepts"
 linkTitle: "Concepts"
 weight: 4
+description: >
+  The theory behind the solvers and modelling approaches used in DPsim.
 ---
 
-The book introduces the reader to the general concepts implemented in DPsim, a dynamic phasor (DP) real-time simulator, as well as the physical models of the power system components that are used in simulations.
-The first chapters give an overview of dynamic phasors and nodal analysis which are the two pillars of the main solver implemented in DPsim.
-The second part describes in detail what are the physical equations for each model and how they are transformed and implemented for dynamic phasor simulations and other domains that are also supported by DPsim.
+This section covers the general concepts implemented in DPsim and the physical models of the
+power system components used in simulations.
 
-In order to be able to run a dynamic simulation, DPsim also includes a loadflow solver to compute the initial state of the network if it is not included in the network data.
-Besides DP simulations, DPsim also comes with EMT models for some components which are used as reference for testing the DP models.
+Dynamic phasors and nodal analysis are the two pillars of the main solver, and are covered
+first. The remaining pages describe the physical equations behind each model and how they are
+transformed for dynamic phasor simulation and for the other supported domains.
+
+DPsim also includes a load flow solver, used either on its own or to compute the initial state
+of a network when that state is not part of the network data. Alongside the dynamic phasor
+models there are electromagnetic transient models, which serve both as a simulation domain in
+their own right and as the reference against which the dynamic phasor models are tested.

--- a/docs/hugo/content/en/docs/Development/guidelines.md
+++ b/docs/hugo/content/en/docs/Development/guidelines.md
@@ -46,10 +46,13 @@ There are no strict formal requirements besides the following:
 
     ```cpp
     /* Author: John Smith <John.Smith@example.com>
-    * SPDX-FileCopyrightText: 2025 Example.com
-    * SPDX-License-Identifier: MPL-2.0
-    */
+     * SPDX-FileCopyrightText: 2025 Example.com
+     * SPDX-License-Identifier: MPL-2.0
+     */
     ```
+
+    Keep the SPDX tags on adjacent lines with no blank line between them, as the tooling
+    reads them as a block.
 
 # Creating New Releases (info for maintainers)
 
@@ -58,11 +61,11 @@ new versions can help to mark significant changes and to analyze new portions of
 
 A new version of DPsim has to be indicated as follows:
 
-- Update setup.cfg
-- Update CMakeLists.txt
-- Update sonar-project.properties
-- Update CHANGELOG.md and include all the unreleaed changes in the list
-- Create a new tag with an increased version number (can be done during the Release in GitHub)
+- Update `version` in `pyproject.toml`
+- Update `VERSION` in the top level `CMakeLists.txt`
+- Update `sonar.projectVersion` in `sonar-project.properties`
+- Update `CHANGELOG.md` and include all the unreleased changes in the list
+- Create a new tag with an increased version number, which can be done during the release in GitHub
 
 ## Python Packages
 

--- a/docs/hugo/content/en/docs/Examples/_index.md
+++ b/docs/hugo/content/en/docs/Examples/_index.md
@@ -1,11 +1,69 @@
-
 ---
 title: "Examples"
 linkTitle: "Examples"
 weight: 8
-date: 2020-03-17
+date: 2026-07-31
 description: >
-  Here you can find some examples to get started with DPsim.
+  Runnable examples in Python and C++.
 ---
 
-The DPsim repository includes [examples](https://github.com/sogno-platform/dpsim/tree/master/examples) that can be run locally.
+The repository carries examples in both languages. The Python notebooks are the better starting
+point, since they run a scenario and plot the result in one place. The C++ examples are the
+better reference for using DPsim as a library, and are what the real time and co-simulation
+scenarios are written in.
+
+## Notebooks
+
+Run them in the browser with no local installation:
+
+[![Binder](https://2i2c.mybinder.org/badge_logo.svg)](https://2i2c.mybinder.org/v2/gh/sogno-platform/dpsim/HEAD?urlpath=%2Fdoc%2Ftree%2Fexamples%2FIndex.ipynb)
+
+Locally, they live under
+[examples/Notebooks](https://github.com/sogno-platform/dpsim/tree/master/examples/Notebooks) and
+need the Python package on the path, as described in the
+[build]({{< ref "/docs/Getting started/build.md" >}}) section.
+
+| Category | Contents |
+| --- | --- |
+| Quickstart Guide | A single notebook covering a first simulation end to end |
+| Circuits | Small networks exercising one modelling aspect at a time |
+| Components | One component at a time, often comparing domains against each other |
+| Grids | Published test systems such as the WSCC 9 bus and CIGRE networks |
+| Features | Cross-cutting capabilities rather than a specific network |
+| Performance | Timing and scaling comparisons |
+| StateSpace | State-space extraction from a running simulation |
+
+`Understanding_DP.ipynb` is worth reading early if dynamic phasors are new to you, since it
+builds the intuition the [concepts]({{< ref "/docs/Concepts" >}}) section then formalises.
+
+## C++ examples
+
+Under [dpsim/examples/cxx](https://github.com/sogno-platform/dpsim/tree/master/dpsim/examples/cxx),
+built as part of a normal build and produced as executables in the build directory.
+
+| Directory | Contents |
+| --- | --- |
+| Circuits | Networks assembled directly in C++ |
+| Components | Single component scenarios |
+| CIM | Reading network data from CIM and CGMES files |
+| StateSpace | State-space extraction |
+| RealTime | Scenarios run against the wall clock |
+| DAE, signals, timer | Smaller scenarios for the DAE solver, signal models and timing |
+
+The target name is the source file name without its extension, regardless of which directory the
+source sits in, and the executables are written flat into the build tree. So to build and run a
+single example from your build directory:
+
+```shell
+cmake --build . --target DP_VS_RL1
+./dpsim/examples/cxx/DP_VS_RL1
+```
+
+## Co-simulation
+
+The [dpsim-villas](https://github.com/sogno-platform/dpsim/tree/master/dpsim-villas/examples/cxx)
+examples exchange data with other simulators or with hardware through VILLASnode. These need
+`WITH_VILLAS` enabled and are therefore not available on Windows. See
+[interfaces]({{< ref "/docs/Overview/interfaces.md" >}}) for how the coupling works and
+[real time]({{< ref "/docs/Getting started/real-time.md" >}}) for running them against the wall
+clock.

--- a/docs/hugo/content/en/docs/Models/_index.md
+++ b/docs/hugo/content/en/docs/Models/_index.md
@@ -6,24 +6,118 @@ description: >
   Mathematical description of the models implemented in DPsim.
 ---
 
-The following models are currently available:
+Models are implemented per simulation domain and per phase count, so the same component may
+exist as a single phase dynamic phasor model, a three phase electromagnetic transient model, or
+both. The tables below list what exists today, which is the question this page is most often
+asked.
 
-- Dynamic phasors
-   - inductor, capacitor, resistor
-   - current and voltage source
-   - load (PQ and Z type)
-   - pi-line
-   - transmission line (Bergeron)
-   - synchronous generator dq-frame full order (Kundur, Krause)
-   - inverter averaged
-   - inverter with harmonics (comparable to switched model)
-   - switch
-- EMT
-   - inductor, capacitor, resistor
-   - current and voltage source
-   - load (Z type)
-   - pi-line
-   - transmission line (Bergeron)
-   - synchronous generator dq-frame full order (Kundur, Krause)
-   - inverter averaged
-   - switch
+`DP` is the dynamic phasor domain, `EMT` the electromagnetic transient domain and `SP` the
+static phasor domain, each with `Ph1` for single phase and `Ph3` for three phase. The generated
+[reference]({{< ref "/docs/Reference" >}}) is authoritative for exact class names and signatures.
+
+## Passive elements and sources
+
+| Model | Domains |
+| --- | --- |
+| Resistor, Inductor, Capacitor | DP::Ph1, DP::Ph3, EMT::Ph1, EMT::Ph3, SP::Ph1, SP::Ph3 |
+| VoltageSource | DP::Ph1, DP::Ph3, EMT::Ph1, EMT::Ph3, SP::Ph1, SP::Ph3 |
+| CurrentSource | DP::Ph1, DP::Ph3, EMT::Ph1, EMT::Ph3 |
+| VoltageSourceNorton | DP::Ph1, EMT::Ph1, EMT::Ph3 |
+| VoltageSourceRamp | DP::Ph1, EMT::Ph1 |
+| ProfileVoltageSource | DP::Ph1 |
+| ControlledVoltageSource, ControlledCurrentSource | DP::Ph1, EMT::Ph3, SP::Ph1 |
+| NetworkInjection | DP::Ph1, DP::Ph3, EMT::Ph3, SP::Ph1 |
+
+## Branches
+
+Covered in more detail under [branches]({{< ref "branches.md" >}}),
+[RLC elements]({{< ref "RLC-Elements" >}}) and [transformer]({{< ref "Transformer" >}}).
+
+| Model | Domains |
+| --- | --- |
+| PiLine | DP::Ph1, DP::Ph3, EMT::Ph1, EMT::Ph3, SP::Ph1 |
+| RxLine | DP::Ph1, EMT::Ph3, SP::Ph1, SP::Ph3 |
+| SeriesResistor | DP::Ph3, EMT::Ph3 |
+| Transformer | DP::Ph1, EMT::Ph3, SP::Ph1 |
+| SolidStateTransformer | SP::Ph1 |
+
+## Switches and loads
+
+| Model | Domains |
+| --- | --- |
+| Switch | DP::Ph1, DP::Ph3, EMT::Ph1, EMT::Ph3, SP::Ph1 |
+| SeriesSwitch | DP::Ph3, EMT::Ph3 |
+| varResSwitch | DP::Ph1, SP::Ph1 |
+| RXLoad | DP::Ph1, EMT::Ph3 |
+| RXLoadSwitch, PQLoadCS | DP::Ph1 |
+| Load | SP::Ph1 |
+| Shunt | DP::Ph1, EMT::Ph3, SP::Ph1 |
+| SVC | DP::Ph1 |
+
+## Synchronous generators
+
+See [synchronous generator]({{< ref "Synchronous Generator" >}}) for the model equations. VBR
+denotes the voltage-behind-reactance formulation, PCM the predictor-corrector method and TPM the
+two-stage predictor method.
+
+| Model | Domains |
+| --- | --- |
+| SynchronGenerator3OrderVBR | DP::Ph1, EMT::Ph3, SP::Ph1 |
+| SynchronGenerator4OrderVBR | DP::Ph1, EMT::Ph3, SP::Ph1 |
+| SynchronGenerator5OrderVBR | DP::Ph1, EMT::Ph3, SP::Ph1 |
+| SynchronGenerator6aOrderVBR, SynchronGenerator6bOrderVBR | DP::Ph1, EMT::Ph3, SP::Ph1 |
+| SynchronGenerator4OrderPCM | DP::Ph1, EMT::Ph3 |
+| SynchronGenerator6OrderPCM, SynchronGenerator4OrderTPM | DP::Ph1 |
+| SynchronGeneratorDQ, DQODE, DQTrapez (full order) | DP::Ph3, EMT::Ph3 |
+| SynchronGeneratorTrStab | DP::Ph1, EMT::Ph3, SP::Ph1 |
+| SynchronGeneratorIdeal | DP::Ph1, EMT::Ph3 |
+| SynchronGeneratorIter | DP::Ph1 |
+
+## Power electronics
+
+See [power electronics]({{< ref "power-electronics.md" >}}).
+
+| Model | Domains |
+| --- | --- |
+| AvVoltageSourceInverterDQ | DP::Ph1, EMT::Ph3, SP::Ph1 |
+| AvVoltSourceInverterStateSpace | DP::Ph1, DP::Ph3, EMT::Ph3 |
+| Inverter (with harmonics) | DP::Ph1 |
+| VoltageSourceInverter | SP::Ph1 |
+| VSIVoltageControlVCO | EMT::Ph3 |
+| SSN_GFM (grid forming) | EMT::Ph3 |
+
+## State-space nodal components
+
+Components solved simultaneously with the network rather than through a delayed current
+injection. The method is described under
+[state-space nodal]({{< ref "/docs/Concepts/state-space-nodal.md" >}}).
+
+| Model | Domains |
+| --- | --- |
+| SSN_Full_Serial_RLC | DP::Ph1, DP::Ph3, EMT::Ph1, EMT::Ph3 |
+| SSN_Variable_Serial_RLC | DP::Ph1 |
+| SSN_Capacitor, SSN_Inductor | EMT::Ph3 |
+| GenericTwoTerminalVTypeSSN, GenericTwoTerminalITypeSSN | DP::Ph1, DP::Ph3, EMT::Ph3 |
+| GenericFourTerminalVTypeSSN | EMT::Ph3 |
+| MixedVTypeVariableSSNComp | DP::Ph1, DP::Ph3 |
+
+## Signal and control models
+
+These are domain independent and live in the `Signal` namespace.
+
+Excitation and voltage control: ExciterDC1, ExciterDC1Simp, ExciterST1Simp, ExciterStatic and
+PSS1A, described under
+[synchronous generator regulators]({{< ref "Synchronous Generator Regulators" >}}).
+
+Turbines and governors: SteamTurbine, SteamTurbineGovernor, HydroTurbine, HydroTurbineGovernor,
+TurbineGovernor and TurbineGovernorType1.
+
+Converter control: PowerControllerVSI, VoltageControllerVSI, PLL and VCO.
+
+Signal generators and filters: SineWaveGenerator, CosineFMGenerator, DCGenerator,
+FrequencyRampGenerator, FIRFilter and Integrator.
+
+Decoupling components, used to split a network across solvers or simulators: DecouplingLine,
+DecouplingLineEMT, DecouplingLineEMT_Ph3, and DecouplingIdealTransformer for DP::Ph1, EMT::Ph1,
+EMT::Ph3 and SP::Ph1. The underlying method is described under
+[ideal transformer model]({{< ref "Ideal Transformer Model" >}}).

--- a/docs/hugo/content/en/docs/Models/branches.md
+++ b/docs/hugo/content/en/docs/Models/branches.md
@@ -1,11 +1,65 @@
 ---
 title: "Branches"
 linkTitle: "Branches"
-date: 2020-03-18
+date: 2026-07-31
+description: >
+  Line models connecting two nodes of the network.
 ---
 
-# RX-Line
+Both line models below are composite components: they do not stamp the system matrix directly
+but are built from resistor, inductor and capacitor subcomponents, each of which contributes its
+own stamp. See [subcomponents]({{< ref "/docs/Overview/subcomponents.md" >}}) for how that
+composition works, and [RLC elements]({{< ref "RLC-Elements" >}}) for the stamps of the
+individual elements.
 
-# PI-Line
+The transformer is documented separately under [transformer]({{< ref "Transformer" >}}).
 
-# Transformer
+## RX-Line
+
+The RX line represents a line by its series resistance and series inductance only, ignoring the
+shunt admittance. It is the appropriate choice for short lines, where the charging current is
+negligible, and it is what the CIM reader produces for an `ACLineSegment` when no shunt data is
+present.
+
+The model is composed of a series resistor and a series inductor between the two terminals:
+
+```math
+\underline{Z} = R + j \omega L
+```
+
+An additional resistor from the inductor terminal to ground is present to make initialisation
+well posed. It is not part of the physical model.
+
+`RxLine` exists in `DP::Ph1`, `EMT::Ph3`, `SP::Ph1` and `SP::Ph3`.
+
+## PI-Line
+
+The PI line adds the shunt admittance of the line, split evenly between the two terminals, which
+matters once the line is long enough for the charging current to affect the result. The name
+comes from the shape of the equivalent circuit: a series branch with one shunt branch at each
+end.
+
+The series branch carries the resistance and inductance as above. Each terminal additionally
+carries half of the total shunt capacitance and half of the total shunt conductance:
+
+```math
+\underline{Y}_{shunt} = \frac{G + j \omega C}{2}
+```
+
+Parameters are set through `setParameters(seriesResistance, seriesInductance, parallelCapacitance,
+parallelConductance)`, where the capacitance and conductance given are the totals for the line;
+the model performs the halving itself. The corresponding attributes are `mSeriesRes`,
+`mSeriesInd`, `mParallelCap` and `mParallelCond`.
+
+`PiLine` exists in `DP::Ph1`, `DP::Ph3`, `EMT::Ph1`, `EMT::Ph3` and `SP::Ph1`.
+
+## Choosing between them
+
+Use the RX line when the shunt admittance can be neglected and you want the smaller system
+matrix, since the PI line introduces additional nodes for its shunt branches. Use the PI line
+when the line is long enough that its charging current matters, or when you are comparing
+against a reference tool that models the shunt branch.
+
+Note that both are lumped parameter models and therefore do not reproduce travelling wave
+behaviour. For splitting a network across solvers or simulators, see the decoupling components
+listed under [models]({{< ref "_index.md" >}}).

--- a/docs/hugo/content/en/docs/Models/induction-machine.md
+++ b/docs/hugo/content/en/docs/Models/induction-machine.md
@@ -1,5 +1,0 @@
----
-title: "Induction Machine"
-linkTitle: "Induction Machine"
-date: 2020-03-18
----

--- a/docs/hugo/content/en/docs/Tasks/_index.md
+++ b/docs/hugo/content/en/docs/Tasks/_index.md
@@ -1,16 +1,15 @@
-
 ---
 title: "Core Tasks"
 linkTitle: "Core Tasks"
 weight: 6
-date: 2017-01-05
 description: >
   Description of typical simulation and development tasks.
 ---
 
-Each task should give the user
+Two tasks come up often enough to be written down.
 
-* The prerequisites for this task, if any (this can be specified at the top of a multi-task page if they're the same for all the page's tasks. "All these tasks assume that you understand....and that you have already....").
-* What this task accomplishes.
-* Instructions for the task. If it involves editing a file, running a command, or writing code, provide code-formatted example snippets to show the user what to do! If there are multiple steps, provide them as a numbered list.
-* If appropriate, links to related concept, tutorial, or example pages.
+[Create a new simulation]({{< ref "create-simulation.md" >}}) covers using DPsim as a library
+from your own C++ project, for cases where the Python bindings are not the right fit.
+
+[Add a new model]({{< ref "add-model.md" >}}) covers extending the simulator with a new component
+or control model, including where the files go and what has to be registered.

--- a/docs/hugo/content/en/docs/Tasks/add-model.md
+++ b/docs/hugo/content/en/docs/Tasks/add-model.md
@@ -2,75 +2,116 @@
 title: "Add New Model"
 linkTitle: "Add New Model"
 weight: 6
-date: 2020-03-17
+date: 2026-07-31
 description: >
   Extending the simulator with new component or control models.
 ---
 
-# Add a Component Model
+This page walks through adding a component model, using a three phase dynamic phasor inductor as
+the example.
 
-In this section we will show the implementation of a new component model by means a three-phase dynamic phasor inductor model.
+## Where the code lives
 
-## C++ OOP
-
-DPsim implements component models in a sub project called CPowerSystems (CPS) that is located in the *models* folder.
-This folder is added to the DPsim CMake project.
-Every component in DPsim is represented by a C++ class.
-
-DPsim supports different types of solvers (MNA, DAE, NRP).
-Each solver requires certain member functions in the component class to be implemented.
-These functions are specified by the solver interface classes: ``MNAInterface.h``, ``DAEInterface.h``, etc.
-
-## Directory / Namespace Structure
-
-For the implementation of the new component, we add two new files
-
-- ``models/Source/DP/DP_Ph3_Inductor.cpp``
-- ``models/Include/DP/DP_Ph3_Inductor.h``
-
-In these files, we will implement a new C++ class with the name ``CPS::DP::Ph3::Inductor``.
-The general structure looks as follows.
-
-Directories:
+Component models live in the `dpsim-models` subproject, which builds the `CPS` library. Headers
+and sources are separate trees, both organised by domain:
 
 ```text
-DPsim
- |
- |- Source
- |- Include
-  \ models
-      |- Source
-          |- DP
-          |- EMT
-          |- Static
-            \ Signal
-      |- Include
-          |- DP
-          |- EMT
-          |- Static
-            \ Signal
+dpsim-models
+ |- include
+ |   \ dpsim-models
+ |       |- Base            shared base classes, one per component family
+ |       |- DP              dynamic phasor
+ |       |- EMT             electromagnetic transient
+ |       |- SP              static phasor
+ |       \ Signal           domain independent control and signal models
+ \- src
+     |- Base
+     |- DP
+     |- EMT
+     |- SP
+     \ Signal
 ```
 
-Namespaces:
+Namespaces follow the same shape, with the phase count nested inside the domain:
 
 ```cpp
-CPS::{DP,EMT,Static,Signal}::{Ph1,Ph3}::{Name}
+CPS::{DP,EMT,SP}::{Ph1,Ph3}::{Name}
+CPS::Signal::{Name}
 ```
+
+File names encode the same information, so the example model needs two files:
+
+- `dpsim-models/include/dpsim-models/DP/DP_Ph3_Inductor.h`
+- `dpsim-models/src/DP/DP_Ph3_Inductor.cpp`
+
+declaring the class `CPS::DP::Ph3::Inductor`.
+
+## Choosing a base class
+
+DPsim supports several solvers, and each requires certain member functions on the component.
+Which ones you implement is determined by the interfaces you inherit rather than by the solver
+itself.
+
+For an MNA component, derive from `MNASimPowerComp<VarType>`, with `Complex` as the variable
+type in the `DP` and `SP` domains and `Real` in `EMT`. The MNA hooks are declared on
+`MNAInterface`, which `MNASimPowerComp` implements, so that is where to look for the full set.
+
+If the model is naturally expressed as several existing components wired together rather than as
+a single stamp, derive from `CompositePowerComp` and add subcomponents instead. The pi-line is a
+worked example. See [subcomponents]({{< ref "/docs/Overview/subcomponents.md" >}}).
+
+If the component is better described by its own state-space model coupled to the network, see
+[state-space nodal]({{< ref "/docs/Concepts/state-space-nodal.md" >}}) for that alternative.
 
 ## Attributes
 
-Each components has a list of attributes, which has to be specified when creating the components class.
+Every component exposes its parameters and state through attributes, declared in the class and
+registered in the constructor. Attributes are what make a value visible to the logger, to the
+Python bindings and to the task scheduler.
 
-TODO: explain attribute system
+How to declare, read and derive attributes is described under
+[attributes]({{< ref "/docs/Overview/Attributes/index.md" >}}) and
+[attribute usage]({{< ref "/docs/Development/attribute-usage.md" >}}).
 
-## Tasks for Pre/Post-step Functions
+## Tasks and step functions
 
-TODO: add example task dependency graph
+Pre-step and post-step functions are registered as tasks, and the scheduler derives the order in
+which they may run from the attributes each task reads and writes. Declaring those dependencies
+correctly matters: a task that modifies an attribute without declaring it can be scheduled in
+the wrong order, or in parallel with a reader.
 
-## Adding the new Component to DPsim
+How tasks are built and how the dependency graph is derived is described under
+[scheduling]({{< ref "/docs/Overview/Scheduling/index.md" >}}).
 
-After finishing the implementation of the new component, it needs to be added to the following files:
+## Registering the new component
 
-- `models/Include/cps/Components.h`
-- `models/Source/CMakeLists.txt`
-- `Sources/Python/Module.cpp`
+A new component is not picked up automatically. Three places have to be updated:
+
+- `dpsim-models/src/CMakeLists.txt`, adding the new source file to the list, for example
+  `DP/DP_Ph3_Inductor.cpp`
+- `dpsim-models/include/dpsim-models/Components.h`, adding the header so that including that one
+  file gives access to every component
+- `dpsim/src/pybind/DPComponents.cpp`, or the matching `EMTComponents.cpp`, `SPComponents.cpp`
+  or `SignalComponents.cpp`, to expose the class to Python
+
+The Python binding follows the existing pattern in those files:
+
+```cpp
+py::class_<CPS::DP::Ph1::Resistor, std::shared_ptr<CPS::DP::Ph1::Resistor>,
+           CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "Resistor", py::multiple_inheritance())
+    .def("set_parameters", &CPS::DP::Ph1::Resistor::setParameters, "R"_a);
+```
+
+Name the arguments using the `"R"_a` form shown above. Without it the Python signature and the
+generated reference fall back to positional placeholders such as `arg0`, and callers cannot use
+keyword arguments.
+
+## Initialization
+
+Components are initialized either from power flow results or from explicitly set initial values,
+and the solver calls into the component in a defined order. Do not add an `initialize(Real)`
+overload of your own for user-facing initialization; use the documented hooks instead.
+
+See [initialization]({{< ref "/docs/Overview/initialization.md" >}}) for the full sequence, and
+note the scaling conventions in [guidelines]({{< ref "/docs/Development/guidelines.md" >}}),
+since initialization quantities are RMS3PH while EMT simulation quantities are PEAK1PH.

--- a/docs/hugo/content/en/docs/Tasks/create-simulation.md
+++ b/docs/hugo/content/en/docs/Tasks/create-simulation.md
@@ -1,14 +1,14 @@
 ---
 title: "Create New Simulation"
 linkTitle: "Create New Simulation"
-date: 2020-03-25
+date: 2026-07-31
 description: >
   Using DPsim for a new simulation scenario.
 ---
 
 Here, we will show the implementation of a new simulation scenario defined in C++, which is using DPsim as a library.
 
-# Directory Structure
+## Directory Structure
 
 In the end, your directory structure should look like as follows:
 
@@ -20,12 +20,12 @@ my-project
   |- dpsim (as submodule)
 ```
 
-# CMake File
+## CMake File
 
 Your `CMakeLists.txt` could look like this:
 
 ```cmake
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(my-project CXX)
 
 add_subdirectory(dpsim)
@@ -34,7 +34,7 @@ add_executable(my-scenario source/my-scenario.cpp)
 target_link_libraries(my-scenario dpsim)
 ```
 
-# Build the Project
+## Build the Project
 
 The build process is similar to the one of DPsim:
 


### PR DESCRIPTION
The models index listed a Bergeron line that exists nowhere in the tree and omitted the SP domain, all Ph3 models, the reduced-order generators and the SSN components. It is regenerated from the headers as a per-domain availability table. add-model.md pointed at a source layout that has not existed for years and now describes the real dpsim-models tree and the three registration points.

Also deletes induction-machine.md, since no such model exists and history shows the page is an orphan, fills the empty branches.md, and scopes markdownlint MD002 to non-Hugo files, since Docsy emits the h1 from front matter. Verified with pre-commit run --all-files and a Hugo build.