### PR TITLE
fix(ci): let the approved fork gate check out fork pull requests

### DIFF
--- a/.github/workflows/prepare-images.yaml
+++ b/.github/workflows/prepare-images.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
@@ -86,6 +87,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Every image build from a fork pull request dies at actions/checkout@v6 before Docker starts: under pull_request_target the action refuses a fork head SHA unless the step opts in. First seen on #670, run 31228900159.

Adds allow-unsafe-pr-checkout to both checkout steps in the reusable image workflow. The trusted push path is unaffected, and the fork-pr approval remains the only gate. Needs to be on master before #670 can re-fire its gate.