### PR TITLE
fix: resolve Python dependencies with uv in the remaining images and scripts

### DIFF
--- a/packaging/Docker/Dockerfile.dev
+++ b/packaging/Docker/Dockerfile.dev
@@ -65,11 +65,9 @@ ENV LD_LIBRARY_PATH="/usr/local/lib64:${LD_LIBRARY_PATH}"
 # Python dependencies
 ADD pyproject.toml .
 RUN pip3 install --no-cache-dir --upgrade wheel build setuptools packaging && \
-	pip3 install --no-cache-dir pip-tools && \
-	pip-compile --no-header --extra dev --output-file /tmp/requirements.txt pyproject.toml && \
-	pip3 install --no-cache-dir -r /tmp/requirements.txt && \
-	pip3 uninstall -y pip-tools && \
-	rm /tmp/requirements.txt && \
+	pip3 install --no-cache-dir uv && \
+	uv pip install --system --no-cache -r pyproject.toml --extra dev && \
+	pip3 uninstall -y uv && \
 	pip3 cache purge
 
 # Install libcimpp from prebuilt RPMs (x86_64 only) or build from source

--- a/packaging/Docker/Dockerfile.dev-debian
+++ b/packaging/Docker/Dockerfile.dev-debian
@@ -67,11 +67,9 @@ RUN cd /tmp && \
 ## Python dependencies
 ADD pyproject.toml .
 RUN pip3 install --no-cache-dir --upgrade wheel build setuptools packaging && \
-	pip3 install --no-cache-dir pip-tools && \
-	pip-compile --no-header --extra dev --output-file /tmp/requirements.txt pyproject.toml && \
-	pip3 install --no-cache-dir -r /tmp/requirements.txt && \
-	pip3 uninstall -y pip-tools && \
-	rm /tmp/requirements.txt && \
+	pip3 install --no-cache-dir uv && \
+	uv pip install --system --no-cache -r pyproject.toml --extra dev && \
+	pip3 uninstall -y uv && \
 	pip3 cache purge
 
 ## Install libcimpp from prebuilt Debian packages

--- a/packaging/Docker/Dockerfile.dev-minimal
+++ b/packaging/Docker/Dockerfile.dev-minimal
@@ -23,11 +23,9 @@ RUN set -eux; \
 # Python dependencies
 ADD pyproject.toml .
 RUN pip3 install --no-cache-dir --upgrade wheel build setuptools packaging && \
-	pip3 install --no-cache-dir pip-tools && \
-	pip-compile --no-header --extra dev --output-file /tmp/requirements.txt pyproject.toml && \
-	pip3 install --no-cache-dir -r /tmp/requirements.txt && \
-	pip3 uninstall -y pip-tools && \
-	rm /tmp/requirements.txt && \
+	pip3 install --no-cache-dir uv && \
+	uv pip install --system --no-cache -r pyproject.toml --extra dev && \
+	pip3 uninstall -y uv && \
 	pip3 cache purge
 
 EXPOSE 8888

--- a/packaging/Docker/Dockerfile.rpm
+++ b/packaging/Docker/Dockerfile.rpm
@@ -42,11 +42,9 @@ RUN set -eux; \
 
 ADD pyproject.toml .
 RUN pip3 install --no-cache-dir --upgrade wheel build setuptools packaging && \
-	pip3 install --no-cache-dir pip-tools && \
-	pip-compile --no-header --extra dev --output-file /tmp/requirements.txt pyproject.toml && \
-	pip3 install --no-cache-dir -r /tmp/requirements.txt && \
-	pip3 uninstall -y pip-tools && \
-	rm /tmp/requirements.txt && \
+	pip3 install --no-cache-dir uv && \
+	uv pip install --system --no-cache -r pyproject.toml --extra dev && \
+	pip3 uninstall -y uv && \
 	pip3 cache purge
 
 RUN set -eux; \

--- a/packaging/Shell/install-fedora-deps-dev.sh
+++ b/packaging/Shell/install-fedora-deps-dev.sh
@@ -61,11 +61,9 @@ dnf -y install \
 	libconfig-devel \
     libnl3-devel
 
-pip3 install pip-tools
-pip-compile --no-header --extra dev --output-file /tmp/requirements.txt pyproject.toml
-pip3 install -r /tmp/requirements.txt
-pip3 uninstall -y pip-tools
-rm /tmp/requirements.txt
+pip3 install uv
+uv pip install --system -r pyproject.toml --extra dev
+pip3 uninstall -y uv
 
 cd /tmp && \
 	git clone --recurse-submodules --depth 1 https://github.com/cim-iec/libcimpp.git && \

--- a/packaging/Shell/install-fedora-deps.sh
+++ b/packaging/Shell/install-fedora-deps.sh
@@ -31,11 +31,9 @@ dnf --refresh -y install \
 	gsl-devel
 
 # Python
-pip3 install pip-tools
-pip-compile --no-header --extra dev --output-file /tmp/requirements.txt pyproject.toml
-pip3 install -r /tmp/requirements.txt
-pip3 uninstall -y pip-tools
-rm /tmp/requirements.txt
+pip3 install uv
+uv pip install --system -r pyproject.toml --extra dev
+pip3 uninstall -y uv
 
 # Activate Jupyter extensions
 dnf -y --refresh install npm


### PR DESCRIPTION
pip-tools 7.6.0 is broken on every Python (undeclared typing_extensions below 3.11, removed pip internals from 26.2 up). The rocky and manylinux images already tripped and were fixed; these six spots carry the same pattern and fail the same way on their next base refresh, dev-debian (Python 3.9) already would. Convert Dockerfile.dev, dev-minimal, dev-debian, Dockerfile.rpm and both install-fedora-deps scripts to uv, as #648/#651 did. Verified the converted stage on fedora:42 and debian:11, dev extra installs and imports. Related to #647.