### PR TITLE
PFSolver: SVC voltage-control outer loop

### DIFF
--- a/dpsim/include/dpsim/PFSolver.h
+++ b/dpsim/include/dpsim/PFSolver.h
@@ -77,6 +77,8 @@ protected:
   /// Vector of average voltage source inverters
   std::vector<std::shared_ptr<CPS::SP::Ph1::AvVoltageSourceInverterDQ>>
       mAverageVoltageSourceInverters;
+  /// Vector of static VAR compensator components
+  std::vector<std::shared_ptr<CPS::SP::Ph1::SVC>> mSVCs;
   /// Map providing determined base voltages for each node
   std::map<CPS::TopologicalNode::Ptr, CPS::Real> mBaseVoltageAtNode;
 
@@ -92,6 +94,12 @@ protected:
   CPS::UInt mMaxOuterIterations = 10;
   /// Maximum number of PV<->PQ switches per bus before it is frozen (anti-oscillation)
   CPS::UInt mMaxQLimitSwitchesPerBus = 2;
+  /// Hold each SVC bus at its voltage setpoint via a reactive-injection outer loop
+  CPS::Bool mEnforceSvcControl = false;
+  /// Voltage tolerance [pu] at which an SVC bus is considered on setpoint
+  CPS::Real mSvcVoltageTolerance = 1e-7;
+  /// Damping applied to each SVC reactive-injection step (1.0 = full secant/Newton)
+  CPS::Real mSvcDamping = 1.0;
   /// Relative tolerance for non-authoritative (e.g. Load) base-voltage candidates vs. the zone's rating
   CPS::Real mBaseVoltageLooseTolerance = 0.1;
   /// Relative tolerance between authoritative base-voltage sources (generator/transformer/network-injection/VSI) within a zone
@@ -158,6 +166,8 @@ protected:
   Bool runNewtonRaphson();
   /// Switch generators violating their Q limits between PV/PQ; base impl is a no-op
   virtual CPS::Bool enforceReactiveLimits() { return false; }
+  /// Adjust SVC reactive injections to hold their voltage setpoints; base is a no-op
+  virtual CPS::Bool enforceSvcVoltageControl() { return false; }
   /// Allocate Jacobian storage; dense by default, sparse subclass overrides
   virtual void setUpJacobianStorage();
   /// Solve the linearized system mJ*mX = mF into mX; sparse subclass overrides
@@ -197,6 +207,9 @@ public:
   void setEnforceReactiveLimits(CPS::Bool value) {
     mEnforceReactiveLimits = value;
   }
+
+  /// Enable SVC voltage control (reactive-injection outer loop)
+  void setEnforceSvcControl(CPS::Bool value) { mEnforceSvcControl = value; }
 
   /// Raise for grids with legitimate large voltage drop (e.g. untapped feeders)
   void setBaseVoltageLooseTolerance(CPS::Real tolerance) {

--- a/dpsim/include/dpsim/PFSolverPowerPolar.h
+++ b/dpsim/include/dpsim/PFSolverPowerPolar.h
@@ -75,6 +75,12 @@ protected:
   CPS::Real loadReactivePowerPerUnit(CPS::TopologicalNode::Ptr node);
   /// Q-limit PV<->PQ switching pass (overrides the base no-op)
   CPS::Bool enforceReactiveLimits() override;
+  /// SVC voltage-control pass: nudge each SVC's reactive injection toward its
+  /// voltage setpoint (overrides the base no-op)
+  CPS::Bool enforceSvcVoltageControl() override;
+  /// Previous (Q_pu, V_pu) per SVC bus for the secant sensitivity estimate
+  std::map<CPS::TopologicalNode::Ptr, std::pair<CPS::Real, CPS::Real>>
+      mSvcPrevQV;
   /// Clear the Q-limit conversion bookkeeping between solves
   void clearReactiveLimitState() override;
   /// Buses switched PV->PQ by the Q-limit loop -> pinned at Qmax (true) or Qmin (false)

--- a/dpsim/include/dpsim/Simulation.h
+++ b/dpsim/include/dpsim/Simulation.h
@@ -59,6 +59,10 @@ public:
   /// switching. Default false; opt in via setPFSolverEnforceReactiveLimits(true).
   const CPS::Attribute<Bool>::Ptr mPFEnforceReactiveLimits;
 
+  /// Hold each SVC bus at its voltage setpoint in the powerflow via a reactive-
+  /// injection outer loop. Default false; opt in via setPFSolverEnforceSvcControl(true).
+  const CPS::Attribute<Bool>::Ptr mPFEnforceSvcControl;
+
   /// Loose tolerance for a zone's Load base-voltage vs. its rating; default 0.1
   const CPS::Attribute<Real>::Ptr mPFBaseVoltageLooseTolerance;
 
@@ -283,6 +287,10 @@ public:
   void setPFSolverEnforceReactiveLimits(Bool value);
 
   Bool getPFSolverEnforceReactiveLimits() const;
+
+  void setPFSolverEnforceSvcControl(Bool value);
+
+  Bool getPFSolverEnforceSvcControl() const;
 
   void setPFSolverBaseVoltageLooseTolerance(Real tolerance);
 

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -64,6 +64,9 @@ void PFSolver::initialize() {
   initializeComponents();
   determinePFBusType();
   propagateAndVerifyBaseVoltage();
+  // An SVC gets its base voltage from the propagation above, so convert it after
+  for (auto svc : mSVCs)
+    svc->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
   composeAdmittanceMatrix();
 
   setUpJacobianStorage();
@@ -134,9 +137,6 @@ void PFSolver::initializeComponents() {
   }
   for (auto sst : mSolidStateTransformers) {
     sst->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
-  }
-  for (auto svc : mSVCs) {
-    svc->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
   }
 }
 

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -54,7 +54,9 @@ void PFSolver::initialize() {
                  std::dynamic_pointer_cast<
                      CPS::SP::Ph1::AvVoltageSourceInverterDQ>(comp)) {
       mAverageVoltageSourceInverters.push_back(vsi);
-    }
+    } else if (std::shared_ptr<CPS::SP::Ph1::SVC> svc =
+                   std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp))
+      mSVCs.push_back(svc);
   }
 
   setBaseApparentPower();
@@ -132,6 +134,9 @@ void PFSolver::initializeComponents() {
   }
   for (auto sst : mSolidStateTransformers) {
     sst->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
+  }
+  for (auto svc : mSVCs) {
+    svc->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
   }
 }
 
@@ -631,26 +636,30 @@ Bool PFSolver::runNewtonRaphson() {
 Bool PFSolver::solvePowerflow() {
   Bool converged = runNewtonRaphson();
 
-  if (!mEnforceReactiveLimits)
+  if (!mEnforceReactiveLimits && !mEnforceSvcControl)
     return converged;
 
-  // Outer loop: switch PV<->PQ on Q-limit violations, re-solve until no bus switches.
+  // Outer loop: apply Q-limit PV<->PQ switching and/or SVC voltage control, then
+  // re-solve, until neither pass changes anything (both settled).
   Bool settled = false;
   for (CPS::UInt outer = 0; converged && outer < mMaxOuterIterations; ++outer) {
-    if (!enforceReactiveLimits()) {
+    Bool qLimitChanged = mEnforceReactiveLimits && enforceReactiveLimits();
+    Bool svcChanged = mEnforceSvcControl && enforceSvcVoltageControl();
+    if (!qLimitChanged && !svcChanged) {
       settled = true;
-      break; // all generators within their reactive limits
+      break; // all generators within limits and all SVCs on setpoint
     }
-    reclassifyBuses();
+    if (qLimitChanged)
+      reclassifyBuses();
     converged = runNewtonRaphson();
   }
 
   if (converged && !settled) {
-    // Unsettled PV/PQ classification must not look converged to setSolution().
+    // Unsettled classification/SVC control must not look converged to setSolution().
     SPDLOG_LOGGER_WARN(
         mSLog,
-        "Q-limit outer loop did not settle within {} iterations; "
-        "PV/PQ classification may still be oscillating",
+        "PF outer loop did not settle within {} iterations; Q-limit "
+        "classification or SVC control may still be oscillating",
         mMaxOuterIterations);
     isConverged = false;
     converged = false;

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -57,7 +57,14 @@ void PFSolverPowerPolar::generateInitialSolution(Real time,
             std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(comp)) {
       gen->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
     }
+
+    if (auto svc = std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp)) {
+      svc->calculatePerUnitParameters(mBaseApparentPower, mSystem.mSystemOmega);
+    }
   }
+
+  // SVC secant history is per-solve; start each solve fresh.
+  mSvcPrevQV.clear();
 
   // PQ buses
   for (auto pq : mPQBuses) {
@@ -90,6 +97,10 @@ void PFSolverPowerPolar::generateInitialSolution(Real time,
                          comp)) {
         sol_P(idx) += gen->attributeTyped<CPS::Real>("P_set_pu")->get();
         sol_Q(idx) += gen->attributeTyped<CPS::Real>("Q_set_pu")->get();
+      } else if (auto svc =
+                     std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp)) {
+        // SVC injects reactive power only; the outer control loop moves Q_set_pu.
+        sol_Q(idx) += svc->attributeTyped<CPS::Real>("Q_set_pu")->get();
       }
     }
 
@@ -641,6 +652,69 @@ CPS::Bool PFSolverPowerPolar::enforceReactiveLimits() {
   }
 
   return !toPQ.empty() || !toPV.empty();
+}
+
+CPS::Bool PFSolverPowerPolar::enforceSvcVoltageControl() {
+  // The SVC component holding the controlled voltage/band at a node, if any.
+  auto svcAtNode = [&](CPS::TopologicalNode::Ptr node)
+      -> std::shared_ptr<CPS::SP::Ph1::SVC> {
+    for (auto comp : mSystem.mComponentsAtNode[node])
+      if (auto svc = std::dynamic_pointer_cast<CPS::SP::Ph1::SVC>(comp))
+        return svc;
+    return nullptr;
+  };
+
+  CPS::Bool anyChanged = false;
+  for (auto node : mPQBuses) {
+    auto svc = svcAtNode(node);
+    if (!svc)
+      continue;
+    UInt idx = node->matrixNodeIndex();
+    CPS::Real vSetPU = svc->attributeTyped<CPS::Real>("V_set_pu")->get();
+    CPS::Real qMaxPU = svc->attributeTyped<CPS::Real>("Q_max_pu")->get();
+    CPS::Real qMinPU = svc->attributeTyped<CPS::Real>("Q_min_pu")->get();
+    CPS::Real qOld = svc->attributeTyped<CPS::Real>("Q_set_pu")->get();
+    CPS::Real v = sol_V(idx);
+    CPS::Real vErr = vSetPU - v;
+
+    if (std::abs(vErr) < mSvcVoltageTolerance)
+      continue; // already on setpoint
+
+    // Reactive-injection sensitivity dQ/dV: seeded from the local diagonal
+    // susceptance |B_kk| (the decoupled Newton sensitivity, self-scaling at
+    // stiff buses) and refined by a secant estimate once a prior iterate exists.
+    CPS::Real dQdV = std::abs(B(idx, idx));
+    auto prev = mSvcPrevQV.find(node);
+    if (prev != mSvcPrevQV.end()) {
+      CPS::Real dV = v - prev->second.second;
+      CPS::Real dQ = qOld - prev->second.first;
+      if (std::abs(dV) > 1e-12 && std::abs(dQ) > 1e-15)
+        dQdV = dQ / dV;
+    }
+    if (!CPS::Math::isFinite(dQdV) || std::abs(dQdV) < 1e-9)
+      dQdV = 1.0; // degenerate sensitivity -> unit fallback
+
+    CPS::Real qNew = qOld + mSvcDamping * dQdV * vErr;
+    if (CPS::Math::isFinite(qMaxPU) && qNew > qMaxPU)
+      qNew = qMaxPU;
+    if (CPS::Math::isFinite(qMinPU) && qNew < qMinPU)
+      qNew = qMinPU;
+
+    CPS::Real dq = qNew - qOld;
+    if (std::abs(dq) < 1e-12)
+      continue; // pinned at a limit or converged -> contributes to settling
+
+    mSvcPrevQV[node] = std::make_pair(qOld, v);
+    Qesp(idx) += dq;
+    sol_Q(idx) += dq;
+    svc->updateReactivePowerInjection(
+        CPS::Complex(0., qNew * mBaseApparentPower));
+    anyChanged = true;
+    SPDLOG_LOGGER_INFO(mSLog,
+                       "SVC {}: V={:.6f} (set {:.6f}), Q {:.6f} -> {:.6f} pu",
+                       svc->name(), v, vSetPU, qOld, qNew);
+  }
+  return anyChanged;
 }
 
 void PFSolverPowerPolar::clearReactiveLimitState() {

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -664,6 +664,11 @@ CPS::Bool PFSolverPowerPolar::enforceSvcVoltageControl() {
     return nullptr;
   };
 
+  // Per-unit floors for the secant sensitivity estimate (heuristic).
+  constexpr CPS::Real svcSecantDQFloor = 1e-15; // dQ below this is noise
+  constexpr CPS::Real svcMinSensitivity =
+      1e-9; // |dQ/dV| below this is degenerate
+
   CPS::Bool anyChanged = false;
   for (auto node : mPQBuses) {
     auto svc = svcAtNode(node);
@@ -688,10 +693,10 @@ CPS::Bool PFSolverPowerPolar::enforceSvcVoltageControl() {
     if (prev != mSvcPrevQV.end()) {
       CPS::Real dV = v - prev->second.second;
       CPS::Real dQ = qOld - prev->second.first;
-      if (std::abs(dV) > 1e-12 && std::abs(dQ) > 1e-15)
+      if (std::abs(dV) > DOUBLE_EPSILON && std::abs(dQ) > svcSecantDQFloor)
         dQdV = dQ / dV;
     }
-    if (!CPS::Math::isFinite(dQdV) || std::abs(dQdV) < 1e-9)
+    if (!CPS::Math::isFinite(dQdV) || std::abs(dQdV) < svcMinSensitivity)
       dQdV = 1.0; // degenerate sensitivity -> unit fallback
 
     CPS::Real qNew = qOld + mSvcDamping * dQdV * vErr;
@@ -701,7 +706,7 @@ CPS::Bool PFSolverPowerPolar::enforceSvcVoltageControl() {
       qNew = qMinPU;
 
     CPS::Real dq = qNew - qOld;
-    if (std::abs(dq) < 1e-12)
+    if (std::abs(dq) < DOUBLE_EPSILON)
       continue; // pinned at a limit or converged -> contributes to settling
 
     mSvcPrevQV[node] = std::make_pair(qOld, v);

--- a/dpsim/src/Simulation.cpp
+++ b/dpsim/src/Simulation.cpp
@@ -40,6 +40,7 @@ Simulation::Simulation(String name, Logger::Level logLevel)
       mPFMaxIterations(CPS::AttributeStatic<CPS::UInt>::make(20)),
       mPFSolverUseSparse(CPS::AttributeStatic<Bool>::make(false)),
       mPFEnforceReactiveLimits(CPS::AttributeStatic<Bool>::make(false)),
+      mPFEnforceSvcControl(CPS::AttributeStatic<Bool>::make(false)),
       mPFBaseVoltageLooseTolerance(CPS::AttributeStatic<Real>::make(0.1)),
       mPFBaseVoltageStrictTolerance(CPS::AttributeStatic<Real>::make(0.01)),
       mSplitSubnets(AttributeStatic<Bool>::make(true)),
@@ -58,6 +59,7 @@ Simulation::Simulation(String name, CommandLineArgs &args)
       mPFMaxIterations(CPS::AttributeStatic<CPS::UInt>::make(20)),
       mPFSolverUseSparse(CPS::AttributeStatic<Bool>::make(false)),
       mPFEnforceReactiveLimits(CPS::AttributeStatic<Bool>::make(false)),
+      mPFEnforceSvcControl(CPS::AttributeStatic<Bool>::make(false)),
       mPFBaseVoltageLooseTolerance(CPS::AttributeStatic<Real>::make(0.1)),
       mPFBaseVoltageStrictTolerance(CPS::AttributeStatic<Real>::make(0.01)),
       mSplitSubnets(AttributeStatic<Bool>::make(true)),
@@ -136,6 +138,7 @@ template <typename VarType> void Simulation::createSolvers() {
     pfSolver->setBaseApparentPowerFallback(**mPFBaseApparentPowerFallback);
     pfSolver->setMaxIterations(**mPFMaxIterations);
     pfSolver->setEnforceReactiveLimits(**mPFEnforceReactiveLimits);
+    pfSolver->setEnforceSvcControl(**mPFEnforceSvcControl);
     pfSolver->setBaseVoltageLooseTolerance(**mPFBaseVoltageLooseTolerance);
     pfSolver->setBaseVoltageStrictTolerance(**mPFBaseVoltageStrictTolerance);
 
@@ -383,6 +386,14 @@ void Simulation::setPFSolverEnforceReactiveLimits(Bool value) {
 
 Bool Simulation::getPFSolverEnforceReactiveLimits() const {
   return **mPFEnforceReactiveLimits;
+}
+
+void Simulation::setPFSolverEnforceSvcControl(Bool value) {
+  **mPFEnforceSvcControl = value;
+}
+
+Bool Simulation::getPFSolverEnforceSvcControl() const {
+  return **mPFEnforceSvcControl;
 }
 
 void Simulation::setPFSolverBaseVoltageLooseTolerance(Real tolerance) {

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -253,6 +253,10 @@ PYBIND11_MODULE(dpsimpy, m) {
            &DPsim::Simulation::setPFSolverEnforceReactiveLimits)
       .def("get_pf_solver_enforce_q_limits",
            &DPsim::Simulation::getPFSolverEnforceReactiveLimits)
+      .def("set_pf_solver_enforce_svc_control",
+           &DPsim::Simulation::setPFSolverEnforceSvcControl)
+      .def("get_pf_solver_enforce_svc_control",
+           &DPsim::Simulation::getPFSolverEnforceSvcControl)
       .def("set_pf_solver_base_voltage_loose_tolerance",
            &DPsim::Simulation::setPFSolverBaseVoltageLooseTolerance)
       .def("get_pf_solver_base_voltage_loose_tolerance",

--- a/examples/Notebooks/Grids/PF_SVC_VoltageControl.ipynb
+++ b/examples/Notebooks/Grids/PF_SVC_VoltageControl.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "svc-intro",
+   "metadata": {},
+   "source": [
+    "# Static VAR compensator (SVC) voltage control\n",
+    "\n",
+    "DPsim's Newton-Raphson powerflow can hold an `SP::Ph1::SVC` bus at a voltage setpoint by moving the device's reactive injection within its Q band, an outer loop that runs alongside the generator Q-limit switching. Enforcement is opt-in via `set_pf_solver_enforce_svc_control(True)` on the `Simulation` (default off). Inside the band the SVC holds the bus at its setpoint; at the band edge the injection pins at Qmax or Qmin and the voltage misses the setpoint.\n",
+    "\n",
+    "This notebook uses a hand-wired three-bus case (slack, two PiLines, a mid-bus load, and an SVC at the far bus) and checks the behaviour under both the dense and sparse solvers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "svc-imports",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "import dpsimpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "svc-runpf",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASE_V = 110e3\n",
+    "BASE_S = 100e6\n",
+    "\n",
+    "\n",
+    "def run_pf(\n",
+    "    v_set_pu, q_max_mvar, q_min_mvar, load_p_mw, load_q_mvar, enforce, use_sparse\n",
+    "):\n",
+    "    n1 = dpsimpy.sp.SimNode(\"n1\", dpsimpy.PhaseType.Single)\n",
+    "    n2 = dpsimpy.sp.SimNode(\"n2\", dpsimpy.PhaseType.Single)\n",
+    "    n3 = dpsimpy.sp.SimNode(\"n3\", dpsimpy.PhaseType.Single)\n",
+    "\n",
+    "    slack = dpsimpy.sp.ph1.SynchronGenerator(\"slack\")\n",
+    "    slack.set_parameters(\n",
+    "        rated_apparent_power=BASE_S,\n",
+    "        rated_voltage=BASE_V,\n",
+    "        set_point_active_power=0.0,\n",
+    "        set_point_voltage=BASE_V,\n",
+    "        powerflow_bus_type=dpsimpy.PowerflowBusType.VD,\n",
+    "    )\n",
+    "    slack.set_base_voltage(BASE_V)\n",
+    "    slack.modify_power_flow_bus_type(dpsimpy.PowerflowBusType.VD)\n",
+    "    slack.connect([n1])\n",
+    "\n",
+    "    load = dpsimpy.sp.ph1.Load(\"load\")\n",
+    "    load.set_parameters(load_p_mw * 1e6, load_q_mvar * 1e6, BASE_V)\n",
+    "    load.modify_power_flow_bus_type(dpsimpy.PowerflowBusType.PQ)\n",
+    "    load.connect([n2])\n",
+    "\n",
+    "    svc = dpsimpy.sp.ph1.SVC(\"svc\")\n",
+    "    svc.set_parameters(\n",
+    "        rated_apparent_power=BASE_S,\n",
+    "        rated_voltage=BASE_V,\n",
+    "        set_point_voltage=v_set_pu * BASE_V,\n",
+    "        q_limit_max=q_max_mvar * 1e6,\n",
+    "        q_limit_min=q_min_mvar * 1e6,\n",
+    "    )\n",
+    "    svc.set_base_voltage(BASE_V)\n",
+    "    svc.connect([n3])\n",
+    "\n",
+    "    z_base = BASE_V**2 / BASE_S\n",
+    "    line12 = dpsimpy.sp.ph1.PiLine(\"line12\")\n",
+    "    line12.set_parameters(0.02 * z_base, 0.08 * z_base / (2 * math.pi * 50), 0.0, 0.0)\n",
+    "    line12.set_base_voltage(BASE_V)\n",
+    "    line12.connect([n1, n2])\n",
+    "\n",
+    "    line23 = dpsimpy.sp.ph1.PiLine(\"line23\")\n",
+    "    line23.set_parameters(0.02 * z_base, 0.08 * z_base / (2 * math.pi * 50), 0.0, 0.0)\n",
+    "    line23.set_base_voltage(BASE_V)\n",
+    "    line23.connect([n2, n3])\n",
+    "\n",
+    "    system = dpsimpy.SystemTopology(\n",
+    "        50, [n1, n2, n3], [slack, load, svc, line12, line23]\n",
+    "    )\n",
+    "\n",
+    "    sim = dpsimpy.Simulation(\"svc_pf\", dpsimpy.LogLevel.off)\n",
+    "    sim.set_system(system)\n",
+    "    sim.set_time_step(0.1)\n",
+    "    sim.set_final_time(0.1)\n",
+    "    sim.set_domain(dpsimpy.Domain.SP)\n",
+    "    sim.set_solver(dpsimpy.Solver.NRP)\n",
+    "    sim.set_solver_component_behaviour(dpsimpy.SolverBehaviour.Simulation)\n",
+    "    sim.set_pf_solver_use_sparse(use_sparse)\n",
+    "    sim.set_pf_solver_enforce_svc_control(enforce)\n",
+    "    sim.run()\n",
+    "\n",
+    "    v_svc = abs(complex(n3.single_voltage()) / BASE_V)\n",
+    "    q_svc = svc.get_apparent_power().imag / 1e6\n",
+    "    return v_svc, q_svc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "svc-cases-md",
+   "metadata": {},
+   "source": [
+    "The load moves the far bus off nominal: an inductive load pulls it down, a capacitive load pushes it up. A wide Q band lets the SVC reach its setpoint; a tight band forces it to pin at the reactive limit and miss. With enforcement off the SVC injects nothing and the bus is left uncompensated. The cases below exercise a hold by injecting, a hold by absorbing, a pin at each limit, and the enforcement-off baseline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "svc-cases",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# label, Vset [pu], Qmax [MVAr], Qmin [MVAr], load P [MW], load Q [MVAr], enforce, expected\n",
+    "CASES = [\n",
+    "    (\"wide band, inductive load, holds\", 1.00, 1000, -1000, 30, 15, True, \"hold\"),\n",
+    "    (\"tight Qmax, inductive load, pins max\", 1.00, 5, -5, 30, 15, True, \"max\"),\n",
+    "    (\"wide band, capacitive load, holds\", 0.98, 1000, -1000, 5, -60, True, \"hold\"),\n",
+    "    (\"tight Qmin, capacitive load, pins min\", 0.98, 5, -5, 5, -60, True, \"min\"),\n",
+    "    (\"enforcement off, no support\", 1.00, 1000, -1000, 30, 15, False, \"off\"),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "svc-run",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = []\n",
+    "for use_sparse in (False, True):\n",
+    "    for label, v_set, q_max, q_min, load_p, load_q, enforce, expected in CASES:\n",
+    "        v, q = run_pf(v_set, q_max, q_min, load_p, load_q, enforce, use_sparse)\n",
+    "        rows.append(\n",
+    "            {\n",
+    "                \"case\": label,\n",
+    "                \"solver\": \"sparse\" if use_sparse else \"dense\",\n",
+    "                \"Vset [pu]\": v_set,\n",
+    "                \"Qmax [MVAr]\": q_max,\n",
+    "                \"Qmin [MVAr]\": q_min,\n",
+    "                \"expected\": expected,\n",
+    "                \"V [pu]\": v,\n",
+    "                \"SVC Q [MVAr]\": q,\n",
+    "            }\n",
+    "        )\n",
+    "results = pd.DataFrame(rows)\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "svc-assert",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for _, row in results.iterrows():\n",
+    "    if row[\"expected\"] == \"max\":\n",
+    "        assert (\n",
+    "            abs(row[\"SVC Q [MVAr]\"] - row[\"Qmax [MVAr]\"]) < 0.5\n",
+    "        ), f\"{row['solver']}/{row['case']}: SVC not pinned at Qmax\"\n",
+    "    elif row[\"expected\"] == \"min\":\n",
+    "        assert (\n",
+    "            abs(row[\"SVC Q [MVAr]\"] - row[\"Qmin [MVAr]\"]) < 0.5\n",
+    "        ), f\"{row['solver']}/{row['case']}: SVC not pinned at Qmin\"\n",
+    "    elif row[\"expected\"] == \"hold\":\n",
+    "        assert (\n",
+    "            abs(row[\"V [pu]\"] - row[\"Vset [pu]\"]) < 1e-3\n",
+    "        ), f\"{row['solver']}/{row['case']}: SVC bus not held at Vset\"\n",
+    "    else:\n",
+    "        assert (\n",
+    "            abs(row[\"SVC Q [MVAr]\"]) < 1e-6\n",
+    "        ), f\"{row['solver']}/{row['case']}: SVC injected with enforcement off\"\n",
+    "\n",
+    "print(\"all SVC voltage-control cases passed\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/Notebooks/Grids/PF_SVC_VoltageControl.ipynb
+++ b/examples/Notebooks/Grids/PF_SVC_VoltageControl.ipynb
@@ -14,8 +14,8 @@
   },
   {
    "cell_type": "code",
-   "id": "svc-imports",
    "execution_count": null,
+   "id": "svc-imports",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,8 +29,8 @@
   },
   {
    "cell_type": "code",
-   "id": "svc-runpf",
    "execution_count": null,
+   "id": "svc-runpf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,8 +114,8 @@
   },
   {
    "cell_type": "code",
-   "id": "svc-cases",
    "execution_count": null,
+   "id": "svc-cases",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,8 +131,8 @@
   },
   {
    "cell_type": "code",
-   "id": "svc-run",
    "execution_count": null,
+   "id": "svc-run",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,8 +158,8 @@
   },
   {
    "cell_type": "code",
-   "id": "svc-assert",
    "execution_count": null,
+   "id": "svc-assert",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Adds the solver-side outer loop that holds each SVC bus at its voltage setpoint. Opt in via `set_pf_solver_enforce_svc_control`.

Builds on the pull request below it in the stack, which adds the SP domain SVC component itself.
