### PR TITLE
feat(models): add a half decoupling line so the two ends can be solved separately

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -149,3 +149,6 @@
 /dpsim-models/src/DP/DP_Ph1_SSN_Full_Serial_RLC.cpp @georgii-tishenin @leonardocarreras
 /dpsim-models/src/DP/DP_Ph1_MixedVTypeVariableSSNComp.cpp @georgii-tishenin @leonardocarreras
 /dpsim-models/src/DP/DP_Ph1_SSN_Variable_Serial_RLC.cpp @georgii-tishenin @leonardocarreras
+
+# Half decoupling line.
+/dpsim-models/**/*HalfDecouplingLine* @leonardocarreras

--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -192,6 +192,7 @@
 #include <dpsim-models/EMT/EMT_Ph3_Transformer.h>
 #include <dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeVariableSSNComp.h>
 #include <dpsim-models/EMT/EMT_Ph3_VSIVoltageControlVCO.h>
+#include <dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h>
 
 #include <dpsim-models/Signal/CosineFMGenerator.h>
 #include <dpsim-models/Signal/DecouplingIdealTransformer_DP_Ph1.h>

--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -179,6 +179,7 @@
 #ifdef WITH_SUNDIALS
 #include <dpsim-models/EMT/EMT_Ph3_SynchronGeneratorDQODE.h>
 #endif
+#include <dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h>
 #include <dpsim-models/EMT/EMT_Ph3_NetworkInjection.h>
 #include <dpsim-models/EMT/EMT_Ph3_PiLine.h>
 #include <dpsim-models/EMT/EMT_Ph3_PiecewiseLinearInductor.h>
@@ -192,7 +193,6 @@
 #include <dpsim-models/EMT/EMT_Ph3_Transformer.h>
 #include <dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeVariableSSNComp.h>
 #include <dpsim-models/EMT/EMT_Ph3_VSIVoltageControlVCO.h>
-#include <dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h>
 
 #include <dpsim-models/Signal/CosineFMGenerator.h>
 #include <dpsim-models/Signal/DecouplingIdealTransformer_DP_Ph1.h>

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h
@@ -1,0 +1,96 @@
+/* Copyright 2017-2020 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+#pragma once
+#include <dpsim-models/Definitions.h>
+#include <dpsim-models/CompositePowerComp.h>
+#include <dpsim-models/EMT/EMT_Ph3_ControlledCurrentSource.h>
+#include <dpsim-models/EMT/EMT_Ph3_Resistor.h>
+#include <dpsim-models/Solver/MNAInterface.h>
+
+namespace CPS {
+namespace EMT {
+namespace Ph3 {
+/// HalfDecouplingLine ....
+
+class HalfDecouplingLine :
+public CompositePowerComp<Real>,
+public SharedFactory<HalfDecouplingLine> {
+protected:
+
+  Real mDelay;
+  Matrix mResistance= Matrix::Zero(3, 3);
+  Matrix mInductance= Matrix::Zero(3, 3);
+  Matrix mCapacitance= Matrix::Zero(3, 3);
+  Real mSurgeImpedance= 0;
+
+  // ### Electrical Subcomponents ###
+  /// Controlled current source
+  std::shared_ptr<EMT::Ph3::ControlledCurrentSource> mSubCtrledCurrentSource;
+  /// Parallel impedance calculated from line parameters
+  std::shared_ptr<EMT::Ph3::Resistor> mSubRes;
+
+  
+  // Ringbuffers for the values of previous timesteps
+  // TODO make these matrix attributes
+  // For 3-Phase change vector to Matrix with time as row and phases as column
+  // std::vector<Real> mVoltBuf, mCurBuf;
+  // UInt mBufIdx = 0;
+  // UInt mBufSize;
+  // Real mAlpha;
+
+  // Real interpolate(std::vector<Real> &data);
+
+public:
+  // typedef std::shared_ptr<HalfDecouplingLine> Ptr;
+
+  const Attribute<Matrix>::Ptr mSrcCtrledCurrent;
+  const Attribute<Matrix>::Ptr mReceivingVolt;
+  const Attribute<Matrix>::Ptr mReceivingCur;
+  const Attribute<Matrix>::Ptr mSendingVoltage;
+  const Attribute<Matrix>::Ptr mSendingCur;
+
+  /// Defines UID, name and logging level
+  HalfDecouplingLine(String name, Logger::Level logLevel = Logger::Level::off) : HalfDecouplingLine(name, name, logLevel) {}
+  HalfDecouplingLine(String uid, String name, Logger::Level logLevel = Logger::Level::off);
+  ///
+
+  // #### General ####
+  /// Initializes component from power flow data
+  void initializeFromNodesAndTerminals(Real frequency) override;
+  /// Setter for reference current
+  void setParameters(Matrix resistance, Matrix inductance, Matrix capacitance, 
+                     Attribute<Matrix>::Ptr ReceivingVoltRef, Attribute<Matrix>::Ptr ReceivingCurRef);
+
+  ///
+  void Step(Real time);
+
+  // #### MNA section ####
+  /// Updates internal current variable of the component
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
+  /// Updates internal voltage variable of the component
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
+  /// MNA pre step operations
+  void mnaParentPreStep(Real time, Int timeStepCount) override;
+  /// MNA post step operations
+  void mnaParentPostStep(Real time, Int timeStepCount,
+                         Attribute<Matrix>::Ptr &leftVector) override;
+  /// Add MNA pre step dependencies
+  void mnaParentAddPreStepDependencies(
+      AttributeBase::List &prevStepDependencies,
+      AttributeBase::List &attributeDependencies,
+      AttributeBase::List &modifiedAttributes) override;
+  /// Add MNA post step dependencies
+  void
+  mnaParentAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
+                                   AttributeBase::List &attributeDependencies,
+                                   AttributeBase::List &modifiedAttributes,
+                                   Attribute<Matrix>::Ptr &leftVector) override;
+};
+} // namespace Ph3
+} // namespace EMT
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h
@@ -22,11 +22,11 @@ public CompositePowerComp<Real>,
 public SharedFactory<HalfDecouplingLine> {
 protected:
 
-  Real mDelay;
+  Matrix mDelay= Matrix::Zero(3, 3);
   Matrix mResistance= Matrix::Zero(3, 3);
   Matrix mInductance= Matrix::Zero(3, 3);
   Matrix mCapacitance= Matrix::Zero(3, 3);
-  Real mSurgeImpedance= 0;
+  Matrix mSurgeImpedance= Matrix::Zero(3, 3);
 
   // ### Electrical Subcomponents ###
   /// Controlled current source
@@ -46,12 +46,12 @@ protected:
   // Real interpolate(std::vector<Real> &data);
 
 public:
-  // typedef std::shared_ptr<HalfDecouplingLine> Ptr;
 
   const Attribute<Matrix>::Ptr mSrcCtrledCurrent;
+  const Attribute<Matrix>::Ptr mSrcRes;
   const Attribute<Matrix>::Ptr mReceivingVolt;
   const Attribute<Matrix>::Ptr mReceivingCur;
-  const Attribute<Matrix>::Ptr mSendingVoltage;
+  const Attribute<Matrix>::Ptr mSendingVolt;
   const Attribute<Matrix>::Ptr mSendingCur;
 
   /// Defines UID, name and logging level

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h
@@ -10,18 +10,19 @@
 namespace CPS {
 namespace EMT {
 namespace Ph3 {
-/// One end of a Bergeron travelling-wave line. Two of these replace a single
-/// DecouplingLineEMT_Ph3 and can live in different systems or different
-/// simulators, since each only ever reads far-end quantities that are one
-/// travel time old.
-
+/// @brief One end of a Bergeron travelling-wave line. Two of these replace a
+/// single Signal::DecouplingLineEMT_Ph3 and can live in different systems or
+/// different simulators, since each only ever reads far-end quantities that are
+/// one travel time old.
 class HalfDecouplingLine : public CompositePowerComp<Real>,
                            public SharedFactory<HalfDecouplingLine> {
 protected:
+  /// Travel time of the whole line
   Real mDelay;
   Matrix mResistance = Matrix::Zero(3, 3);
   Matrix mInductance = Matrix::Zero(3, 3);
   Matrix mCapacitance = Matrix::Zero(3, 3);
+  /// Surge impedance, sqrt(L/C)
   Matrix mSurgeImpedance = Matrix::Zero(3, 3);
 
   // ### Electrical Subcomponents ###
@@ -30,18 +31,21 @@ protected:
   /// Terminating impedance calculated from line parameters
   std::shared_ptr<EMT::Ph3::Resistor> mSubRes;
 
-  // Ringbuffers for the values of previous timesteps, one row per stored step
+  /// Ring buffers for the values of previous timesteps, one row per stored step
   Matrix mVoltBuf, mCurBuf;
   UInt mBufIdx = 0;
   UInt mBufSize;
   Real mAlpha;
 
+  /// Reads a ring buffer one travel time back
   Matrix interpolate(Matrix &data);
 
 public:
   typedef std::shared_ptr<HalfDecouplingLine> Ptr;
 
+  /// History current fed into the controlled current source
   const Attribute<Matrix>::Ptr mSrcCtrledCurrent;
+  /// Terminating resistance
   const Attribute<Matrix>::Ptr mSrcRes;
   /// Far-end voltage one travel time ago, supplied by the other half
   const Attribute<Matrix>::Ptr mReceivingVolt;
@@ -52,9 +56,10 @@ public:
   /// This end's current one travel time ago, for the other half to read
   const Attribute<Matrix>::Ptr mSendingCur;
 
-  /// Defines UID, name and logging level
+  /// Defines name and logging level
   HalfDecouplingLine(String name, Logger::Level logLevel = Logger::Level::off)
       : HalfDecouplingLine(name, name, logLevel) {}
+  /// Defines UID, name and logging level
   HalfDecouplingLine(String uid, String name,
                      Logger::Level logLevel = Logger::Level::off);
 
@@ -65,13 +70,18 @@ public:
   /// attributes in the same process, or an Interface in a co-simulation.
   void setCouplingSource(Attribute<Matrix>::Ptr receivingVolt,
                          Attribute<Matrix>::Ptr receivingCur);
+  /// Creates the terminating resistor and the history current source
   void createSubComponents() override;
+  /// Seeds the interface quantities and the sending attributes
   void initializeParentFromNodesAndTerminals(Real frequency) override;
 
+  /// Updates the history current from the exchanged quantities
   void step(Real time, Int timeStepCount);
+  /// Records this end's quantities and publishes them one travel time delayed
   void postStep();
 
   // #### MNA section ####
+  /// Sizes the ring buffers and seeds them from the steady state
   void mnaParentInitialize(Real omega, Real timeStep,
                            Attribute<Matrix>::Ptr leftVector) override;
   /// Updates internal current variable of the component

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h
@@ -6,8 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *********************************************************************************/
 #pragma once
-#include <dpsim-models/Definitions.h>
 #include <dpsim-models/CompositePowerComp.h>
+#include <dpsim-models/Definitions.h>
 #include <dpsim-models/EMT/EMT_Ph3_ControlledCurrentSource.h>
 #include <dpsim-models/EMT/EMT_Ph3_Resistor.h>
 #include <dpsim-models/Solver/MNAInterface.h>
@@ -15,61 +15,70 @@
 namespace CPS {
 namespace EMT {
 namespace Ph3 {
-/// HalfDecouplingLine ....
+/// One end of a Bergeron travelling-wave line. Two of these replace a single
+/// DecouplingLineEMT_Ph3 and can live in different systems or different
+/// simulators, since each only ever reads far-end quantities that are one
+/// travel time old.
 
-class HalfDecouplingLine :
-public CompositePowerComp<Real>,
-public SharedFactory<HalfDecouplingLine> {
+class HalfDecouplingLine : public CompositePowerComp<Real>,
+                           public SharedFactory<HalfDecouplingLine> {
 protected:
-
-  Matrix mDelay= Matrix::Zero(3, 3);
-  Matrix mResistance= Matrix::Zero(3, 3);
-  Matrix mInductance= Matrix::Zero(3, 3);
-  Matrix mCapacitance= Matrix::Zero(3, 3);
-  Matrix mSurgeImpedance= Matrix::Zero(3, 3);
+  Real mDelay;
+  Matrix mResistance = Matrix::Zero(3, 3);
+  Matrix mInductance = Matrix::Zero(3, 3);
+  Matrix mCapacitance = Matrix::Zero(3, 3);
+  Matrix mSurgeImpedance = Matrix::Zero(3, 3);
 
   // ### Electrical Subcomponents ###
-  /// Controlled current source
+  /// Controlled current source carrying the history term
   std::shared_ptr<EMT::Ph3::ControlledCurrentSource> mSubCtrledCurrentSource;
-  /// Parallel impedance calculated from line parameters
+  /// Terminating impedance calculated from line parameters
   std::shared_ptr<EMT::Ph3::Resistor> mSubRes;
 
-  
-  // Ringbuffers for the values of previous timesteps
-  // TODO make these matrix attributes
-  // For 3-Phase change vector to Matrix with time as row and phases as column
-  // std::vector<Real> mVoltBuf, mCurBuf;
-  // UInt mBufIdx = 0;
-  // UInt mBufSize;
-  // Real mAlpha;
+  // Ringbuffers for the values of previous timesteps, one row per stored step
+  Matrix mVoltBuf, mCurBuf;
+  UInt mBufIdx = 0;
+  UInt mBufSize;
+  Real mAlpha;
 
-  // Real interpolate(std::vector<Real> &data);
+  Matrix interpolate(Matrix &data);
 
 public:
+  typedef std::shared_ptr<HalfDecouplingLine> Ptr;
 
   const Attribute<Matrix>::Ptr mSrcCtrledCurrent;
   const Attribute<Matrix>::Ptr mSrcRes;
+  /// Far-end voltage one travel time ago, supplied by the other half
   const Attribute<Matrix>::Ptr mReceivingVolt;
+  /// Far-end current one travel time ago, supplied by the other half
   const Attribute<Matrix>::Ptr mReceivingCur;
+  /// This end's voltage one travel time ago, for the other half to read
   const Attribute<Matrix>::Ptr mSendingVolt;
+  /// This end's current one travel time ago, for the other half to read
   const Attribute<Matrix>::Ptr mSendingCur;
 
   /// Defines UID, name and logging level
-  HalfDecouplingLine(String name, Logger::Level logLevel = Logger::Level::off) : HalfDecouplingLine(name, name, logLevel) {}
-  HalfDecouplingLine(String uid, String name, Logger::Level logLevel = Logger::Level::off);
-  ///
+  HalfDecouplingLine(String name, Logger::Level logLevel = Logger::Level::off)
+      : HalfDecouplingLine(name, name, logLevel) {}
+  HalfDecouplingLine(String uid, String name,
+                     Logger::Level logLevel = Logger::Level::off);
 
   // #### General ####
-  /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency) override;
-  /// Setter for reference current
-  void setParameters(Matrix resistance, Matrix inductance, Matrix capacitance, 
-                     Attribute<Matrix>::Ptr ReceivingVoltRef, Attribute<Matrix>::Ptr ReceivingCurRef);
+  /// Line data. Give the parameters of the whole line, not of this half.
+  void setParameters(Matrix resistance, Matrix inductance, Matrix capacitance);
+  /// Where the far-end quantities come from: the other half's sending
+  /// attributes in the same process, or an Interface in a co-simulation.
+  void setCouplingSource(Attribute<Matrix>::Ptr receivingVolt,
+                         Attribute<Matrix>::Ptr receivingCur);
+  void createSubComponents() override;
+  void initializeParentFromNodesAndTerminals(Real frequency) override;
 
-  ///
-  void Step(Real time);
+  void step(Real time, Int timeStepCount);
+  void postStep();
 
   // #### MNA section ####
+  void mnaParentInitialize(Real omega, Real timeStep,
+                           Attribute<Matrix>::Ptr leftVector) override;
   /// Updates internal current variable of the component
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;
   /// Updates internal voltage variable of the component

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h
@@ -1,10 +1,5 @@
-/* Copyright 2017-2020 Institute for Automation of Complex Power Systems,
- *                     EONERC, RWTH Aachen University
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- *********************************************************************************/
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
 #pragma once
 #include <dpsim-models/CompositePowerComp.h>
 #include <dpsim-models/Definitions.h>

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -170,6 +170,7 @@ list(APPEND MODELS_SOURCES
 	EMT/EMT_Ph3_SSN_InductionMotor.cpp
 	EMT/EMT_Ph3_PiecewiseLinearInductor.cpp
 	EMT/EMT_Ph3_VSIVoltageControlVCO.cpp
+	EMT/EMT_Ph3_HalfDecouplingLine.cpp
 
 	SP/SP_Ph1_ControlledCurrentSource.cpp
 	SP/SP_Ph1_VoltageSource.cpp

--- a/dpsim-models/src/EMT/EMT_Ph3_HalfDecouplingLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_HalfDecouplingLine.cpp
@@ -1,0 +1,153 @@
+/* Copyright 2017-2020 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h>
+
+using namespace CPS;
+
+EMT::Ph3::HalfDecouplingLine::HalfDecouplingLine(String uid, String name, Logger::Level logLevel)
+    :CompositePowerComp<Real>(uid, name, true, true, logLevel),
+      mSrcCtrledCurrent(mAttributes->create<Matrix>("i_src_ctrl")),
+      mReceivingVolt(mAttributes->createDynamic<Matrix>("receiving_volt")),
+      mReceivingCur(mAttributes->createDynamic<Matrix>("receiving_cur")),
+      mSendingVoltage(mAttributes->create<Matrix>("sending_volt")),
+      mSendingCur(mAttributes->create<Matrix>("sending_cur")) {
+
+  mSubRes = EMT::Ph3::Resistor::make(**mName + "_r", mLogLevel);
+  addMNASubComponent(mSubRes, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
+                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
+
+
+  mSubCtrledCurrentSource = EMT::Ph3::ControlledCurrentSource::make(name + "_i", logLevel);
+  // Pre-step of the subcontrolled current source is handled explicitly in mnaParentPreStep
+  addMNASubComponent(mSubCtrledCurrentSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
+                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
+  
+  mSrcCtrledCurrent->setReference(mSubCtrledCurrentSource->mCurrentRef);
+
+  mPhaseType = PhaseType::ABC;
+  setVirtualNodeNumber(0);
+  setTerminalNumber(2);
+  **mIntfVoltage = Matrix::Zero(3, 1);
+  **mIntfCurrent = Matrix::Zero(3, 1);
+}
+
+void EMT::Ph3::HalfDecouplingLine::setParameters(
+  Matrix resistance, Matrix inductance, Matrix capacitance,
+  Attribute<Matrix>::Ptr ReceivingVoltRef, Attribute<Matrix>::Ptr ReceivingCurRef) {
+
+  mReceivingVolt->setReference(ReceivingVoltRef);
+  mReceivingCur->setReference(ReceivingCurRef);
+
+  mResistance = resistance;
+  mInductance = inductance;
+  mCapacitance = capacitance;
+  mSurgeImpedance = sqrt(inductance(0,0) / capacitance(0,0));
+
+  mDelay = sqrt(inductance(0,0) * capacitance(0,0));
+
+  SPDLOG_LOGGER_INFO(mSLog, "surge impedance: {}", mSurgeImpedance);
+  SPDLOG_LOGGER_INFO(mSLog, "delay: {}", mDelay);
+
+  mSubCtrledCurrentSource->setParameters(Matrix::Zero(3, 1));
+  mSubCtrledCurrentSource->connect({mTerminals[0]->node(), SimNode::GND});
+  mSubRes->setParameters(Math::singlePhaseParameterToThreePhase(mSurgeImpedance + mResistance(0,0) / 4));
+  mSubRes->connect({mTerminals[0]->node(), SimNode::GND});
+
+  mParametersSet = true;
+}
+
+void EMT::Ph3::HalfDecouplingLine::initializeFromNodesAndTerminals(Real frequency) {
+  // if (mDelay < timeStep)
+  //   throw SystemError("Timestep too large for decoupling");
+
+  // mBufSize = static_cast<UInt>(ceil(mDelay / timeStep));
+  // mAlpha = 1 - (mBufSize - mDelay / timeStep);
+  // SPDLOG_LOGGER_INFO(mSLog, "bufsize {} alpha {}", mBufSize, mAlpha);
+
+  // // Initialization based on static PI-line model
+  // Complex volt1 = mNode1->initialSingleVoltage();
+  // Complex volt2 = mNode2->initialSingleVoltage();
+  // Complex initAdmittance = 1. / Complex(mResistance, omega * mInductance) +
+  //                          Complex(0, omega * mCapacitance / 2);
+  // Complex cur1 = volt1 * initAdmittance -
+  //                volt2 / Complex(mResistance, omega * mInductance);
+  // Complex cur2 = volt2 * initAdmittance -
+  //                volt1 / Complex(mResistance, omega * mInductance);
+  // SPDLOG_LOGGER_INFO(mSLog, "initial voltages: v_k {} v_m {}", volt1, volt2);
+  // SPDLOG_LOGGER_INFO(mSLog, "initial currents: i_km {} i_mk {}", cur1, cur2);
+
+  // // Resize ring buffers and initialize
+  // mVoltBuf.resize(mBufSize, volt1.real());
+  // mCurBuf.resize(mBufSize, cur1.real());
+}
+
+void EMT::Ph3::HalfDecouplingLine::mnaParentAddPreStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes) {
+  prevStepDependencies.push_back(mIntfVoltage);
+}
+
+void EMT::Ph3::HalfDecouplingLine::mnaParentAddPostStepDependencies(
+    AttributeBase::List &prevStepDependencies,
+    AttributeBase::List &attributeDependencies,
+    AttributeBase::List &modifiedAttributes,
+    Attribute<Matrix>::Ptr &leftVector) {
+  attributeDependencies.push_back(leftVector);
+  modifiedAttributes.push_back(mIntfVoltage);
+}
+
+void EMT::Ph3::HalfDecouplingLine::Step(Real time) {
+  // calculate 
+
+  // Real denom =
+  //     (mSurgeImpedance + mResistance / 4) * (mSurgeImpedance + mResistance / 4);
+
+  // // Calculate current
+  // **mSrcCurRef = -mSurgeImpedance / denom *
+  //                     (**mReceivingVolt + (mSurgeImpedance - mResistance / 4) * **mReceivingCur) -
+  //                 mResistance / 4 / denom *
+  //                     (**mSendingVoltage + (mSurgeImpedance - mResistance / 4) * **mSendingVoltage);
+}
+
+void EMT::Ph3::HalfDecouplingLine::mnaParentPreStep(Real time, Int timeStepCount) {
+  // // Pre-step of the subcontrolled current source is handled explicitly in mnaParentPreStep
+  // addMNASubComponent(mSubCtrledCurrentSource, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
+  //                    MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
+  // // pre-step of subcomponents - controlled source
+  // std::dynamic_pointer_cast<MNAInterface>(mSubCtrledCurrentSource)
+  //     ->mnaPreStep(time, timeStepCount);
+  
+  // pre-step of composite component
+  Step(time);
+  mnaCompApplyRightSideVectorStamp(**mRightVector);
+}
+
+void EMT::Ph3::HalfDecouplingLine::mnaParentPostStep(
+    Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+  mnaCompUpdateVoltage(**leftVector);
+  mnaCompUpdateCurrent(**leftVector);
+}
+
+void EMT::Ph3::HalfDecouplingLine::mnaCompUpdateVoltage(
+    const Matrix &leftVector) {
+  SPDLOG_LOGGER_DEBUG(mSLog, "Read voltage from {:d}", matrixNodeIndex(0));
+  (**mIntfVoltage)(0, 0) =
+      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 0));
+  (**mIntfVoltage)(1, 0) =
+      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 1));
+  (**mIntfVoltage)(2, 0) =
+      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 2));
+}
+
+void EMT::Ph3::HalfDecouplingLine::mnaCompUpdateCurrent(
+    const Matrix &leftVector) {
+  SPDLOG_LOGGER_DEBUG(mSLog, "Read current from {:d}", matrixNodeIndex(0));
+  **mIntfCurrent = **mSubRes->mIntfCurrent + **mSubCtrledCurrentSource->mIntfCurrent;
+}

--- a/dpsim-models/src/EMT/EMT_Ph3_HalfDecouplingLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_HalfDecouplingLine.cpp
@@ -1,10 +1,5 @@
-/* Copyright 2017-2020 Institute for Automation of Complex Power Systems,
- *                     EONERC, RWTH Aachen University
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- *********************************************************************************/
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
 
 #include <dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h>
 #include <dpsim-models/MathUtils.h>

--- a/dpsim-models/src/EMT/EMT_Ph3_HalfDecouplingLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_HalfDecouplingLine.cpp
@@ -58,9 +58,6 @@ void EMT::Ph3::HalfDecouplingLine::createSubComponents() {
 
   mSubRes = EMT::Ph3::Resistor::make(**mName + "_r", mLogLevel);
   mSubRes->setParameters(**mSrcRes);
-  /* As in DecouplingLineEMT_Ph3, the terminating resistor is connected from
-     GND to the terminal, since the Ph3 resistor has the opposite sign
-     convention for voltage and current compared to its Ph1 counterpart. */
   mSubRes->connect({SimNode::GND, mTerminals[0]->node()});
   addMNASubComponent(mSubRes, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
@@ -79,9 +76,6 @@ void EMT::Ph3::HalfDecouplingLine::initializeParentFromNodesAndTerminals(
   **mIntfVoltage = initialVoltage(0).real();
   **mIntfCurrent = Matrix::Zero(3, 1);
 
-  // The sending quantities follow the internal sign convention of
-  // DecouplingLineEMT_Ph3, in which the recorded voltage is the negated
-  // terminal voltage.
   **mSendingVolt = -(**mIntfVoltage);
   **mSendingCur = Matrix::Zero(3, 1);
 }
@@ -95,9 +89,6 @@ void EMT::Ph3::HalfDecouplingLine::mnaParentInitialize(
   mAlpha = 1 - (mBufSize - mDelay / timeStep);
   SPDLOG_LOGGER_INFO(mSLog, "bufsize {} alpha {}", mBufSize, mAlpha);
 
-  // Initialization based on static PI-line model. The far end voltage is read
-  // from the coupling source, which the other half published during its own
-  // initializeParentFromNodesAndTerminals.
   MatrixComp voltNear = -initialVoltage(0);
   MatrixComp voltFar = (**mReceivingVolt).cast<Complex>();
 
@@ -110,7 +101,6 @@ void EMT::Ph3::HalfDecouplingLine::mnaParentInitialize(
   SPDLOG_LOGGER_INFO(mSLog, "initial voltage: v_k {}", voltNear);
   SPDLOG_LOGGER_INFO(mSLog, "initial current: i_k {}", curNear);
 
-  // Resize ring buffers and initialize
   mVoltBuf = voltNear.real().transpose().replicate(mBufSize, 1);
   mCurBuf = curNear.real().transpose().replicate(mBufSize, 1);
 
@@ -119,7 +109,6 @@ void EMT::Ph3::HalfDecouplingLine::mnaParentInitialize(
 }
 
 Matrix EMT::Ph3::HalfDecouplingLine::interpolate(Matrix &data) {
-  // linear interpolation of the nearest values
   Matrix c1 = data.row(mBufIdx);
   Matrix c2 = mBufIdx == mBufSize - 1 ? data.row(0) : data.row(mBufIdx + 1);
   return (mAlpha * c1 + (1 - mAlpha) * c2).transpose();
@@ -157,9 +146,6 @@ void EMT::Ph3::HalfDecouplingLine::postStep() {
   if (mBufIdx == mBufSize)
     mBufIdx = 0;
 
-  // Publish this end's quantities as of one travel time ago. Doing it here
-  // rather than in the pre-step is what keeps the two halves free of any
-  // same-step dependency on each other, so they can be solved separately.
   **mSendingVolt = interpolate(mVoltBuf);
   **mSendingCur = interpolate(mCurBuf);
 }

--- a/dpsim-models/src/EMT/EMT_Ph3_HalfDecouplingLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_HalfDecouplingLine.cpp
@@ -7,120 +7,195 @@
  *********************************************************************************/
 
 #include <dpsim-models/EMT/EMT_Ph3_HalfDecouplingLine.h>
+#include <dpsim-models/MathUtils.h>
 
 using namespace CPS;
 
-EMT::Ph3::HalfDecouplingLine::HalfDecouplingLine(String uid, String name, Logger::Level logLevel)
-    :CompositePowerComp<Real>(uid, name, true, true, logLevel),
-      mSrcCtrledCurrent(mAttributes->create<Matrix>("i_src_ctrl", Matrix::Zero(3, 1))),
+EMT::Ph3::HalfDecouplingLine::HalfDecouplingLine(String uid, String name,
+                                                 Logger::Level logLevel)
+    : CompositePowerComp<Real>(uid, name, true, true, logLevel),
+      mSrcCtrledCurrent(
+          mAttributes->create<Matrix>("i_src_ctrl", Matrix::Zero(3, 1))),
       mSrcRes(mAttributes->create<Matrix>("src_res", Matrix::Zero(3, 3))),
       mReceivingVolt(mAttributes->createDynamic<Matrix>("receiving_volt")),
       mReceivingCur(mAttributes->createDynamic<Matrix>("receiving_cur")),
-      mSendingVolt(mAttributes->create<Matrix>("sending_volt")),
-      mSendingCur(mAttributes->create<Matrix>("sending_cur")) {
-
-  mSubRes = EMT::Ph3::Resistor::make(**mName + "_r", mLogLevel);
-  addMNASubComponent(mSubRes, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
-                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
-
-
-  mSubCtrledCurrentSource = EMT::Ph3::ControlledCurrentSource::make(name + "_i", logLevel);
-  // Pre-step of the subcontrolled current source is handled explicitly in mnaParentPreStep
-  addMNASubComponent(mSubCtrledCurrentSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
-                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
-  // addMNASubComponent(mSubCtrledCurrentSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT,
-  //                    MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
-  
+      mSendingVolt(
+          mAttributes->create<Matrix>("sending_volt", Matrix::Zero(3, 1))),
+      mSendingCur(
+          mAttributes->create<Matrix>("sending_cur", Matrix::Zero(3, 1))) {
 
   mPhaseType = PhaseType::ABC;
   setVirtualNodeNumber(0);
-  setTerminalNumber(2);
+  setTerminalNumber(1);
   **mIntfVoltage = Matrix::Zero(3, 1);
   **mIntfCurrent = Matrix::Zero(3, 1);
 }
 
-void EMT::Ph3::HalfDecouplingLine::setParameters(
-  Matrix resistance, Matrix inductance, Matrix capacitance,
-  Attribute<Matrix>::Ptr ReceivingVoltRef, Attribute<Matrix>::Ptr ReceivingCurRef) {
-
-  mReceivingVolt->setReference(ReceivingVoltRef);
-  mReceivingCur->setReference(ReceivingCurRef);
+void EMT::Ph3::HalfDecouplingLine::setParameters(Matrix resistance,
+                                                 Matrix inductance,
+                                                 Matrix capacitance) {
 
   mResistance = resistance;
   mInductance = inductance;
   mCapacitance = capacitance;
 
-  mSurgeImpedance << sqrt(inductance(0,0) / capacitance(0,0)), 0, 0,
-                      0, sqrt(inductance(1,1) / capacitance(1,1)), 0,
-                      0, 0, sqrt(inductance(2,2) / capacitance(2,2));
+  mSurgeImpedance = (inductance * capacitance.inverse()).array().sqrt();
+  mDelay = (inductance.array() * capacitance.array()).sqrt().maxCoeff();
 
-  mDelay << sqrt(inductance(0,0) * capacitance(0,0)), 0, 0,
-            0, sqrt(inductance(1,1) * capacitance(1,1)), 0,
-            0, 0, sqrt(inductance(2,2) * capacitance(2,2));
-
-   **mSrcRes << (mSurgeImpedance(0,0) + mResistance(0,0) / 4), 0, 0,
-                0, (mSurgeImpedance(1,1) + mResistance(1,1) / 4), 0,
-                0, 0, (mSurgeImpedance(2,2) + mResistance(2,2) / 4);
+  **mSrcRes = mSurgeImpedance + mResistance / 4;
 
   SPDLOG_LOGGER_INFO(mSLog, "surge impedance: {}", mSurgeImpedance);
   SPDLOG_LOGGER_INFO(mSLog, "delay: {}", mDelay);
 
-  mSubCtrledCurrentSource->setParameters(**mSrcCtrledCurrent);
-  mSubCtrledCurrentSource->connect({mTerminals[0]->node(), SimNode::GND});
-  mSubRes->setParameters(**mSrcRes);
-  mSubRes->connect({mTerminals[0]->node(), SimNode::GND});
-
   mParametersSet = true;
 }
 
-void EMT::Ph3::HalfDecouplingLine::initializeFromNodesAndTerminals(Real frequency) {
-  // if (mDelay < timeStep)
-  //   throw SystemError("Timestep too large for decoupling");
+void EMT::Ph3::HalfDecouplingLine::setCouplingSource(
+    Attribute<Matrix>::Ptr receivingVolt, Attribute<Matrix>::Ptr receivingCur) {
+  mReceivingVolt->setReference(receivingVolt);
+  mReceivingCur->setReference(receivingCur);
+}
 
-  // mBufSize = static_cast<UInt>(ceil(mDelay / timeStep));
-  // mAlpha = 1 - (mBufSize - mDelay / timeStep);
-  // SPDLOG_LOGGER_INFO(mSLog, "bufsize {} alpha {}", mBufSize, mAlpha);
+void EMT::Ph3::HalfDecouplingLine::createSubComponents() {
+  if (mSubCompCreated)
+    return;
+  mSubCompCreated = true;
 
-  // Initialization based on static PI-line model
-  MatrixComp vInit = MatrixComp::Zero(3, 1);
-  vInit(0, 0) = initialSingleVoltage(0); // rms value
-  vInit(1, 0) = vInit(0, 0) * SHIFT_TO_PHASE_B;
-  vInit(2, 0) = vInit(0, 0) * SHIFT_TO_PHASE_C;
+  mSubRes = EMT::Ph3::Resistor::make(**mName + "_r", mLogLevel);
+  mSubRes->setParameters(**mSrcRes);
+  /* As in DecouplingLineEMT_Ph3, the terminating resistor is connected from
+     GND to the terminal, since the Ph3 resistor has the opposite sign
+     convention for voltage and current compared to its Ph1 counterpart. */
+  mSubRes->connect({SimNode::GND, mTerminals[0]->node()});
+  addMNASubComponent(mSubRes, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
+                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, false);
 
-  MatrixComp iInit = MatrixComp::Zero(3, 1);
-  // Complex sInit = terminal(0)->singlePower(); // returns zero
+  mSubCtrledCurrentSource =
+      EMT::Ph3::ControlledCurrentSource::make(**mName + "_i", mLogLevel);
+  mSubCtrledCurrentSource->setParameters(**mSrcCtrledCurrent);
+  mSubCtrledCurrentSource->connect({mTerminals[0]->node(), SimNode::GND});
+  addMNASubComponent(mSubCtrledCurrentSource, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
+                     MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
+}
 
-  // iInit(0, 0) = std::conj(sInit / vInit(0, 0) / sqrt(3.));  // rms value
-  // iInit(1, 0) = std::conj(sInit / vInit(1, 0) / sqrt(3.));
-  // iInit(2, 0) = std::conj(sInit / vInit(2, 0) / sqrt(3.));
+void EMT::Ph3::HalfDecouplingLine::initializeParentFromNodesAndTerminals(
+    Real frequency) {
 
-  **mIntfVoltage = vInit.real();
-  **mIntfCurrent = iInit.real();
+  **mIntfVoltage = initialVoltage(0).real();
+  **mIntfCurrent = Matrix::Zero(3, 1);
 
-  // Initialize electrical subcomponents
-  for (auto subcomp : mSubComponents) {
-    subcomp->initialize(mFrequencies);
-    subcomp->initializeFromNodesAndTerminals(frequency);
+  // The sending quantities follow the internal sign convention of
+  // DecouplingLineEMT_Ph3, in which the recorded voltage is the negated
+  // terminal voltage.
+  **mSendingVolt = -(**mIntfVoltage);
+  **mSendingCur = Matrix::Zero(3, 1);
+}
+
+void EMT::Ph3::HalfDecouplingLine::mnaParentInitialize(
+    Real omega, Real timeStep, Attribute<Matrix>::Ptr leftVector) {
+  if (mDelay < timeStep)
+    throw SystemError("Timestep too large for decoupling");
+
+  mBufSize = static_cast<UInt>(ceil(mDelay / timeStep));
+  mAlpha = 1 - (mBufSize - mDelay / timeStep);
+  SPDLOG_LOGGER_INFO(mSLog, "bufsize {} alpha {}", mBufSize, mAlpha);
+
+  // Initialization based on static PI-line model. The far end voltage is read
+  // from the coupling source, which the other half published during its own
+  // initializeParentFromNodesAndTerminals.
+  MatrixComp voltNear = -initialVoltage(0);
+  MatrixComp voltFar = (**mReceivingVolt).cast<Complex>();
+
+  MatrixComp seriesAdmittance =
+      (mResistance + Complex(0, omega) * mInductance).inverse();
+  MatrixComp initAdmittance =
+      seriesAdmittance + Complex(0, omega) * mCapacitance / 2;
+  MatrixComp curNear = initAdmittance * voltNear - seriesAdmittance * voltFar;
+
+  SPDLOG_LOGGER_INFO(mSLog, "initial voltage: v_k {}", voltNear);
+  SPDLOG_LOGGER_INFO(mSLog, "initial current: i_k {}", curNear);
+
+  // Resize ring buffers and initialize
+  mVoltBuf = voltNear.real().transpose().replicate(mBufSize, 1);
+  mCurBuf = curNear.real().transpose().replicate(mBufSize, 1);
+
+  **mSendingVolt = voltNear.real();
+  **mSendingCur = curNear.real();
+}
+
+Matrix EMT::Ph3::HalfDecouplingLine::interpolate(Matrix &data) {
+  // linear interpolation of the nearest values
+  Matrix c1 = data.row(mBufIdx);
+  Matrix c2 = mBufIdx == mBufSize - 1 ? data.row(0) : data.row(mBufIdx + 1);
+  return (mAlpha * c1 + (1 - mAlpha) * c2).transpose();
+}
+
+void EMT::Ph3::HalfDecouplingLine::step(Real time, Int timeStepCount) {
+  Matrix voltNear = **mSendingVolt;
+  Matrix curNear = **mSendingCur;
+  Matrix voltFar = **mReceivingVolt;
+  Matrix curFar = **mReceivingCur;
+
+  Matrix denom =
+      (mSurgeImpedance + mResistance / 4) * (mSurgeImpedance + mResistance / 4);
+
+  if (timeStepCount == 0) {
+    **mSrcCtrledCurrent =
+        curNear - (mSurgeImpedance + mResistance / 4).inverse() * voltNear;
+  } else {
+    **mSrcCtrledCurrent =
+        -mSurgeImpedance * denom.inverse() *
+            (voltFar + (mSurgeImpedance - mResistance / 4) * curFar) -
+        mResistance / 4 * denom.inverse() *
+            (voltNear + (mSurgeImpedance - mResistance / 4) * curNear);
   }
 
-  **mSendingVolt= **mIntfVoltage;
-  **mSendingCur= **mIntfCurrent;
+  mSubCtrledCurrentSource->mCurrentRef->set(**mSrcCtrledCurrent);
+}
 
-  // // Initialization based on static PI-line model
-  // Complex volt1 = mNode1->initialSingleVoltage();
-  // Complex volt2 = mNode2->initialSingleVoltage();
-  // Complex initAdmittance = 1. / Complex(mResistance, omega * mInductance) +
-  //                          Complex(0, omega * mCapacitance / 2);
-  // Complex cur1 = volt1 * initAdmittance -
-  //                volt2 / Complex(mResistance, omega * mInductance);
-  // Complex cur2 = volt2 * initAdmittance -
-  //                volt1 / Complex(mResistance, omega * mInductance);
-  // SPDLOG_LOGGER_INFO(mSLog, "initial voltages: v_k {} v_m {}", volt1, volt2);
-  // SPDLOG_LOGGER_INFO(mSLog, "initial currents: i_km {} i_mk {}", cur1, cur2);
+void EMT::Ph3::HalfDecouplingLine::postStep() {
+  mVoltBuf.row(mBufIdx) = -mSubRes->intfVoltage().transpose();
+  mCurBuf.row(mBufIdx) =
+      -mSubRes->intfCurrent().transpose() + (**mSrcCtrledCurrent).transpose();
 
-  // // Resize ring buffers and initialize
-  // mVoltBuf.resize(mBufSize, volt1.real());
-  // mCurBuf.resize(mBufSize, cur1.real());
+  mBufIdx++;
+  if (mBufIdx == mBufSize)
+    mBufIdx = 0;
+
+  // Publish this end's quantities as of one travel time ago. Doing it here
+  // rather than in the pre-step is what keeps the two halves free of any
+  // same-step dependency on each other, so they can be solved separately.
+  **mSendingVolt = interpolate(mVoltBuf);
+  **mSendingCur = interpolate(mCurBuf);
+}
+
+void EMT::Ph3::HalfDecouplingLine::mnaParentPreStep(Real time,
+                                                    Int timeStepCount) {
+  step(time, timeStepCount);
+  mSubCtrledCurrentSource->mnaPreStep(time, timeStepCount);
+  mnaCompApplyRightSideVectorStamp(**mRightVector);
+}
+
+void EMT::Ph3::HalfDecouplingLine::mnaParentPostStep(
+    Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
+  mnaCompUpdateVoltage(**leftVector);
+  mnaCompUpdateCurrent(**leftVector);
+  postStep();
+}
+
+void EMT::Ph3::HalfDecouplingLine::mnaCompUpdateVoltage(
+    const Matrix &leftVector) {
+  (**mIntfVoltage)(0, 0) =
+      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 0));
+  (**mIntfVoltage)(1, 0) =
+      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 1));
+  (**mIntfVoltage)(2, 0) =
+      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 2));
+}
+
+void EMT::Ph3::HalfDecouplingLine::mnaCompUpdateCurrent(
+    const Matrix &leftVector) {
+  **mIntfCurrent = -mSubRes->intfCurrent() + **mSrcCtrledCurrent;
 }
 
 void EMT::Ph3::HalfDecouplingLine::mnaParentAddPreStepDependencies(
@@ -129,6 +204,8 @@ void EMT::Ph3::HalfDecouplingLine::mnaParentAddPreStepDependencies(
     AttributeBase::List &modifiedAttributes) {
   prevStepDependencies.push_back(mIntfCurrent);
   prevStepDependencies.push_back(mIntfVoltage);
+  prevStepDependencies.push_back(mReceivingVolt);
+  prevStepDependencies.push_back(mReceivingCur);
   modifiedAttributes.push_back(mRightVector);
 }
 
@@ -140,64 +217,6 @@ void EMT::Ph3::HalfDecouplingLine::mnaParentAddPostStepDependencies(
   attributeDependencies.push_back(leftVector);
   modifiedAttributes.push_back(mIntfVoltage);
   modifiedAttributes.push_back(mIntfCurrent);
-}
-
-void EMT::Ph3::HalfDecouplingLine::Step(Real time) { 
-
-  **mSendingVolt= **mIntfVoltage;
-  **mSendingCur= **mIntfCurrent;
-
-  Matrix denom = Matrix::Zero(3,3);
-  
-  denom << (mSurgeImpedance(0,0) + mResistance(0,0) / 4) * (mSurgeImpedance(0,0) + mResistance(0,0) / 4), 0, 0,
-            0, (mSurgeImpedance(1,1) + mResistance(1,1) / 4) * (mSurgeImpedance(1,1) + mResistance(1,1) / 4), 0,
-            0, 0, (mSurgeImpedance(2,2) + mResistance(2,2) / 4) * (mSurgeImpedance(2,2) + mResistance(2,2) / 4);
-
-
-  // Calculate current
-  (**mSrcCtrledCurrent)(0,0) = -mSurgeImpedance(0,0) / denom(0,0) *
-                      ((**mReceivingVolt)(0,0) + (mSurgeImpedance(0,0) - mResistance(0,0) / 4) * (**mReceivingCur)(0,0)) -
-                  mResistance(0,0) / 4 / denom(0,0) *
-                      ((**mSendingVolt)(0,0) + (mSurgeImpedance(0,0) - mResistance(0,0) / 4) * (**mSendingVolt)(0,0));
-                      
-  (**mSrcCtrledCurrent)(1,0) = -mSurgeImpedance(1,1) / denom(1,1) *
-                      ((**mReceivingVolt)(1,0) + (mSurgeImpedance(1,1) - mResistance(1,1) / 4) * (**mReceivingCur)(1,0)) -
-                  mResistance(1,1) / 4 / denom(1,1) *
-                      ((**mSendingVolt)(1,0) + (mSurgeImpedance(1,1) - mResistance(1,1) / 4) * (**mSendingVolt)(1,0));
-                      
-  (**mSrcCtrledCurrent)(2,0) = -mSurgeImpedance(2,2) / denom(2,2) *
-                      ((**mReceivingVolt)(2,0) + (mSurgeImpedance(2,2) - mResistance(2,2) / 4) * (**mReceivingCur)(2,0)) -
-                  mResistance(2,2) / 4 / denom(2,2) *
-                      ((**mSendingVolt)(2,0) + (mSurgeImpedance(2,2) - mResistance(2,2) / 4) * (**mSendingVolt)(2,0));
-
-  mSubCtrledCurrentSource->mCurrentRef->set(**mSrcCtrledCurrent);
-}
-
-void EMT::Ph3::HalfDecouplingLine::mnaParentPreStep(Real time, Int timeStepCount) {
-  // pre-step of composite component
-  Step(time);
-  mnaCompApplyRightSideVectorStamp(**mRightVector);
-}
-
-void EMT::Ph3::HalfDecouplingLine::mnaParentPostStep(
-    Real time, Int timeStepCount, Attribute<Matrix>::Ptr &leftVector) {
-  mnaCompUpdateVoltage(**leftVector);
-  mnaCompUpdateCurrent(**leftVector);
-}
-
-void EMT::Ph3::HalfDecouplingLine::mnaCompUpdateVoltage(
-    const Matrix &leftVector) {
-  SPDLOG_LOGGER_DEBUG(mSLog, "Read voltage from {:d}", matrixNodeIndex(0));
-  (**mIntfVoltage)(0, 0) =
-      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 0));
-  (**mIntfVoltage)(1, 0) =
-      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 1));
-  (**mIntfVoltage)(2, 0) =
-      Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 2));
-}
-
-void EMT::Ph3::HalfDecouplingLine::mnaCompUpdateCurrent(
-    const Matrix &leftVector) {
-  SPDLOG_LOGGER_DEBUG(mSLog, "Read current from {:d}", matrixNodeIndex(0));
-  **mIntfCurrent = **mSubRes->mIntfCurrent + **mSubCtrledCurrentSource->mIntfCurrent;
+  modifiedAttributes.push_back(mSendingVolt);
+  modifiedAttributes.push_back(mSendingCur);
 }

--- a/dpsim-models/src/EMT/EMT_Ph3_HalfDecouplingLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_HalfDecouplingLine.cpp
@@ -12,10 +12,11 @@ using namespace CPS;
 
 EMT::Ph3::HalfDecouplingLine::HalfDecouplingLine(String uid, String name, Logger::Level logLevel)
     :CompositePowerComp<Real>(uid, name, true, true, logLevel),
-      mSrcCtrledCurrent(mAttributes->create<Matrix>("i_src_ctrl")),
+      mSrcCtrledCurrent(mAttributes->create<Matrix>("i_src_ctrl", Matrix::Zero(3, 1))),
+      mSrcRes(mAttributes->create<Matrix>("src_res", Matrix::Zero(3, 3))),
       mReceivingVolt(mAttributes->createDynamic<Matrix>("receiving_volt")),
       mReceivingCur(mAttributes->createDynamic<Matrix>("receiving_cur")),
-      mSendingVoltage(mAttributes->create<Matrix>("sending_volt")),
+      mSendingVolt(mAttributes->create<Matrix>("sending_volt")),
       mSendingCur(mAttributes->create<Matrix>("sending_cur")) {
 
   mSubRes = EMT::Ph3::Resistor::make(**mName + "_r", mLogLevel);
@@ -27,8 +28,9 @@ EMT::Ph3::HalfDecouplingLine::HalfDecouplingLine(String uid, String name, Logger
   // Pre-step of the subcontrolled current source is handled explicitly in mnaParentPreStep
   addMNASubComponent(mSubCtrledCurrentSource, MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT,
                      MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
+  // addMNASubComponent(mSubCtrledCurrentSource, MNA_SUBCOMP_TASK_ORDER::TASK_AFTER_PARENT,
+  //                    MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
   
-  mSrcCtrledCurrent->setReference(mSubCtrledCurrentSource->mCurrentRef);
 
   mPhaseType = PhaseType::ABC;
   setVirtualNodeNumber(0);
@@ -47,16 +49,25 @@ void EMT::Ph3::HalfDecouplingLine::setParameters(
   mResistance = resistance;
   mInductance = inductance;
   mCapacitance = capacitance;
-  mSurgeImpedance = sqrt(inductance(0,0) / capacitance(0,0));
 
-  mDelay = sqrt(inductance(0,0) * capacitance(0,0));
+  mSurgeImpedance << sqrt(inductance(0,0) / capacitance(0,0)), 0, 0,
+                      0, sqrt(inductance(1,1) / capacitance(1,1)), 0,
+                      0, 0, sqrt(inductance(2,2) / capacitance(2,2));
+
+  mDelay << sqrt(inductance(0,0) * capacitance(0,0)), 0, 0,
+            0, sqrt(inductance(1,1) * capacitance(1,1)), 0,
+            0, 0, sqrt(inductance(2,2) * capacitance(2,2));
+
+   **mSrcRes << (mSurgeImpedance(0,0) + mResistance(0,0) / 4), 0, 0,
+                0, (mSurgeImpedance(1,1) + mResistance(1,1) / 4), 0,
+                0, 0, (mSurgeImpedance(2,2) + mResistance(2,2) / 4);
 
   SPDLOG_LOGGER_INFO(mSLog, "surge impedance: {}", mSurgeImpedance);
   SPDLOG_LOGGER_INFO(mSLog, "delay: {}", mDelay);
 
-  mSubCtrledCurrentSource->setParameters(Matrix::Zero(3, 1));
+  mSubCtrledCurrentSource->setParameters(**mSrcCtrledCurrent);
   mSubCtrledCurrentSource->connect({mTerminals[0]->node(), SimNode::GND});
-  mSubRes->setParameters(Math::singlePhaseParameterToThreePhase(mSurgeImpedance + mResistance(0,0) / 4));
+  mSubRes->setParameters(**mSrcRes);
   mSubRes->connect({mTerminals[0]->node(), SimNode::GND});
 
   mParametersSet = true;
@@ -69,6 +80,31 @@ void EMT::Ph3::HalfDecouplingLine::initializeFromNodesAndTerminals(Real frequenc
   // mBufSize = static_cast<UInt>(ceil(mDelay / timeStep));
   // mAlpha = 1 - (mBufSize - mDelay / timeStep);
   // SPDLOG_LOGGER_INFO(mSLog, "bufsize {} alpha {}", mBufSize, mAlpha);
+
+  // Initialization based on static PI-line model
+  MatrixComp vInit = MatrixComp::Zero(3, 1);
+  vInit(0, 0) = initialSingleVoltage(0); // rms value
+  vInit(1, 0) = vInit(0, 0) * SHIFT_TO_PHASE_B;
+  vInit(2, 0) = vInit(0, 0) * SHIFT_TO_PHASE_C;
+
+  MatrixComp iInit = MatrixComp::Zero(3, 1);
+  // Complex sInit = terminal(0)->singlePower(); // returns zero
+
+  // iInit(0, 0) = std::conj(sInit / vInit(0, 0) / sqrt(3.));  // rms value
+  // iInit(1, 0) = std::conj(sInit / vInit(1, 0) / sqrt(3.));
+  // iInit(2, 0) = std::conj(sInit / vInit(2, 0) / sqrt(3.));
+
+  **mIntfVoltage = vInit.real();
+  **mIntfCurrent = iInit.real();
+
+  // Initialize electrical subcomponents
+  for (auto subcomp : mSubComponents) {
+    subcomp->initialize(mFrequencies);
+    subcomp->initializeFromNodesAndTerminals(frequency);
+  }
+
+  **mSendingVolt= **mIntfVoltage;
+  **mSendingCur= **mIntfCurrent;
 
   // // Initialization based on static PI-line model
   // Complex volt1 = mNode1->initialSingleVoltage();
@@ -91,7 +127,9 @@ void EMT::Ph3::HalfDecouplingLine::mnaParentAddPreStepDependencies(
     AttributeBase::List &prevStepDependencies,
     AttributeBase::List &attributeDependencies,
     AttributeBase::List &modifiedAttributes) {
+  prevStepDependencies.push_back(mIntfCurrent);
   prevStepDependencies.push_back(mIntfVoltage);
+  modifiedAttributes.push_back(mRightVector);
 }
 
 void EMT::Ph3::HalfDecouplingLine::mnaParentAddPostStepDependencies(
@@ -101,29 +139,41 @@ void EMT::Ph3::HalfDecouplingLine::mnaParentAddPostStepDependencies(
     Attribute<Matrix>::Ptr &leftVector) {
   attributeDependencies.push_back(leftVector);
   modifiedAttributes.push_back(mIntfVoltage);
+  modifiedAttributes.push_back(mIntfCurrent);
 }
 
-void EMT::Ph3::HalfDecouplingLine::Step(Real time) {
-  // calculate 
+void EMT::Ph3::HalfDecouplingLine::Step(Real time) { 
 
-  // Real denom =
-  //     (mSurgeImpedance + mResistance / 4) * (mSurgeImpedance + mResistance / 4);
+  **mSendingVolt= **mIntfVoltage;
+  **mSendingCur= **mIntfCurrent;
 
-  // // Calculate current
-  // **mSrcCurRef = -mSurgeImpedance / denom *
-  //                     (**mReceivingVolt + (mSurgeImpedance - mResistance / 4) * **mReceivingCur) -
-  //                 mResistance / 4 / denom *
-  //                     (**mSendingVoltage + (mSurgeImpedance - mResistance / 4) * **mSendingVoltage);
+  Matrix denom = Matrix::Zero(3,3);
+  
+  denom << (mSurgeImpedance(0,0) + mResistance(0,0) / 4) * (mSurgeImpedance(0,0) + mResistance(0,0) / 4), 0, 0,
+            0, (mSurgeImpedance(1,1) + mResistance(1,1) / 4) * (mSurgeImpedance(1,1) + mResistance(1,1) / 4), 0,
+            0, 0, (mSurgeImpedance(2,2) + mResistance(2,2) / 4) * (mSurgeImpedance(2,2) + mResistance(2,2) / 4);
+
+
+  // Calculate current
+  (**mSrcCtrledCurrent)(0,0) = -mSurgeImpedance(0,0) / denom(0,0) *
+                      ((**mReceivingVolt)(0,0) + (mSurgeImpedance(0,0) - mResistance(0,0) / 4) * (**mReceivingCur)(0,0)) -
+                  mResistance(0,0) / 4 / denom(0,0) *
+                      ((**mSendingVolt)(0,0) + (mSurgeImpedance(0,0) - mResistance(0,0) / 4) * (**mSendingVolt)(0,0));
+                      
+  (**mSrcCtrledCurrent)(1,0) = -mSurgeImpedance(1,1) / denom(1,1) *
+                      ((**mReceivingVolt)(1,0) + (mSurgeImpedance(1,1) - mResistance(1,1) / 4) * (**mReceivingCur)(1,0)) -
+                  mResistance(1,1) / 4 / denom(1,1) *
+                      ((**mSendingVolt)(1,0) + (mSurgeImpedance(1,1) - mResistance(1,1) / 4) * (**mSendingVolt)(1,0));
+                      
+  (**mSrcCtrledCurrent)(2,0) = -mSurgeImpedance(2,2) / denom(2,2) *
+                      ((**mReceivingVolt)(2,0) + (mSurgeImpedance(2,2) - mResistance(2,2) / 4) * (**mReceivingCur)(2,0)) -
+                  mResistance(2,2) / 4 / denom(2,2) *
+                      ((**mSendingVolt)(2,0) + (mSurgeImpedance(2,2) - mResistance(2,2) / 4) * (**mSendingVolt)(2,0));
+
+  mSubCtrledCurrentSource->mCurrentRef->set(**mSrcCtrledCurrent);
 }
 
 void EMT::Ph3::HalfDecouplingLine::mnaParentPreStep(Real time, Int timeStepCount) {
-  // // Pre-step of the subcontrolled current source is handled explicitly in mnaParentPreStep
-  // addMNASubComponent(mSubCtrledCurrentSource, MNA_SUBCOMP_TASK_ORDER::NO_TASK,
-  //                    MNA_SUBCOMP_TASK_ORDER::TASK_BEFORE_PARENT, true);
-  // // pre-step of subcomponents - controlled source
-  // std::dynamic_pointer_cast<MNAInterface>(mSubCtrledCurrentSource)
-  //     ->mnaPreStep(time, timeStepCount);
-  
   // pre-step of composite component
   Step(time);
   mnaCompApplyRightSideVectorStamp(**mRightVector);

--- a/dpsim/examples/cxx/CIM/EMT_WSCC_9bus_split_decoupledHalfComp.cpp
+++ b/dpsim/examples/cxx/CIM/EMT_WSCC_9bus_split_decoupledHalfComp.cpp
@@ -1,0 +1,134 @@
+/* Copyright 2017-2021 Institute for Automation of Complex Power Systems,
+ *                     EONERC, RWTH Aachen University
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *********************************************************************************/
+
+#include <fstream>
+#include <iostream>
+#include <list>
+
+#include <DPsim.h>
+#include <dpsim/ThreadLevelScheduler.h>
+
+using namespace DPsim;
+using namespace CPS;
+
+void decoupleLine(SystemTopology &sys, const String &lineName, const String &node1, const String node2, String** dLineNames) {
+  auto origLine = sys.component<EMT::Ph3::PiLine>(lineName);
+  Matrix Rline = origLine->attributeTyped<Matrix>("R_series")->get();
+  Matrix Lline = origLine->attributeTyped<Matrix>("L_series")->get();
+  Matrix Cline = origLine->attributeTyped<Matrix>("C_parallel")->get();
+
+  sys.removeComponent(lineName);
+
+  String nameDLineA = "dlineA_" + node1 + "_" + node2;
+  String nameDLineB = "dlineB_" + node2 + "_" + node1;
+
+  // try
+  // {
+  //   if(dLineNames[0] == nullptr || dLineNames[1] == nullptr) throw (std::invalid_argument("dLineNames needs to contain (at least) two writable Strings. Decoupling Line names will not be saved."));
+  //   dLineNames[0]->resize(nameDLineA.size());
+  //   *dLineNames[0] = nameDLineA;
+  //   dLineNames[1]->resize(nameDLineB.size());
+  //   *dLineNames[1] = nameDLineB; 
+  // }
+  // catch(const std::exception& e)
+  // {
+  //   std::cerr << e.what() << '\n';
+  // }
+
+  auto HalfDecouplingLineA = EMT::Ph3::HalfDecouplingLine::make("dlineA_", Logger::Level::debug);
+  auto HalfDecouplingLineB = EMT::Ph3::HalfDecouplingLine::make("dlineB", Logger::Level::debug);
+
+  HalfDecouplingLineA->setParameters(Rline, Lline, Cline,
+                       HalfDecouplingLineB->attributeTyped<Matrix>("sending_volt"),
+                       HalfDecouplingLineB->attributeTyped<Matrix>("sending_cur"));
+  sys.addComponent(HalfDecouplingLineA);
+  HalfDecouplingLineA->connect({CPS::SimNode<Real>::GND, sys.node<CPS::SimNode<Real>>(node1)});
+
+  HalfDecouplingLineB->setParameters(Rline, Lline, Cline,
+                       HalfDecouplingLineA->attributeTyped<Matrix>("sending_volt"),
+                       HalfDecouplingLineA->attributeTyped<Matrix>("sending_cur"));
+  sys.addComponent(HalfDecouplingLineB);
+  HalfDecouplingLineB->connect({CPS::SimNode<Real>::GND, sys.node<CPS::SimNode<Real>>(node2)});
+}
+
+void doSim(String &name, SystemTopology &sys, Int threads) {
+
+  // Logging
+  auto logger = DataLogger::make(name);
+  for (Int bus  = 1; bus <= 9; bus++) {
+    String attrName = "v" + std::to_string(bus);
+    String nodeName = "BUS" + std::to_string(bus);
+    logger->logAttribute(attrName, sys.node<EMT::SimNode>(nodeName)->attribute("v"));
+  }
+
+  Simulation sim(name, Logger::Level::debug);
+  sim.setSystem(sys);
+  sim.setTimeStep(0.0001);
+  sim.setFinalTime(0.5);
+  sim.setDomain(Domain::EMT);
+  sim.doSplitSubnets(true);
+  sim.doInitFromNodesAndTerminals(true);
+  sim.addLogger(logger);
+  if (threads > 0)
+    sim.setScheduler(std::make_shared<OpenMPLevelScheduler>(threads));
+
+  //std::ofstream of1("topology_graph.svg");
+  //sys.topologyGraph().render(of1));
+
+  sim.run();
+  sim.logStepTimes(name + "_step_times");
+}
+
+int main(int argc, char *argv[]) {
+  CommandLineArgs args(argc, argv);
+
+  std::list<fs::path> filenames;
+  filenames = DPsim::Utils::findFiles(
+      {"WSCC-09_DI.xml", "WSCC-09_EQ.xml", "WSCC-09_SV.xml",
+       "WSCC-09_TP.xml"},
+      "build/_deps/cim-data-src/WSCC-09/WSCC-09", "CIMPATH");
+
+  Int numThreads = 0;
+  Int numSeq = 0;
+
+  if (args.options.find("threads") != args.options.end())
+    numThreads = args.getOptionInt("threads");
+  if (args.options.find("seq") != args.options.end())
+    numSeq = args.getOptionInt("seq");
+
+  std::cout << "Simulate with " << numThreads
+            << " threads, sequence number " << numSeq << std::endl;
+
+  // Monolithic Simulation
+  ///TODO: Is this needed? Already done in "EMT_WSCC_9bus_split_decoupled.cpp"
+  String simNameMonolithic = "WSCC-9bus_monolithic_EMT";
+  Logger::setLogDir("logs/" + simNameMonolithic);
+  CIM::Reader readerMonolithic(simNameMonolithic, Logger::Level::debug, Logger::Level::debug);
+  SystemTopology systemMonolithic =
+      readerMonolithic.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
+                     CPS::GeneratorType::IdealVoltageSource);
+
+  doSim(simNameMonolithic, systemMonolithic, 0);
+
+  // Decoupled Simulation
+  String simNameDecoupledHalf = "WSCC_9bus_split_decoupledHalf_EMT_" + std::to_string(numThreads) + "_" + std::to_string(numSeq);
+  Logger::setLogDir("logs/" + simNameDecoupledHalf);
+  CIM::Reader readerDecoupled(simNameDecoupledHalf, Logger::Level::debug, Logger::Level::debug);
+  SystemTopology systemDecoupled = readerDecoupled.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
+                                   CPS::GeneratorType::IdealVoltageSource);
+
+  String* dline_75[2];
+  decoupleLine(systemDecoupled, "LINE75", "BUS5", "BUS7", dline_75);
+  // decouple_line(system, "LINE78", "BUS7", "BUS8");
+  String* dline_64[2];
+  decoupleLine(systemDecoupled, "LINE64", "BUS6", "BUS4", dline_64);
+  String* dline_89[2];
+  decoupleLine(systemDecoupled, "LINE89", "BUS8", "BUS9", dline_89);
+
+  doSim(simNameDecoupledHalf, systemDecoupled, numThreads);
+}

--- a/dpsim/examples/cxx/CIM/EMT_WSCC_9bus_split_decoupledHalfComp.cpp
+++ b/dpsim/examples/cxx/CIM/EMT_WSCC_9bus_split_decoupledHalfComp.cpp
@@ -16,7 +16,8 @@
 using namespace DPsim;
 using namespace CPS;
 
-void decoupleLine(SystemTopology &sys, const String &lineName, const String &node1, const String node2, String** dLineNames) {
+void decoupleLine(SystemTopology &sys, const String &lineName,
+                  const String &node1, const String &node2) {
   auto origLine = sys.component<EMT::Ph3::PiLine>(lineName);
   Matrix Rline = origLine->attributeTyped<Matrix>("R_series")->get();
   Matrix Lline = origLine->attributeTyped<Matrix>("L_series")->get();
@@ -27,43 +28,32 @@ void decoupleLine(SystemTopology &sys, const String &lineName, const String &nod
   String nameDLineA = "dlineA_" + node1 + "_" + node2;
   String nameDLineB = "dlineB_" + node2 + "_" + node1;
 
-  // try
-  // {
-  //   if(dLineNames[0] == nullptr || dLineNames[1] == nullptr) throw (std::invalid_argument("dLineNames needs to contain (at least) two writable Strings. Decoupling Line names will not be saved."));
-  //   dLineNames[0]->resize(nameDLineA.size());
-  //   *dLineNames[0] = nameDLineA;
-  //   dLineNames[1]->resize(nameDLineB.size());
-  //   *dLineNames[1] = nameDLineB; 
-  // }
-  // catch(const std::exception& e)
-  // {
-  //   std::cerr << e.what() << '\n';
-  // }
+  auto halfLineA =
+      EMT::Ph3::HalfDecouplingLine::make(nameDLineA, Logger::Level::debug);
+  auto halfLineB =
+      EMT::Ph3::HalfDecouplingLine::make(nameDLineB, Logger::Level::debug);
 
-  auto HalfDecouplingLineA = EMT::Ph3::HalfDecouplingLine::make(nameDLineA, Logger::Level::debug);
-  auto HalfDecouplingLineB = EMT::Ph3::HalfDecouplingLine::make(nameDLineB, Logger::Level::debug);
+  halfLineA->connect({sys.node<CPS::SimNode<Real>>(node1)});
+  halfLineA->setParameters(Rline, Lline, Cline);
+  halfLineA->setCouplingSource(halfLineB->mSendingVolt, halfLineB->mSendingCur);
 
-  sys.addComponent(HalfDecouplingLineA);
-  HalfDecouplingLineA->connect({CPS::SimNode<Real>::GND, sys.node<CPS::SimNode<Real>>(node1)});
-  HalfDecouplingLineA->setParameters(Rline, Lline, Cline,
-                       HalfDecouplingLineB->attributeTyped<Matrix>("sending_volt"),
-                       HalfDecouplingLineB->attributeTyped<Matrix>("sending_cur"));
+  halfLineB->connect({sys.node<CPS::SimNode<Real>>(node2)});
+  halfLineB->setParameters(Rline, Lline, Cline);
+  halfLineB->setCouplingSource(halfLineA->mSendingVolt, halfLineA->mSendingCur);
 
-  sys.addComponent(HalfDecouplingLineB);
-  HalfDecouplingLineB->connect({CPS::SimNode<Real>::GND, sys.node<CPS::SimNode<Real>>(node2)});
-  HalfDecouplingLineB->setParameters(Rline, Lline, Cline,
-                       HalfDecouplingLineA->attributeTyped<Matrix>("sending_volt"),
-                       HalfDecouplingLineA->attributeTyped<Matrix>("sending_cur"));
+  sys.addComponent(halfLineA);
+  sys.addComponent(halfLineB);
 }
 
 void doSim(String &name, SystemTopology &sys, Int threads) {
 
   // Logging
   auto logger = DataLogger::make(name);
-  for (Int bus  = 1; bus <= 9; bus++) {
+  for (Int bus = 1; bus <= 9; bus++) {
     String attrName = "v" + std::to_string(bus);
     String nodeName = "BUS" + std::to_string(bus);
-    logger->logAttribute(attrName, sys.node<EMT::SimNode>(nodeName)->attribute("v"));
+    logger->logAttribute(attrName,
+                         sys.node<EMT::SimNode>(nodeName)->attribute("v"));
   }
 
   Simulation sim(name, Logger::Level::debug);
@@ -89,8 +79,7 @@ int main(int argc, char *argv[]) {
 
   std::list<fs::path> filenames;
   filenames = DPsim::Utils::findFiles(
-      {"WSCC-09_DI.xml", "WSCC-09_EQ.xml", "WSCC-09_SV.xml",
-       "WSCC-09_TP.xml"},
+      {"WSCC-09_DI.xml", "WSCC-09_EQ.xml", "WSCC-09_SV.xml", "WSCC-09_TP.xml"},
       "build/_deps/cim-data-src/WSCC-09/WSCC-09", "CIMPATH");
 
   Int numThreads = 0;
@@ -101,34 +90,36 @@ int main(int argc, char *argv[]) {
   if (args.options.find("seq") != args.options.end())
     numSeq = args.getOptionInt("seq");
 
-  std::cout << "Simulate with " << numThreads
-            << " threads, sequence number " << numSeq << std::endl;
+  std::cout << "Simulate with " << numThreads << " threads, sequence number "
+            << numSeq << std::endl;
 
   // Monolithic Simulation
   ///TODO: Is this needed? Already done in "EMT_WSCC_9bus_split_decoupled.cpp"
   String simNameMonolithic = "WSCC-9bus_monolithic_EMT";
   Logger::setLogDir("logs/" + simNameMonolithic);
-  CIM::Reader readerMonolithic(simNameMonolithic, Logger::Level::debug, Logger::Level::debug);
+  CIM::Reader readerMonolithic(simNameMonolithic, Logger::Level::debug,
+                               Logger::Level::debug);
   SystemTopology systemMonolithic =
       readerMonolithic.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
-                     CPS::GeneratorType::IdealVoltageSource);
+                               CPS::GeneratorType::IdealVoltageSource);
 
   doSim(simNameMonolithic, systemMonolithic, 0);
 
   // Decoupled Simulation
-  String simNameDecoupledHalf = "WSCC_9bus_split_decoupledHalfComp_EMT_" + std::to_string(numThreads) + "_" + std::to_string(numSeq);
+  String simNameDecoupledHalf = "WSCC_9bus_split_decoupledHalfComp_EMT_" +
+                                std::to_string(numThreads) + "_" +
+                                std::to_string(numSeq);
   Logger::setLogDir("logs/" + simNameDecoupledHalf);
-  CIM::Reader readerDecoupled(simNameDecoupledHalf, Logger::Level::debug, Logger::Level::debug);
-  SystemTopology systemDecoupled = readerDecoupled.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
-                                   CPS::GeneratorType::IdealVoltageSource);
+  CIM::Reader readerDecoupled(simNameDecoupledHalf, Logger::Level::debug,
+                              Logger::Level::debug);
+  SystemTopology systemDecoupled =
+      readerDecoupled.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
+                              CPS::GeneratorType::IdealVoltageSource);
 
-  String* dline_75[2];
-  decoupleLine(systemDecoupled, "LINE75", "BUS7", "BUS5", dline_75);
+  decoupleLine(systemDecoupled, "LINE75", "BUS7", "BUS5");
   // decouple_line(system, "LINE78", "BUS7", "BUS8");
-  String* dline_64[2];
-  decoupleLine(systemDecoupled, "LINE64", "BUS6", "BUS4", dline_64);
-  String* dline_89[2];
-  decoupleLine(systemDecoupled, "LINE89", "BUS8", "BUS9", dline_89);
+  decoupleLine(systemDecoupled, "LINE64", "BUS6", "BUS4");
+  decoupleLine(systemDecoupled, "LINE89", "BUS8", "BUS9");
 
   doSim(simNameDecoupledHalf, systemDecoupled, numThreads);
 }

--- a/dpsim/examples/cxx/CIM/EMT_WSCC_9bus_split_decoupledHalfComp.cpp
+++ b/dpsim/examples/cxx/CIM/EMT_WSCC_9bus_split_decoupledHalfComp.cpp
@@ -42,7 +42,6 @@ void decoupleLine(SystemTopology &sys, const String &lineName,
 
 void doSim(String &name, SystemTopology &sys, Int threads) {
 
-  // Logging
   auto logger = DataLogger::make(name);
   for (Int bus = 1; bus <= 9; bus++) {
     String attrName = "v" + std::to_string(bus);
@@ -61,9 +60,6 @@ void doSim(String &name, SystemTopology &sys, Int threads) {
   sim.addLogger(logger);
   if (threads > 0)
     sim.setScheduler(std::make_shared<OpenMPLevelScheduler>(threads));
-
-  //std::ofstream of1("topology_graph.svg");
-  //sys.topologyGraph().render(of1));
 
   sim.run();
   sim.logStepTimes(name + "_step_times");
@@ -88,7 +84,6 @@ int main(int argc, char *argv[]) {
   std::cout << "Simulate with " << numThreads << " threads, sequence number "
             << numSeq << std::endl;
 
-  // Monolithic Simulation
   ///TODO: Is this needed? Already done in "EMT_WSCC_9bus_split_decoupled.cpp"
   String simNameMonolithic = "WSCC-9bus_monolithic_EMT";
   Logger::setLogDir("logs/" + simNameMonolithic);
@@ -100,7 +95,6 @@ int main(int argc, char *argv[]) {
 
   doSim(simNameMonolithic, systemMonolithic, 0);
 
-  // Decoupled Simulation
   String simNameDecoupledHalf = "WSCC_9bus_split_decoupledHalfComp_EMT_" +
                                 std::to_string(numThreads) + "_" +
                                 std::to_string(numSeq);
@@ -112,7 +106,6 @@ int main(int argc, char *argv[]) {
                               CPS::GeneratorType::IdealVoltageSource);
 
   decoupleLine(systemDecoupled, "LINE75", "BUS7", "BUS5");
-  // decouple_line(system, "LINE78", "BUS7", "BUS8");
   decoupleLine(systemDecoupled, "LINE64", "BUS6", "BUS4");
   decoupleLine(systemDecoupled, "LINE89", "BUS8", "BUS9");
 

--- a/dpsim/examples/cxx/CIM/EMT_WSCC_9bus_split_decoupledHalfComp.cpp
+++ b/dpsim/examples/cxx/CIM/EMT_WSCC_9bus_split_decoupledHalfComp.cpp
@@ -1,10 +1,5 @@
-/* Copyright 2017-2021 Institute for Automation of Complex Power Systems,
- *                     EONERC, RWTH Aachen University
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- *********************************************************************************/
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
 
 #include <fstream>
 #include <iostream>

--- a/dpsim/examples/cxx/CIM/EMT_WSCC_9bus_split_decoupledHalfComp.cpp
+++ b/dpsim/examples/cxx/CIM/EMT_WSCC_9bus_split_decoupledHalfComp.cpp
@@ -40,20 +40,20 @@ void decoupleLine(SystemTopology &sys, const String &lineName, const String &nod
   //   std::cerr << e.what() << '\n';
   // }
 
-  auto HalfDecouplingLineA = EMT::Ph3::HalfDecouplingLine::make("dlineA_", Logger::Level::debug);
-  auto HalfDecouplingLineB = EMT::Ph3::HalfDecouplingLine::make("dlineB", Logger::Level::debug);
+  auto HalfDecouplingLineA = EMT::Ph3::HalfDecouplingLine::make(nameDLineA, Logger::Level::debug);
+  auto HalfDecouplingLineB = EMT::Ph3::HalfDecouplingLine::make(nameDLineB, Logger::Level::debug);
 
+  sys.addComponent(HalfDecouplingLineA);
+  HalfDecouplingLineA->connect({CPS::SimNode<Real>::GND, sys.node<CPS::SimNode<Real>>(node1)});
   HalfDecouplingLineA->setParameters(Rline, Lline, Cline,
                        HalfDecouplingLineB->attributeTyped<Matrix>("sending_volt"),
                        HalfDecouplingLineB->attributeTyped<Matrix>("sending_cur"));
-  sys.addComponent(HalfDecouplingLineA);
-  HalfDecouplingLineA->connect({CPS::SimNode<Real>::GND, sys.node<CPS::SimNode<Real>>(node1)});
 
+  sys.addComponent(HalfDecouplingLineB);
+  HalfDecouplingLineB->connect({CPS::SimNode<Real>::GND, sys.node<CPS::SimNode<Real>>(node2)});
   HalfDecouplingLineB->setParameters(Rline, Lline, Cline,
                        HalfDecouplingLineA->attributeTyped<Matrix>("sending_volt"),
                        HalfDecouplingLineA->attributeTyped<Matrix>("sending_cur"));
-  sys.addComponent(HalfDecouplingLineB);
-  HalfDecouplingLineB->connect({CPS::SimNode<Real>::GND, sys.node<CPS::SimNode<Real>>(node2)});
 }
 
 void doSim(String &name, SystemTopology &sys, Int threads) {
@@ -116,14 +116,14 @@ int main(int argc, char *argv[]) {
   doSim(simNameMonolithic, systemMonolithic, 0);
 
   // Decoupled Simulation
-  String simNameDecoupledHalf = "WSCC_9bus_split_decoupledHalf_EMT_" + std::to_string(numThreads) + "_" + std::to_string(numSeq);
+  String simNameDecoupledHalf = "WSCC_9bus_split_decoupledHalfComp_EMT_" + std::to_string(numThreads) + "_" + std::to_string(numSeq);
   Logger::setLogDir("logs/" + simNameDecoupledHalf);
   CIM::Reader readerDecoupled(simNameDecoupledHalf, Logger::Level::debug, Logger::Level::debug);
   SystemTopology systemDecoupled = readerDecoupled.loadCIM(60, filenames, Domain::EMT, PhaseType::ABC,
                                    CPS::GeneratorType::IdealVoltageSource);
 
   String* dline_75[2];
-  decoupleLine(systemDecoupled, "LINE75", "BUS5", "BUS7", dline_75);
+  decoupleLine(systemDecoupled, "LINE75", "BUS7", "BUS5", dline_75);
   // decouple_line(system, "LINE78", "BUS7", "BUS8");
   String* dline_64[2];
   decoupleLine(systemDecoupled, "LINE64", "BUS6", "BUS4", dline_64);

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -261,6 +261,7 @@ if(WITH_CIM)
 		CIM/DP_WSCC_9bus_split_decoupled.cpp
 		CIM/EMT_WSCC_9bus_split_decoupled.cpp
 		CIM/EMT_WSCC_9bus_split_decoupled_node.cpp
+		CIM/EMT_WSCC_9bus_split_decoupledHalfComp.cpp
 
 		# CIGRE MV examples
 		CIM/PF_CIGRE_MV_withDG.cpp

--- a/dpsim/src/pybind/EMTComponents.cpp
+++ b/dpsim/src/pybind/EMTComponents.cpp
@@ -28,6 +28,8 @@
 using json = nlohmann::json;
 #endif
 
+PYBIND11_DECLARE_HOLDER_TYPE(T, CPS::AttributePointer<T>);
+
 namespace py = pybind11;
 using namespace pybind11::literals;
 
@@ -384,6 +386,19 @@ void addEMTPh3Components(py::module_ mEMTPh3) {
            "parallel_capacitance"_a = zeroMatrix(3),
            "parallel_conductance"_a = zeroMatrix(3))
       .def("connect", &CPS::EMT::Ph3::PiLine::connect);
+
+  py::class_<CPS::EMT::Ph3::HalfDecouplingLine,
+             std::shared_ptr<CPS::EMT::Ph3::HalfDecouplingLine>,
+             CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "HalfDecouplingLine",
+                                           py::multiple_inheritance())
+      .def(py::init<std::string, CPS::Logger::Level>(), "name"_a,
+           "loglevel"_a = CPS::Logger::Level::off)
+      .def("set_parameters", &CPS::EMT::Ph3::HalfDecouplingLine::setParameters,
+           "resistance"_a, "inductance"_a, "capacitance"_a)
+      .def("set_coupling_source",
+           &CPS::EMT::Ph3::HalfDecouplingLine::setCouplingSource,
+           "receiving_volt"_a, "receiving_cur"_a)
+      .def("connect", &CPS::EMT::Ph3::HalfDecouplingLine::connect);
 
   py::class_<CPS::EMT::Ph3::RXLoad, std::shared_ptr<CPS::EMT::Ph3::RXLoad>,
              CPS::SimPowerComp<CPS::Real>>(mEMTPh3, "RXLoad",


### PR DESCRIPTION
Adds EMT::Ph3::HalfDecouplingLine, one end of a Bergeron line, so the two ends can sit in different systems or different simulators. Each half only reads far-end values one travel time old, so there is no same-step dependency. Builds on Ghassen's commits.

Two halves match DecouplingLineEMT_Ph3 to five significant figures on the 9-bus example, 0.017% worst RMS versus monolithic. The Interface wiring across simulators is not in here.