### PR TITLE
fix(ci): resolve Python dependencies with uv in the Rocky container

### DIFF
--- a/packaging/Docker/Dockerfile.dev-rocky
+++ b/packaging/Docker/Dockerfile.dev-rocky
@@ -165,10 +165,8 @@ RUN echo "/usr/local/openDSSC/bin" > /etc/ld.so.conf.d/opendssc.conf && \
 # Python dependencies
 ADD pyproject.toml pyproject.toml
 RUN pip3 install --no-cache-dir --upgrade wheel build setuptools packaging && \
-	pip3 install --no-cache-dir pip-tools && \
-	pip-compile --no-header --extra dev --output-file /tmp/requirements.txt pyproject.toml && \
-	pip3 install --no-cache-dir --ignore-installed -r /tmp/requirements.txt && \
-	pip3 uninstall -y pip-tools && \
-	rm /tmp/requirements.txt
+	pip3 install --no-cache-dir uv && \
+	uv pip install --system --no-cache -r pyproject.toml --extra dev && \
+	pip3 uninstall -y uv
 
 EXPOSE 8888


### PR DESCRIPTION
pip-tools 7.6.0 imports typing_extensions on Python < 3.11 without declaring it as a dependency, so pip-compile crashes under Rocky 9's Python 3.9 and create-docker-rocky fails. Resolve the dev extra with uv instead, as the manylinux container does in #648. Verified on rockylinux:9 with Python 3.9. Related to #647.