### PR TITLE
docs: document the log level guideline and installing from master

### DIFF
--- a/docs/hugo/content/en/docs/Developer Guide/Architecture and Conventions/conventions.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Architecture and Conventions/conventions.md
@@ -29,3 +29,29 @@ Current quantities are expressed either as `RMS` or as `PEAK` values:
 Debug or trace should be the default log level for information that might be nice to have but not necessary for every simulation case.
 
 Calls to the logger that might occur during simulation must use spdlog macros, like `SPDLOG_LOGGER_INFO`.
+
+### Which level to write at
+
+The level is chosen by what the message is for, not by how important it feels while writing it.
+
+| Level | What belongs at it |
+| --- | --- |
+| `off` | Nothing. Selected when running a case study where only the simulation results matter |
+| `error` | All errors |
+| `warn` | All warnings |
+| `info` | Basic information logged once, before or after the simulation |
+| `debug` | Information for debugging: extended static information such as initialisation values, matrix stamps, subcomponents |
+| `trace` | Information produced in each simulation step |
+
+The dividing line that matters is between `debug` and `trace`. Anything written once per simulation
+can be `debug`; anything written once per step has to be `trace`, because the cost is multiplied by
+the step count and a run of 100 000 steps turns a single stray line into 100 000.
+
+### Debug and trace are compiled out
+
+`SPDLOG_ACTIVE_LEVEL` is fixed at `SPDLOG_LEVEL_INFO` in `dpsim-models/include/dpsim-models/Logger.h`,
+so `SPDLOG_LOGGER_DEBUG` and `SPDLOG_LOGGER_TRACE` calls are removed by the preprocessor and produce
+no output whatever level the logger is set to at runtime. Seeing them requires changing that line and
+rebuilding, which is deliberate: it keeps per-step logging out of the release binary rather than
+merely disabled. Raising the level on a component alone is therefore not enough, and that surprise is
+tracked in [issue #300](https://github.com/sogno-platform/dpsim/issues/300).

--- a/docs/hugo/content/en/docs/User Guide/install.md
+++ b/docs/hugo/content/en/docs/User Guide/install.md
@@ -50,6 +50,28 @@ conda activate dpsim
 pip install dpsim
 ```
 
+## Installing from master
+
+A platform without a published wheel, or a fix that is on master but not yet released, can be
+installed straight from the repository:
+
+```shell
+pip install git+https://github.com/sogno-platform/dpsim
+```
+
+This compiles the C++ core rather than downloading a wheel, so it takes several minutes and needs
+the same toolchain a source build does: CMake, a C++17 compiler, and on Windows Visual Studio with
+the C++ desktop development workload. The
+[build page]({{< ref "/docs/Developer Guide/Architecture and Conventions/build.md" >}}) lists them
+per platform, and the CMake options described there are not reachable this way, so a build that
+needs VILLAS or a solver backend turned on has to be configured directly.
+
+Append `@` and a branch or tag to pin what gets built, for example
+`pip install git+https://github.com/sogno-platform/dpsim@v1.2.1`.
+
+To work on DPsim itself, build with CMake instead. An editable install is not a substitute: it links
+only the pure Python sources and leaves the compiled module behind.
+
 ## Docker
 
 You need [Docker](https://docs.docker.com/install/) installed first. The prepared image on


### PR DESCRIPTION
Adds the log level table from #88 to the coding conventions, together with the reason raising a component's level is not enough on its own: SPDLOG_ACTIVE_LEVEL is fixed at INFO in Logger.h, so the debug and trace macros are compiled out entirely, which is the surprise reported in #300.

Also documents installing from master with pip install git+https://github.com/sogno-platform/dpsim, which is what #501 asked for while there is still no Windows or macOS wheel. Built locally with the pinned Hugo 0.108, 133 pages and no errors. Closes #88 and #501.