### PR TITLE
fix(examples): damp the IEEE9 example with inverters

### DIFF
--- a/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
+++ b/dpsim/examples/cxx/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.cpp
@@ -250,6 +250,13 @@ SystemTopology buildTopology(CommandLineArgs &args,
       ieee9.gen1.XdPrime, ieee9.gen1.XqPrime, ieee9.gen1.TdoPrime,
       ieee9.gen1.TqoPrime);
 
+  // Optional overrides for studying the tuning from a notebook.
+  auto opt = [&](const String &key, Real def) {
+    return args.options.find(key) != args.options.end()
+               ? args.getOptionReal(key)
+               : def;
+  };
+
   auto exciter1Params = std::make_shared<Signal::ExciterDC1SimpParameters>();
   exciter1Params->Ta = ieee9.exc1.TA;
   exciter1Params->Ka = ieee9.exc1.KA;
@@ -283,18 +290,19 @@ SystemTopology buildTopology(CommandLineArgs &args,
 
   gen1EMT->addGovernor(turbineGovernor1);
 
+  auto pss1Params =
+      std::make_shared<CPS::CIM::Examples::Components::PSS1A::Ieee9Gen1>();
+  pss1Params->Kw = opt("pss_kw", pss1Params->Kw);
+  if (pss1Params->Kw > 0.0)
+    gen1EMT->addPSS(Signal::PSS1A::make("Gen1_PSS", CPS::Logger::Level::off),
+                    pss1Params);
+
   const Real omegaN = 2.0 * PI * ieee9.nomFreq;
 
   // gen2 replaced by a grid-forming SSN inverter, keeping the GEN2 identity.
   // nominalVoltage is the peak phase target at the 1.025 pu PV setpoint.
   const Real gfmNominalVoltage = RMS3PH_TO_PEAK1PH * ieee9.gen2.InitialVoltage;
   GfmParams gfm;
-  // Optional overrides for studying the grid-forming tuning from a notebook.
-  auto opt = [&](const String &key, Real def) {
-    return args.options.find(key) != args.options.end()
-               ? args.getOptionReal(key)
-               : def;
-  };
   gfm.dampingCoefficient = opt("gfm_d", gfm.dampingCoefficient);
   gfm.KpVoltage = opt("gfm_kpv", gfm.KpVoltage);
   gfm.KiVoltage = opt("gfm_kiv", gfm.KiVoltage);

--- a/dpsim/examples/cxx/Examples.h
+++ b/dpsim/examples/cxx/Examples.h
@@ -160,6 +160,19 @@ struct Parameters {
   Real Vs_min = -0.1;
   Real Tw = 10.0;
 };
+
+struct Ieee9Gen1 : Signal::PSS1AParameters {
+  Ieee9Gen1() {
+    Kw = 20.0;
+    T1 = 0.4;
+    T2 = 0.05;
+    T3 = 0.4;
+    T4 = 0.05;
+    Vs_max = 0.1;
+    Vs_min = -0.1;
+    Tw = 10.0;
+  }
+};
 } // namespace PSS1A
 
 namespace SteamGovernor {
@@ -415,7 +428,7 @@ struct Ieee9AvVsi {
   Real KpPLL = 7.246377e-3;
   Real KiPLL = 5.797101e-3;
   Real KpPowerCtrl = 1.449275e-3;
-  Real KiPowerCtrl = 5.797101e-3;
+  Real KiPowerCtrl = 2.898551e-3;
 
   // Current loop (rebased by the impedance ratio)
   Real KpCurrCtrl = 2.975625e-2;

--- a/examples/Notebooks/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.ipynb
+++ b/examples/Notebooks/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.ipynb
@@ -31,7 +31,7 @@
     "import os\n",
     "import subprocess\n",
     "\n",
-    "duration = 2.0\n",
+    "duration = 8.0\n",
     "\n",
     "root_path = (\n",
     "    subprocess.Popen([\"git\", \"rev-parse\", \"--show-toplevel\"], stdout=subprocess.PIPE)\n",
@@ -198,7 +198,7 @@
    "source": [
     "Sweeping the tuning. On a stiff grid the grid-forming source needs enough damping; here the swing-damping `gfm_d` is swept and the gen2 active power is compared.\n",
     "\n",
-    "Grid-forming knobs: `gfm_d`, `gfm_dq`, `gfm_dqc`, `gfm_kpv`, `gfm_kiv`, `gfm_ff`, `gfm_rv`. Grid-following knobs (gen3): `gfl_kppll`, `gfl_kipll`, `gfl_kpp`, `gfl_kip`, `gfl_kpi`, `gfl_kii`. Pass any of them to `run(...)`, e.g. `run(gfl_kppll=0.02)`."
+    "Grid-forming knobs: `gfm_d`, `gfm_dq`, `gfm_dqc`, `gfm_kpv`, `gfm_kiv`, `gfm_ff`, `gfm_rv`. Grid-following knobs (gen3): `gfl_kppll`, `gfl_kipll`, `gfl_kpp`, `gfl_kip`, `gfl_kpi`, `gfl_kii`. Stabiliser knob (gen1): `pss_kw`. Pass any of them to `run(...)`, e.g. `run(gfl_kppll=0.02)`."
    ]
   },
   {
@@ -231,7 +231,7 @@
    "id": "abde2b26",
    "metadata": {},
    "source": [
-    "Virtual resistance as a substitute for a large swing-damping coefficient. The baseline holds the swing with a large `gfm_d`. Lowering `gfm_d` leaves the grid-forming frequency oscillating; adding a virtual output resistance `gfm_rv` damps it back down through a physical output-impedance path rather than the artificial swing-damping term. It recovers most, though not all, of the sustained swing damping."
+    "Damping of the slow mode. The oscillation left in the plots above is the gen1 rotor swinging against the network at about 0.51 Hz. Two independent things damp it, and the example uses both. The stabiliser `pss_kw` on gen1 supplies damping torque through the exciter, which the machine otherwise lacks entirely: it is modelled without damper windings and its AVR alone contributes none. The grid-following power loop at gen3 supplies the rest through `gfl_kip`, whose integral gain must stay clear of the electromechanical band; rebasing the 400 V reference by voltage ratio alone gives 5.797101e-3, which sits right on the mode, so the example halves it. Measured from the decay of successive speed peaks, damping goes from about 3 percent with neither to 9 percent with the power loop alone, 18 percent with the stabiliser alone and 19 percent with both."
    ]
   },
   {
@@ -242,17 +242,19 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(12, 6))\n",
+    "kip_rebased = 5.797101e-3\n",
     "cases = [\n",
-    "    (\"gfm_d = 3e6, gfm_rv = 0\", dict(gfm_d=3.0e6, gfm_rv=0.0)),\n",
-    "    (\"gfm_d = 3e5, gfm_rv = 0\", dict(gfm_d=3.0e5, gfm_rv=0.0)),\n",
-    "    (\"gfm_d = 3e5, gfm_rv = 8\", dict(gfm_d=3.0e5, gfm_rv=8.0)),\n",
+    "    (\"neither\", dict(pss_kw=0.0, gfl_kip=kip_rebased)),\n",
+    "    (\"power loop only\", dict(pss_kw=0.0)),\n",
+    "    (\"stabiliser only\", dict(gfl_kip=kip_rebased)),\n",
+    "    (\"both (example default)\", dict()),\n",
     "]\n",
     "for label, opts in cases:\n",
     "    ts_c = run(**opts)\n",
-    "    t, w = xy(ts_c, \"GEN2.omega\")\n",
-    "    plt.plot(t, (w / (2 * np.pi) - 60.0) * 1e3, label=label)\n",
+    "    t, w = xy(ts_c, \"GEN1.omega\")\n",
+    "    plt.plot(t, (w - 1.0) * 1e4, label=label)\n",
     "plt.xlabel(\"time [s]\")\n",
-    "plt.ylabel(\"GEN2 frequency deviation [mHz]\")\n",
+    "plt.ylabel(\"GEN1 speed deviation [1e-4 pu]\")\n",
     "plt.legend()\n",
     "plt.show()"
    ]


### PR DESCRIPTION
Damped because it does not converge fast.

What was done:

1. Add a PSS1A on the gen1, tailored to 0.51Hz which is closer to the ripple frequency.
2. KiPowerCtl was adjusted.