### PR TITLE
pybind: restore SystemTopology.add as a deprecated alias

### DIFF
--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -24,6 +24,19 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, CPS::AttributePointer<T>);
 namespace py = pybind11;
 using namespace pybind11::literals;
 
+/// Dispatches a single argument of the deprecated SystemTopology.add
+/// alias to add_node or add_component depending on its type
+static void systemTopologyAddSingle(DPsim::SystemTopology &sys,
+                                    const py::handle &item) {
+  if (py::isinstance<CPS::TopologicalNode>(item))
+    sys.addNode(item.cast<CPS::TopologicalNode::Ptr>());
+  else if (py::isinstance<CPS::IdentifiedObject>(item))
+    sys.addComponent(item.cast<CPS::IdentifiedObject::Ptr>());
+  else
+    throw py::type_error("SystemTopology.add expects a node, a component, "
+                         "or a list of nodes and components");
+}
+
 PYBIND11_MODULE(dpsimpy, m) {
   m.doc() = R"pbdoc(
   DPsim Python bindings
@@ -323,28 +336,12 @@ PYBIND11_MODULE(dpsimpy, m) {
                              1) == -1)
               throw py::error_already_set();
 
-            auto addSingle = [&sys](const py::handle &item) {
-              try {
-                sys.addNode(item.cast<CPS::TopologicalNode::Ptr>());
-                return;
-              } catch (const py::cast_error &) {
-              }
-              try {
-                sys.addComponent(item.cast<CPS::IdentifiedObject::Ptr>());
-                return;
-              } catch (const py::cast_error &) {
-              }
-              throw py::type_error(
-                  "SystemTopology.add expects a node, a component, or a "
-                  "list of nodes and components");
-            };
-
             if (py::isinstance<py::list>(obj) ||
                 py::isinstance<py::tuple>(obj)) {
               for (const py::handle &item : obj)
-                addSingle(item);
+                systemTopologyAddSingle(sys, item);
             } else {
-              addSingle(obj);
+              systemTopologyAddSingle(sys, obj);
             }
           },
           "Deprecated alias for add_component and add_node.")

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -311,6 +311,43 @@ PYBIND11_MODULE(dpsimpy, m) {
       .def("add_component", &DPsim::SystemTopology::addComponent)
       .def("add_component", &DPsim::SystemTopology::addComponents)
       .def("add_node", &DPsim::SystemTopology::addNode)
+      // Deprecated alias for add_component/add_node, kept so that scripts
+      // written before the rename keep working
+      .def(
+          "add",
+          [](DPsim::SystemTopology &sys, const py::object &obj) {
+            if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                             "SystemTopology.add is deprecated; use "
+                             "add_component for components and add_node "
+                             "for nodes instead.",
+                             1) == -1)
+              throw py::error_already_set();
+
+            auto addSingle = [&sys](const py::handle &item) {
+              try {
+                sys.addNode(item.cast<CPS::TopologicalNode::Ptr>());
+                return;
+              } catch (const py::cast_error &) {
+              }
+              try {
+                sys.addComponent(item.cast<CPS::IdentifiedObject::Ptr>());
+                return;
+              } catch (const py::cast_error &) {
+              }
+              throw py::type_error(
+                  "SystemTopology.add expects a node, a component, or a "
+                  "list of nodes and components");
+            };
+
+            if (py::isinstance<py::list>(obj) ||
+                py::isinstance<py::tuple>(obj)) {
+              for (const py::handle &item : obj)
+                addSingle(item);
+            } else {
+              addSingle(obj);
+            }
+          },
+          "Deprecated alias for add_component and add_node.")
       .def("node", py::overload_cast<std::string_view>(
                        &DPsim::SystemTopology::node<CPS::TopologicalNode>))
       .def("node", py::overload_cast<CPS::UInt>(
@@ -338,7 +375,6 @@ PYBIND11_MODULE(dpsimpy, m) {
       .def("list_idobjects", &DPsim::SystemTopology::listIdObjects)
       .def("init_with_powerflow", &DPsim::SystemTopology::initWithPowerflow,
            "systemPF"_a, "domain"_a)
-      .def("add_component", &DPsim::SystemTopology::addComponent)
       .def("add_components", &DPsim::SystemTopology::addComponents)
       .def("remove_component", &DPsim::SystemTopology::removeComponent);
 

--- a/examples/Notebooks/Features/SystemTopologyAddAlias.ipynb
+++ b/examples/Notebooks/Features/SystemTopologyAddAlias.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "942fb481",
+   "metadata": {},
+   "source": [
+    "# SystemTopology `add` Alias\n",
+    "\n",
+    "Regression test for the deprecated `SystemTopology.add` alias\n",
+    "([#530](https://github.com/sogno-platform/dpsim/issues/530)): it must keep\n",
+    "working for scripts written before the rename to `add_component`/`add_node`,\n",
+    "emit a `DeprecationWarning`, dispatch nodes and components to the right\n",
+    "method, accept lists and tuples, and reject invalid input with a `TypeError`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af21ab2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "import dpsimpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f89611f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system = dpsimpy.SystemTopology(50)\n",
+    "\n",
+    "n1 = dpsimpy.emt.SimNode(\"n1\")\n",
+    "r1 = dpsimpy.emt.ph1.Resistor(\"r1\")\n",
+    "r1.set_parameters(R=1)\n",
+    "\n",
+    "with warnings.catch_warnings(record=True) as caught:\n",
+    "    warnings.simplefilter(\"always\")\n",
+    "    system.add(r1)\n",
+    "    system.add(n1)\n",
+    "\n",
+    "assert len(caught) == 2\n",
+    "assert all(issubclass(w.category, DeprecationWarning) for w in caught)\n",
+    "assert [c.name() for c in system.components] == [\"r1\"]\n",
+    "assert any(n.name() == \"n1\" for n in system.nodes)\n",
+    "print(\"single component and node dispatch: ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3d4d6cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r2 = dpsimpy.emt.ph1.Resistor(\"r2\")\n",
+    "r2.set_parameters(R=2)\n",
+    "r3 = dpsimpy.emt.ph1.Resistor(\"r3\")\n",
+    "r3.set_parameters(R=3)\n",
+    "n2 = dpsimpy.emt.SimNode(\"n2\")\n",
+    "\n",
+    "with warnings.catch_warnings(record=True) as caught:\n",
+    "    warnings.simplefilter(\"always\")\n",
+    "    system.add([r2, n2])\n",
+    "    system.add((r3,))\n",
+    "\n",
+    "assert len(caught) == 2\n",
+    "assert sorted(c.name() for c in system.components) == [\"r1\", \"r2\", \"r3\"]\n",
+    "assert any(n.name() == \"n2\" for n in system.nodes)\n",
+    "print(\"list and tuple dispatch: ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b8681d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    with warnings.catch_warnings():\n",
+    "        warnings.simplefilter(\"ignore\")\n",
+    "        system.add(42)\n",
+    "except TypeError:\n",
+    "    print(\"invalid input raises TypeError: ok\")\n",
+    "else:\n",
+    "    raise AssertionError(\"add(42) must raise TypeError\")\n",
+    "\n",
+    "with warnings.catch_warnings():\n",
+    "    warnings.simplefilter(\"error\", DeprecationWarning)\n",
+    "    try:\n",
+    "        system.add(r1)\n",
+    "    except DeprecationWarning:\n",
+    "        print(\"warning-as-error propagates: ok\")\n",
+    "    else:\n",
+    "        raise AssertionError(\"expected DeprecationWarning to be raised\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41cad3bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with warnings.catch_warnings(record=True) as caught:\n",
+    "    warnings.simplefilter(\"always\")\n",
+    "    r4 = dpsimpy.emt.ph1.Resistor(\"r4\")\n",
+    "    r4.set_parameters(R=4)\n",
+    "    system.add_component(r4)\n",
+    "    system.add_node(dpsimpy.emt.SimNode(\"n3\"))\n",
+    "\n",
+    "assert not any(issubclass(w.category, DeprecationWarning) for w in caught)\n",
+    "print(\"add_component and add_node stay silent: ok\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes #530. Follow-up to #423.

#423 renamed the Python `add` to `add_component`/`add_node`, which removed `add` entirely, so existing user scripts calling `system.add(...)` break with an `AttributeError`. This restores `add` as a deprecated alias, as suggested in the issue:

- Emits a `DeprecationWarning` pointing to `add_component`/`add_node`. The `PyErr_WarnEx` return value is checked, so running with `-W error::DeprecationWarning` raises cleanly instead of the warning being swallowed.
- Dispatches by type: nodes go to `addNode`, components to `addComponent`. Lists and tuples are dispatched per element, which covers the old `add(list)` overload.
- Anything else raises a `TypeError` with a descriptive message.
- `add_component` / `add_node` stay the documented names; nothing else in the API changes.

Also drops one duplicated `.def("add_component", ...)` line further down in the same binding block (a leftover duplicate of the definition a few lines above).

Verified with a self-contained check (`PYTHONPATH=build`):

```python
import warnings, dpsimpy

system = dpsimpy.SystemTopology(50)
n1 = dpsimpy.emt.SimNode("n1")
r1 = dpsimpy.emt.ph1.Resistor("r1"); r1.set_parameters(R=1)
r2 = dpsimpy.emt.ph1.Resistor("r2"); r2.set_parameters(R=2)

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    system.add(r1)      # -> add_component, warns
    system.add(n1)      # -> add_node, warns
    system.add([r2])    # list form, warns
assert len(w) == 3 and all(issubclass(x.category, DeprecationWarning) for x in w)
assert sorted(c.name() for c in system.components) == ["r1", "r2"]
assert any(n.name() == "n1" for n in system.nodes)

# invalid input
try:
    system.add(42)
except TypeError:
    pass

# warning-as-error propagates
with warnings.catch_warnings():
    warnings.simplefilter("error", DeprecationWarning)
    try:
        system.add(r1)
    except DeprecationWarning:
        pass
```

`add_component`/`add_node` were also checked to still work without emitting any warning.
