### PR TITLE
SystemTopology::removeNode: remove connected components too

### DIFF
--- a/dpsim-models/include/dpsim-models/SystemTopology.h
+++ b/dpsim-models/include/dpsim-models/SystemTopology.h
@@ -151,6 +151,8 @@ public:
   /// @param name name of the component
   void removeComponent(const String &name);
 
+  /// @brief Remove node and all components connected to it
+  /// @param name name of the node
   void removeNode(const String &name);
 
   ///
@@ -170,5 +172,8 @@ public:
 
 private:
   template <typename VarType> void multiplyPowerComps(Int numberCopies);
+  /// Removes all components connected to the given node from the
+  /// component list and from the per-node component map
+  void removeComponentsConnectedTo(const TopologicalNode::Ptr &node);
 };
 } // namespace CPS

--- a/dpsim-models/src/SystemTopology.cpp
+++ b/dpsim-models/src/SystemTopology.cpp
@@ -267,12 +267,12 @@ static bool isConnectedTo(const IdentifiedObject::Ptr &comp,
   if (!powerComp)
     return false;
 
-  for (auto terminal : powerComp->topologicalTerminals()) {
-    // Terminals may not be connected yet
-    if (terminal && terminal->topologicalNodes() == node)
-      return true;
-  }
-  return false;
+  // Terminals may not be connected yet
+  const auto terminals = powerComp->topologicalTerminals();
+  return std::any_of(terminals.begin(), terminals.end(),
+                     [&node](const TopologicalTerminal::Ptr &terminal) {
+                       return terminal && terminal->topologicalNodes() == node;
+                     });
 }
 
 void SystemTopology::removeComponentsConnectedTo(

--- a/dpsim-models/src/SystemTopology.cpp
+++ b/dpsim-models/src/SystemTopology.cpp
@@ -296,11 +296,18 @@ void SystemTopology::removeComponentsConnectedTo(
                   comps.end());
     }
   }
+
+  for (const auto &removed : removedComponents) {
+    mTearComponents.erase(
+        std::remove(mTearComponents.begin(), mTearComponents.end(), removed),
+        mTearComponents.end());
+  }
 }
 
 void SystemTopology::removeNode(const String &name) {
   for (auto it = mNodes.begin(); it != mNodes.end();) {
-    if ((*it)->name() == name) {
+    // The ground node is the network reference and must never be removed
+    if ((*it)->name() == name && !(*it)->isGround()) {
       removeComponentsConnectedTo(*it);
       mComponentsAtNode.erase(*it);
       it = mNodes.erase(it);

--- a/dpsim-models/src/SystemTopology.cpp
+++ b/dpsim-models/src/SystemTopology.cpp
@@ -259,10 +259,50 @@ void SystemTopology::removeComponent(const String &name) {
   }
 }
 
+/// Returns true if the component has a terminal that is connected
+/// to the given node
+static bool isConnectedTo(const IdentifiedObject::Ptr &comp,
+                          const TopologicalNode::Ptr &node) {
+  auto powerComp = std::dynamic_pointer_cast<TopologicalPowerComp>(comp);
+  if (!powerComp)
+    return false;
+
+  for (auto terminal : powerComp->topologicalTerminals()) {
+    // Terminals may not be connected yet
+    if (terminal && terminal->topologicalNodes() == node)
+      return true;
+  }
+  return false;
+}
+
+void SystemTopology::removeComponentsConnectedTo(
+    const TopologicalNode::Ptr &node) {
+  IdentifiedObject::List removedComponents;
+
+  for (auto it = mComponents.begin(); it != mComponents.end();) {
+    if (isConnectedTo(*it, node)) {
+      removedComponents.push_back(*it);
+      it = mComponents.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  // A removed component may also be connected to other nodes,
+  // so drop it from the remaining per-node component lists as well
+  for (auto &[topoNode, comps] : mComponentsAtNode) {
+    for (const auto &removed : removedComponents) {
+      comps.erase(std::remove(comps.begin(), comps.end(), removed),
+                  comps.end());
+    }
+  }
+}
+
 void SystemTopology::removeNode(const String &name) {
-  // TODO: Check if any components are connected to the node and remove them as well
   for (auto it = mNodes.begin(); it != mNodes.end();) {
     if ((*it)->name() == name) {
+      removeComponentsConnectedTo(*it);
+      mComponentsAtNode.erase(*it);
       it = mNodes.erase(it);
     } else {
       ++it;

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -374,7 +374,8 @@ PYBIND11_MODULE(dpsimpy, m) {
       .def("init_with_powerflow", &DPsim::SystemTopology::initWithPowerflow,
            "systemPF"_a, "domain"_a)
       .def("add_components", &DPsim::SystemTopology::addComponents)
-      .def("remove_component", &DPsim::SystemTopology::removeComponent);
+      .def("remove_component", &DPsim::SystemTopology::removeComponent)
+      .def("remove_node", &DPsim::SystemTopology::removeNode);
 
   py::class_<DPsim::Interface, std::shared_ptr<DPsim::Interface>>(m,
                                                                   "Interface");

--- a/examples/Notebooks/Features/SystemTopologyRemoveNode.ipynb
+++ b/examples/Notebooks/Features/SystemTopologyRemoveNode.ipynb
@@ -1,0 +1,137 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "efd3eee1",
+   "metadata": {},
+   "source": [
+    "# SystemTopology `remove_node`\n",
+    "\n",
+    "Regression test for `SystemTopology::removeNode`\n",
+    "([#529](https://github.com/sogno-platform/dpsim/issues/529)): removing a node\n",
+    "must also remove the components connected to it, keep unrelated components,\n",
+    "and leave the per-node component map (`components_at_node`) consistent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "073e87d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dpsimpy\n",
+    "\n",
+    "\n",
+    "def comp_names(system):\n",
+    "    return sorted(c.name() for c in system.components)\n",
+    "\n",
+    "\n",
+    "def node_names(system):\n",
+    "    return sorted(n.name() for n in system.nodes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d2f72c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnd = dpsimpy.emt.SimNode.gnd\n",
+    "n1 = dpsimpy.emt.SimNode(\"n1\")\n",
+    "n2 = dpsimpy.emt.SimNode(\"n2\")\n",
+    "\n",
+    "vs = dpsimpy.emt.ph1.VoltageSource(\"vs\")\n",
+    "vs.set_parameters(V_ref=complex(10, 0), f_src=50)\n",
+    "r1 = dpsimpy.emt.ph1.Resistor(\"r1\")\n",
+    "r1.set_parameters(R=1)\n",
+    "c1 = dpsimpy.emt.ph1.Capacitor(\"c1\")\n",
+    "c1.set_parameters(C=1e-3)\n",
+    "\n",
+    "vs.connect([gnd, n1])\n",
+    "r1.connect([n1, n2])\n",
+    "c1.connect([n2, gnd])\n",
+    "\n",
+    "system = dpsimpy.SystemTopology(50, [gnd, n1, n2], [vs, r1, c1])\n",
+    "assert comp_names(system) == [\"c1\", \"r1\", \"vs\"]\n",
+    "print(\"before:\", node_names(system), comp_names(system))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ba1c040",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system.remove_node(\"n2\")\n",
+    "print(\"after:\", node_names(system), comp_names(system))\n",
+    "\n",
+    "assert \"n2\" not in node_names(system)\n",
+    "assert comp_names(system) == [\"vs\"]\n",
+    "\n",
+    "for node, comps in system.components_at_node.items():\n",
+    "    assert node.name() != \"n2\", \"stale map entry for removed node\"\n",
+    "    for comp in comps:\n",
+    "        assert comp.name() not in (\"r1\", \"c1\"), \"stale map reference\"\n",
+    "print(\"connected components removed, map consistent: ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5318c856",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system.remove_node(\"does_not_exist\")\n",
+    "assert comp_names(system) == [\"vs\"]\n",
+    "print(\"removing a non-existent node is a no-op: ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6041141d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k1 = dpsimpy.emt.SimNode(\"k1\")\n",
+    "k2 = dpsimpy.emt.SimNode(\"k2\")\n",
+    "k3 = dpsimpy.emt.SimNode(\"k3\")\n",
+    "rx = dpsimpy.emt.ph1.Resistor(\"rx\")\n",
+    "rx.set_parameters(R=1)\n",
+    "rx.connect([k1, k2])\n",
+    "ry = dpsimpy.emt.ph1.Resistor(\"ry\")\n",
+    "ry.set_parameters(R=1)\n",
+    "ry.connect([k2, k3])\n",
+    "\n",
+    "s2 = dpsimpy.SystemTopology(50, [k1, k2, k3], [rx, ry])\n",
+    "s2.remove_node(\"k3\")\n",
+    "\n",
+    "assert comp_names(s2) == [\"rx\"]\n",
+    "at_k2 = [\n",
+    "    c.name()\n",
+    "    for node, comps in s2.components_at_node.items()\n",
+    "    if node.name() == \"k2\"\n",
+    "    for c in comps\n",
+    "]\n",
+    "assert \"rx\" in at_k2\n",
+    "print(\"component sharing only another node survives: ok\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/Notebooks/Features/SystemTopologyRemoveNode.ipynb
+++ b/examples/Notebooks/Features/SystemTopologyRemoveNode.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "efd3eee1",
+   "id": "e3e007ba",
    "metadata": {},
    "source": [
     "# SystemTopology `remove_node`\n",
@@ -16,7 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "073e87d3",
+   "id": "88b4a965",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d2f72c2",
+   "id": "dac72da5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ba1c040",
+   "id": "89346d18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5318c856",
+   "id": "969af448",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +93,45 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6041141d",
+   "id": "7a2f807e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system.remove_node(\"gnd\")\n",
+    "\n",
+    "assert \"gnd\" in node_names(system)\n",
+    "assert comp_names(system) == [\"vs\"]\n",
+    "print(\"ground node is protected: ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae02d20e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t1 = dpsimpy.emt.SimNode(\"t1\")\n",
+    "t2 = dpsimpy.emt.SimNode(\"t2\")\n",
+    "rt = dpsimpy.emt.ph1.Resistor(\"rt\")\n",
+    "rt.set_parameters(R=1)\n",
+    "rt.connect([t1, t2])\n",
+    "\n",
+    "s3 = dpsimpy.SystemTopology(50, [t1, t2], [rt])\n",
+    "s3.add_tear_component(rt)\n",
+    "assert any(c.name() == \"rt\" for c in s3.tear_components)\n",
+    "\n",
+    "s3.remove_node(\"t2\")\n",
+    "\n",
+    "assert comp_names(s3) == []\n",
+    "assert not any(c.name() == \"rt\" for c in s3.tear_components)\n",
+    "print(\"tear component list stays consistent: ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c44ffff",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Closes #529. Follow-up to #423.

`removeNode` now cleans up the components connected to the removed node instead of leaving that to the caller:

- Components whose terminals reference the removed node are removed from `mComponents`. Connectivity is checked through `topologicalTerminals()`; terminals that are not connected yet (`nullptr`) are skipped, so partially-wired components cannot crash the check.
- The removed node's entry in `mComponentsAtNode` is erased, and removed components are also purged from the remaining per-node lists (a two-terminal component disappears from the lists of both of its nodes).
- `SystemTopology.remove_node` is now exposed in the Python bindings next to `remove_component`.

Existing callers (e.g. the `*_split_decoupled_node` examples) remove the connected components by hand *before* calling `removeNode`; for them the new cleanup finds nothing left to remove, so their behaviour is unchanged.

One observation kept out of this PR to keep it small: `removeComponent` also leaves stale entries in `mComponentsAtNode` today. Happy to address that in a follow-up if you would like it handled the same way.

Verified with a self-contained Python check (built with the Python bindings, `PYTHONPATH=build`):

```python
import dpsimpy

gnd = dpsimpy.emt.SimNode.gnd
n1, n2 = dpsimpy.emt.SimNode("n1"), dpsimpy.emt.SimNode("n2")
vs = dpsimpy.emt.ph1.VoltageSource("vs"); vs.set_parameters(V_ref=10+0j, f_src=50)
r1 = dpsimpy.emt.ph1.Resistor("r1"); r1.set_parameters(R=1)
c1 = dpsimpy.emt.ph1.Capacitor("c1"); c1.set_parameters(C=1e-3)
vs.connect([gnd, n1]); r1.connect([n1, n2]); c1.connect([n2, gnd])

system = dpsimpy.SystemTopology(50, [gnd, n1, n2], [vs, r1, c1])
system.remove_node("n2")

assert sorted(c.name() for c in system.components) == ["vs"]
assert all(n.name() != "n2" for n in system.nodes)
assert all(n.name() != "n2" for n in system.components_at_node)
```

Also checked: removing a non-existent node stays a no-op, the old caller pattern (remove components first, then the node) is unaffected, and a component that only shares another node with the removed component keeps its entry in `components_at_node`.
