### PR TITLE
fix(pybind): register bound types before the signatures that reference them

### DIFF
--- a/dpsim/include/dpsim/pybind/SignalComponents.h
+++ b/dpsim/include/dpsim/pybind/SignalComponents.h
@@ -16,4 +16,5 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
+void addSignalComponentBases(py::module_ mSignal);
 void addSignalComponents(py::module_ mSignal);

--- a/dpsim/include/dpsim/pybind/Utils.h
+++ b/dpsim/include/dpsim/pybind/Utils.h
@@ -30,6 +30,8 @@ py::cpp_function createAttributeGetter(const std::string name) {
   };
 }
 
+py::arg_v logLevelArg(CPS::Logger::Level level, const char *name = "loglevel");
+
 CPS::Matrix zeroMatrix(int dim);
 
 std::string getAttributeList(CPS::IdentifiedObject &obj);

--- a/dpsim/src/pybind/DPComponents.cpp
+++ b/dpsim/src/pybind/DPComponents.cpp
@@ -34,7 +34,8 @@ void addDPComponents(py::module_ mDP) {
            py::overload_cast<CPS::Complex, int>(
                &CPS::DP::SimNode::setInitialVoltage, py::const_))
       .def("single_voltage", &CPS::DP::SimNode::singleVoltage,
-           "phase_type"_a = CPS::PhaseType::Single)
+           py::arg_v("phase_type", CPS::PhaseType::Single,
+                     "dpsimpy.PhaseType.Single"))
       .def_readonly_static("gnd", &CPS::DP::SimNode::GND);
 
   py::module mDPPh1 =
@@ -129,7 +130,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "NetworkInjection",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters",
            py::overload_cast<CPS::Complex, CPS::Real>(
                &CPS::DP::Ph1::NetworkInjection::setParameters),
@@ -140,7 +141,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "PiLine",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::DP::Ph1::PiLine::setParameters,
            "series_resistance"_a, "series_inductance"_a,
            "parallel_capacitance"_a = 0, "parallel_conductance"_a = 0)
@@ -150,7 +151,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "RXLoad",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::DP::Ph1::RXLoad::setParameters,
            "active_power"_a, "reactive_power"_a, "volt"_a)
       .def("connect", &CPS::DP::Ph1::RXLoad::connect);
@@ -159,7 +160,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "Shunt",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::DP::Ph1::Shunt::setParameters, "G"_a, "B"_a)
       .def("connect", &CPS::DP::Ph1::Shunt::connect);
 
@@ -167,7 +168,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>, CPS::Base::Ph1::Switch>(
       mDPPh1, "Switch", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::DP::Ph1::Switch::setParameters,
            "open_resistance"_a, "closed_resistance"_a,
            // cppcheck-suppress assignBoolToPointer
@@ -181,7 +182,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>, CPS::Base::Ph1::Switch>(
       mDPPh1, "varResSwitch", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::DP::Ph1::varResSwitch::setParameters,
            "open_resistance"_a, "closed_resistance"_a,
            // cppcheck-suppress assignBoolToPointer
@@ -207,9 +208,9 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(
       mDPPh1, "AvVoltSourceInverterStateSpace", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def(py::init<std::string, std::string, CPS::Logger::Level>(), "uid"_a,
-           "name"_a, "loglevel"_a = CPS::Logger::Level::off)
+           "name"_a, logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters",
            &CPS::DP::Ph1::AvVoltSourceInverterStateSpace::setParameters, "Lf"_a,
            "Cf"_a, "Rf"_a, "Rc"_a, "omega_n"_a, "Kp_pll"_a, "Ki_pll"_a,
@@ -257,7 +258,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "SynchronGeneratorIdeal",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("connect", &CPS::DP::Ph1::SynchronGeneratorIdeal::connect);
 
   py::class_<CPS::DP::Ph1::SynchronGeneratorTrStab,
@@ -265,7 +266,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "SynchronGeneratorTrStab",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_standard_parameters_PU",
            &CPS::DP::Ph1::SynchronGeneratorTrStab::setStandardParametersPU,
            "nom_power"_a, "nom_volt"_a, "nom_freq"_a, "Xpd"_a, "inertia"_a,
@@ -304,7 +305,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::DP::Ph1::ReducedOrderSynchronGeneratorVBR>(
       mDPPh1, "SynchronGenerator3OrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -320,7 +321,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::DP::Ph1::ReducedOrderSynchronGeneratorVBR>(
       mDPPh1, "SynchronGenerator4OrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -336,7 +337,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::DP::Ph1::ReducedOrderSynchronGeneratorVBR>(
       mDPPh1, "SynchronGenerator5OrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -354,7 +355,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::DP::Ph1::ReducedOrderSynchronGeneratorVBR>(
       mDPPh1, "SynchronGenerator6aOrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -372,7 +373,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::DP::Ph1::ReducedOrderSynchronGeneratorVBR>(
       mDPPh1, "SynchronGenerator6bOrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -391,7 +392,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::MNASyncGenInterface>(mDPPh1, "SynchronGenerator4OrderTPM",
                                        py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -408,7 +409,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::MNASyncGenInterface>(mDPPh1, "SynchronGenerator4OrderPCM",
                                        py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -425,7 +426,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::MNASyncGenInterface>(mDPPh1, "SynchronGenerator6OrderPCM",
                                        py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -443,9 +444,9 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(
       mDPPh1, "AvVoltageSourceInverterDQ", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def(py::init<std::string, std::string, CPS::Logger::Level, CPS::Bool>(),
-           "uid"_a, "name"_a, "loglevel"_a = CPS::Logger::Level::off,
+           "uid"_a, "name"_a, logLevelArg(CPS::Logger::Level::off),
            // cppcheck-suppress assignBoolToPointer
            "with_trafo"_a = false)
       .def("set_parameters",
@@ -474,7 +475,7 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "Inverter",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::DP::Ph1::Inverter::setParameters,
            "carrier_harms"_a, "modul_harms"_a, "input_voltage"_a, "ratio"_a,
            "phase"_a)
@@ -485,9 +486,9 @@ void addDPPh1Components(py::module_ mDPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mDPPh1, "Transformer",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def(py::init<std::string, std::string, CPS::Logger::Level, CPS::Bool>(),
-           "uid"_a, "name"_a, "loglevel"_a = CPS::Logger::Level::off,
+           "uid"_a, "name"_a, logLevelArg(CPS::Logger::Level::off),
            // cppcheck-suppress assignBoolToPointer
            "with_resistive_losses"_a = false)
       .def("set_parameters",
@@ -525,7 +526,7 @@ void addDPPh3Components(py::module_ mDPPh3) {
              CPS::SimPowerComp<CPS::Complex>>(mDPPh3, "NetworkInjection",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::DP::Ph3::NetworkInjection::setParameters,
            "V_ref"_a, "f_src"_a = 0.0)
       .def("connect", &CPS::DP::Ph3::NetworkInjection::connect);
@@ -534,7 +535,7 @@ void addDPPh3Components(py::module_ mDPPh3) {
              CPS::SimPowerComp<CPS::Complex>>(mDPPh3, "PiLine",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::DP::Ph3::PiLine::setParameters,
            "series_resistance"_a, "series_inductance"_a,
            "parallel_capacitance"_a = zeroMatrix(3),
@@ -586,7 +587,7 @@ void addDPPh3Components(py::module_ mDPPh3) {
              CPS::SimPowerComp<CPS::Complex>>(mDPPh3, "SynchronGeneratorDQODE",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters_fundamental_per_unit",
            &CPS::DP::Ph3::SynchronGeneratorDQODE::
                setParametersFundamentalPerUnit,
@@ -605,7 +606,7 @@ void addDPPh3Components(py::module_ mDPPh3) {
              CPS::SimPowerComp<CPS::Complex>>(
       mDPPh3, "SynchronGeneratorDQTrapez", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters_fundamental_per_unit",
            &CPS::DP::Ph3::SynchronGeneratorDQTrapez::
                setParametersFundamentalPerUnit,
@@ -632,7 +633,7 @@ void addDPPh3Components(py::module_ mDPPh3) {
              CPS::SimPowerComp<CPS::Complex>, CPS::Base::Ph1::Switch>(
       mDPPh3, "SeriesSwitch", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::DP::Ph3::SeriesSwitch::setParameters,
            "open_resistance"_a, "closed_resistance"_a,
            // cppcheck-suppress assignBoolToPointer
@@ -645,7 +646,7 @@ void addDPPh3Components(py::module_ mDPPh3) {
              CPS::SimPowerComp<CPS::Complex>, CPS::Base::Ph3::Switch>(
       mDPPh3, "Switch", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::DP::Ph3::Switch::setParameters,
            "open_resistance"_a, "closed_resistance"_a,
            // cppcheck-suppress assignBoolToPointer
@@ -669,11 +670,11 @@ void addDPPh3Components(py::module_ mDPPh3) {
              CPS::SimPowerComp<CPS::Complex>>(
       mDPPh3, "AvVoltSourceInverterStateSpace", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level, CPS::Bool>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off,
+           logLevelArg(CPS::Logger::Level::off),
            // cppcheck-suppress assignBoolToPointer
            "enable_neg_seq_control"_a = false)
       .def(py::init<std::string, std::string, CPS::Logger::Level, CPS::Bool>(),
-           "uid"_a, "name"_a, "loglevel"_a = CPS::Logger::Level::off,
+           "uid"_a, "name"_a, logLevelArg(CPS::Logger::Level::off),
            // cppcheck-suppress assignBoolToPointer
            "enable_neg_seq_control"_a = false)
       .def("set_parameters",

--- a/dpsim/src/pybind/EMTComponents.cpp
+++ b/dpsim/src/pybind/EMTComponents.cpp
@@ -36,7 +36,7 @@ void addEMTDCComponents(py::module_ mEMTDC) {
              CPS::SimPowerComp<CPS::Real>>(mEMTDC, "VoltageSource",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::EMT::DC::VoltageSource::setParameters,
            "voltage"_a)
       .def("connect", &CPS::EMT::DC::VoltageSource::connect)
@@ -48,7 +48,7 @@ void addEMTDCComponents(py::module_ mEMTDC) {
              CPS::SimPowerComp<CPS::Real>>(mEMTDC, "CurrentSource",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::EMT::DC::CurrentSource::setParameters,
            "current"_a)
       .def("connect", &CPS::EMT::DC::CurrentSource::connect)
@@ -59,7 +59,7 @@ void addEMTDCComponents(py::module_ mEMTDC) {
              CPS::SimPowerComp<CPS::Real>>(mEMTDC, "Resistor",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::EMT::DC::Resistor::setParameters,
            "resistance"_a)
       .def("connect", &CPS::EMT::DC::Resistor::connect)
@@ -69,7 +69,7 @@ void addEMTDCComponents(py::module_ mEMTDC) {
              CPS::SimPowerComp<CPS::Real>>(mEMTDC, "Capacitor",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::EMT::DC::Capacitor::setParameters,
            "capacitance"_a)
       .def("connect", &CPS::EMT::DC::Capacitor::connect)
@@ -80,7 +80,7 @@ void addEMTDCComponents(py::module_ mEMTDC) {
              CPS::SimPowerComp<CPS::Real>>(mEMTDC, "Inductor",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::EMT::DC::Inductor::setParameters,
            "inductance"_a, "initial_current"_a = 0.0)
       .def("connect", &CPS::EMT::DC::Inductor::connect)
@@ -93,7 +93,7 @@ void addEMTDCComponents(py::module_ mEMTDC) {
              CPS::SimPowerComp<CPS::Real>>(mEMTDC, "PiLine",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::EMT::DC::PiLine::setParameters,
            "series_resistance"_a, "series_inductance"_a,
            "parallel_capacitance"_a = 0.0, "parallel_conductance"_a = 0.0,
@@ -207,7 +207,7 @@ void addEMTPh1Components(py::module_ mEMTPh1) {
              CPS::SimPowerComp<CPS::Real>, CPS::Base::Ph1::Switch>(
       mEMTPh1, "Switch", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::EMT::Ph1::Switch::setParameters,
            "open_resistance"_a, "closed_resistance"_a,
            "closed"_a = false) // cppcheck-suppress assignBoolToPointer
@@ -364,7 +364,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "NetworkInjection",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters",
            py::overload_cast<CPS::MatrixComp, CPS::Real>(
                &CPS::EMT::Ph3::NetworkInjection::setParameters),
@@ -375,7 +375,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "PiLine",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::EMT::Ph3::PiLine::setParameters,
            "series_resistance"_a, "series_inductance"_a,
            "parallel_capacitance"_a = zeroMatrix(3),
@@ -386,7 +386,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "RXLoad",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::EMT::Ph3::RXLoad::setParameters,
            "active_power"_a, "reactive_power"_a, "volt"_a,
            // cppcheck-suppress assignBoolToPointer
@@ -397,7 +397,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "Shunt",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters",
            static_cast<void (CPS::EMT::Ph3::Shunt::*)(CPS::Real, CPS::Real)>(
                &CPS::EMT::Ph3::Shunt::setParameters),
@@ -408,7 +408,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>, CPS::Base::Ph3::Switch>(
       mEMTPh3, "Switch", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::EMT::Ph3::Switch::setParameters,
            "open_resistance"_a, "closed_resistance"_a,
            // cppcheck-suppress assignBoolToPointer
@@ -422,7 +422,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "SynchronGeneratorIdeal",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("connect", &CPS::EMT::Ph3::SynchronGeneratorIdeal::connect);
 
   py::class_<CPS::EMT::Ph3::SynchronGeneratorDQTrapez,
@@ -430,7 +430,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "SynchronGeneratorDQTrapez",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters_operational_per_unit",
            &CPS::EMT::Ph3::SynchronGeneratorDQTrapez::
                setParametersOperationalPerUnit,
@@ -467,7 +467,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
       .def(py::init<std::string>())
       .def(py::init<std::string, CPS::Logger::Level>())
       .def(py::init<std::string, std::string, CPS::Logger::Level, CPS::Bool>(),
-           "uid"_a, "name"_a, "log_level"_a = CPS::Logger::Level::off,
+           "uid"_a, "name"_a, logLevelArg(CPS::Logger::Level::off, "log_level"),
            py::arg("with_trafo") = false)
       .def("set_parameters",
            &CPS::EMT::Ph3::VSIVoltageControlVCO::setParameters, "sys_omega"_a,
@@ -501,7 +501,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::EMT::Ph3::ReducedOrderSynchronGeneratorVBR>(
       mEMTPh3, "SynchronGenerator3OrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -517,7 +517,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::EMT::Ph3::ReducedOrderSynchronGeneratorVBR>(
       mEMTPh3, "SynchronGenerator4OrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -533,7 +533,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::EMT::Ph3::ReducedOrderSynchronGeneratorVBR>(
       mEMTPh3, "SynchronGenerator5OrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -551,7 +551,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::EMT::Ph3::ReducedOrderSynchronGeneratorVBR>(
       mEMTPh3, "SynchronGenerator6aOrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -569,7 +569,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::EMT::Ph3::ReducedOrderSynchronGeneratorVBR>(
       mEMTPh3, "SynchronGenerator6bOrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -589,7 +589,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "SynchronGeneratorDQODE",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters_operational_per_unit",
            &CPS::EMT::Ph3::SynchronGeneratorDQODE::
                setParametersOperationalPerUnit,
@@ -626,9 +626,9 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "AvVoltageSourceInverterDQ",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def(py::init<std::string, std::string, CPS::Logger::Level, CPS::Bool>(),
-           "uid"_a, "name"_a, "loglevel"_a = CPS::Logger::Level::off,
+           "uid"_a, "name"_a, logLevelArg(CPS::Logger::Level::off),
            // cppcheck-suppress assignBoolToPointer
            "with_trafo"_a = false)
       .def("set_parameters",
@@ -659,9 +659,9 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "Transformer",
                                            py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def(py::init<std::string, std::string, CPS::Logger::Level, CPS::Bool>(),
-           "uid"_a, "name"_a, "loglevel"_a = CPS::Logger::Level::off,
+           "uid"_a, "name"_a, logLevelArg(CPS::Logger::Level::off),
            // cppcheck-suppress assignBoolToPointer
            "with_resistive_losses"_a = false)
       .def("set_parameters", &CPS::EMT::Ph3::Transformer::setParameters,
@@ -684,7 +684,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>, CPS::Base::Ph1::Switch>(
       mEMTPh3, "SeriesSwitch", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::EMT::Ph3::SeriesSwitch::setParameters,
            "open_resistance"_a, "closed_resistance"_a,
            // cppcheck-suppress assignBoolToPointer
@@ -751,9 +751,9 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>>(
       mEMTPh3, "AvVoltSourceInverterStateSpace", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def(py::init<std::string, std::string, CPS::Logger::Level>(), "uid"_a,
-           "name"_a, "loglevel"_a = CPS::Logger::Level::off)
+           "name"_a, logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters",
            &CPS::EMT::Ph3::AvVoltSourceInverterStateSpace::setParameters,
            "Lf"_a, "Cf"_a, "Rf"_a, "Rc"_a, "omega_n"_a, "Kp_pll"_a, "Ki_pll"_a,
@@ -776,7 +776,7 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
              CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "SSN_GFM",
                                            py::multiple_inheritance())
       .def(py::init<std::string, std::string, CPS::Logger::Level>(), "uid"_a,
-           "name"_a, "log_level"_a = CPS::Logger::Level::off)
+           "name"_a, logLevelArg(CPS::Logger::Level::off, "log_level"))
       .def("set_parameters", &CPS::EMT::Ph3::SSN_GFM::setParameters, "lf"_a,
            "cf"_a, "rf"_a, "rc"_a, "nominal_voltage"_a, "omega_nominal"_a,
            "p_ref"_a, "q_ref"_a, "virtual_inertia"_a, "damping_coefficient"_a,

--- a/dpsim/src/pybind/SPComponents.cpp
+++ b/dpsim/src/pybind/SPComponents.cpp
@@ -81,7 +81,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mSPPh1, "NetworkInjection",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters",
            py::overload_cast<CPS::Real>(
                &CPS::SP::Ph1::NetworkInjection::setParameters),
@@ -101,7 +101,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mSPPh1, "PiLine",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::SP::Ph1::PiLine::setParameters, "R"_a, "L"_a,
            "C"_a = -1, "G"_a = -1)
       .def("set_base_voltage", &CPS::SP::Ph1::PiLine::setBaseVoltage,
@@ -112,7 +112,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mSPPh1, "Shunt",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::SP::Ph1::Shunt::setParameters, "G"_a, "B"_a)
       .def("set_base_voltage", &CPS::SP::Ph1::Shunt::setBaseVoltage,
            "base_voltage"_a)
@@ -122,7 +122,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mSPPh1, "Load",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::SP::Ph1::Load::setParameters,
            "active_power"_a, "reactive_power"_a, "nominal_voltage"_a)
       .def("modify_power_flow_bus_type",
@@ -133,7 +133,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SimPowerComp<CPS::Complex>, CPS::Base::Ph1::Switch>(
       mSPPh1, "Switch", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::SP::Ph1::Switch::setParameters,
            "open_resistance"_a, "closed_resistance"_a,
            // cppcheck-suppress assignBoolToPointer
@@ -147,7 +147,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mSPPh1, "SynchronGenerator",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", (&CPS::SP::Ph1::SynchronGenerator::setParameters),
            "rated_apparent_power"_a, "rated_voltage"_a,
            "set_point_active_power"_a, "set_point_voltage"_a,
@@ -168,7 +168,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SimPowerComp<CPS::Complex>, CPS::Base::Ph1::Switch>(
       mSPPh1, "varResSwitch", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_parameters", &CPS::SP::Ph1::varResSwitch::setParameters,
            "open_resistance"_a, "closed_resistance"_a,
            // cppcheck-suppress assignBoolToPointer
@@ -184,7 +184,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mSPPh1, "SynchronGeneratorTrStab",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_standard_parameters_PU",
            &CPS::SP::Ph1::SynchronGeneratorTrStab::setStandardParametersPU,
            "nom_power"_a, "nom_volt"_a, "nom_freq"_a, "Xpd"_a, "inertia"_a,
@@ -219,7 +219,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SP::Ph1::ReducedOrderSynchronGeneratorVBR>(
       mSPPh1, "SynchronGenerator3OrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -235,7 +235,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SP::Ph1::ReducedOrderSynchronGeneratorVBR>(
       mSPPh1, "SynchronGenerator4OrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -251,7 +251,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SP::Ph1::ReducedOrderSynchronGeneratorVBR>(
       mSPPh1, "SynchronGenerator5OrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -269,7 +269,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SP::Ph1::ReducedOrderSynchronGeneratorVBR>(
       mSPPh1, "SynchronGenerator6aOrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -287,7 +287,7 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SP::Ph1::ReducedOrderSynchronGeneratorVBR>(
       mSPPh1, "SynchronGenerator6bOrderVBR", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("set_operational_parameters_per_unit",
            py::overload_cast<CPS::Real, CPS::Real, CPS::Real, CPS::Real,
                              CPS::Real, CPS::Real, CPS::Real, CPS::Real,
@@ -305,9 +305,9 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(
       mSPPh1, "AvVoltageSourceInverterDQ", py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def(py::init<std::string, std::string, CPS::Logger::Level, CPS::Bool>(),
-           "uid"_a, "name"_a, "loglevel"_a = CPS::Logger::Level::off,
+           "uid"_a, "name"_a, logLevelArg(CPS::Logger::Level::off),
            // cppcheck-suppress assignBoolToPointer
            "with_trafo"_a = false)
       .def("set_parameters",
@@ -337,9 +337,9 @@ void addSPPh1Components(py::module_ mSPPh1) {
              CPS::SimPowerComp<CPS::Complex>>(mSPPh1, "Transformer",
                                               py::multiple_inheritance())
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def(py::init<std::string, std::string, CPS::Logger::Level, CPS::Bool>(),
-           "uid"_a, "name"_a, "loglevel"_a = CPS::Logger::Level::off,
+           "uid"_a, "name"_a, logLevelArg(CPS::Logger::Level::off),
            // cppcheck-suppress assignBoolToPointer
            "with_resistive_losses"_a = false)
       .def("set_parameters",

--- a/dpsim/src/pybind/SignalComponents.cpp
+++ b/dpsim/src/pybind/SignalComponents.cpp
@@ -25,7 +25,7 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-void addSignalComponents(py::module_ mSignal) {
+void addSignalComponentBases(py::module_ mSignal) {
 
   py::class_<CPS::TopologicalSignalComp,
              std::shared_ptr<CPS::TopologicalSignalComp>,
@@ -39,6 +39,39 @@ void addSignalComponents(py::module_ mSignal) {
   py::class_<CPS::Base::ExciterParameters,
              std::shared_ptr<CPS::Base::ExciterParameters>>(
       mSignal, "ExciterParameters");
+
+  py::class_<CPS::Base::PSSParameters,
+             std::shared_ptr<CPS::Base::PSSParameters>>(mSignal,
+                                                        "PSSParameters");
+
+  py::class_<CPS::Base::PSS, std::shared_ptr<CPS::Base::PSS>>(mSignal, "PSS");
+
+  py::class_<CPS::Signal::TurbineGovernorType1,
+             std::shared_ptr<CPS::Signal::TurbineGovernorType1>,
+             CPS::SimSignalComp>(mSignal, "TurbineGovernorType1",
+                                 py::multiple_inheritance())
+      .def(py::init<std::string>())
+      .def(py::init<std::string, CPS::Logger::Level>())
+      .def("set_parameters", &CPS::Signal::TurbineGovernorType1::setParameters,
+           "T3"_a, "T4"_a, "T5"_a, "Tc"_a, "Ts"_a, "R"_a, "Tmin"_a, "Tmax"_a,
+           "OmRef"_a)
+      .def("initialize_states",
+           &CPS::Signal::TurbineGovernorType1::initializeStates, "TmRef"_a);
+
+  py::class_<CPS::Base::GovernorParameters,
+             std::shared_ptr<CPS::Base::GovernorParameters>>(
+      mSignal, "GovernorParameters");
+  py::class_<CPS::Base::Governor, std::shared_ptr<CPS::Base::Governor>>(
+      mSignal, "Governor");
+
+  py::class_<CPS::Base::TurbineParameters,
+             std::shared_ptr<CPS::Base::TurbineParameters>>(
+      mSignal, "TurbineParameters");
+  py::class_<CPS::Base::Turbine, std::shared_ptr<CPS::Base::Turbine>>(
+      mSignal, "Turbine");
+}
+
+void addSignalComponents(py::module_ mSignal) {
 
   py::class_<CPS::Signal::ExciterDC1Parameters,
              std::shared_ptr<CPS::Signal::ExciterDC1Parameters>,
@@ -244,12 +277,6 @@ void addSignalComponents(py::module_ mSignal) {
       .def("get_virtual_node",
            &CPS::Signal::DecouplingIdealTransformer_DP_Ph1::getVirtualNode);
 
-  py::class_<CPS::Base::PSSParameters,
-             std::shared_ptr<CPS::Base::PSSParameters>>(mSignal,
-                                                        "PSSParameters");
-
-  py::class_<CPS::Base::PSS, std::shared_ptr<CPS::Base::PSS>>(mSignal, "PSS");
-
   py::class_<CPS::Signal::PSS1AParameters,
              std::shared_ptr<CPS::Signal::PSS1AParameters>,
              CPS::Base::PSSParameters>(mSignal, "PSS1AParameters",
@@ -273,31 +300,6 @@ void addSignalComponents(py::module_ mSignal) {
       .def(py::init<std::string, CPS::Logger::Level>())
       .def("set_parameters", &CPS::Signal::PSS1A::setParameters,
            "parameters"_a);
-
-  py::class_<CPS::Signal::TurbineGovernorType1,
-             std::shared_ptr<CPS::Signal::TurbineGovernorType1>,
-             CPS::SimSignalComp>(mSignal, "TurbineGovernorType1",
-                                 py::multiple_inheritance())
-      .def(py::init<std::string>())
-      .def(py::init<std::string, CPS::Logger::Level>())
-      .def("set_parameters", &CPS::Signal::TurbineGovernorType1::setParameters,
-           "T3"_a, "T4"_a, "T5"_a, "Tc"_a, "Ts"_a, "R"_a, "Tmin"_a, "Tmax"_a,
-           "OmRef"_a)
-      .def("initialize_states",
-           &CPS::Signal::TurbineGovernorType1::initializeStates, "TmRef"_a);
-
-  // Base Governor / Turbine
-  py::class_<CPS::Base::GovernorParameters,
-             std::shared_ptr<CPS::Base::GovernorParameters>>(
-      mSignal, "GovernorParameters");
-  py::class_<CPS::Base::Governor, std::shared_ptr<CPS::Base::Governor>>(
-      mSignal, "Governor");
-
-  py::class_<CPS::Base::TurbineParameters,
-             std::shared_ptr<CPS::Base::TurbineParameters>>(
-      mSignal, "TurbineParameters");
-  py::class_<CPS::Base::Turbine, std::shared_ptr<CPS::Base::Turbine>>(
-      mSignal, "Turbine");
 
   // SteamTurbineGovernor
   py::class_<CPS::Signal::SteamGovernorParameters,

--- a/dpsim/src/pybind/Utils.cpp
+++ b/dpsim/src/pybind/Utils.cpp
@@ -8,6 +8,36 @@
 
 #include <dpsim/pybind/Utils.h>
 
+py::arg_v logLevelArg(CPS::Logger::Level level, const char *name) {
+  const char *descr = nullptr;
+  switch (level) {
+  case CPS::Logger::Level::trace:
+    descr = "dpsimpy.LogLevel.trace";
+    break;
+  case CPS::Logger::Level::debug:
+    descr = "dpsimpy.LogLevel.debug";
+    break;
+  case CPS::Logger::Level::info:
+    descr = "dpsimpy.LogLevel.info";
+    break;
+  case CPS::Logger::Level::warn:
+    descr = "dpsimpy.LogLevel.warn";
+    break;
+  case CPS::Logger::Level::err:
+    descr = "dpsimpy.LogLevel.err";
+    break;
+  case CPS::Logger::Level::critical:
+    descr = "dpsimpy.LogLevel.critical";
+    break;
+  case CPS::Logger::Level::off:
+    descr = "dpsimpy.LogLevel.off";
+    break;
+  default:
+    break;
+  }
+  return py::arg_v(name, level, descr);
+}
+
 CPS::Matrix zeroMatrix(int dim) { return CPS::Matrix::Zero(dim, dim); }
 
 std::string getAttributeList(CPS::IdentifiedObject &obj) {

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -227,9 +227,59 @@ PYBIND11_MODULE(dpsimpy, m) {
       .def("get_state_names", &DPsim::StateSpaceModalAnalysis::getStateNames,
            py::return_value_policy::reference_internal);
 
-  py::class_<DPsim::Simulation>(m, "Simulation")
+  py::module mEvent = m.def_submodule("event", "events");
+  py::module mBase = m.def_submodule("base", "base models");
+  py::module mDP = m.def_submodule("dp", "dynamic phasor models");
+  py::module mEMT = m.def_submodule("emt", "electromagnetic-transient models");
+  py::module mSP = m.def_submodule("sp", "static phasor models");
+  py::module mSignal = m.def_submodule("signal", "signal models");
+
+  py::class_<CPS::IdentifiedObject, std::shared_ptr<CPS::IdentifiedObject>>
+      identifiedObject(m, "IdentifiedObject");
+  py::class_<CPS::TopologicalPowerComp,
+             std::shared_ptr<CPS::TopologicalPowerComp>, CPS::IdentifiedObject>(
+      m, "TopologicalPowerComp");
+  py::class_<CPS::SimPowerComp<CPS::Complex>,
+             std::shared_ptr<CPS::SimPowerComp<CPS::Complex>>,
+             CPS::TopologicalPowerComp>
+      simPowerCompComplex(m, "SimPowerCompComplex");
+  py::class_<CPS::SimPowerComp<CPS::Real>,
+             std::shared_ptr<CPS::SimPowerComp<CPS::Real>>,
+             CPS::TopologicalPowerComp>
+      simPowerCompReal(m, "SimPowerCompReal");
+  py::class_<CPS::TopologicalNode, std::shared_ptr<CPS::TopologicalNode>,
+             CPS::IdentifiedObject>
+      topologicalNode(m, "TopologicalNode");
+  py::class_<CPS::TopologicalTerminal,
+             std::shared_ptr<CPS::TopologicalTerminal>, CPS::IdentifiedObject>
+      topologicalTerminal(m, "TopologicalTerminal");
+  py::class_<CPS::SimTerminal<CPS::Complex>,
+             std::shared_ptr<CPS::SimTerminal<CPS::Complex>>,
+             CPS::TopologicalTerminal>(m, "SimTerminalComplex");
+  py::class_<CPS::SimTerminal<CPS::Real>,
+             std::shared_ptr<CPS::SimTerminal<CPS::Real>>,
+             CPS::TopologicalTerminal>(m, "SimTerminalReal");
+  py::class_<DPsim::Interface, std::shared_ptr<DPsim::Interface>>(m,
+                                                                  "Interface");
+  py::class_<DPsim::DataLoggerInterface,
+             std::shared_ptr<DPsim::DataLoggerInterface>>
+      dataLoggerInterface(m, "DataLoggerInterface");
+  py::class_<CPS::SystemTopology, std::shared_ptr<CPS::SystemTopology>>
+      systemTopology(m, "SystemTopology");
+  py::class_<DPsim::Simulation> simulation(m, "Simulation");
+  py::class_<DPsim::Event, std::shared_ptr<DPsim::Event>>(mEvent, "Event");
+
+  addSignalComponentBases(mSignal);
+  addBaseComponents(mBase);
+  addDPComponents(mDP);
+  addEMTComponents(mEMT);
+  mSP.attr("SimNode") = mDP.attr("SimNode");
+  addSPComponents(mSP);
+  addSignalComponents(mSignal);
+
+  simulation
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::off)
+           logLevelArg(CPS::Logger::Level::off))
       .def("name", &DPsim::Simulation::name)
       .def("set_time_step", &DPsim::Simulation::setTimeStep)
       .def("set_final_time", &DPsim::Simulation::setFinalTime)
@@ -302,7 +352,7 @@ PYBIND11_MODULE(dpsimpy, m) {
   py::class_<DPsim::RealTimeSimulation, DPsim::Simulation>(m,
                                                            "RealTimeSimulation")
       .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
-           "loglevel"_a = CPS::Logger::Level::info)
+           logLevelArg(CPS::Logger::Level::info))
       .def("name", &DPsim::RealTimeSimulation::name)
       .def("set_time_step", &DPsim::RealTimeSimulation::setTimeStep)
       .def("set_final_time", &DPsim::RealTimeSimulation::setFinalTime)
@@ -315,8 +365,7 @@ PYBIND11_MODULE(dpsimpy, m) {
       .def("set_domain", &DPsim::RealTimeSimulation::setDomain);
 #endif
 
-  py::class_<CPS::SystemTopology, std::shared_ptr<CPS::SystemTopology>>(
-      m, "SystemTopology")
+  systemTopology
       .def(py::init<CPS::Real, CPS::TopologicalNode::List,
                     CPS::IdentifiedObject::List>())
       .def(py::init<CPS::Real, CPS::Matrix, CPS::TopologicalNode::List,
@@ -381,12 +430,7 @@ PYBIND11_MODULE(dpsimpy, m) {
       .def("remove_component", &DPsim::SystemTopology::removeComponent)
       .def("remove_node", &DPsim::SystemTopology::removeNode);
 
-  py::class_<DPsim::Interface, std::shared_ptr<DPsim::Interface>>(m,
-                                                                  "Interface");
-
-  py::class_<DPsim::DataLoggerInterface,
-             std::shared_ptr<DPsim::DataLoggerInterface>>(m,
-                                                          "DataLoggerInterface")
+  dataLoggerInterface
       .def("log_attribute",
            py::overload_cast<const CPS::String &, CPS::AttributeBase::Ptr,
                              CPS::UInt, CPS::UInt>(
@@ -493,8 +537,7 @@ PYBIND11_MODULE(dpsimpy, m) {
           "names"_a, "attr"_a, "comp"_a);
 #endif
 
-  py::class_<CPS::IdentifiedObject, std::shared_ptr<CPS::IdentifiedObject>>(
-      m, "IdentifiedObject")
+  identifiedObject
       .def("name", &CPS::IdentifiedObject::name)
       /// CHECK: It would be nicer if all the attributes of an IdObject were bound as properties so they show up in the documentation and auto-completion.
       /// I don't know if this is possible to do because it depends on if the attribute map is filled before or after the code in this file is run.
@@ -513,8 +556,8 @@ PYBIND11_MODULE(dpsimpy, m) {
 
   py::class_<CPS::CIM::Reader>(m, "CIMReader")
       .def(py::init<std::string, CPS::Logger::Level, CPS::Logger::Level>(),
-           "name"_a, "loglevel"_a = CPS::Logger::Level::info,
-           "comploglevel"_a = CPS::Logger::Level::off)
+           "name"_a, logLevelArg(CPS::Logger::Level::info),
+           logLevelArg(CPS::Logger::Level::off, "comploglevel"))
       .def("loadCIM", (CPS::SystemTopology(CPS::CIM::Reader::*)(
                           CPS::Real, const std::list<CPS::String> &,
                           CPS::Domain, CPS::PhaseType, CPS::GeneratorType)) &
@@ -530,48 +573,27 @@ PYBIND11_MODULE(dpsimpy, m) {
 
   //Base Classes
 
-  py::class_<CPS::TopologicalPowerComp,
-             std::shared_ptr<CPS::TopologicalPowerComp>, CPS::IdentifiedObject>(
-      m, "TopologicalPowerComp");
-  py::class_<CPS::SimPowerComp<CPS::Complex>,
-             std::shared_ptr<CPS::SimPowerComp<CPS::Complex>>,
-             CPS::TopologicalPowerComp>(m, "SimPowerCompComplex")
-      .def("connect", &CPS::SimPowerComp<CPS::Complex>::connect)
+  simPowerCompComplex.def("connect", &CPS::SimPowerComp<CPS::Complex>::connect)
       .def("set_intf_current", &CPS::SimPowerComp<CPS::Complex>::setIntfCurrent)
       .def("set_intf_voltage", &CPS::SimPowerComp<CPS::Complex>::setIntfVoltage)
       .def("get_terminal", &CPS::SimPowerComp<CPS::Complex>::terminal,
            "index"_a);
-  py::class_<CPS::SimPowerComp<CPS::Real>,
-             std::shared_ptr<CPS::SimPowerComp<CPS::Real>>,
-             CPS::TopologicalPowerComp>(m, "SimPowerCompReal")
-      .def("connect", &CPS::SimPowerComp<CPS::Real>::connect)
+  simPowerCompReal.def("connect", &CPS::SimPowerComp<CPS::Real>::connect)
       .def("set_intf_current", &CPS::SimPowerComp<CPS::Real>::setIntfCurrent)
       .def("set_intf_voltage", &CPS::SimPowerComp<CPS::Real>::setIntfVoltage)
       .def("get_terminal", &CPS::SimPowerComp<CPS::Real>::terminal, "index"_a);
-  py::class_<CPS::TopologicalNode, std::shared_ptr<CPS::TopologicalNode>,
-             CPS::IdentifiedObject>(m, "TopologicalNode")
-      .def("initial_single_voltage",
-           &CPS::TopologicalNode::initialSingleVoltage,
-           "phase_type"_a = CPS::PhaseType::Single);
+  topologicalNode.def("initial_single_voltage",
+                      &CPS::TopologicalNode::initialSingleVoltage,
+                      py::arg_v("phase_type", CPS::PhaseType::Single,
+                                "dpsimpy.PhaseType.Single"));
 
-  py::class_<CPS::TopologicalTerminal,
-             std::shared_ptr<CPS::TopologicalTerminal>, CPS::IdentifiedObject>(
-      m, "TopologicalTerminal")
+  topologicalTerminal
       .def("set_power",
            py::overload_cast<CPS::Complex>(&CPS::TopologicalTerminal::setPower))
       .def("set_power", py::overload_cast<CPS::MatrixComp>(
                             &CPS::TopologicalTerminal::setPower));
 
-  py::class_<CPS::SimTerminal<CPS::Complex>,
-             std::shared_ptr<CPS::SimTerminal<CPS::Complex>>,
-             CPS::TopologicalTerminal>(m, "SimTerminalComplex");
-  py::class_<CPS::SimTerminal<CPS::Real>,
-             std::shared_ptr<CPS::SimTerminal<CPS::Real>>,
-             CPS::TopologicalTerminal>(m, "SimTerminalReal");
-
   //Events
-  py::module mEvent = m.def_submodule("event", "events");
-  py::class_<DPsim::Event, std::shared_ptr<DPsim::Event>>(mEvent, "Event");
   py::class_<DPsim::SwitchEvent, std::shared_ptr<DPsim::SwitchEvent>,
              DPsim::Event>(mEvent, "SwitchEvent", py::multiple_inheritance())
       .def(py::init<CPS::Real, const std::shared_ptr<CPS::Base::Ph1::Switch>,
@@ -580,23 +602,6 @@ PYBIND11_MODULE(dpsimpy, m) {
              DPsim::Event>(mEvent, "SwitchEvent3Ph", py::multiple_inheritance())
       .def(py::init<CPS::Real, const std::shared_ptr<CPS::Base::Ph3::Switch>,
                     CPS::Bool>());
-
-  //Components
-  py::module mBase = m.def_submodule("base", "base models");
-  addBaseComponents(mBase);
-
-  py::module mDP = m.def_submodule("dp", "dynamic phasor models");
-  addDPComponents(mDP);
-
-  py::module mEMT = m.def_submodule("emt", "electromagnetic-transient models");
-  addEMTComponents(mEMT);
-
-  py::module mSP = m.def_submodule("sp", "static phasor models");
-  mSP.attr("SimNode") = mDP.attr("SimNode");
-  addSPComponents(mSP);
-
-  py::module mSignal = m.def_submodule("signal", "signal models");
-  addSignalComponents(mSignal);
 
 #ifdef VERSION_INFO
   m.attr("__version__") = VERSION_INFO;


### PR DESCRIPTION
pybind11 resolves a parameter's type when `def()` runs, so a class registered later in the module renders as its raw C++ name, for example `CPS::IdentifiedObject`, `CPS::SystemTopology` or `CPS::SimNode<double>`. pybind11-stubgen degrades those to `...`, so the shipped stubs typed `set_system`, `add_event`, `connect` and `connect_component` as bare Any.

Declares every `py::class_` handle up front, populates the submodules, then attaches the `.def()`s, and splits `addSignalComponentBases()` out of `addSignalComponents()` to break the signal to base to dp dependency cycle. Together with the pull request below this takes pybind11-stubgen from 129 errors to 0, verified by rebuilding the module both ways on the same toolchain.
