### PR TITLE
Build and publish Windows wheels

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -40,27 +40,37 @@ jobs:
 
   build-wheels:
     name: Build DPsim Python wheel
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        platform: [manylinux_x86_64]
+        os: [ubuntu-24.04, windows-latest]
         python: [cp39, cp310, cp311, cp312, cp313]
+        include:
+        - os: ubuntu-24.04
+          platform: manylinux_x86_64
+        - os: windows-latest
+          platform: win_amd64
     steps:
     - name: Checkout
       uses: actions/checkout@v6
       with:
         submodules: recursive
 
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
+
     - name: Set development version for Test PyPI
       if: "!startsWith(github.ref, 'refs/tags')"
       shell: bash
-      run: python3 scripts/set_dev_version.py pyproject.toml ${{ github.run_number }}
+      run: python scripts/set_dev_version.py pyproject.toml ${{ github.run_number }}
 
     - name: Build wheel
       uses: pypa/cibuildwheel@v3.4.1
       env:
         CIBW_BUILD: "${{ matrix.python }}-${{ matrix.platform }}"
-        CIBW_MANYLINUX_X86_64_IMAGE: sogno/dpsim:manylinux
       with:
         output-dir: dist
 

--- a/docs/hugo/content/en/docs/User Guide/install.md
+++ b/docs/hugo/content/en/docs/User Guide/install.md
@@ -34,10 +34,22 @@ source venv/bin/activate
 pip install dpsim
 ```
 
+On Windows the same three steps are:
+
+```powershell
+py -m venv venv
+venv\Scripts\activate
+pip install dpsim
+```
+
 {{% alert title="Published wheels cover Linux and Windows" color="info" %}}
-Two limitations are worth knowing before you start.
+Three limitations are worth knowing before you start.
 Wheels are published for Linux and Windows on x86-64, for CPython 3.9 through 3.13, so on macOS
 you have to build from source for now.
+The Windows wheel is built without VILLASnode, real-time support and Sundials, so it has no
+`dpsimpyvillas` module, no `RealTimeSimulation` and `RealTimeDataLogger`, and no
+`SynchronGeneratorDQODE` in `dpsimpy.dp.ph3` and `dpsimpy.emt.ph3`; the solvers, the models and
+the CIM/CGMES reader are all available.
 The package also contains only the simulation core; the example notebooks additionally need
 plotting and data handling packages, which are listed in the import section of each notebook.
 {{% /alert %}}

--- a/docs/hugo/content/en/docs/User Guide/install.md
+++ b/docs/hugo/content/en/docs/User Guide/install.md
@@ -34,9 +34,9 @@ source venv/bin/activate
 pip install dpsim
 ```
 
-{{% alert title="Requires Linux for the published wheels" color="info" %}}
+{{% alert title="Published wheels cover Linux and Windows" color="info" %}}
 Two limitations are worth knowing before you start.
-Only Linux wheels are currently published, for CPython 3.9 through 3.13, so on Windows and macOS
+Wheels are published for Linux and Windows on x86-64, for CPython 3.9 through 3.13, so on macOS
 you have to build from source for now.
 The package also contains only the simulation core; the example notebooks additionally need
 plotting and data handling packages, which are listed in the import section of each notebook.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,9 +69,12 @@ test-command = "python -c \"import dpsimpy; import dpsim\""
 [tool.cibuildwheel.linux]
 build = "cp3{9,10,11,12,13}-manylinux_x86_64"
 manylinux-x86_64-image = "sogno/dpsim:manylinux"
+test-command = "python -c \"import dpsimpy; import dpsimpyvillas; import dpsim\""
 
 [tool.cibuildwheel.windows]
 build = "cp3{9,10,11,12,13}-win_amd64"
+before-build = "pip install delvewheel"
+repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,14 @@ namespaces = false
 
 [tool.cibuildwheel]
 build-verbosity = 3
+test-command = "python -c \"import dpsimpy; import dpsim\""
+
+[tool.cibuildwheel.linux]
 build = "cp3{9,10,11,12,13}-manylinux_x86_64"
 manylinux-x86_64-image = "sogno/dpsim:manylinux"
+
+[tool.cibuildwheel.windows]
+build = "cp3{9,10,11,12,13}-win_amd64"
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]


### PR DESCRIPTION
cibuildwheel was pinned to cp3{9,10,11,12,13}-manylinux_x86_64 in a single table, so on a Windows runner it selected nothing at all, which is why #392 needed a second workflow with a competing publish job. Split into per-platform tables and one job builds both.

The matrix gains an os dimension mapped to a platform tag, and the existing publish jobs pick the new wheels up through their dist-* pattern, so there is still one publish path. Also adds a test-command importing dpsimpy and dpsim, which Linux never had.

Linux is unchanged: `manylinux-x86-64-image` only moved into `[tool.cibuildwheel.linux]`, the log still shows `sogno/dpsim:manylinux` being pulled, and the artifact is the same 57.5 MB as master. The Windows wheel was run by hand rather than trusted from a green tick: same EMT circuit, same KLUAdapter, 1002 rows, identical final values as the Linux wheel.

Three things are absent on Windows, from diffing the type stubs in both wheels: `dpsimpyvillas` (VILLASnode has no Windows port), `RealTimeSimulation` and `RealTimeDataLogger` (`WITH_RT` is gated on `Linux_FOUND`), and `SynchronGeneratorDQODE` (needs Sundials). KLU and the CGMES reader are present. The install page now says so.

Supersedes #392, closes #368.
