### PR TITLE
fix(solver): account for inverter and SST injections at PV and slack buses

### DIFF
--- a/.github/workflows/build_test_linux_fedora.yaml
+++ b/.github/workflows/build_test_linux_fedora.yaml
@@ -241,6 +241,9 @@ jobs:
     - name: Run Binaries 4/4
       run: ./build/dpsim/examples/cxx/EMT_WSCC_9bus_split_decoupled
 
+    - name: Check the power flow accounting of an inverter injection
+      run: ./build/dpsim/examples/cxx/PF_Inverter_Injection
+
   cpp-check:
     name: Scan Sourcecode with Cppcheck
     runs-on: ubuntu-latest

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -24,6 +24,7 @@ set(CIRCUIT_SOURCES
 
 	# Powerflow examples
 	Circuits/PF_Slack_PiLine_PQLoad.cpp
+	Circuits/PF_Inverter_Injection.cpp
 
 	# EMT examples
 	Circuits/EMT_CS_RL1.cpp

--- a/dpsim/examples/cxx/Circuits/PF_Inverter_Injection.cpp
+++ b/dpsim/examples/cxx/Circuits/PF_Inverter_Injection.cpp
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <cmath>
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS;
+
+namespace {
+
+const String simName = "PF_Inverter_Injection";
+
+const Real nominalVoltage = 20e3;
+const Real ratedApparentPower = 10e6;
+const Real loadActivePower = 1e6;
+const Real loadReactivePower = 0.5e6;
+const Real generatorActivePower = 2e6;
+const Real inverterSetPointActivePower = 1.5e6;
+const Real inverterSetPointReactivePower = 0.3e6;
+
+enum class InverterPosition { None, SlackBus, GeneratorBus, LoadBus };
+
+struct Solution {
+  Real slackActivePower = 0;
+  Real slackReactivePower = 0;
+  Real generatorReactivePower = 0;
+  Real loadBusVoltage = 0;
+};
+
+Solution solve(const String &caseName, InverterPosition position,
+               Real inverterActivePower, Real inverterReactivePower) {
+  Logger::setLogDir("logs/" + caseName);
+
+  auto slackNode = SimNode<Complex>::make("n1", PhaseType::Single);
+  auto generatorNode = SimNode<Complex>::make("n2", PhaseType::Single);
+  auto loadNode = SimNode<Complex>::make("n3", PhaseType::Single);
+
+  auto slack = SP::Ph1::NetworkInjection::make("Slack", Logger::Level::off);
+  slack->setParameters(nominalVoltage);
+  slack->setBaseVoltage(nominalVoltage);
+  slack->modifyPowerFlowBusType(PowerflowBusType::VD);
+  slack->connect({slackNode});
+
+  auto lineToGenerator =
+      SP::Ph1::PiLine::make("PiLine_n1_n2", Logger::Level::off);
+  lineToGenerator->setParameters(0.05, 0.1, 0);
+  lineToGenerator->setBaseVoltage(nominalVoltage);
+  lineToGenerator->connect({slackNode, generatorNode});
+
+  auto lineToLoad = SP::Ph1::PiLine::make("PiLine_n2_n3", Logger::Level::off);
+  lineToLoad->setParameters(0.05, 0.1, 0);
+  lineToLoad->setBaseVoltage(nominalVoltage);
+  lineToLoad->connect({generatorNode, loadNode});
+
+  auto generator = SP::Ph1::SynchronGenerator::make("Gen", Logger::Level::off);
+  generator->setParameters(ratedApparentPower, nominalVoltage,
+                           generatorActivePower, nominalVoltage,
+                           PowerflowBusType::PV);
+  generator->setBaseVoltage(nominalVoltage);
+  generator->modifyPowerFlowBusType(PowerflowBusType::PV);
+  generator->connect({generatorNode});
+
+  auto load = SP::Ph1::Load::make("Load", Logger::Level::off);
+  load->setParameters(loadActivePower, loadReactivePower, nominalVoltage);
+  load->modifyPowerFlowBusType(PowerflowBusType::PQ);
+  load->connect({loadNode});
+
+  SystemComponentList components{slack, lineToGenerator, lineToLoad, generator,
+                                 load};
+
+  auto inverter = SP::Ph1::AvVoltageSourceInverterDQ::make(
+      "Inverter", "Inverter", Logger::Level::off, false);
+  inverter->setParameters(2 * PI * 50, nominalVoltage, inverterActivePower,
+                          inverterReactivePower);
+
+  if (position != InverterPosition::None) {
+    if (position == InverterPosition::SlackBus)
+      inverter->connect({slackNode});
+    else if (position == InverterPosition::GeneratorBus)
+      inverter->connect({generatorNode});
+    else
+      inverter->connect({loadNode});
+    components.push_back(inverter);
+  }
+
+  auto system =
+      SystemTopology(50, SystemNodeList{slackNode, generatorNode, loadNode},
+                     SystemComponentList{components});
+
+  Simulation simulation(caseName, Logger::Level::off);
+  simulation.setSystem(system);
+  simulation.setTimeStep(1.0);
+  simulation.setFinalTime(1.0);
+  simulation.setDomain(Domain::SP);
+  simulation.setSolverType(Solver::Type::NRP);
+  simulation.setSolverAndComponentBehaviour(Solver::Behaviour::Initialization);
+  simulation.doInitFromNodesAndTerminals(false);
+  simulation.run();
+
+  Solution solution;
+  solution.slackActivePower = **slack->mActivePowerInjection;
+  solution.slackReactivePower = **slack->mReactivePowerInjection;
+  solution.generatorReactivePower = **generator->mSetPointReactivePower;
+  solution.loadBusVoltage = std::abs(loadNode->singleVoltage());
+  return solution;
+}
+
+} // namespace
+
+int main() {
+  Logger::setLogDir("logs/" + simName);
+  auto log = Logger::get(simName, Logger::Level::info, Logger::Level::info);
+
+  Bool passed = true;
+  const auto fail = [&passed, &log](const String &message) {
+    log->error(message);
+    passed = false;
+  };
+
+  const Solution without =
+      solve(simName + "_NoInverter", InverterPosition::None, 0.0, 0.0);
+  const Solution atSlack =
+      solve(simName + "_AtSlackBus", InverterPosition::SlackBus,
+            inverterSetPointActivePower, inverterSetPointReactivePower);
+  const Solution atGenerator =
+      solve(simName + "_AtGeneratorBus", InverterPosition::GeneratorBus, 0.0,
+            inverterSetPointReactivePower);
+  const Solution atLoad =
+      solve(simName + "_AtLoadBus", InverterPosition::LoadBus,
+            inverterSetPointActivePower, inverterSetPointReactivePower);
+
+  log->info("slack power: no inverter {:.3f} W {:.3f} VAr, inverter on the "
+            "slack bus {:.3f} W {:.3f} VAr",
+            without.slackActivePower, without.slackReactivePower,
+            atSlack.slackActivePower, atSlack.slackReactivePower);
+  log->info("generator reactive power: no inverter {:.3f} VAr, reactive "
+            "inverter on the generator bus {:.3f} VAr",
+            without.generatorReactivePower, atGenerator.generatorReactivePower);
+
+  const Real powerTolerance = 1e-6 * ratedApparentPower;
+  const Real voltageTolerance = 1e-6 * nominalVoltage;
+
+  if (std::abs(atSlack.loadBusVoltage - without.loadBusVoltage) >
+      voltageTolerance)
+    fail("An inverter on the slack bus must not move the solved voltages, so "
+         "the reported slack power is the only thing left to compare.");
+
+  if (std::abs(atSlack.slackActivePower - without.slackActivePower +
+               inverterSetPointActivePower) > powerTolerance)
+    fail("An inverter on the slack bus must reduce the reported slack active "
+         "power by its active power set point.");
+
+  if (std::abs(atSlack.slackReactivePower - without.slackReactivePower +
+               inverterSetPointReactivePower) > powerTolerance)
+    fail("An inverter on the slack bus must reduce the reported slack reactive "
+         "power by its reactive power set point.");
+
+  if (std::abs(atGenerator.loadBusVoltage - without.loadBusVoltage) >
+      voltageTolerance)
+    fail("A purely reactive inverter on a voltage controlled bus must not move "
+         "the solved voltages, so the reported generator power is the only "
+         "thing left to compare.");
+
+  if (std::abs(atGenerator.generatorReactivePower -
+               without.generatorReactivePower + inverterSetPointReactivePower) >
+      powerTolerance)
+    fail("An inverter on a generator bus must reduce the reactive power "
+         "credited to the generator by its reactive power set point.");
+
+  if (std::abs(atLoad.loadBusVoltage - without.loadBusVoltage) <
+      voltageTolerance)
+    fail("An inverter on a load bus must change the solved voltage, so the "
+         "comparison against the other positions is void.");
+
+  if (!passed) {
+    log->error("Inverter injection check failed.");
+    return 1;
+  }
+
+  log->info("Inverter injection check passed.");
+  return 0;
+}

--- a/dpsim/include/dpsim/PFSolverPowerPolar.h
+++ b/dpsim/include/dpsim/PFSolverPowerPolar.h
@@ -71,8 +71,8 @@ protected:
   void calculateQAtPVBuses();
   /// Generator reactive-power injection at a bus [pu], used by the Q-limit check
   CPS::Real generatorReactivePowerPerUnit(CPS::TopologicalNode::Ptr node);
-  /// Complex power [pu] injected at a bus by the components that do not regulate it
-  CPS::Complex nonRegulatingPowerPerUnit(CPS::TopologicalNode::Ptr node);
+  /// Scheduled complex power [pu] injected at a bus by the components that do not regulate it
+  CPS::Complex scheduledPowerPerUnit(CPS::TopologicalNode::Ptr node);
   /// Q-limit PV<->PQ switching pass (overrides the base no-op)
   CPS::Bool enforceReactiveLimits() override;
   /// Clear the Q-limit conversion bookkeeping between solves

--- a/dpsim/include/dpsim/PFSolverPowerPolar.h
+++ b/dpsim/include/dpsim/PFSolverPowerPolar.h
@@ -71,8 +71,8 @@ protected:
   void calculateQAtPVBuses();
   /// Generator reactive-power injection at a bus [pu], used by the Q-limit check
   CPS::Real generatorReactivePowerPerUnit(CPS::TopologicalNode::Ptr node);
-  /// Total local load reactive power at a bus [pu]
-  CPS::Real loadReactivePowerPerUnit(CPS::TopologicalNode::Ptr node);
+  /// Complex power [pu] injected at a bus by the components that do not regulate it
+  CPS::Complex nonRegulatingPowerPerUnit(CPS::TopologicalNode::Ptr node);
   /// Q-limit PV<->PQ switching pass (overrides the base no-op)
   CPS::Bool enforceReactiveLimits() override;
   /// Clear the Q-limit conversion bookkeeping between solves

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -71,7 +71,7 @@ void PFSolverPowerPolar::generateInitialSolution(Real time,
       sol_D(idx) = 0.0;
     }
 
-    CPS::Complex nonRegulating = nonRegulatingPowerPerUnit(pq);
+    CPS::Complex nonRegulating = scheduledPowerPerUnit(pq);
     sol_P(idx) += nonRegulating.real();
     sol_Q(idx) += nonRegulating.imag();
 
@@ -99,7 +99,7 @@ void PFSolverPowerPolar::generateInitialSolution(Real time,
       sol_V(idx) = 1.0;
     }
 
-    CPS::Complex nonRegulating = nonRegulatingPowerPerUnit(pv);
+    CPS::Complex nonRegulating = scheduledPowerPerUnit(pv);
     sol_P(idx) += nonRegulating.real();
     sol_Q(idx) += nonRegulating.imag();
 
@@ -130,7 +130,7 @@ void PFSolverPowerPolar::generateInitialSolution(Real time,
     sol_D(idx) = 0.0;
     sol_V(idx) = 1.0;
 
-    CPS::Complex nonRegulating = nonRegulatingPowerPerUnit(vd);
+    CPS::Complex nonRegulating = scheduledPowerPerUnit(vd);
     sol_P(idx) += nonRegulating.real();
     sol_Q(idx) += nonRegulating.imag();
 
@@ -443,7 +443,7 @@ void PFSolverPowerPolar::calculatePAndQAtSlackBus() {
     CPS::Complex S = sol_Vcx(node_idx) * conj(I);
 
     // Generator/source power: S_gen = S_inj - S_nonregulating
-    CPS::Complex Sgen = S - nonRegulatingPowerPerUnit(topoNode);
+    CPS::Complex Sgen = S - scheduledPowerPerUnit(topoNode);
 
     // Update connected VD source/generator with actual generated power
     for (auto comp : mSystem.mComponentsAtNode[topoNode]) {
@@ -478,7 +478,7 @@ void PFSolverPowerPolar::calculateQAtPVBuses() {
     CPS::Complex S = sol_Vcx(node_idx) * conj(I);
 
     // Generator power: S_gen = S_inj - S_nonregulating
-    CPS::Complex Sgen = S - nonRegulatingPowerPerUnit(topoNode);
+    CPS::Complex Sgen = S - scheduledPowerPerUnit(topoNode);
 
     // Update PV generator with actual generator Q
     for (auto comp : mSystem.mComponentsAtNode[topoNode]) {
@@ -496,7 +496,7 @@ void PFSolverPowerPolar::calculateQAtPVBuses() {
 }
 
 CPS::Complex
-PFSolverPowerPolar::nonRegulatingPowerPerUnit(CPS::TopologicalNode::Ptr node) {
+PFSolverPowerPolar::scheduledPowerPerUnit(CPS::TopologicalNode::Ptr node) {
   CPS::Complex power(0.0, 0.0);
   for (auto comp : mSystem.mComponentsAtNode[node]) {
     if (auto load = std::dynamic_pointer_cast<CPS::SP::Ph1::Load>(comp)) {
@@ -523,7 +523,7 @@ CPS::Real PFSolverPowerPolar::generatorReactivePowerPerUnit(
     I += mY.coeff(k, j) * sol_Vcx(j);
   // Net nodal injection S = generator + non-regulating; remove the latter.
   CPS::Complex S = sol_Vcx(k) * conj(I);
-  return S.imag() - nonRegulatingPowerPerUnit(node).imag();
+  return S.imag() - scheduledPowerPerUnit(node).imag();
 }
 
 CPS::Bool PFSolverPowerPolar::enforceReactiveLimits() {
@@ -599,7 +599,7 @@ CPS::Bool PFSolverPowerPolar::enforceReactiveLimits() {
                    mPVBuses.end());
     mPQBuses.push_back(node);
     UInt idx = node->matrixNodeIndex();
-    Qesp(idx) = qLimPU + nonRegulatingPowerPerUnit(node).imag();
+    Qesp(idx) = qLimPU + scheduledPowerPerUnit(node).imag();
     sol_Q(idx) = Qesp(idx);
     mQLimitConvertedAtMax[node] = atMax;
     if (++mQLimitSwitchCount[node] >= mMaxQLimitSwitchesPerBus)

--- a/dpsim/src/PFSolverPowerPolar.cpp
+++ b/dpsim/src/PFSolverPowerPolar.cpp
@@ -71,23 +71,13 @@ void PFSolverPowerPolar::generateInitialSolution(Real time,
       sol_D(idx) = 0.0;
     }
 
+    CPS::Complex nonRegulating = nonRegulatingPowerPerUnit(pq);
+    sol_P(idx) += nonRegulating.real();
+    sol_Q(idx) += nonRegulating.imag();
+
     for (auto comp : mSystem.mComponentsAtNode[pq]) {
-      if (auto load = std::dynamic_pointer_cast<CPS::SP::Ph1::Load>(comp)) {
-        sol_P(idx) -= load->attributeTyped<CPS::Real>("P_pu")->get();
-        sol_Q(idx) -= load->attributeTyped<CPS::Real>("Q_pu")->get();
-      } else if (auto sst = std::dynamic_pointer_cast<
-                     CPS::SP::Ph1::SolidStateTransformer>(comp)) {
-        sol_P(idx) -= sst->getNodalInjection(pq).real();
-        sol_Q(idx) -= sst->getNodalInjection(pq).imag();
-      } else if (auto vsi = std::dynamic_pointer_cast<
-                     CPS::SP::Ph1::AvVoltageSourceInverterDQ>(comp)) {
-        sol_P(idx) +=
-            vsi->attributeTyped<CPS::Real>("P_ref")->get() / mBaseApparentPower;
-        sol_Q(idx) +=
-            vsi->attributeTyped<CPS::Real>("Q_ref")->get() / mBaseApparentPower;
-      } else if (auto gen =
-                     std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(
-                         comp)) {
+      if (auto gen = std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(
+              comp)) {
         sol_P(idx) += gen->attributeTyped<CPS::Real>("P_set_pu")->get();
         sol_Q(idx) += gen->attributeTyped<CPS::Real>("Q_set_pu")->get();
       }
@@ -109,19 +99,15 @@ void PFSolverPowerPolar::generateInitialSolution(Real time,
       sol_V(idx) = 1.0;
     }
 
+    CPS::Complex nonRegulating = nonRegulatingPowerPerUnit(pv);
+    sol_P(idx) += nonRegulating.real();
+    sol_Q(idx) += nonRegulating.imag();
+
     for (auto comp : mSystem.mComponentsAtNode[pv]) {
       if (auto gen = std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(
               comp)) {
         sol_P(idx) += gen->attributeTyped<CPS::Real>("P_set_pu")->get();
         sol_V(idx) = gen->attributeTyped<CPS::Real>("V_set_pu")->get();
-      } else if (auto load =
-                     std::dynamic_pointer_cast<CPS::SP::Ph1::Load>(comp)) {
-        sol_P(idx) -= load->attributeTyped<CPS::Real>("P_pu")->get();
-        sol_Q(idx) -= load->attributeTyped<CPS::Real>("Q_pu")->get();
-      } else if (auto vsi = std::dynamic_pointer_cast<
-                     CPS::SP::Ph1::AvVoltageSourceInverterDQ>(comp)) {
-        sol_P(idx) +=
-            vsi->attributeTyped<CPS::Real>("P_ref")->get() / mBaseApparentPower;
       } else if (auto extnet =
                      std::dynamic_pointer_cast<CPS::SP::Ph1::NetworkInjection>(
                          comp)) {
@@ -144,14 +130,14 @@ void PFSolverPowerPolar::generateInitialSolution(Real time,
     sol_D(idx) = 0.0;
     sol_V(idx) = 1.0;
 
+    CPS::Complex nonRegulating = nonRegulatingPowerPerUnit(vd);
+    sol_P(idx) += nonRegulating.real();
+    sol_Q(idx) += nonRegulating.imag();
+
     for (auto comp : mSystem.mComponentsAtNode[vd]) {
       if (auto extnet =
               std::dynamic_pointer_cast<CPS::SP::Ph1::NetworkInjection>(comp)) {
         sol_V(idx) = extnet->attributeTyped<CPS::Real>("V_set_pu")->get();
-      } else if (auto load =
-                     std::dynamic_pointer_cast<CPS::SP::Ph1::Load>(comp)) {
-        sol_P(idx) -= load->attributeTyped<CPS::Real>("P_pu")->get();
-        sol_Q(idx) -= load->attributeTyped<CPS::Real>("Q_pu")->get();
       } else if (auto gen =
                      std::dynamic_pointer_cast<CPS::SP::Ph1::SynchronGenerator>(
                          comp)) {
@@ -456,14 +442,8 @@ void PFSolverPowerPolar::calculatePAndQAtSlackBus() {
 
     CPS::Complex S = sol_Vcx(node_idx) * conj(I);
 
-    // Generator/source power: S_gen = S_inj + S_load
-    CPS::Complex Sgen = S;
-    for (auto comp : mSystem.mComponentsAtNode[topoNode]) {
-      if (auto loadPtr = std::dynamic_pointer_cast<CPS::SP::Ph1::Load>(comp)) {
-        Sgen += CPS::Complex(**(loadPtr->mActivePowerPerUnit),
-                             **(loadPtr->mReactivePowerPerUnit));
-      }
-    }
+    // Generator/source power: S_gen = S_inj - S_nonregulating
+    CPS::Complex Sgen = S - nonRegulatingPowerPerUnit(topoNode);
 
     // Update connected VD source/generator with actual generated power
     for (auto comp : mSystem.mComponentsAtNode[topoNode]) {
@@ -497,14 +477,8 @@ void PFSolverPowerPolar::calculateQAtPVBuses() {
 
     CPS::Complex S = sol_Vcx(node_idx) * conj(I);
 
-    // Generator power: S_gen = S_inj + S_load
-    CPS::Complex Sgen = S;
-    for (auto comp : mSystem.mComponentsAtNode[topoNode]) {
-      if (auto loadPtr = std::dynamic_pointer_cast<CPS::SP::Ph1::Load>(comp)) {
-        Sgen += CPS::Complex(**(loadPtr->mActivePowerPerUnit),
-                             **(loadPtr->mReactivePowerPerUnit));
-      }
-    }
+    // Generator power: S_gen = S_inj - S_nonregulating
+    CPS::Complex Sgen = S - nonRegulatingPowerPerUnit(topoNode);
 
     // Update PV generator with actual generator Q
     for (auto comp : mSystem.mComponentsAtNode[topoNode]) {
@@ -521,13 +495,24 @@ void PFSolverPowerPolar::calculateQAtPVBuses() {
   }
 }
 
-CPS::Real
-PFSolverPowerPolar::loadReactivePowerPerUnit(CPS::TopologicalNode::Ptr node) {
-  CPS::Real q = 0.0;
-  for (auto comp : mSystem.mComponentsAtNode[node])
-    if (auto load = std::dynamic_pointer_cast<CPS::SP::Ph1::Load>(comp))
-      q += load->attributeTyped<CPS::Real>("Q_pu")->get();
-  return q;
+CPS::Complex
+PFSolverPowerPolar::nonRegulatingPowerPerUnit(CPS::TopologicalNode::Ptr node) {
+  CPS::Complex power(0.0, 0.0);
+  for (auto comp : mSystem.mComponentsAtNode[node]) {
+    if (auto load = std::dynamic_pointer_cast<CPS::SP::Ph1::Load>(comp)) {
+      power -= CPS::Complex(**(load->mActivePowerPerUnit),
+                            **(load->mReactivePowerPerUnit));
+    } else if (auto sst = std::dynamic_pointer_cast<
+                   CPS::SP::Ph1::SolidStateTransformer>(comp)) {
+      power -= sst->getNodalInjection(node);
+    } else if (auto vsi = std::dynamic_pointer_cast<
+                   CPS::SP::Ph1::AvVoltageSourceInverterDQ>(comp)) {
+      power += CPS::Complex(vsi->attributeTyped<CPS::Real>("P_ref")->get(),
+                            vsi->attributeTyped<CPS::Real>("Q_ref")->get()) /
+               mBaseApparentPower;
+    }
+  }
+  return power;
 }
 
 CPS::Real PFSolverPowerPolar::generatorReactivePowerPerUnit(
@@ -536,9 +521,9 @@ CPS::Real PFSolverPowerPolar::generatorReactivePowerPerUnit(
   CPS::Complex I(0.0, 0.0);
   for (UInt j = 0; j < mSystem.mNodes.size(); ++j)
     I += mY.coeff(k, j) * sol_Vcx(j);
-  // Net nodal injection S = generator - load; add load back for generator Q.
+  // Net nodal injection S = generator + non-regulating; remove the latter.
   CPS::Complex S = sol_Vcx(k) * conj(I);
-  return S.imag() + loadReactivePowerPerUnit(node);
+  return S.imag() - nonRegulatingPowerPerUnit(node).imag();
 }
 
 CPS::Bool PFSolverPowerPolar::enforceReactiveLimits() {
@@ -614,7 +599,7 @@ CPS::Bool PFSolverPowerPolar::enforceReactiveLimits() {
                    mPVBuses.end());
     mPQBuses.push_back(node);
     UInt idx = node->matrixNodeIndex();
-    Qesp(idx) = qLimPU - loadReactivePowerPerUnit(node);
+    Qesp(idx) = qLimPU + nonRegulatingPowerPerUnit(node).imag();
     sol_Q(idx) = Qesp(idx);
     mQLimitConvertedAtMax[node] = atMax;
     if (++mQLimitSwitchCount[node] >= mMaxQLimitSwitchesPerBus)


### PR DESCRIPTION
An inverter or solid state transformer on a slack or PV bus was silently worth zero, since the reported slack and generator power came from the nodal injection plus local loads only.

Adds scheduledPowerPerUnit, the power injected at a node by everything that does not regulate it. CIGRE MV with DG is byte-identical and the matpower sweep unchanged.

Overlaps #643 in two lines, so whichever lands second needs a trivial fix.