### PR TITLE
fix(pf): share solved bus power across all generators at a bus

### DIFF
--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
@@ -48,6 +48,9 @@ public:
   const Attribute<Real>::Ptr mReactivePowerMaxPerUnit;
   /// Minimum reactive power limit [pu]
   const Attribute<Real>::Ptr mReactivePowerMinPerUnit;
+  /// Share of the bus power this machine takes in the PF write-back at a bus with
+  /// several generators. 0 means grid-following: the set points are left untouched.
+  const Attribute<Real>::Ptr mSlackWeight;
 
   /// Defines UID, name and logging level
   SynchronGenerator(String uid, String name,

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
@@ -26,6 +26,11 @@ private:
   Real mBaseVoltage;
   /// Base apparent power[VA]
   Real mBaseApparentPower;
+  /// Rated apparent power [VA], 0 means unknown and caps nothing
+  Real mRatedApparentPower = 0.;
+  /// Share of the bus power this machine takes when several sit on one bus,
+  /// 0 means grid-following: the set points are left untouched
+  Real mSlackWeight = 1.;
 
 public:
   /// Active power set point of the machine [W]
@@ -48,9 +53,6 @@ public:
   const Attribute<Real>::Ptr mReactivePowerMaxPerUnit;
   /// Minimum reactive power limit [pu]
   const Attribute<Real>::Ptr mReactivePowerMinPerUnit;
-  /// Share of the bus power this machine takes in the PF write-back at a bus with
-  /// several generators. 0 means grid-following: the set points are left untouched.
-  const Attribute<Real>::Ptr mSlackWeight;
 
   /// Defines UID, name and logging level
   SynchronGenerator(String uid, String name,
@@ -71,6 +73,12 @@ public:
   Real getBaseVoltage() const;
   /// Set base voltage
   void setBaseVoltage(Real baseVoltage);
+  /// Rated apparent power [VA] as handed to setParameters
+  Real getRatedApparentPower() const;
+  /// Share of the bus power taken when several machines sit on one bus
+  Real getSlackWeight() const;
+  /// Set the share of the bus power taken, 0 to hold the set points instead
+  void setSlackWeight(Real slackWeight);
   /// Initializes component from power flow data
   void calculatePerUnitParameters(Real baseApparentPower, Real baseOmega);
   /// Modify powerflow bus type

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator.h
@@ -28,8 +28,7 @@ private:
   Real mBaseApparentPower;
   /// Rated apparent power [VA], 0 means unknown and caps nothing
   Real mRatedApparentPower = 0.;
-  /// Share of the bus power this machine takes when several sit on one bus,
-  /// 0 means grid-following: the set points are left untouched
+  /// Share of the bus power taken when co-located, 0 holds the set points instead
   Real mSlackWeight = 1.;
 
 public:

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGenerator.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGenerator.cpp
@@ -26,8 +26,7 @@ SP::Ph1::SynchronGenerator::SynchronGenerator(String uid, String name,
       mReactivePowerMaxPerUnit(mAttributes->create<Real>(
           "Q_max_pu", std::numeric_limits<Real>::infinity())),
       mReactivePowerMinPerUnit(mAttributes->create<Real>(
-          "Q_min_pu", -std::numeric_limits<Real>::infinity())),
-      mSlackWeight(mAttributes->create<Real>("slack_weight", 1.0)) {
+          "Q_min_pu", -std::numeric_limits<Real>::infinity())) {
 
   SPDLOG_LOGGER_INFO(mSLog, "Create {} of type {}", name, this->type());
   mSLog->flush();
@@ -44,6 +43,7 @@ void SP::Ph1::SynchronGenerator::setParameters(
   **mSetPointVoltage = setPointVoltage;
   **mReactivePowerMax = qLimMax;
   **mReactivePowerMin = qLimMin;
+  mRatedApparentPower = ratedApparentPower;
   mPowerflowBusType = powerflowBusType;
 
   SPDLOG_LOGGER_INFO(mSLog, "Rated Apparent Power={} [VA] Rated Voltage={} [V]",
@@ -62,6 +62,16 @@ Real SP::Ph1::SynchronGenerator::getBaseVoltage() const { return mBaseVoltage; }
 
 void SP::Ph1::SynchronGenerator::setBaseVoltage(Real baseVoltage) {
   mBaseVoltage = baseVoltage;
+}
+
+Real SP::Ph1::SynchronGenerator::getRatedApparentPower() const {
+  return mRatedApparentPower;
+}
+
+Real SP::Ph1::SynchronGenerator::getSlackWeight() const { return mSlackWeight; }
+
+void SP::Ph1::SynchronGenerator::setSlackWeight(Real slackWeight) {
+  mSlackWeight = slackWeight;
 }
 
 void SP::Ph1::SynchronGenerator::calculatePerUnitParameters(

--- a/dpsim-models/src/SP/SP_Ph1_SynchronGenerator.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_SynchronGenerator.cpp
@@ -26,7 +26,8 @@ SP::Ph1::SynchronGenerator::SynchronGenerator(String uid, String name,
       mReactivePowerMaxPerUnit(mAttributes->create<Real>(
           "Q_max_pu", std::numeric_limits<Real>::infinity())),
       mReactivePowerMinPerUnit(mAttributes->create<Real>(
-          "Q_min_pu", -std::numeric_limits<Real>::infinity())) {
+          "Q_min_pu", -std::numeric_limits<Real>::infinity())),
+      mSlackWeight(mAttributes->create<Real>("slack_weight", 1.0)) {
 
   SPDLOG_LOGGER_INFO(mSLog, "Create {} of type {}", name, this->type());
   mSLog->flush();

--- a/dpsim/include/dpsim/PFSolverPowerPolar.h
+++ b/dpsim/include/dpsim/PFSolverPowerPolar.h
@@ -69,6 +69,17 @@ protected:
   void calculatePAndQAtSlackBus();
   /// Calculate the reactive power at all PV buses from current solution
   void calculateQAtPVBuses();
+  /// All synchronous generators connected to a bus, in system component order
+  std::vector<std::shared_ptr<CPS::SP::Ph1::SynchronGenerator>>
+  generatorsAtNode(CPS::TopologicalNode::Ptr node);
+  /// Share a bus-aggregate Q [pu] out over co-located generators
+  std::vector<CPS::Real> splitReactivePower(
+      const std::vector<std::shared_ptr<CPS::SP::Ph1::SynchronGenerator>>
+          &generators,
+      CPS::Real totalQ);
+  /// Write the solved bus generation back to every generator at the bus
+  void distributeGeneratorPower(CPS::TopologicalNode::Ptr node,
+                                CPS::Complex Sgen, bool withActivePower);
   /// Generator reactive-power injection at a bus [pu], used by the Q-limit check
   CPS::Real generatorReactivePowerPerUnit(CPS::TopologicalNode::Ptr node);
   /// Total local load reactive power at a bus [pu]

--- a/dpsim/include/dpsim/PFSolverPowerPolar.h
+++ b/dpsim/include/dpsim/PFSolverPowerPolar.h
@@ -77,6 +77,11 @@ protected:
       const std::vector<std::shared_ptr<CPS::SP::Ph1::SynchronGenerator>>
           &generators,
       CPS::Real totalQ);
+  /// Share a bus-aggregate P [pu] out, bounded by what Q leaves of each rating
+  std::vector<CPS::Real> splitActivePower(
+      const std::vector<std::shared_ptr<CPS::SP::Ph1::SynchronGenerator>>
+          &generators,
+      CPS::Real totalP, const std::vector<CPS::Real> &sharesQ);
   /// Write the solved bus generation back to every generator at the bus
   void distributeGeneratorPower(CPS::TopologicalNode::Ptr node,
                                 CPS::Complex Sgen, bool withActivePower);

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -445,6 +445,115 @@ Real PFSolverPowerPolar::Q(UInt k) {
   return sol_V.coeff(k) * val;
 }
 
+std::vector<std::shared_ptr<CPS::SP::Ph1::SynchronGenerator>>
+PFSolverPowerPolar::generatorsAtNode(CPS::TopologicalNode::Ptr node) {
+  std::vector<std::shared_ptr<CPS::SP::Ph1::SynchronGenerator>> generators;
+  for (auto comp : mSystem.mComponentsAtNode[node])
+    if (auto sgPtr =
+            std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(comp))
+      generators.push_back(sgPtr);
+  return generators;
+}
+
+std::vector<CPS::Real> PFSolverPowerPolar::splitReactivePower(
+    const std::vector<std::shared_ptr<CPS::SP::Ph1::SynchronGenerator>>
+        &generators,
+    CPS::Real totalQ) {
+  // Load every machine to the same fraction of its own [Qmin, Qmax] range, the
+  // convention MATPOWER's pfsoln uses. Falls back to the weight split when a
+  // limit is infinite or the ranges collapse, which is the hand-built-grid case.
+  std::vector<Real> shares(generators.size(), 0.0);
+  // A lone machine takes the whole amount, bit for bit as before this split existed
+  if (generators.size() == 1) {
+    shares[0] = totalQ;
+    return shares;
+  }
+
+  Real rangeSum = 0.0;
+  Real minSum = 0.0;
+  bool finiteRanges = true;
+  for (auto gen : generators) {
+    Real qMin = **(gen->mReactivePowerMinPerUnit);
+    Real qMax = **(gen->mReactivePowerMaxPerUnit);
+    // isFinite is bit-pattern based, so it's immune to -Ofast/-ffast-math.
+    if (!CPS::Math::isFinite(qMin) || !CPS::Math::isFinite(qMax) ||
+        qMax < qMin) {
+      finiteRanges = false;
+      break;
+    }
+    rangeSum += qMax - qMin;
+    minSum += qMin;
+  }
+
+  if (finiteRanges && rangeSum > 0.0) {
+    Real loading = (totalQ - minSum) / rangeSum;
+    for (UInt i = 0; i < generators.size(); ++i) {
+      Real qMin = **(generators[i]->mReactivePowerMinPerUnit);
+      Real qMax = **(generators[i]->mReactivePowerMaxPerUnit);
+      shares[i] = qMin + loading * (qMax - qMin);
+    }
+    return shares;
+  }
+
+  Real weightSum = 0.0;
+  for (auto gen : generators)
+    weightSum += std::max(0.0, **(gen->mSlackWeight));
+  for (UInt i = 0; i < generators.size(); ++i)
+    shares[i] = weightSum > 0.0
+                    ? totalQ * std::max(0.0, **(generators[i]->mSlackWeight)) /
+                          weightSum
+                    : totalQ / static_cast<Real>(generators.size());
+  return shares;
+}
+
+void PFSolverPowerPolar::distributeGeneratorPower(
+    CPS::TopologicalNode::Ptr node, CPS::Complex Sgen, bool withActivePower) {
+  auto generators = generatorsAtNode(node);
+  if (generators.empty())
+    return;
+
+  // Zero-weight machines hold their set point, the others share what is left over
+  std::vector<std::shared_ptr<CPS::SP::Ph1::SynchronGenerator>> participants;
+  Real followerP = 0.0;
+  Real followerQ = 0.0;
+  for (auto gen : generators) {
+    if (**(gen->mSlackWeight) > 0.0) {
+      participants.push_back(gen);
+    } else {
+      followerP += **(gen->mSetPointActivePowerPerUnit);
+      followerQ += **(gen->mSetPointReactivePowerPerUnit);
+    }
+  }
+  // Every machine following would leave the bus balance on nobody, so share it out
+  if (participants.empty()) {
+    participants = generators;
+    followerP = 0.0;
+    followerQ = 0.0;
+  }
+
+  auto sharesQ = splitReactivePower(participants, Sgen.imag() - followerQ);
+  Real residualP = Sgen.real() - followerP;
+  Real weightSum = 0.0;
+  for (auto gen : participants)
+    weightSum += **(gen->mSlackWeight);
+
+  for (UInt i = 0; i < participants.size(); ++i) {
+    if (!withActivePower) {
+      participants[i]->updateReactivePowerInjection(
+          CPS::Complex(0.0, sharesQ[i]) * mBaseApparentPower);
+      continue;
+    }
+    Real shareP =
+        participants.size() == 1
+            ? residualP
+            : (weightSum > 0.0
+                   ? residualP * **(participants[i]->mSlackWeight) / weightSum
+                   : residualP / static_cast<Real>(participants.size()));
+    participants[i]->updatePowerInjection(CPS::Complex(shareP, sharesQ[i]) *
+                                          mBaseApparentPower);
+  }
+}
+
 void PFSolverPowerPolar::calculatePAndQAtSlackBus() {
   for (auto topoNode : mVDBuses) {
     auto node_idx = topoNode->matrixNodeIndex();
@@ -466,20 +575,17 @@ void PFSolverPowerPolar::calculatePAndQAtSlackBus() {
     }
 
     // Update connected VD source/generator with actual generated power
+    bool handledByExtnet = false;
     for (auto comp : mSystem.mComponentsAtNode[topoNode]) {
       if (auto extnetPtr =
               std::dynamic_pointer_cast<CPS::SP::Ph1::NetworkInjection>(comp)) {
         extnetPtr->updatePowerInjection(Sgen * mBaseApparentPower);
-        break;
-      }
-
-      if (auto sgPtr =
-              std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(
-                  comp)) {
-        sgPtr->updatePowerInjection(Sgen * mBaseApparentPower);
+        handledByExtnet = true;
         break;
       }
     }
+    if (!handledByExtnet)
+      distributeGeneratorPower(topoNode, Sgen, true);
 
     // Store net nodal injection, not generator power
     sol_P(node_idx) = S.real();
@@ -506,15 +612,8 @@ void PFSolverPowerPolar::calculateQAtPVBuses() {
       }
     }
 
-    // Update PV generator with actual generator Q
-    for (auto comp : mSystem.mComponentsAtNode[topoNode]) {
-      if (auto sgPtr =
-              std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(
-                  comp)) {
-        sgPtr->updateReactivePowerInjection(Sgen * mBaseApparentPower);
-        break;
-      }
-    }
+    // Update PV generators with actual generator Q
+    distributeGeneratorPower(topoNode, Sgen, false);
 
     // Store net nodal Q injection, not generator Q
     sol_Q(node_idx) = S.imag();

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -459,9 +459,7 @@ std::vector<CPS::Real> PFSolverPowerPolar::splitReactivePower(
     const std::vector<std::shared_ptr<CPS::SP::Ph1::SynchronGenerator>>
         &generators,
     CPS::Real totalQ) {
-  // Load every machine to the same fraction of its own [Qmin, Qmax] range, the
-  // convention MATPOWER's pfsoln uses. Falls back to the weight split when a
-  // limit is infinite or the ranges collapse, which is the hand-built-grid case.
+  // Same fraction of each machine's own [Qmin, Qmax] range, as MATPOWER's pfsoln does
   std::vector<Real> shares(generators.size(), 0.0);
   // A lone machine takes the whole amount, bit for bit as before this split existed
   if (generators.size() == 1) {
@@ -557,8 +555,7 @@ std::vector<CPS::Real> PFSolverPowerPolar::splitActivePower(
     return shares;
   }
 
-  // What is left of the capability circle once Q is placed: P <= sqrt(S^2 - Q^2).
-  // A rating of 0 means none was given, so that machine stays uncapped.
+  // What the capability circle leaves once Q is placed, a rating of 0 means uncapped
   std::vector<Real> headroom(generators.size(), 0.0);
   for (UInt i = 0; i < generators.size(); ++i) {
     Real sRated = generators[i]->getRatedApparentPower() / mBaseApparentPower;
@@ -568,8 +565,7 @@ std::vector<CPS::Real> PFSolverPowerPolar::splitActivePower(
                       : 0.0;
   }
 
-  // Hand out in proportion to weight, then re-share what the saturated machines
-  // cannot take among those with headroom left, until nothing more saturates
+  // Share by weight, then re-share what the saturated machines cannot take
   std::vector<bool> capped(generators.size(), false);
   Real cappedP = 0.0;
   for (UInt pass = 0; pass < generators.size(); ++pass) {
@@ -597,8 +593,7 @@ std::vector<CPS::Real> PFSolverPowerPolar::splitActivePower(
       return shares;
   }
 
-  // Every machine sits on its capability circle and the bus still needs more, so
-  // overload them in proportion rather than silently dropping the bus balance
+  // All saturated and the bus still needs more, overload rather than lose the balance
   Real assigned = 0.0;
   for (auto share : shares)
     assigned += share;

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -497,10 +497,10 @@ std::vector<CPS::Real> PFSolverPowerPolar::splitReactivePower(
 
   Real weightSum = 0.0;
   for (auto gen : generators)
-    weightSum += std::max(0.0, **(gen->mSlackWeight));
+    weightSum += std::max(0.0, gen->getSlackWeight());
   for (UInt i = 0; i < generators.size(); ++i)
     shares[i] = weightSum > 0.0
-                    ? totalQ * std::max(0.0, **(generators[i]->mSlackWeight)) /
+                    ? totalQ * std::max(0.0, generators[i]->getSlackWeight()) /
                           weightSum
                     : totalQ / static_cast<Real>(generators.size());
   return shares;
@@ -517,7 +517,7 @@ void PFSolverPowerPolar::distributeGeneratorPower(
   Real followerP = 0.0;
   Real followerQ = 0.0;
   for (auto gen : generators) {
-    if (**(gen->mSlackWeight) > 0.0) {
+    if (gen->getSlackWeight() > 0.0) {
       participants.push_back(gen);
     } else {
       followerP += **(gen->mSetPointActivePowerPerUnit);
@@ -532,26 +532,85 @@ void PFSolverPowerPolar::distributeGeneratorPower(
   }
 
   auto sharesQ = splitReactivePower(participants, Sgen.imag() - followerQ);
-  Real residualP = Sgen.real() - followerP;
-  Real weightSum = 0.0;
-  for (auto gen : participants)
-    weightSum += **(gen->mSlackWeight);
-
-  for (UInt i = 0; i < participants.size(); ++i) {
-    if (!withActivePower) {
+  if (!withActivePower) {
+    for (UInt i = 0; i < participants.size(); ++i)
       participants[i]->updateReactivePowerInjection(
           CPS::Complex(0.0, sharesQ[i]) * mBaseApparentPower);
-      continue;
-    }
-    Real shareP =
-        participants.size() == 1
-            ? residualP
-            : (weightSum > 0.0
-                   ? residualP * **(participants[i]->mSlackWeight) / weightSum
-                   : residualP / static_cast<Real>(participants.size()));
-    participants[i]->updatePowerInjection(CPS::Complex(shareP, sharesQ[i]) *
-                                          mBaseApparentPower);
+    return;
   }
+
+  auto sharesP =
+      splitActivePower(participants, Sgen.real() - followerP, sharesQ);
+  for (UInt i = 0; i < participants.size(); ++i)
+    participants[i]->updatePowerInjection(CPS::Complex(sharesP[i], sharesQ[i]) *
+                                          mBaseApparentPower);
+}
+
+std::vector<CPS::Real> PFSolverPowerPolar::splitActivePower(
+    const std::vector<std::shared_ptr<CPS::SP::Ph1::SynchronGenerator>>
+        &generators,
+    CPS::Real totalP, const std::vector<CPS::Real> &sharesQ) {
+  std::vector<Real> shares(generators.size(), 0.0);
+  // A lone machine takes the whole amount, bit for bit as before this split existed
+  if (generators.size() == 1) {
+    shares[0] = totalP;
+    return shares;
+  }
+
+  // What is left of the capability circle once Q is placed: P <= sqrt(S^2 - Q^2).
+  // A rating of 0 means none was given, so that machine stays uncapped.
+  std::vector<Real> headroom(generators.size(), 0.0);
+  for (UInt i = 0; i < generators.size(); ++i) {
+    Real sRated = generators[i]->getRatedApparentPower() / mBaseApparentPower;
+    headroom[i] = sRated > 0.0
+                      ? std::sqrt(std::max(0.0, sRated * sRated -
+                                                    sharesQ[i] * sharesQ[i]))
+                      : 0.0;
+  }
+
+  // Hand out in proportion to weight, then re-share what the saturated machines
+  // cannot take among those with headroom left, until nothing more saturates
+  std::vector<bool> capped(generators.size(), false);
+  Real cappedP = 0.0;
+  for (UInt pass = 0; pass < generators.size(); ++pass) {
+    Real weightSum = 0.0;
+    for (UInt i = 0; i < generators.size(); ++i)
+      if (!capped[i])
+        weightSum += generators[i]->getSlackWeight();
+    if (weightSum <= 0.0)
+      break;
+
+    Real remaining = totalP - cappedP;
+    bool saturated = false;
+    for (UInt i = 0; i < generators.size(); ++i) {
+      if (capped[i])
+        continue;
+      shares[i] = remaining * generators[i]->getSlackWeight() / weightSum;
+      if (headroom[i] > 0.0 && shares[i] > headroom[i]) {
+        shares[i] = headroom[i];
+        capped[i] = true;
+        cappedP += headroom[i];
+        saturated = true;
+      }
+    }
+    if (!saturated)
+      return shares;
+  }
+
+  // Every machine sits on its capability circle and the bus still needs more, so
+  // overload them in proportion rather than silently dropping the bus balance
+  Real assigned = 0.0;
+  for (auto share : shares)
+    assigned += share;
+  if (assigned > 0.0 && std::abs(totalP - assigned) > 1e-12) {
+    SPDLOG_LOGGER_WARN(mSLog,
+                       "Generators can take {} pu of active power but the bus "
+                       "needs {} pu, overloading them proportionally",
+                       assigned, totalP);
+    for (UInt i = 0; i < shares.size(); ++i)
+      shares[i] *= totalP / assigned;
+  }
+  return shares;
 }
 
 void PFSolverPowerPolar::calculatePAndQAtSlackBus() {

--- a/dpsim/src/pybind/SPComponents.cpp
+++ b/dpsim/src/pybind/SPComponents.cpp
@@ -160,6 +160,11 @@ void addSPPh1Components(py::module_ mSPPh1) {
       .def("modify_power_flow_bus_type",
            &CPS::SP::Ph1::SynchronGenerator::modifyPowerFlowBusType,
            "bus_type"_a)
+      .def("set_slack_weight", &CPS::SP::Ph1::SynchronGenerator::setSlackWeight,
+           "slack_weight"_a)
+      .def("get_slack_weight", &CPS::SP::Ph1::SynchronGenerator::getSlackWeight)
+      .def("get_rated_apparent_power",
+           &CPS::SP::Ph1::SynchronGenerator::getRatedApparentPower)
       .def("get_apparent_power",
            &CPS::SP::Ph1::SynchronGenerator::getApparentPower);
 

--- a/examples/Notebooks/pf-multi-generator-split.ipynb
+++ b/examples/Notebooks/pf-multi-generator-split.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sharing the solved bus power between generators\n",
+    "\n",
+    "When several synchronous generators sit on one bus the power flow solves for\n",
+    "the bus as a whole. This notebook checks how that bus total is written back to\n",
+    "the individual machines, at a slack bus and at a PV bus, and what happens when\n",
+    "a machine is too small to take its share.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A slack bus carrying two generators\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "import dpsimpy\n",
+    "\n",
+    "MW = 1e6\n",
+    "KV = 230e3\n",
+    "\n",
+    "\n",
+    "def slack_bus_case(name, weights, ratings=(100 * MW, 100 * MW), q_limits=None):\n",
+    "    n1 = dpsimpy.sp.SimNode(\"N1\", dpsimpy.PhaseType.Single)\n",
+    "    n2 = dpsimpy.sp.SimNode(\"N2\", dpsimpy.PhaseType.Single)\n",
+    "\n",
+    "    generators = []\n",
+    "    for i in range(2):\n",
+    "        gen = dpsimpy.sp.ph1.SynchronGenerator(\"Gen\" + str(i), dpsimpy.LogLevel.off)\n",
+    "        q_max, q_min = q_limits[i] if q_limits else (np.inf, -np.inf)\n",
+    "        gen.set_parameters(\n",
+    "            ratings[i],\n",
+    "            KV,\n",
+    "            20 * MW,\n",
+    "            KV,\n",
+    "            dpsimpy.PowerflowBusType.VD,\n",
+    "            5 * MW,\n",
+    "            q_max,\n",
+    "            q_min,\n",
+    "        )\n",
+    "        gen.set_base_voltage(KV)\n",
+    "        gen.set_slack_weight(weights[i])\n",
+    "        gen.connect([n1])\n",
+    "        generators.append(gen)\n",
+    "\n",
+    "    line = dpsimpy.sp.ph1.PiLine(\"line\", dpsimpy.LogLevel.off)\n",
+    "    line.set_parameters(20.0, 0.1, 0.0)\n",
+    "    line.set_base_voltage(KV)\n",
+    "    line.connect([n1, n2])\n",
+    "\n",
+    "    load = dpsimpy.sp.ph1.Load(\"load\", dpsimpy.LogLevel.off)\n",
+    "    load.set_parameters(100 * MW, 40 * MW, KV)\n",
+    "    load.modify_power_flow_bus_type(dpsimpy.PowerflowBusType.PQ)\n",
+    "    load.connect([n2])\n",
+    "\n",
+    "    system = dpsimpy.SystemTopology(60, [n1, n2], generators + [line, load])\n",
+    "    sim = dpsimpy.Simulation(name, dpsimpy.LogLevel.off)\n",
+    "    sim.set_system(system)\n",
+    "    sim.set_time_step(1)\n",
+    "    sim.set_final_time(1)\n",
+    "    sim.set_domain(dpsimpy.Domain.SP)\n",
+    "    sim.set_solver(dpsimpy.Solver.NRP)\n",
+    "    sim.do_init_from_nodes_and_terminals(False)\n",
+    "    sim.run()\n",
+    "\n",
+    "    return [\n",
+    "        (gen.attr(\"P_set\").get() / MW, gen.attr(\"Q_set\").get() / MW)\n",
+    "        for gen in generators\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Equal machines take equal shares\n",
+    "\n",
+    "The default slack weight is 1.0 for every machine, so two identical generators\n",
+    "each take half of the bus total.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "equal = slack_bus_case(\"equal\", [1.0, 1.0])\n",
+    "print(equal)\n",
+    "\n",
+    "assert np.isclose(equal[0][0], equal[1][0])\n",
+    "assert np.isclose(equal[0][1], equal[1][1])\n",
+    "\n",
+    "total_p = sum(p for p, _ in equal)\n",
+    "total_q = sum(q for _, q in equal)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The weight sets the proportion\n",
+    "\n",
+    "A machine with three times the weight of its neighbour takes three times the\n",
+    "active power, and the bus total is unchanged.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weighted = slack_bus_case(\"weighted\", [3.0, 1.0])\n",
+    "print(weighted)\n",
+    "\n",
+    "assert np.isclose(weighted[0][0], 3.0 * weighted[1][0])\n",
+    "assert np.isclose(sum(p for p, _ in weighted), total_p)\n",
+    "assert np.isclose(sum(q for _, q in weighted), total_q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A weight of zero means grid following\n",
+    "\n",
+    "A machine given a weight of zero keeps the set points it was configured with,\n",
+    "and the remaining machines absorb everything else.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "follower = slack_bus_case(\"follower\", [1.0, 0.0])\n",
+    "print(follower)\n",
+    "\n",
+    "assert np.isclose(follower[1][0], 20.0)\n",
+    "assert np.isclose(follower[1][1], 5.0)\n",
+    "assert np.isclose(sum(p for p, _ in follower), total_p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The rating limits the share\n",
+    "\n",
+    "Once the reactive power is placed, a machine can only take what is left of its\n",
+    "apparent power rating. The smaller machine here would otherwise be given more\n",
+    "than it is rated for, so it stops on its capability circle and the larger one\n",
+    "picks up the rest.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "capped = slack_bus_case(\"capped\", [3.0, 1.0], ratings=(60 * MW, 200 * MW))\n",
+    "print(capped)\n",
+    "\n",
+    "apparent = np.hypot(capped[0][0], capped[0][1])\n",
+    "print(\"apparent power of the small machine:\", apparent)\n",
+    "\n",
+    "assert np.isclose(apparent, 60.0)\n",
+    "assert np.isclose(sum(p for p, _ in capped), total_p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reactive power follows the reactive limits\n",
+    "\n",
+    "When both machines declare finite reactive limits, each is loaded to the same\n",
+    "fraction of its own range, which is the convention MATPOWER uses.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "limits = [(80 * MW, -20 * MW), (20 * MW, -5 * MW)]\n",
+    "ranged = slack_bus_case(\"ranged\", [1.0, 1.0], q_limits=limits)\n",
+    "print(ranged)\n",
+    "\n",
+    "loading = [\n",
+    "    (ranged[i][1] - limits[i][1] / MW) / ((limits[i][0] - limits[i][1]) / MW)\n",
+    "    for i in range(2)\n",
+    "]\n",
+    "print(\"fraction of each reactive range:\", loading)\n",
+    "\n",
+    "assert np.isclose(loading[0], loading[1])\n",
+    "assert np.isclose(sum(q for _, q in ranged), total_q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Two generators on a PV bus\n",
+    "\n",
+    "At a PV bus each machine keeps its own active power and only the reactive power\n",
+    "is shared out, so the voltage set point is held while the reactive support is\n",
+    "divided between the machines.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n1 = dpsimpy.sp.SimNode(\"N1\", dpsimpy.PhaseType.Single)\n",
+    "n2 = dpsimpy.sp.SimNode(\"N2\", dpsimpy.PhaseType.Single)\n",
+    "n3 = dpsimpy.sp.SimNode(\"N3\", dpsimpy.PhaseType.Single)\n",
+    "\n",
+    "slack = dpsimpy.sp.ph1.NetworkInjection(\"slack\", dpsimpy.LogLevel.off)\n",
+    "slack.set_parameters(KV)\n",
+    "slack.set_base_voltage(KV)\n",
+    "slack.modify_power_flow_bus_type(dpsimpy.PowerflowBusType.VD)\n",
+    "slack.connect([n1])\n",
+    "\n",
+    "pv_limits = [(60 * MW, -20 * MW), (30 * MW, -10 * MW)]\n",
+    "pv_generators = []\n",
+    "for i in range(2):\n",
+    "    gen = dpsimpy.sp.ph1.SynchronGenerator(\"PvGen\" + str(i), dpsimpy.LogLevel.off)\n",
+    "    gen.set_parameters(\n",
+    "        100 * MW,\n",
+    "        KV,\n",
+    "        (30 + 10 * i) * MW,\n",
+    "        KV,\n",
+    "        dpsimpy.PowerflowBusType.PV,\n",
+    "        0.0,\n",
+    "        pv_limits[i][0],\n",
+    "        pv_limits[i][1],\n",
+    "    )\n",
+    "    gen.set_base_voltage(KV)\n",
+    "    gen.connect([n2])\n",
+    "    pv_generators.append(gen)\n",
+    "\n",
+    "line_a = dpsimpy.sp.ph1.PiLine(\"line_a\", dpsimpy.LogLevel.off)\n",
+    "line_a.set_parameters(10.0, 0.05, 0.0)\n",
+    "line_a.set_base_voltage(KV)\n",
+    "line_a.connect([n1, n2])\n",
+    "\n",
+    "line_b = dpsimpy.sp.ph1.PiLine(\"line_b\", dpsimpy.LogLevel.off)\n",
+    "line_b.set_parameters(10.0, 0.05, 0.0)\n",
+    "line_b.set_base_voltage(KV)\n",
+    "line_b.connect([n2, n3])\n",
+    "\n",
+    "pv_load = dpsimpy.sp.ph1.Load(\"pv_load\", dpsimpy.LogLevel.off)\n",
+    "pv_load.set_parameters(120 * MW, 15 * MW, KV)\n",
+    "pv_load.modify_power_flow_bus_type(dpsimpy.PowerflowBusType.PQ)\n",
+    "pv_load.connect([n3])\n",
+    "\n",
+    "pv_system = dpsimpy.SystemTopology(\n",
+    "    60, [n1, n2, n3], [slack] + pv_generators + [line_a, line_b, pv_load]\n",
+    ")\n",
+    "pv_sim = dpsimpy.Simulation(\"pv_bus\", dpsimpy.LogLevel.off)\n",
+    "pv_sim.set_system(pv_system)\n",
+    "pv_sim.set_time_step(1)\n",
+    "pv_sim.set_final_time(1)\n",
+    "pv_sim.set_domain(dpsimpy.Domain.SP)\n",
+    "pv_sim.set_solver(dpsimpy.Solver.NRP)\n",
+    "pv_sim.do_init_from_nodes_and_terminals(False)\n",
+    "pv_sim.run()\n",
+    "\n",
+    "pv_result = [\n",
+    "    (gen.attr(\"P_set\").get() / MW, gen.attr(\"Q_set\").get() / MW)\n",
+    "    for gen in pv_generators\n",
+    "]\n",
+    "print(pv_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each machine keeps the active power it was given, and both are loaded to the\n",
+    "same fraction of their own reactive range.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert np.isclose(pv_result[0][0], 30.0)\n",
+    "assert np.isclose(pv_result[1][0], 40.0)\n",
+    "\n",
+    "pv_loading = [\n",
+    "    (pv_result[i][1] - pv_limits[i][1] / MW)\n",
+    "    / ((pv_limits[i][0] - pv_limits[i][1]) / MW)\n",
+    "    for i in range(2)\n",
+    "]\n",
+    "print(\"fraction of each reactive range:\", pv_loading)\n",
+    "\n",
+    "assert np.isclose(pv_loading[0], pv_loading[1])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/src/dpsim/matpower.py
+++ b/python/src/dpsim/matpower.py
@@ -123,6 +123,9 @@ class Reader:
         self.mpc_gen_data["bus"] = self.mpc_gen_data["bus"].astype(int)
         self.mpc_gen_data["status"] = self.mpc_gen_data["status"].astype(int)
 
+        # offline generators must not inject power, dropped regardless of filter_out_of_service
+        self.mpc_gen_data = self.mpc_gen_data[self.mpc_gen_data["status"] == 1]
+
         #### Branches #####
         # extract only first 13 columns since following columns include results
         mpc_branch_raw = self.mpc_raw[self.mpc_name]["branch"][:, :13]
@@ -300,6 +303,7 @@ class Reader:
         with_tg=True,
         filter_out_of_service=False,
         generator_model=None,
+        map_pq_bus_generators=True,
     ):
         """
         Create dpsim objects with the data contained in the mpc files.
@@ -315,6 +319,8 @@ class Reader:
         @param generator_model: explicit generator model to use for dynamic
                                 simulations. Use `GenModel` values or raw integer
                                 values 1, 3, 4, 5, 6.
+        @param map_pq_bus_generators: if True, also map generators sitting on a bus
+                                      labelled PQ, as some MATPOWER exports do
         """
         self.log_level = log_level
         self.domain = domain
@@ -414,12 +420,25 @@ class Reader:
                 # shunts
                 self.map_shunt(index, bus_index)
 
+                # some exports put generators on a bus labelled PQ
+                if map_pq_bus_generators:
+                    self.map_generators_at_bus(
+                        index,
+                        bus_index,
+                        bus_type=dpsimpy.PowerflowBusType.PQ,
+                        with_pss=with_pss,
+                        with_tg=with_tg,
+                        with_avr=with_avr,
+                        gen_model=generator_model,
+                    )
+
             # Generators
             elif bus_type == 2:
                 # map SG
-                self.map_synchronous_machine(
+                self.map_generators_at_bus(
                     index,
                     bus_index,
+                    bus_type=dpsimpy.PowerflowBusType.PV,
                     with_pss=with_pss,
                     with_tg=with_tg,
                     with_avr=with_avr,
@@ -650,6 +669,16 @@ class Reader:
 
         return bus_name
 
+    def gen_data_at_bus(self, index):
+        return self.mpc_gen_data.loc[
+            self.mpc_gen_data["bus"] == self.mpc_bus_data.at[index, "bus_i"]
+        ]
+
+    def map_generators_at_bus(self, index, bus_index, **kwargs):
+        # the PF solver sums P/Q and the Q limits over all components at a node
+        for gen_i in range(self.gen_data_at_bus(index).shape[0]):
+            self.map_synchronous_machine(index, bus_index, gen_i=gen_i, **kwargs)
+
     def map_synchronous_machine(
         self,
         index,
@@ -659,16 +688,18 @@ class Reader:
         with_tg=True,
         with_avr=True,
         gen_model=None,
+        gen_i=0,
     ):
-        #
-        gen_name = "Gen_N" + str(bus_index)
+        # the first generator keeps its unsuffixed name, so single-gen grids are unaffected
+        gen_name = "Gen_N" + str(bus_index) + ("" if gen_i == 0 else "_" + str(gen_i))
 
         # relevant data from self.mpc_gen_data. Identification with bus number available in mpc_bus_data and mpc_gen_data
-        gen_data = self.mpc_gen_data.loc[
-            self.mpc_gen_data["bus"] == self.mpc_bus_data.at[index, "bus_i"]
-        ]
+        gen_data = self.gen_data_at_bus(index).iloc[[gen_i]]
+        # a MATPOWER mBase of 0 means "use the system baseMVA"
         gen_baseS = (
             gen_data["mBase"].values[0] * mw_w
+            if gen_data["mBase"].values[0] > 0
+            else self.mpc_base_power_MVA
         )  # gen base MVA default is mpc.baseMVA
         gen_baseV = self.mpc_bus_data.at[index, "baseKV"] * kv_v  # gen base kV
         gen_v = (
@@ -701,7 +732,9 @@ class Reader:
                 q_limit_min=gen_q_min,
             )
             gen.set_base_voltage(gen_baseV)
-            gen.modify_power_flow_bus_type(bus_type)
+            # modifyPowerFlowBusType throws for PQ, set_parameters already stored it
+            if bus_type != dpsimpy.PowerflowBusType.PQ:
+                gen.modify_power_flow_bus_type(bus_type)
         else:
             # get dynamic data of the generator
             gen_dyn_row_idx = self.mpc_dyn_gen_data.index[
@@ -1166,6 +1199,7 @@ class Reader:
         with_avr=True,
         with_tg=True,
         filter_out_of_service=False,
+        map_pq_bus_generators=True,
     ):
         """
         Read mpc files and create DPsim topology
@@ -1175,6 +1209,7 @@ class Reader:
         @param filter_out_of_service: if True, exclude out-of-service
                                       generators/branches and isolated buses
                                       instead of instantiating them
+        @param map_pq_bus_generators: see create_dpsim_objects
         """
         self.create_dpsim_objects(
             domain=domain,
@@ -1183,6 +1218,7 @@ class Reader:
             with_avr=with_avr,
             with_tg=with_tg,
             filter_out_of_service=filter_out_of_service,
+            map_pq_bus_generators=map_pq_bus_generators,
         )
         self.create_dpsim_topology()
 
@@ -1242,12 +1278,10 @@ class Reader:
             p_gen = 0
             q_gen = 0
             # if PV or Slack bus --> add gen power
-            gen_data = self.mpc_gen_data.loc[
-                self.mpc_gen_data["bus"] == self.mpc_bus_data.at[i, "bus_i"]
-            ]
+            gen_data = self.gen_data_at_bus(i)
             if gen_data.shape[0] > 0:
-                p_gen = gen_data["Pg"].values[0]
-                q_gen = gen_data["Qg"].values[0]
+                p_gen = gen_data["Pg"].sum()
+                q_gen = gen_data["Qg"].sum()
 
             pf_results.loc[i] = (
                 [node_name]


### PR DESCRIPTION
`PFSolverPowerPolar` gave the whole bus P/Q to the first generator at a PV or VD bus, so the others kept stale setpoints.

Now split: Q range-proportional, P by `slack_weight`, capped at the rating. Single-generator buses unchanged. Stacked on #589.