### PR TITLE
CODEOWNERS: update for the next release

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @dinkelbachjan and @georgii-tishenin will be requested for
+# @dinkelbachjan, @georgii-tishenin and @leonardocarreras will be requested for
 # review when someone opens a pull request.
-* @dinkelbachjan @georgii-tishenin
+* @dinkelbachjan @georgii-tishenin @leonardocarreras
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
@@ -25,10 +25,6 @@
 /dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator6bOrderVBR.h @martinmoraga
 /dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGeneratorTrStab.h @gnakti
 /dpsim-models/include/dpsim-models/DP/DP_Ph1_varResSwitch.h @gnakti
-/dpsim-models/include/dpsim-models/DP/DP_Ph1_TwoTerminalVTypeSSNComp.h @leonardocarreras
-/dpsim-models/include/dpsim-models/DP/DP_Ph1_SSN_Full_Serial_RLC.h @leonardocarreras
-/dpsim-models/include/dpsim-models/DP/DP_Ph1_MixedVTypeVariableSSNComp.h @leonardocarreras
-/dpsim-models/include/dpsim-models/DP/DP_Ph1_SSN_Variable_Serial_RLC.h @leonardocarreras
 /dpsim-models/include/dpsim-models/EMT/EMT_SSNComp.h @georgii-tishenin
 /dpsim-models/include/dpsim-models/EMT/EMT_VTypeSSNComp.h @georgii-tishenin
 /dpsim-models/include/dpsim-models/EMT/EMT_VTypeVariableSSNComp.h @georgii-tishenin
@@ -58,10 +54,6 @@
 /dpsim-models/src/DP/DP_Ph1_SynchronGenerator6bOrderVBR.cpp @martinmoraga
 /dpsim-models/src/DP/DP_Ph1_SynchronGeneratorTrStab.cpp @gnakti
 /dpsim-models/src/DP/DP_Ph1_varResSwitch.cpp @gnakti
-/dpsim-models/src/DP/DP_Ph1_TwoTerminalVTypeSSNComp.cpp @leonardocarreras
-/dpsim-models/src/DP/DP_Ph1_SSN_Full_Serial_RLC.cpp @leonardocarreras
-/dpsim-models/src/DP/DP_Ph1_MixedVTypeVariableSSNComp.cpp @leonardocarreras
-/dpsim-models/src/DP/DP_Ph1_SSN_Variable_Serial_RLC.cpp @leonardocarreras
 /dpsim-models/src/EMT/EMT_SSNComp.cpp @georgii-tishenin
 /dpsim-models/src/EMT/EMT_VTypeSSNComp.cpp @georgii-tishenin
 /dpsim-models/src/EMT/EMT_VTypeVariableSSNComp.cpp @georgii-tishenin
@@ -148,3 +140,13 @@
 /dpsim-models/**/Signal/VCO.* @matthiasmees
 /dpsim-models/**/Signal/VoltageControllerVSI.* @matthiasmees
 /dpsim/examples/cxx/Components/EMT_Ph3_GFM_Test.cpp @matthiasmees
+
+# DP SSN components, shared with the SSN owner.
+/dpsim-models/include/dpsim-models/DP/DP_Ph1_TwoTerminalVTypeSSNComp.h @georgii-tishenin @leonardocarreras
+/dpsim-models/include/dpsim-models/DP/DP_Ph1_SSN_Full_Serial_RLC.h @georgii-tishenin @leonardocarreras
+/dpsim-models/include/dpsim-models/DP/DP_Ph1_MixedVTypeVariableSSNComp.h @georgii-tishenin @leonardocarreras
+/dpsim-models/include/dpsim-models/DP/DP_Ph1_SSN_Variable_Serial_RLC.h @georgii-tishenin @leonardocarreras
+/dpsim-models/src/DP/DP_Ph1_TwoTerminalVTypeSSNComp.cpp @georgii-tishenin @leonardocarreras
+/dpsim-models/src/DP/DP_Ph1_SSN_Full_Serial_RLC.cpp @georgii-tishenin @leonardocarreras
+/dpsim-models/src/DP/DP_Ph1_MixedVTypeVariableSSNComp.cpp @georgii-tishenin @leonardocarreras
+/dpsim-models/src/DP/DP_Ph1_SSN_Variable_Serial_RLC.cpp @georgii-tishenin @leonardocarreras

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @dinkelbachjan will be requested for
+# @dinkelbachjan and @georgii-tishenin will be requested for
 # review when someone opens a pull request.
-* @dinkelbachjan
+* @dinkelbachjan @georgii-tishenin
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
@@ -129,3 +129,12 @@
 /packaging/Nix @stv0g
 /python @gnakti
 /requirements-manylinux.txt @dinkelbachjan
+
+# SSN components and state-space extraction.
+/dpsim-models/**/*SSN* @georgii-tishenin
+/dpsim-models/**/*StateSpace* @georgii-tishenin
+/dpsim/include/dpsim/MNAStateSpace* @georgii-tishenin
+/dpsim/src/MNAStateSpace* @georgii-tishenin
+/dpsim/include/dpsim/StateSpaceModalAnalysis.h @georgii-tishenin
+/dpsim/src/StateSpaceModalAnalysis.cpp @georgii-tishenin
+/dpsim/examples/cxx/StateSpace/ @georgii-tishenin

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -138,3 +138,13 @@
 /dpsim/include/dpsim/StateSpaceModalAnalysis.h @georgii-tishenin
 /dpsim/src/StateSpaceModalAnalysis.cpp @georgii-tishenin
 /dpsim/examples/cxx/StateSpace/ @georgii-tishenin
+
+# SSN types and grid-forming control.
+/dpsim-models/**/EMT_DC_* @matthiasmees
+/dpsim-models/**/*ITypeSSN* @matthiasmees
+/dpsim-models/**/*FourTerminalVTypeSSN* @matthiasmees
+/dpsim-models/**/EMT_Ph3_SSN_GFM.* @matthiasmees
+/dpsim-models/**/EMT_Ph3_VSIVoltageControlVCO.* @matthiasmees
+/dpsim-models/**/Signal/VCO.* @matthiasmees
+/dpsim-models/**/Signal/VoltageControllerVSI.* @matthiasmees
+/dpsim/examples/cxx/Components/EMT_Ph3_GFM_Test.cpp @matthiasmees

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -98,7 +98,7 @@
 /dpsim/include/dpsim/MNASolverPlugin.h @n-eiling
 /dpsim/include/dpsim/PFSolver.h @gnakti
 /dpsim/include/dpsim/PFSolverPowerPolar.h @gnakti
-/dpsim/include/Utils.h @n-eiling
+/dpsim/include/dpsim/Utils.h @n-eiling @georgii-tishenin @leonardocarreras
 /dpsim/src/MNAStateSpaceContributor.cpp @georgii-tishenin
 /dpsim/src/MNAStateSpaceExtractor.cpp @georgii-tishenin
 /dpsim/src/StateSpaceModalAnalysis.cpp @georgii-tishenin
@@ -109,7 +109,7 @@
 /dpsim/src/PFSolver.cpp @gnakti
 /dpsim/src/PFSolverPowerPolar.cpp @gnakti
 /dpsim/src/SolverPlugins @n-eiling
-/dpsim/src/Utils.h @n-eiling
+/dpsim/src/Utils.cpp @n-eiling @georgii-tishenin @leonardocarreras
 /examples/Notebooks/Circuits @gnakti
 /examples/Notebooks/Circuits/SP_Validation_ReducedOrderSG_VBR_SMIB_Fault_withPSAT.ipynb @martinmoraga
 /examples/Notebooks/Grids @gnakti
@@ -120,7 +120,6 @@
 /packaging/Docker/Dockerfile.dev-rocky @n-eiling
 /packaging/Nix @stv0g
 /python @gnakti
-/requirements-manylinux.txt @dinkelbachjan
 
 # SSN components and state-space extraction.
 /dpsim-models/**/*SSN* @georgii-tishenin

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,21 +1,21 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @m-mirz and @dinkelbachjan will be requested for
+# @dinkelbachjan will be requested for
 # review when someone opens a pull request.
-* @m-mirz @dinkelbachjan
+* @dinkelbachjan
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
 # modifies the following files, only the following members
 # and not the global owner(s) will be requested for a review.
 
-/.clang-format @stv0g @m-mirz
-/.devcontainer @stv0g @m-mirz
+/.clang-format @stv0g
+/.devcontainer @stv0g
 /.dockerignore @stv0g
-/.editorconfig @stv0g @m-mirz
+/.editorconfig @stv0g
 /.git-blame-ignore-revs @stv0g
-/.github @m-mirz @leonardocarreras @stv0g
-/.gitignore @stv0g @m-mirz
+/.github @leonardocarreras @stv0g
+/.gitignore @stv0g
 /cmake @stv0g
 /cmake/FindMAGMA.cmake @n-eiling
 /configs/shmem_cosim/ @stv0g
@@ -128,16 +128,12 @@
 /examples/villas @stv0g @pipeacosta
 /examples/villas-deprecated @stv0g
 /gitlab-ci.yml @stv0g
-/packaging @m-mirz
 /packaging/Docker @stv0g
 /packaging/Docker/Dockerfile.dev-rocky @n-eiling
 /pyproject.toml @stv0g
 /pytest.ini @stv0g
 /python @gnakti @stv0g
-/README.md @m-mirz
 /requirements-manylinux.txt @dinkelbachjan
-/requirements.txt @m-mirz @stv0g
-/setup.cfg @m-mirz @stv0g
-/setup.py @m-mirz @stv0g
-/sonar-project.properties @m-mirz
-CMakeLists.txt @m-mirz
+/requirements.txt @stv0g
+/setup.cfg @stv0g
+/setup.py @stv0g

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,15 +9,12 @@
 # modifies the following files, only the following members
 # and not the global owner(s) will be requested for a review.
 
-/.clang-format @stv0g
-/.devcontainer @stv0g
-/.dockerignore @stv0g
-/.editorconfig @stv0g
-/.git-blame-ignore-revs @stv0g
-/.github @leonardocarreras @stv0g
-/.gitignore @stv0g
-/cmake @stv0g
+/.github @leonardocarreras
+/.github/workflows/build-nix.yaml @stv0g
+/.github/workflows/run_villas_example.yaml @stv0g
+/cmake/FetchVILLASnode.cmake @stv0g
 /cmake/FindMAGMA.cmake @n-eiling
+/cmake/FindVILLASnode.cmake @stv0g
 /configs/shmem_cosim/ @stv0g
 /dpsim-models/include/dpsim-models/Base/Base_ReducedOrderSynchronGenerator.h @martinmoraga
 /dpsim-models/include/dpsim-models/CIM/Reader.h @gnakti
@@ -119,7 +116,6 @@
 /dpsim/src/MNASolverPlugin.cpp @n-eiling
 /dpsim/src/PFSolver.cpp @gnakti
 /dpsim/src/PFSolverPowerPolar.cpp @gnakti
-/dpsim/src/pybind @stv0g
 /dpsim/src/SolverPlugins @n-eiling
 /dpsim/src/Utils.h @n-eiling
 /examples/Notebooks/Circuits @gnakti
@@ -127,13 +123,9 @@
 /examples/Notebooks/Grids @gnakti
 /examples/villas @stv0g @pipeacosta
 /examples/villas-deprecated @stv0g
-/gitlab-ci.yml @stv0g
-/packaging/Docker @stv0g
+/flake.lock @stv0g
+/flake.nix @stv0g
 /packaging/Docker/Dockerfile.dev-rocky @n-eiling
-/pyproject.toml @stv0g
-/pytest.ini @stv0g
-/python @gnakti @stv0g
+/packaging/Nix @stv0g
+/python @gnakti
 /requirements-manylinux.txt @dinkelbachjan
-/requirements.txt @stv0g
-/setup.cfg @stv0g
-/setup.py @stv0g


### PR DESCRIPTION
Collects proposals in #636, one commit per request.

Summary:

1. @m-mirz asked to be removed entirely
2. @stv0g asked to be removed from the catch-all, keeping only VILLAS integration and Nix builds
3. @georgii-tishenin joins the catch-all and takes the SSN models and state-space extraction
4. @matthiasmees takes the SSN types and grid-forming control he was involved in
5. @leonardocarreras joins the catch-all

Paths that were moved are corrected. Others/owners are untouched for the time being.