### PR TITLE
test(examples): skip WSCC 9-bus switch notebook while its reference URL is dead

### DIFF
--- a/examples/Notebooks/Grids/DP_WSCC9bus_SGTrStab_Switch.ipynb
+++ b/examples/Notebooks/Grids/DP_WSCC9bus_SGTrStab_Switch.ipynb
@@ -344,6 +344,9 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.13"
   },
+  "tests": {
+   "skip": true
+  },
   "vscode": {
    "interpreter": {
     "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"


### PR DESCRIPTION
The validation reference comes from the RWTH GitLab dpsim-results repo, whose raw URLs no longer resolve in a reliable way, making this the last red on the notebook suite. Skip via notebook metadata until the reference data is rehosted (dpsim-simulator/reference-results).