### PR TITLE
fix(ci): publish sogno/dpsim:dev-vscode and use it for the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "DPsim",
-	"image": "sogno/dpsim:dev",
+	"image": "sogno/dpsim:dev-vscode",
 	// uncomment to build devcontainer image locally
 	// "build": {
 	// 	"dockerfile": "../packaging/Docker/Dockerfile.dev",

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -65,6 +65,15 @@ jobs:
          push: true
          tags: sogno/dpsim:dev
 
+      - name: Build and push vscode devcontainer
+        id: docker_build_dev_vscode
+        uses: docker/build-push-action@v7
+        with:
+         file: packaging/Docker/Dockerfile.dev
+         target: dev-vscode
+         push: true
+         tags: sogno/dpsim:dev-vscode
+
   create-docker-fedora-minimal-dev:
     runs-on: sogno-platform-dpsim-runner
     steps:


### PR DESCRIPTION
The devcontainer pulls sogno/dpsim:dev with remoteUser dpsim, but the Container workflow builds Dockerfile.dev without a target, so the pushed image is the plain final stage and the dpsim user never exists; the devcontainer cannot start as that user out of the box.

This adds a second build-push step publishing the dev-vscode stage as sogno/dpsim:dev-vscode (same job, reuses the layer cache, only the user layer is extra) and points devcontainer.json at it, while sogno/dpsim:dev stays unchanged for CI. User creation verified on fedora:42, uid 1000 with passwordless sudo works. Needs one manual run of the Container workflow after merge, until then the new tag does not exist on Docker Hub.