### PR TITLE
ci: resolve pyproject extras with uv instead of pip-tools

### DIFF
--- a/.github/workflows/build_test_linux_fedora.yaml
+++ b/.github/workflows/build_test_linux_fedora.yaml
@@ -319,18 +319,17 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - name: Install uv
+      uses: astral-sh/setup-uv@v9.0.0
       with:
-        python-version: '3.x'
-    - name: Install pip-tools
-      run: pip install pip-tools
+        python-version: '3.9'
     - name: Resolve all extras
       run: |
         tmpdir=$(mktemp -d)
         cp pyproject.toml "$tmpdir/"
         for extra in dev manylinux test; do
           echo "--- Resolving extra: $extra ---"
-          pip-compile --no-strip-extras --output-file=- --extra "$extra" "$tmpdir/pyproject.toml"
+          uv pip compile --no-strip-extras --extra "$extra" "$tmpdir/pyproject.toml" -o -
         done
         rm -rf "$tmpdir"
 


### PR DESCRIPTION
The extras-resolve check went red when pip 26.2 dropped pip._internal.utils.compat.stdlib_pkgs, which pip-tools 7.6.0 imports at CLI startup. pip-tools declares no upper bound on pip, so every runner that refreshes its toolcache picks the broken combination up; the upstream report jazzband/pip-tools#2436 is still open with no fix released.

Switches the job to uv, which does not reach into pip internals, and drops the separate setup-python step since setup-uv provides the interpreter. The resolution target is pinned to 3.9, the requires-python floor, where an extra would realistically stop resolving first. Reproduced the failure locally on 3.14.7 with pip 26.2.1 and confirmed uv resolves all three extras there and on 3.9.

Same swap as #648, which drops pip-tools from the manylinux image for the same reason.

Same swap as #648, which drops pip-tools from the manylinux image for the same reason.