### PR TITLE
removeComponent: drop the component from mComponentsAtNode too

### DIFF
--- a/dpsim-models/src/SystemTopology.cpp
+++ b/dpsim-models/src/SystemTopology.cpp
@@ -246,6 +246,11 @@ void SystemTopology::reset() {
 void SystemTopology::removeComponent(const String &name) {
   for (auto it = mComponents.begin(); it != mComponents.end();) {
     if ((*it)->name() == name) {
+      // Drop the component from the per-node lists as well, otherwise
+      // the power flow solvers can still pick it up via mComponentsAtNode
+      for (auto &[topoNode, comps] : mComponentsAtNode) {
+        comps.erase(std::remove(comps.begin(), comps.end(), *it), comps.end());
+      }
       it = mComponents.erase(
           it); // safe: returns next valid iterator when erasing
     } else {

--- a/examples/Notebooks/Features/SystemTopologyRemoveComponent.ipynb
+++ b/examples/Notebooks/Features/SystemTopologyRemoveComponent.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3b967ef8",
+   "metadata": {},
+   "source": [
+    "# SystemTopology `remove_component` Map Cleanup\n",
+    "\n",
+    "Regression test for\n",
+    "[#625](https://github.com/sogno-platform/dpsim/issues/625):\n",
+    "`remove_component` must also drop the removed component from\n",
+    "`components_at_node`, otherwise the power flow solvers can still pick it\n",
+    "up while iterating that map during setup."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e807179",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dpsimpy\n",
+    "\n",
+    "\n",
+    "def comp_names(system):\n",
+    "    return sorted(c.name() for c in system.components)\n",
+    "\n",
+    "\n",
+    "def map_names(system):\n",
+    "    return sorted(\n",
+    "        c.name() for comps in system.components_at_node.values() for c in comps\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe39adbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnd = dpsimpy.emt.SimNode.gnd\n",
+    "n1 = dpsimpy.emt.SimNode(\"n1\")\n",
+    "n2 = dpsimpy.emt.SimNode(\"n2\")\n",
+    "\n",
+    "vs = dpsimpy.emt.ph1.VoltageSource(\"vs\")\n",
+    "vs.set_parameters(V_ref=complex(10, 0), f_src=50)\n",
+    "r1 = dpsimpy.emt.ph1.Resistor(\"r1\")\n",
+    "r1.set_parameters(R=1)\n",
+    "c1 = dpsimpy.emt.ph1.Capacitor(\"c1\")\n",
+    "c1.set_parameters(C=1e-3)\n",
+    "\n",
+    "vs.connect([gnd, n1])\n",
+    "r1.connect([n1, n2])\n",
+    "c1.connect([n2, gnd])\n",
+    "\n",
+    "system = dpsimpy.SystemTopology(50, [gnd, n1, n2], [vs, r1, c1])\n",
+    "assert \"r1\" in map_names(system)\n",
+    "print(\"before:\", comp_names(system), \"| map:\", map_names(system))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6187c18a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system.remove_component(\"r1\")\n",
+    "print(\"after:\", comp_names(system), \"| map:\", map_names(system))\n",
+    "\n",
+    "assert comp_names(system) == [\"c1\", \"vs\"]\n",
+    "assert \"r1\" not in map_names(system)\n",
+    "assert \"c1\" in map_names(system) and \"vs\" in map_names(system)\n",
+    "print(\"removed component is gone from components_at_node: ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7954344b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system.remove_component(\"does_not_exist\")\n",
+    "assert comp_names(system) == [\"c1\", \"vs\"]\n",
+    "print(\"removing a non-existent component is a no-op: ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "943b2d53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d1 = dpsimpy.emt.SimNode(\"d1\")\n",
+    "d2 = dpsimpy.emt.SimNode(\"d2\")\n",
+    "ra = dpsimpy.emt.ph1.Resistor(\"dup\")\n",
+    "ra.set_parameters(R=1)\n",
+    "ra.connect([d1, d2])\n",
+    "rb = dpsimpy.emt.ph1.Resistor(\"dup\")\n",
+    "rb.set_parameters(R=2)\n",
+    "rb.connect([d1, d2])\n",
+    "\n",
+    "s2 = dpsimpy.SystemTopology(50, [d1, d2], [ra, rb])\n",
+    "s2.remove_component(\"dup\")\n",
+    "\n",
+    "assert comp_names(s2) == []\n",
+    "assert map_names(s2) == []\n",
+    "print(\"all same-named components purged from the map: ok\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes #625. Follow-up to #621, as offered in that PR's description.

`removeComponent` erased the component from `mComponents` only, so it stayed in `mComponentsAtNode`. Since `PFSolver`/`PFSolverPowerPolar` iterate that map when classifying buses and collecting powers, a removed component could still leak into power flow setup. This is the component-removal counterpart of #621 (node-removal path).

## Changes

- `SystemTopology::removeComponent` now also purges the removed component from every per-node list in `mComponentsAtNode` (same-named duplicates included).
- New regression notebook `examples/Notebooks/Features/SystemTopologyRemoveComponent.ipynb` covering the "Done when" items of #625:
  - the removed component disappears from `components_at_node`,
  - removing a non-existent name is a no-op,
  - all same-named components are purged from the map.

## Testing

- Regression notebook executed locally against the built `dpsimpy` — all assertions pass.
- Extra local edge checks: surviving components keep their exact per-node entries after a removal; removing every component leaves the map empty; an EMT simulation still runs on a topology modified via `remove_component`.
- Repo pre-commit hooks pass on both files (clang-format, black-jupyter, editorconfig, cleared outputs).

Note (out of scope): `addComponent` never inserts into `mComponentsAtNode` either — the map is only populated by the `(frequency, nodes, components)` constructors and `connectComponentToNodes`. Happy to look at that separately if it is considered a gap.
