### PR TITLE
fix(models): reject zero series impedance instead of stamping NaN

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -52,7 +52,9 @@
 /dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGenerator6bOrderVBR.h @martinmoraga
 /dpsim-models/include/dpsim-models/SP/SP_Ph1_SynchronGeneratorTrStab.h @gnakti
 /dpsim-models/include/dpsim-models/SP/SP_Ph1_varResSwitch.h @gnakti
+/dpsim-models/include/dpsim-models/ParameterCheck.h @leonardocarreras
 /dpsim-models/src/Base/Base_ReducedOrderSynchronGenerator.cpp @martinmoraga
+/dpsim-models/src/ParameterCheck.cpp @leonardocarreras
 /dpsim-models/src/CIM/Reader.cpp @gnakti
 /dpsim-models/src/DP/DP_Ph1_SynchronGenerator3OrderVBR.cpp @martinmoraga
 /dpsim-models/src/DP/DP_Ph1_SynchronGenerator4OrderVBR.cpp @martinmoraga

--- a/docs/hugo/content/en/docs/Developer Guide/Writing a Model/parameter-validation.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Writing a Model/parameter-validation.md
@@ -1,0 +1,96 @@
+---
+title: "Parameter Validation"
+linkTitle: "Parameter Validation"
+date: 2026-08-07
+description: >
+  Declaring the constraints a component's parameters must satisfy, so bad data fails with a name instead of a NaN.
+weight: 10
+---
+
+A component that stamps `1/R` or `M.inverse()` produces `inf` or `NaN` when the parameter is zero.
+Nothing in the solver rejects that value: it enters the system matrix, the factorization propagates
+it to every node, and the simulation finishes with a result that is entirely `NaN` and no error
+message. The originating component is not recoverable from the output.
+
+`ParameterCheck` moves the rejection to a single point during initialization, where the component
+that owns the bad value is still known.
+
+## Declaring constraints
+
+Override `validateParameters` and name the constraints each parameter has to satisfy:
+
+```cpp
+void EMT::Ph3::PiLine::validateParameters(ParameterCheck &check) {
+  check(mSeriesRes, {Constraint::Finite, Constraint::Invertible});
+  check(mSeriesInd, {Constraint::Finite, Constraint::Invertible});
+  check(mParallelCap, {Constraint::Finite});
+  check(mParallelCond, {Constraint::Finite});
+}
+```
+
+The parameter name in the error message is resolved from the component's own attribute map, so it
+always matches the attribute the model registered and cannot drift out of sync with a hand-written
+string.
+
+Constraints that relate two parameters have no enum form. Use `require` for those:
+
+```cpp
+check.require(**mSeriesRes != 0. || **mSeriesInd != 0., "series impedance is zero");
+```
+
+## Available constraints
+
+| Constraint | Scalar | Matrix |
+| --- | --- | --- |
+| `Finite` | no `inf` or `NaN` | no `inf` or `NaN` in any entry |
+| `NonNegative` | `>= 0` | every entry `>= 0` |
+| `Positive` | `> DOUBLE_EPSILON` | every entry `> DOUBLE_EPSILON` |
+| `NonZero` | magnitude above `DOUBLE_EPSILON` | not the zero matrix |
+| `DiagonalPositive` | same as `Positive` | square, every diagonal entry `> DOUBLE_EPSILON` |
+| `Invertible` | same as `NonZero` | square, full rank |
+
+A non-finite value fails every constraint, not only `Finite`.
+
+`NonNegative`, `Positive` and `DiagonalPositive` have no meaning for a complex parameter. Applying
+them to one is reported as a violation describing the mismatch, rather than passing silently.
+
+## Choosing between Positive and Invertible for a matrix
+
+`Positive` on a matrix is elementwise, and three-phase parameters built by
+`Math::singlePhaseParameterToThreePhase` carry values on the diagonal only. Every off-diagonal entry
+is a legitimate zero, so `Positive` rejects them all. A matrix with mutual coupling can also carry
+negative off-diagonal terms.
+
+Use `Invertible` where the model inverts the matrix, which is what the stamp actually requires, and
+`DiagonalPositive` where only the self terms are constrained. `Invertible` is decided by the rank of
+a full-pivoting LU decomposition, whose threshold is relative to the largest pivot, so it does not
+reject a well-conditioned matrix merely because its entries are small.
+
+## When the check runs
+
+`Simulation::initialize` calls `SystemTopology::checkParameters`, which visits every component
+before any solver is created. Violations from the whole topology are collected and reported together
+in one `std::invalid_argument`, so a grid with several bad components is diagnosed in a single run
+rather than one exception at a time:
+
+```
+invalid component parameters (2 violations):
+  line1.R_series: must be square and invertible
+  line4.L_series: must be square and invertible
+```
+
+## Constraints that depend on the solver
+
+Some parameters are valid for one solver and not another. A power flow line with zero series
+inductance is well defined, because the model builds an admittance from `R + jX` and never
+discretizes the inductor; the same line in an MNA simulation creates an inductor subcomponent whose
+stamp divides by that inductance.
+
+`validateParameters` is not told which solver will consume the component, so a constraint may only
+express what holds for every solver the component supports. Where the two differ, declare the weaker
+constraint.
+
+Only the `SP::Ph1` models are affected, because the power flow solver handles no other domain. The
+DP and EMT lines have no power flow path and constrain their series inductance strictly. Before
+weakening a constraint for this reason, check whether the component can actually reach the power
+flow solver at all.

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
@@ -52,6 +52,7 @@ public:
   // #### General ####
   /// Constructs and registers MNA subcomponents; idempotent.
   void createSubComponents() override;
+  void validateParameters(ParameterCheck &check) override;
   /// Derives values from power flow data and pushes them to subcomponents
   void initializeParentFromNodesAndTerminals(Real frequency) override;
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
@@ -42,6 +42,7 @@ public:
   // #### General ####
   /// Constructs and registers MNA subcomponents; idempotent.
   void createSubComponents() override;
+  void validateParameters(ParameterCheck &check) override;
   /// Derives values from power flow data and pushes them to subcomponents
   void initializeParentFromNodesAndTerminals(Real frequency) override;
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_PiLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_PiLine.h
@@ -52,6 +52,7 @@ public:
   // #### General ####
   /// Constructs and registers MNA subcomponents; idempotent.
   void createSubComponents() override;
+  void validateParameters(ParameterCheck &check) override;
   /// Derives values from power flow data and pushes them to subcomponents
   void initializeParentFromNodesAndTerminals(Real frequency) override;
 

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph1_PiLine.h
@@ -52,6 +52,7 @@ public:
   // #### General ####
   /// Constructs and registers MNA subcomponents; idempotent.
   void createSubComponents() override;
+  void validateParameters(ParameterCheck &check) override;
   /// Derives values from power flow data and pushes them to subcomponents
   void initializeParentFromNodesAndTerminals(Real frequency) override;
 

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_PiLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_PiLine.h
@@ -55,6 +55,7 @@ public:
   // #### General ####
   /// Constructs and registers MNA subcomponents; idempotent.
   void createSubComponents() override;
+  void validateParameters(ParameterCheck &check) override;
   /// Derives values from power flow data and pushes them to subcomponents
   void initializeParentFromNodesAndTerminals(Real frequency) override;
 

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_RxLine.h
@@ -42,6 +42,7 @@ public:
   // #### General ####
   /// Constructs and registers MNA subcomponents; idempotent.
   void createSubComponents() override;
+  void validateParameters(ParameterCheck &check) override;
   /// Derives values from power flow data and pushes them to subcomponents
   void initializeParentFromNodesAndTerminals(Real frequency) override;
 

--- a/dpsim-models/include/dpsim-models/ParameterCheck.h
+++ b/dpsim-models/include/dpsim-models/ParameterCheck.h
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <initializer_list>
+#include <vector>
+
+#include <dpsim-models/Attribute.h>
+#include <dpsim-models/Definitions.h>
+#include <dpsim-models/MathUtils.h>
+
+namespace CPS {
+
+class IdentifiedObject;
+
+enum class Constraint {
+  Finite,
+  NonNegative,
+  Positive,
+  NonZero,
+  DiagonalPositive,
+  Invertible,
+};
+
+enum class CheckResult {
+  Satisfied,
+  Violated,
+  NotApplicable,
+};
+
+String constraintDescription(Constraint constraint);
+
+CheckResult satisfies(Real value, Constraint constraint);
+CheckResult satisfies(Complex value, Constraint constraint);
+CheckResult satisfies(const Matrix &value, Constraint constraint);
+CheckResult satisfies(const MatrixComp &value, Constraint constraint);
+
+class ParameterCheck {
+public:
+  using ConstraintList = std::initializer_list<Constraint>;
+
+  struct Violation {
+    String component;
+    String parameter;
+    String reason;
+  };
+
+  using Violations = std::vector<Violation>;
+
+  ParameterCheck(const IdentifiedObject &owner, Violations &violations)
+      : mOwner(owner), mViolations(violations) {}
+
+  template <typename T>
+  void operator()(const AttributePointer<Attribute<T>> &attr,
+                  ConstraintList constraints) {
+    if (attr.isNull())
+      return;
+
+    const T &value = **attr;
+    for (auto constraint : constraints) {
+      switch (satisfies(value, constraint)) {
+      case CheckResult::Satisfied:
+        break;
+      case CheckResult::Violated:
+        record(resolveName(attr),
+               "must be " + constraintDescription(constraint));
+        break;
+      case CheckResult::NotApplicable:
+        record(resolveName(attr),
+               "constraint '" + constraintDescription(constraint) +
+                   "' does not apply to this parameter type");
+        break;
+      }
+    }
+  }
+
+  void require(bool condition, const String &reason);
+
+  static void throwIfAny(const Violations &violations);
+
+private:
+  String resolveName(const AttributeBase::Ptr &attr) const;
+  void record(const String &parameter, const String &reason);
+
+  const IdentifiedObject &mOwner;
+  Violations &mViolations;
+};
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_PiLine.h
@@ -110,6 +110,7 @@ public:
                      Real conductance = -1);
   /// Constructs and registers MNA subcomponents; idempotent.
   void createSubComponents() override;
+  void validateParameters(ParameterCheck &check) override;
   /// Derives values from power flow data and pushes them to subcomponents
   void initializeParentFromNodesAndTerminals(Real frequency) override;
 

--- a/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
+++ b/dpsim-models/include/dpsim-models/SP/SP_Ph1_RXLine.h
@@ -123,6 +123,7 @@ public:
   // #### General ####
   /// Constructs and registers MNA subcomponents; idempotent.
   void createSubComponents() override;
+  void validateParameters(ParameterCheck &check) override;
   /// Derives values from power flow data and pushes them to subcomponents
   void initializeParentFromNodesAndTerminals(Real frequency) override;
 

--- a/dpsim-models/include/dpsim-models/SystemTopology.h
+++ b/dpsim-models/include/dpsim-models/SystemTopology.h
@@ -83,6 +83,8 @@ public:
   /// Reset state of components
   void reset();
 
+  void checkParameters() const;
+
   // #### Add Objects to SystemTopology ####
 
   /// Adds node and initializes frequencies

--- a/dpsim-models/include/dpsim-models/TopologicalPowerComp.h
+++ b/dpsim-models/include/dpsim-models/TopologicalPowerComp.h
@@ -15,6 +15,7 @@
 
 #include <dpsim-models/IdentifiedObject.h>
 #include <dpsim-models/Logger.h>
+#include <dpsim-models/ParameterCheck.h>
 #include <dpsim-models/TopologicalNode.h>
 #include <dpsim-models/TopologicalTerminal.h>
 
@@ -40,6 +41,8 @@ protected:
   /// Flag indicating that parameters are set via setParameters() function
   bool mParametersSet = false;
 
+  virtual void validateParameters(ParameterCheck &) {}
+
 public:
   typedef std::shared_ptr<TopologicalPowerComp> Ptr;
   typedef std::vector<Ptr> List;
@@ -59,6 +62,11 @@ public:
       : TopologicalPowerComp(name, name, logLevel) {}
   /// Destructor - does not do anything
   virtual ~TopologicalPowerComp() {}
+
+  void checkParameters(ParameterCheck::Violations &violations) {
+    ParameterCheck check(*this, violations);
+    validateParameters(check);
+  }
 
   /// Returns nodes connected to this component
   virtual TopologicalNode::List topologicalNodes() = 0;

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(dpsim-models STATIC
 	Logger.cpp
 	MathUtils.cpp
 	MNAStampUtils.cpp
+	ParameterCheck.cpp
 	Attribute.cpp
 	TopologicalNode.cpp
 	TopologicalTerminal.cpp

--- a/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_PiLine.cpp
@@ -26,6 +26,13 @@ SimPowerComp<Complex>::Ptr DP::Ph1::PiLine::clone(String name) {
   return copy;
 }
 
+void DP::Ph1::PiLine::validateParameters(ParameterCheck &check) {
+  check(mSeriesRes, {Constraint::Finite, Constraint::Positive});
+  check(mSeriesInd, {Constraint::Finite, Constraint::Positive});
+  check(mParallelCap, {Constraint::Finite, Constraint::NonNegative});
+  check(mParallelCond, {Constraint::Finite});
+}
+
 void DP::Ph1::PiLine::createSubComponents() {
   if (mSubCompCreated)
     return;

--- a/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RxLine.cpp
@@ -28,6 +28,11 @@ SimPowerComp<Complex>::Ptr DP::Ph1::RxLine::clone(String name) {
   return copy;
 }
 
+void DP::Ph1::RxLine::validateParameters(ParameterCheck &check) {
+  check(mSeriesRes, {Constraint::Finite, Constraint::Positive});
+  check(mSeriesInd, {Constraint::Finite, Constraint::Positive});
+}
+
 void DP::Ph1::RxLine::createSubComponents() {
   if (mSubCompCreated)
     return;

--- a/dpsim-models/src/DP/DP_Ph3_PiLine.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_PiLine.cpp
@@ -27,6 +27,13 @@ SimPowerComp<Complex>::Ptr DP::Ph3::PiLine::clone(String name) {
   return copy;
 }
 
+void DP::Ph3::PiLine::validateParameters(ParameterCheck &check) {
+  check(mSeriesRes, {Constraint::Finite, Constraint::Invertible});
+  check(mSeriesInd, {Constraint::Finite, Constraint::Invertible});
+  check(mParallelCap, {Constraint::Finite});
+  check(mParallelCond, {Constraint::Finite});
+}
+
 void DP::Ph3::PiLine::createSubComponents() {
   if (mSubCompCreated)
     return;

--- a/dpsim-models/src/EMT/EMT_Ph1_PiLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_PiLine.cpp
@@ -28,6 +28,13 @@ SimPowerComp<Real>::Ptr EMT::Ph1::PiLine::clone(String name) {
   return copy;
 }
 
+void EMT::Ph1::PiLine::validateParameters(ParameterCheck &check) {
+  check(mSeriesRes, {Constraint::Finite, Constraint::Positive});
+  check(mSeriesInd, {Constraint::Finite, Constraint::Positive});
+  check(mParallelCap, {Constraint::Finite, Constraint::NonNegative});
+  check(mParallelCond, {Constraint::Finite});
+}
+
 void EMT::Ph1::PiLine::createSubComponents() {
   if (mSubCompCreated)
     return;

--- a/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_PiLine.cpp
@@ -32,6 +32,13 @@ SimPowerComp<Real>::Ptr EMT::Ph3::PiLine::clone(String name) {
   return copy;
 }
 
+void EMT::Ph3::PiLine::validateParameters(ParameterCheck &check) {
+  check(mSeriesRes, {Constraint::Finite, Constraint::Invertible});
+  check(mSeriesInd, {Constraint::Finite, Constraint::Invertible});
+  check(mParallelCap, {Constraint::Finite});
+  check(mParallelCond, {Constraint::Finite});
+}
+
 void EMT::Ph3::PiLine::createSubComponents() {
   if (mSubCompCreated)
     return;

--- a/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RxLine.cpp
@@ -34,6 +34,11 @@ SimPowerComp<Real>::Ptr EMT::Ph3::RxLine::clone(String name) {
   return copy;
 }
 
+void EMT::Ph3::RxLine::validateParameters(ParameterCheck &check) {
+  check(mSeriesRes, {Constraint::Finite, Constraint::Invertible});
+  check(mSeriesInd, {Constraint::Finite, Constraint::Invertible});
+}
+
 void EMT::Ph3::RxLine::createSubComponents() {
   if (mSubCompCreated)
     return;

--- a/dpsim-models/src/ParameterCheck.cpp
+++ b/dpsim-models/src/ParameterCheck.cpp
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <sstream>
+#include <stdexcept>
+
+#include <dpsim-models/IdentifiedObject.h>
+#include <dpsim-models/ParameterCheck.h>
+
+using namespace CPS;
+
+namespace {
+
+template <typename MatrixType>
+CheckResult checkInvertible(const MatrixType &value) {
+  if (value.rows() != value.cols() || value.rows() == 0)
+    return CheckResult::Violated;
+  return value.fullPivLu().rank() == value.rows() ? CheckResult::Satisfied
+                                                  : CheckResult::Violated;
+}
+
+CheckResult fromBool(bool satisfied) {
+  return satisfied ? CheckResult::Satisfied : CheckResult::Violated;
+}
+
+} // namespace
+
+String CPS::constraintDescription(Constraint constraint) {
+  switch (constraint) {
+  case Constraint::Finite:
+    return "finite";
+  case Constraint::NonNegative:
+    return "non-negative";
+  case Constraint::Positive:
+    return "strictly positive";
+  case Constraint::NonZero:
+    return "non-zero";
+  case Constraint::DiagonalPositive:
+    return "square with a strictly positive diagonal";
+  case Constraint::Invertible:
+    return "square and invertible";
+  }
+  return "valid";
+}
+
+CheckResult CPS::satisfies(Real value, Constraint constraint) {
+  if (!Math::isFinite(value))
+    return CheckResult::Violated;
+
+  switch (constraint) {
+  case Constraint::Finite:
+    return CheckResult::Satisfied;
+  case Constraint::NonNegative:
+    return fromBool(value >= 0.);
+  case Constraint::Positive:
+  case Constraint::DiagonalPositive:
+    return fromBool(value > DOUBLE_EPSILON);
+  case Constraint::NonZero:
+  case Constraint::Invertible:
+    return fromBool(std::abs(value) > DOUBLE_EPSILON);
+  }
+  return CheckResult::Satisfied;
+}
+
+CheckResult CPS::satisfies(Complex value, Constraint constraint) {
+  if (!Math::isFinite(value))
+    return CheckResult::Violated;
+
+  switch (constraint) {
+  case Constraint::Finite:
+    return CheckResult::Satisfied;
+  case Constraint::NonZero:
+  case Constraint::Invertible:
+    return fromBool(std::abs(value) > DOUBLE_EPSILON);
+  case Constraint::NonNegative:
+  case Constraint::Positive:
+  case Constraint::DiagonalPositive:
+    return CheckResult::NotApplicable;
+  }
+  return CheckResult::Satisfied;
+}
+
+CheckResult CPS::satisfies(const Matrix &value, Constraint constraint) {
+  if (!value.allFinite())
+    return CheckResult::Violated;
+
+  switch (constraint) {
+  case Constraint::Finite:
+    return CheckResult::Satisfied;
+  case Constraint::NonNegative:
+    return fromBool((value.array() >= 0.).all());
+  case Constraint::Positive:
+    return fromBool((value.array() > DOUBLE_EPSILON).all());
+  case Constraint::NonZero:
+    return fromBool(!value.isZero(DOUBLE_EPSILON));
+  case Constraint::DiagonalPositive:
+    if (value.rows() != value.cols() || value.rows() == 0)
+      return CheckResult::Violated;
+    return fromBool(value.diagonal().minCoeff() > DOUBLE_EPSILON);
+  case Constraint::Invertible:
+    return checkInvertible(value);
+  }
+  return CheckResult::Satisfied;
+}
+
+CheckResult CPS::satisfies(const MatrixComp &value, Constraint constraint) {
+  if (!value.allFinite())
+    return CheckResult::Violated;
+
+  switch (constraint) {
+  case Constraint::Finite:
+    return CheckResult::Satisfied;
+  case Constraint::NonZero:
+    return fromBool(!value.isZero(DOUBLE_EPSILON));
+  case Constraint::Invertible:
+    return checkInvertible(value);
+  case Constraint::NonNegative:
+  case Constraint::Positive:
+  case Constraint::DiagonalPositive:
+    return CheckResult::NotApplicable;
+  }
+  return CheckResult::Satisfied;
+}
+
+String ParameterCheck::resolveName(const AttributeBase::Ptr &attr) const {
+  for (const auto &entry : mOwner.attributes())
+    if (entry.second.getPtr() == attr.getPtr())
+      return entry.first;
+  return "<unnamed>";
+}
+
+void ParameterCheck::record(const String &parameter, const String &reason) {
+  mViolations.push_back({**mOwner.mName, parameter, reason});
+}
+
+void ParameterCheck::require(bool condition, const String &reason) {
+  if (!condition)
+    mViolations.push_back({**mOwner.mName, "", reason});
+}
+
+void ParameterCheck::throwIfAny(const Violations &violations) {
+  if (violations.empty())
+    return;
+
+  std::stringstream message;
+  message << "invalid component parameters (" << violations.size()
+          << " violation" << (violations.size() == 1 ? "" : "s") << "):";
+  for (const auto &violation : violations) {
+    message << "\n  " << violation.component;
+    if (!violation.parameter.empty())
+      message << "." << violation.parameter;
+    message << ": " << violation.reason;
+  }
+  throw std::invalid_argument(message.str());
+}

--- a/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_PiLine.cpp
@@ -182,6 +182,13 @@ void SP::Ph1::PiLine::storeNodalInjection(Complex powerInjection) {
 
 MatrixComp SP::Ph1::PiLine::Y_element() { return mY_element; }
 
+void SP::Ph1::PiLine::validateParameters(ParameterCheck &check) {
+  check(mSeriesRes, {Constraint::Finite, Constraint::Positive});
+  check(mSeriesInd, {Constraint::Finite, Constraint::NonNegative});
+  check(mParallelCap, {Constraint::Finite, Constraint::NonNegative});
+  check(mParallelCond, {Constraint::Finite});
+}
+
 void SP::Ph1::PiLine::createSubComponents() {
   if (mSubCompCreated)
     return;

--- a/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
+++ b/dpsim-models/src/SP/SP_Ph1_RXLine.cpp
@@ -119,6 +119,11 @@ SimPowerComp<Complex>::Ptr SP::Ph1::RXLine::clone(String name) {
   return copy;
 }
 
+void SP::Ph1::RXLine::validateParameters(ParameterCheck &check) {
+  check(mSeriesRes, {Constraint::Finite, Constraint::Positive});
+  check(mSeriesInd, {Constraint::Finite, Constraint::NonNegative});
+}
+
 void SP::Ph1::RXLine::createSubComponents() {
   if (mSubCompCreated)
     return;

--- a/dpsim-models/src/SystemTopology.cpp
+++ b/dpsim-models/src/SystemTopology.cpp
@@ -48,6 +48,17 @@ void SystemTopology::addNodes(const TopologicalNode::List &topNodes) {
     addNode(topNode);
 }
 
+void SystemTopology::checkParameters() const {
+  ParameterCheck::Violations violations;
+
+  for (const auto &component : mComponents)
+    if (auto powerComp =
+            std::dynamic_pointer_cast<TopologicalPowerComp>(component))
+      powerComp->checkParameters(violations);
+
+  ParameterCheck::throwIfAny(violations);
+}
+
 void SystemTopology::addComponent(IdentifiedObject::Ptr component) {
   if (auto powerCompComplex =
           std::dynamic_pointer_cast<SimPowerComp<Complex>>(component))

--- a/dpsim/src/Simulation.cpp
+++ b/dpsim/src/Simulation.cpp
@@ -81,6 +81,8 @@ void Simulation::initialize() {
   if (mInitialized)
     return;
 
+  mSystem.checkParameters();
+
   mSolvers.clear();
 
   switch (mDomain) {

--- a/examples/Notebooks/Components/test_parameter_validation.py
+++ b/examples/Notebooks/Components/test_parameter_validation.py
@@ -1,0 +1,50 @@
+import pytest
+import dpsimpy
+
+
+def build_system(resistance):
+    gnd = dpsimpy.emt.SimNode.gnd
+    n1 = dpsimpy.emt.SimNode("n1", dpsimpy.PhaseType.ABC)
+    n2 = dpsimpy.emt.SimNode("n2", dpsimpy.PhaseType.ABC)
+
+    vs = dpsimpy.emt.ph3.VoltageSource("vs")
+    vs.set_parameters(
+        dpsimpy.Math.single_phase_variable_to_three_phase(complex(1000, 0)), 50
+    )
+    vs.connect([gnd, n1])
+
+    line = dpsimpy.emt.ph3.PiLine("line")
+    line.set_parameters(
+        dpsimpy.Math.single_phase_parameter_to_three_phase(resistance),
+        dpsimpy.Math.single_phase_parameter_to_three_phase(0.001),
+        dpsimpy.Math.single_phase_parameter_to_three_phase(1e-6),
+        dpsimpy.Math.single_phase_parameter_to_three_phase(1e-6),
+    )
+    line.connect([n1, n2])
+
+    load = dpsimpy.emt.ph3.Resistor("load")
+    load.set_parameters(dpsimpy.Math.single_phase_parameter_to_three_phase(100))
+    load.connect([n2, gnd])
+
+    return dpsimpy.SystemTopology(50, [gnd, n1, n2], [vs, line, load])
+
+
+def test_zero_series_resistance_is_rejected():
+    sim = dpsimpy.Simulation("piline_zero_resistance")
+    sim.set_system(build_system(0.0))
+    sim.set_domain(dpsimpy.Domain.EMT)
+    sim.set_time_step(1e-4)
+    sim.set_final_time(1e-3)
+
+    with pytest.raises(ValueError, match="R_series"):
+        sim.run()
+
+
+def test_valid_series_resistance_is_accepted():
+    sim = dpsimpy.Simulation("piline_valid_resistance")
+    sim.set_system(build_system(1.0))
+    sim.set_domain(dpsimpy.Domain.EMT)
+    sim.set_time_step(1e-4)
+    sim.set_final_time(1e-3)
+
+    sim.run()


### PR DESCRIPTION
PiLine builds a series resistor even at zero resistance, so the Ph3 stamp inverts a zero matrix and the run ends all-NaN with no error. ParameterCheck lets a component declare what its parameters must satisfy, checked in Simulation::initialize.