### PR TITLE
fix(ci): drop the build-time Python dependency layer from the manylinux image

### DIFF
--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -14,6 +14,8 @@ ARG MAKE_OPTS=-j4
 
 ENV PLAT=manylinux_2_28_x86_64
 
+ENV PATH=/opt/python/cp312-cp312/bin:${PATH}
+
 LABEL \
 	org.opencontainers.image.title="DPsim" \
 	org.opencontainers.image.licenses="MPL 2.0" \
@@ -64,13 +66,8 @@ RUN cd /tmp && \
 
 # Python dependencies
 ADD pyproject.toml .
-RUN pip3 install --upgrade wheel build setuptools packaging
-RUN pip3 install --upgrade pip && \
-	pip3 install --no-cache-dir pip-tools && \
-	pip-compile --no-header --extra manylinux --output-file /tmp/requirements.txt pyproject.toml && \
-	pip3 install --no-cache-dir -r /tmp/requirements.txt && \
-	pip3 uninstall -y pip-tools && \
-	rm /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade wheel build setuptools packaging
+RUN uv pip install --system --no-cache -r pyproject.toml --extra manylinux
 
 # Install CIMpp from source
 RUN cd /tmp && \

--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -14,8 +14,6 @@ ARG MAKE_OPTS=-j4
 
 ENV PLAT=manylinux_2_28_x86_64
 
-ENV PATH=/opt/dpsim-tools/bin:${PATH}
-
 LABEL \
 	org.opencontainers.image.title="DPsim" \
 	org.opencontainers.image.licenses="MPL 2.0" \
@@ -63,11 +61,6 @@ RUN cd /tmp && \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 && \
 	make ${MAKE_OPTS} install
-
-# Python dependencies
-ADD pyproject.toml .
-RUN /opt/python/cp312-cp312/bin/python -m venv /opt/dpsim-tools && \
-	uv pip install --python /opt/dpsim-tools/bin/python --no-cache -r pyproject.toml --extra manylinux
 
 # Install CIMpp from source
 RUN cd /tmp && \

--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -14,7 +14,7 @@ ARG MAKE_OPTS=-j4
 
 ENV PLAT=manylinux_2_28_x86_64
 
-ENV PATH=/opt/python/cp312-cp312/bin:${PATH}
+ENV PATH=/opt/dpsim-tools/bin:${PATH}
 
 LABEL \
 	org.opencontainers.image.title="DPsim" \
@@ -66,8 +66,9 @@ RUN cd /tmp && \
 
 # Python dependencies
 ADD pyproject.toml .
-RUN pip3 install --no-cache-dir --upgrade wheel build setuptools packaging
-RUN uv pip install --system --no-cache -r pyproject.toml --extra manylinux
+RUN /opt/python/cp312-cp312/bin/python -m venv /opt/dpsim-tools && \
+	pip3 install --no-cache-dir --upgrade wheel build setuptools packaging && \
+	uv pip install --python /opt/dpsim-tools/bin/python --no-cache -r pyproject.toml --extra manylinux
 
 # Install CIMpp from source
 RUN cd /tmp && \

--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -67,7 +67,6 @@ RUN cd /tmp && \
 # Python dependencies
 ADD pyproject.toml .
 RUN /opt/python/cp312-cp312/bin/python -m venv /opt/dpsim-tools && \
-	pip3 install --no-cache-dir --upgrade wheel build setuptools packaging && \
 	uv pip install --python /opt/dpsim-tools/bin/python --no-cache -r pyproject.toml --extra manylinux
 
 # Install CIMpp from source


### PR DESCRIPTION
pip-compile ran under the image's Python 3.6 and stopped resolving when pybind11-stubgen and numpy entered [build-system].requires. The layer is unnecessary anyway: cibuildwheel, the image's only consumer, installs everything itself, so remove it. Verified locally: cp39 and cp312 wheels build and pass the import test. Related to #647.