### PR TITLE
fix: re-pivot fully when no variable matrix entries are declared

### DIFF
--- a/dpsim/src/KLUAdapter.cpp
+++ b/dpsim/src/KLUAdapter.cpp
@@ -137,6 +137,10 @@ void KLUAdapter::partialRefactorize(
   if (systemMatrix.nonZeros() != nnz) {
     preprocessing(systemMatrix, listVariableSystemMatrixEntries);
     factorize(systemMatrix);
+  } else if (mPartialRefactorizationMethod !=
+                 PARTIAL_REFACTORIZATION_METHOD::NO_PARTIAL_REFACTORIZATION &&
+             (mVaryingColumns.empty() || mVaryingRows.empty())) {
+    factorize(systemMatrix);
   } else {
     auto Ap =
         Eigen::internal::convert_index<Int *>(systemMatrix.outerIndexPtr());


### PR DESCRIPTION
partialRefactorize() calls klu_partial_factorization_path(), which needs a factorization path. That path only exists if a component declared variable system-matrix entries - factorize() skips computing it otherwise. With an empty list KLU finds Numeric->path == NULL, sets KLU_PATH_INVALID and returns without touching the factorization. Only KLU_PIVOT_FAULT is checked here. --> recomputed matrix is discarded, every later time step is wrong

Found on a network with switched lines: after a trip, all following results were wrong, with no error or warning.

Only VBR synchronous generators fill mVariableSystemMatrixEntries - so empty list is the common case switches e.g. declare none.
Proposed fix: Fall back to a full, re-pivoted factorization when list is empty. Runs only at switch events, so cost is negligible