### PR TITLE
SystemTopology: derive mComponentsAtNode instead of hand-maintaining it

### DIFF
--- a/dpsim-models/src/SimPowerComp.cpp
+++ b/dpsim-models/src/SimPowerComp.cpp
@@ -218,6 +218,10 @@ template <typename VarType>
 TopologicalNode::List SimPowerComp<VarType>::topologicalNodes() {
   TopologicalNode::List nodes;
   for (typename SimTerminal<VarType>::Ptr term : mTerminals) {
+    // mTerminals is preallocated with nullptr and only filled by connect(),
+    // so an unconnected component must not crash the lookup (see #626)
+    if (!term)
+      continue;
     nodes.push_back(term->node());
   }
   return nodes;

--- a/dpsim-models/src/SystemTopology.cpp
+++ b/dpsim-models/src/SystemTopology.cpp
@@ -69,6 +69,9 @@ void SystemTopology::connectComponentToNodes(
 }
 
 void SystemTopology::componentsAtNodeList() {
+  // Idempotent: the map is a view derived from mComponents, so rebuild it
+  // from scratch instead of accumulating entries across calls (see #635)
+  mComponentsAtNode.clear();
   for (auto comp : mComponents) {
     auto powerComp = std::dynamic_pointer_cast<TopologicalPowerComp>(comp);
     if (powerComp)
@@ -246,11 +249,8 @@ void SystemTopology::reset() {
 void SystemTopology::removeComponent(const String &name) {
   for (auto it = mComponents.begin(); it != mComponents.end();) {
     if ((*it)->name() == name) {
-      // Drop the component from the per-node lists as well, otherwise
-      // the power flow solvers can still pick it up via mComponentsAtNode
-      for (auto &[topoNode, comps] : mComponentsAtNode) {
-        comps.erase(std::remove(comps.begin(), comps.end(), *it), comps.end());
-      }
+      // mComponentsAtNode needs no manual cleanup here: it is rebuilt from
+      // mComponents by componentsAtNodeList() wherever it is consumed (#635)
       it = mComponents.erase(
           it); // safe: returns next valid iterator when erasing
     } else {
@@ -288,15 +288,8 @@ void SystemTopology::removeComponentsConnectedTo(
     }
   }
 
-  // A removed component may also be connected to other nodes,
-  // so drop it from the remaining per-node component lists as well
-  for (auto &[topoNode, comps] : mComponentsAtNode) {
-    for (const auto &removed : removedComponents) {
-      comps.erase(std::remove(comps.begin(), comps.end(), removed),
-                  comps.end());
-    }
-  }
-
+  // mComponentsAtNode needs no manual cleanup here: it is rebuilt from
+  // mComponents by componentsAtNodeList() wherever it is consumed (#635)
   for (const auto &removed : removedComponents) {
     mTearComponents.erase(
         std::remove(mTearComponents.begin(), mTearComponents.end(), removed),
@@ -309,7 +302,6 @@ void SystemTopology::removeNode(const String &name) {
     // The ground node is the network reference and must never be removed
     if ((*it)->name() == name && !(*it)->isGround()) {
       removeComponentsConnectedTo(*it);
-      mComponentsAtNode.erase(*it);
       it = mNodes.erase(it);
     } else {
       ++it;

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -23,6 +23,9 @@ PFSolver::PFSolver(CPS::String name, CPS::SystemTopology system,
 
 void PFSolver::initialize() {
   SPDLOG_LOGGER_INFO(mSLog, "#### INITIALIZATION OF POWERFLOW SOLVER ");
+  // mComponentsAtNode is a view derived from mComponents; rebuild it here so
+  // the solver never sees entries for removed or re-added components (#635)
+  mSystem.componentsAtNodeList();
   for (auto comp : mSystem.mComponents) {
     if (std::shared_ptr<CPS::SP::Ph1::SynchronGenerator> gen =
             std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(comp))

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -367,8 +367,12 @@ PYBIND11_MODULE(dpsimpy, m) {
 #endif
       .def_readwrite("nodes", &DPsim::SystemTopology::mNodes)
       .def_readwrite("components", &DPsim::SystemTopology::mComponents)
-      .def_readwrite("components_at_node",
-                     &DPsim::SystemTopology::mComponentsAtNode)
+      .def_property_readonly("components_at_node",
+                             [](DPsim::SystemTopology &sys) {
+                               // Derived view: rebuild before every read (see #635)
+                               sys.componentsAtNodeList();
+                               return sys.mComponentsAtNode;
+                             })
       .def_readonly("tear_components", &DPsim::SystemTopology::mTearComponents)
       .def("list_idobjects", &DPsim::SystemTopology::listIdObjects)
       .def("init_with_powerflow", &DPsim::SystemTopology::initWithPowerflow,

--- a/examples/Notebooks/Features/SystemTopologyComponentsAtNode.ipynb
+++ b/examples/Notebooks/Features/SystemTopologyComponentsAtNode.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "47639cf1",
+   "metadata": {},
+   "source": [
+    "# SystemTopology `components_at_node` as a Derived View\n",
+    "\n",
+    "Regression test for\n",
+    "[#635](https://github.com/sogno-platform/dpsim/issues/635):\n",
+    "`components_at_node` is now derived from the component list instead of\n",
+    "being hand-maintained state, so it cannot drift away from `components`.\n",
+    "Also covers [#626](https://github.com/sogno-platform/dpsim/issues/626):\n",
+    "a component with unconnected terminals must not crash the\n",
+    "`SystemTopology` constructor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17bb3fae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dpsimpy\n",
+    "\n",
+    "\n",
+    "def comp_names(system):\n",
+    "    return sorted(c.name() for c in system.components)\n",
+    "\n",
+    "\n",
+    "def map_names(system):\n",
+    "    return sorted(\n",
+    "        c.name() for comps in system.components_at_node.values() for c in comps\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a70d2adb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 626: an unconnected component must not crash the constructor\n",
+    "n1 = dpsimpy.emt.SimNode(\"n1\")\n",
+    "loose = dpsimpy.emt.ph1.Resistor(\"loose\")\n",
+    "loose.set_parameters(R=1)\n",
+    "\n",
+    "system = dpsimpy.SystemTopology(50, [n1], [loose])\n",
+    "assert comp_names(system) == [\"loose\"]\n",
+    "assert map_names(system) == []\n",
+    "print(\"constructor with an unconnected component does not crash: ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd233f9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# once the component is connected, the derived view picks it up\n",
+    "gnd = dpsimpy.emt.SimNode.gnd\n",
+    "loose.connect([n1, gnd])\n",
+    "assert map_names(system) == [\"loose\", \"loose\"]\n",
+    "print(\"connecting it later makes it appear in the map: ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7c23940",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# components added after construction no longer drift out of the map\n",
+    "vs = dpsimpy.emt.ph1.VoltageSource(\"vs\")\n",
+    "vs.set_parameters(V_ref=complex(10, 0), f_src=50)\n",
+    "vs.connect([gnd, n1])\n",
+    "system.add_component(vs)\n",
+    "\n",
+    "assert \"vs\" in map_names(system)\n",
+    "print(\"component added after construction shows up in the map: ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "534c615d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# reading the map repeatedly must not accumulate duplicate entries\n",
+    "first = map_names(system)\n",
+    "second = map_names(system)\n",
+    "assert first == second\n",
+    "print(\"repeated reads stay identical (rebuild is idempotent): ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea563220",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# removal semantics from 621/634 are preserved by the derived view\n",
+    "system.remove_component(\"loose\")\n",
+    "assert comp_names(system) == [\"vs\"]\n",
+    "assert map_names(system) == [\"vs\", \"vs\"]\n",
+    "print(\"removed component is gone from the map: ok\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes #635. Closes #626.

`mComponentsAtNode` was a snapshot taken by the 3- and 4-arg constructors that quietly drifted away from `mComponents`: `addComponent` never inserted, the removal paths had to purge it by hand, and repeated calls of `componentsAtNodeList()` duplicated entries. The map is now a view derived from `mComponents`, rebuilt where it is consumed.

## Changes

- `componentsAtNodeList()` is idempotent: it clears the map and rebuilds it from `topologicalNodes()`.
- `SimPowerComp::topologicalNodes()` skips unconnected (null) terminals, so a component that is not fully wired no longer segfaults the `SystemTopology(frequency, nodes, components)` constructors — that closes #626. `componentsAtNodeList()` is its only caller, so no other behaviour changes.
- `PFSolver::initialize()` rebuilds the map before the solver classifies buses, so `PFSolver`/`PFSolverPowerPolar` never see entries for removed components or miss components added after construction.
- The Python binding exposes `components_at_node` as a read-only property that rebuilds before every read (nothing in the repo assigned to it).
- The manual purges in `removeComponent` (from #634) and in `removeNode`/`removeComponentsConnectedTo` (from #621) are gone; the derived view keeps the same visible behaviour, which both regression notebooks still verify.
- New regression notebook `examples/Notebooks/Features/SystemTopologyComponentsAtNode.ipynb` covering: the #626 constructor repro, a component connected after construction appearing in the map, no duplicates on repeated reads, and removal staying visible through the derived view.

`CIM::Reader` and `connectComponentToNodes` still write the map so that direct C++ reads (e.g. the CIGRE load-profile example) keep working without a rebuild call; the rebuild simply recreates the same content wherever it runs.

## Testing

- New regression notebook executed locally against the built `dpsimpy` — all assertions pass, including the #626 repro that previously crashed the interpreter.
- The regression notebooks from #621 (`SystemTopologyRemoveNode.ipynb`), #634 (`SystemTopologyRemoveComponent.ipynb`) and #622 (`SystemTopologyAddAlias.ipynb`) all still pass unchanged, plus local edge suites for the removal paths.
- Master comparison: `EMT_Ph3_VSIVoltageControlVCO_PF_Init.ipynb` (power flow init + EMT run) executed on master and on this branch — both CSV outputs are bit-identical, so power flow results are unaffected for well-formed topologies.
- Repo pre-commit hooks pass on all changed files.
