### PR TITLE
fix(build): pin the wheel build to the target interpreter for pybind11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG={extdir}",
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE={extdir}",
             f"-DPython3_EXECUTABLE={sys.executable}",
+            f"-DPYTHON_EXECUTABLE={sys.executable}",
             f"-Dpybind11_DIR={pybind11.get_cmake_dir()}",
             f"-DCMAKE_BUILD_TYPE={cfg}",
             "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",


### PR DESCRIPTION
pybind11 3.1.0 makes the manylinux build fall back to python3.9, so every wheel from cp310 up got 3.9 headers and a .cpython-39 suffix and stub generation failed. Passing PYTHON_EXECUTABLE pins it; verified with cibuildwheel locally for cp313.