### PR TITLE
Fix the Windows build of the notebook test binaries

### DIFF
--- a/.github/workflows/build_test_windows.yaml
+++ b/.github/workflows/build_test_windows.yaml
@@ -38,7 +38,7 @@ jobs:
         git describe --tags --abbrev=0 --match "v*"
         # TODO: Remove '-DCMAKE_POLICY_VERSION_MINIMUM=3.5' once spdlog version has been bumped
         cmake -DWITH_PYBIND=OFF -DCMAKE_POLICY_VERSION_MINIMUM="3.5" ..
-        cmake --build . --target dpsim --target dpsim-models --parallel
+        cmake --build . --config Release --parallel --target dpsim --target dpsim-models --target tests
 
   windows-bindings:
     name: Build on Windows with Pybind

--- a/dpsim/examples/cxx/Circuits/DP_Ph1_IEEE9_4Order.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_Ph1_IEEE9_4Order.cpp
@@ -488,12 +488,18 @@ int main(int argc, char *argv[]) {
   bool log = args.options.find("log") != args.options.end() &&
              args.getOptionBool("log");
 
-  std::filesystem::path logFilename = "./logs/" + args.name + ".csv";
   std::shared_ptr<DataLoggerInterface> logger = nullptr;
 
   if (log) {
+#ifdef WITH_RT
+    std::filesystem::path logFilename = "./logs/" + args.name + ".csv";
     logger =
         RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
+#else
+    // RealTimeDataLogger is only built with WITH_RT, which is Linux-only
+    CPS::Logger::get(args.name)->warn(
+        "Built without WITH_RT, ignoring the log option");
+#endif
   }
 
   auto sys = buildTopology(args, logger);
@@ -502,7 +508,7 @@ int main(int argc, char *argv[]) {
   sim.setSystem(sys);
   sim.setDomain(Domain::DP);
   sim.doSystemMatrixRecomputation(true);
-  if (log) {
+  if (logger) {
     sim.addLogger(logger);
   }
   sim.run();

--- a/dpsim/examples/cxx/Circuits/DP_Ph1_IEEE9_4Order.cpp
+++ b/dpsim/examples/cxx/Circuits/DP_Ph1_IEEE9_4Order.cpp
@@ -496,9 +496,8 @@ int main(int argc, char *argv[]) {
     logger =
         RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
 #else
-    // RealTimeDataLogger is only built with WITH_RT, which is Linux-only
-    CPS::Logger::get(args.name)->warn(
-        "Built without WITH_RT, ignoring the log option");
+    // RealTimeDataLogger needs WITH_RT, which is Linux-only
+    logger = DataLogger::make(args.name);
 #endif
   }
 

--- a/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_4Order.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_4Order.cpp
@@ -521,13 +521,19 @@ int main(int argc, char *argv[]) {
   bool log = args.options.find("log") != args.options.end() &&
              args.getOptionBool("log");
 
-  std::filesystem::path logFilename =
-      "./logs/" + args.name + "/" + args.name + ".csv";
   std::shared_ptr<DataLoggerInterface> logger = nullptr;
 
   if (log) {
+#ifdef WITH_RT
+    std::filesystem::path logFilename =
+        "./logs/" + args.name + "/" + args.name + ".csv";
     logger =
         RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
+#else
+    // RealTimeDataLogger is only built with WITH_RT, which is Linux-only
+    CPS::Logger::get(args.name)->warn(
+        "Built without WITH_RT, ignoring the log option");
+#endif
   }
 
   auto sys = buildTopology(args, logger);
@@ -536,7 +542,7 @@ int main(int argc, char *argv[]) {
   sim.setSystem(sys);
   sim.setDomain(Domain::EMT);
   sim.doSystemMatrixRecomputation(true);
-  if (log) {
+  if (logger) {
     sim.addLogger(logger);
   }
   sim.run();

--- a/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_4Order.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_4Order.cpp
@@ -530,9 +530,8 @@ int main(int argc, char *argv[]) {
     logger =
         RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
 #else
-    // RealTimeDataLogger is only built with WITH_RT, which is Linux-only
-    CPS::Logger::get(args.name)->warn(
-        "Built without WITH_RT, ignoring the log option");
+    // RealTimeDataLogger needs WITH_RT, which is Linux-only
+    logger = DataLogger::make(args.name);
 #endif
   }
 

--- a/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
@@ -542,9 +542,8 @@ int main(int argc, char *argv[]) {
     logger =
         RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
 #else
-    // RealTimeDataLogger is only built with WITH_RT, which is Linux-only
-    CPS::Logger::get(args.name)->warn(
-        "Built without WITH_RT, ignoring the log option");
+    // RealTimeDataLogger needs WITH_RT, which is Linux-only
+    logger = DataLogger::make(args.name);
 #endif
   }
 

--- a/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
@@ -533,13 +533,19 @@ int main(int argc, char *argv[]) {
   bool log = args.options.find("log") != args.options.end() &&
              args.getOptionBool("log");
 
-  std::filesystem::path logFilename =
-      "./logs/" + args.name + "/" + args.name + ".csv";
   std::shared_ptr<DataLoggerInterface> logger = nullptr;
 
   if (log) {
+#ifdef WITH_RT
+    std::filesystem::path logFilename =
+        "./logs/" + args.name + "/" + args.name + ".csv";
     logger =
         RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
+#else
+    // RealTimeDataLogger is only built with WITH_RT, which is Linux-only
+    CPS::Logger::get(args.name)->warn(
+        "Built without WITH_RT, ignoring the log option");
+#endif
   }
 
   auto sys = buildTopology(args, logger);
@@ -548,7 +554,7 @@ int main(int argc, char *argv[]) {
   sim.setSystem(sys);
   sim.setDomain(Domain::EMT);
   sim.doSystemMatrixRecomputation(true);
-  if (log) {
+  if (logger) {
     sim.addLogger(logger);
   }
   sim.run();

--- a/dpsim/examples/cxx/Circuits/SP_Ph1_IEEE9_4Order.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_Ph1_IEEE9_4Order.cpp
@@ -485,12 +485,18 @@ int main(int argc, char *argv[]) {
   bool log = args.options.find("log") != args.options.end() &&
              args.getOptionBool("log");
 
-  std::filesystem::path logFilename = "./logs/" + args.name + ".csv";
   std::shared_ptr<DataLoggerInterface> logger = nullptr;
 
   if (log) {
+#ifdef WITH_RT
+    std::filesystem::path logFilename = "./logs/" + args.name + ".csv";
     logger =
         RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
+#else
+    // RealTimeDataLogger is only built with WITH_RT, which is Linux-only
+    CPS::Logger::get(args.name)->warn(
+        "Built without WITH_RT, ignoring the log option");
+#endif
   }
 
   auto sys = buildTopology(args, logger);
@@ -500,7 +506,7 @@ int main(int argc, char *argv[]) {
   sim.setDomain(Domain::SP);
   sim.setSolverType(Solver::Type::MNA);
   sim.doSystemMatrixRecomputation(true);
-  if (log) {
+  if (logger) {
     sim.addLogger(logger);
   }
   sim.run();

--- a/dpsim/examples/cxx/Circuits/SP_Ph1_IEEE9_4Order.cpp
+++ b/dpsim/examples/cxx/Circuits/SP_Ph1_IEEE9_4Order.cpp
@@ -493,9 +493,8 @@ int main(int argc, char *argv[]) {
     logger =
         RealTimeDataLogger::make(logFilename, args.duration, args.timeStep);
 #else
-    // RealTimeDataLogger is only built with WITH_RT, which is Linux-only
-    CPS::Logger::get(args.name)->warn(
-        "Built without WITH_RT, ignoring the log option");
+    // RealTimeDataLogger needs WITH_RT, which is Linux-only
+    logger = DataLogger::make(args.name);
 #endif
   }
 

--- a/dpsim/include/DPsim.h
+++ b/dpsim/include/DPsim.h
@@ -11,7 +11,8 @@
 #include <dpsim/StateSpaceModalAnalysis.h>
 #include <dpsim/Utils.h>
 
-#ifndef _MSC_VER
+// The real-time classes are only compiled with WITH_RT, which is Linux-only
+#ifdef WITH_RT
 #include <dpsim/RealTimeDataLogger.h>
 #include <dpsim/RealTimeSimulation.h>
 #endif


### PR DESCRIPTION
The four IEEE9 examples in TEST_SOURCES call RealTimeDataLogger::make() unguarded, so they fail to compile wherever WITH_RT is off, which is everything that is not Linux. WITH_RT is a cmake_dependent_option on Linux_FOUND, and DPsim.h gated the real-time headers on _MSC_VER instead, so the header never matched which sources actually get compiled. On Windows this breaks the whole tests target with C2653.

Guarded the call with #ifdef WITH_RT, the same way main.cpp already guards the pybind bindings, and made addLogger check the logger rather than the option, since the logger is null when RT is unavailable. The Windows job now builds dpsim, dpsim-models and tests instead of only the two libraries, so this stays covered without sweeping in the other ~165 example binaries nothing runs there. Verified on Linux by compiling the four files against a Config.h with WITH_RT undefined: master reproduces the MSVC error, the patch compiles clean under -Wall -Werror with the option both on and off. Needed before #568 can run anything.