### PR TITLE
docs: give the Sphinx reference a landing page

### DIFF
--- a/docs/sphinx/_extra/index.html
+++ b/docs/sphinx/_extra/index.html
@@ -1,0 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+     SPDX-License-Identifier: MPL-2.0 -->
+<!-- Sphinx roots this documentation at about.html, so it emits no index.html and /sphinx/ would 404 -->
+<meta http-equiv="refresh" content="0; url=about.html">
+<title>DPsim Python API</title>
+<p>Redirecting to <a href="about.html">the DPsim Python API documentation</a>.</p>

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -103,6 +103,9 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["@CMAKE_CURRENT_SOURCE_DIR@/_static"]
 
+# Copied verbatim into the output root, which is where the index.html redirect to about.html comes from
+html_extra_path = ["@CMAKE_CURRENT_SOURCE_DIR@/_extra"]
+
 # Softens the dense, generated pybind11 signatures.
 html_css_files = ["custom.css"]
 


### PR DESCRIPTION
https://sogno.energy/dpsim/sphinx/ and https://dpsim.fein-aachen.org/sphinx/ both return 404 and always have, while /doxygen/ returns 200. Sphinx roots the Python reference at about.html, so it never emits an index.html and the directory has no landing page. The pages themselves are fine, about.html and Reference.html are both 200.

Adds an index.html that redirects to about.html, copied into the output root through html_extra_path, so master_doc stays as it is and no existing URL changes. Verified by building the Sphinx target locally against a compiled dpsimpy and checking index.html lands next to about.html.