### PR TITLE
ci: cache the container images in the registry instead of the Actions cache

### DIFF
--- a/.github/workflows/prepare-images.yaml
+++ b/.github/workflows/prepare-images.yaml
@@ -67,8 +67,8 @@ jobs:
           context: .
           file: ${{ matrix.file }}
           push: true
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,mode=min,scope=${{ matrix.image }}
+          cache-from: type=registry,ref=${{ inputs.image_prefix }}/${{ matrix.image }}:buildcache
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache,mode=max', inputs.image_prefix, matrix.image) || '' }}
           tags: |
             ${{ inputs.image_prefix }}/${{ matrix.image }}:${{ inputs.ref }}
             ${{ inputs.image_prefix }}/${{ matrix.image }}:${{ inputs.tag }}
@@ -107,8 +107,8 @@ jobs:
           push: true
           build-args: |
             BASE_IMAGE=${{ inputs.base_image }}
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,mode=min,scope=${{ matrix.image }}
+          cache-from: type=registry,ref=${{ inputs.image_prefix }}/${{ matrix.image }}:buildcache
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache,mode=max', inputs.image_prefix, matrix.image) || '' }}
           tags: |
             ${{ inputs.image_prefix }}/${{ matrix.image }}:${{ inputs.ref }}
             ${{ inputs.image_prefix }}/${{ matrix.image }}:${{ inputs.tag }}


### PR DESCRIPTION
The image builds export their layer cache with type=gha, which shares the repository's 10 GB Actions cache quota with ccache and the Windows build caches. The quota is full, so buildx cannot reserve a blob and three of the four image builds on #670 failed at the cache export step after the image had already been built and pushed.

Moves the layer cache to a :buildcache tag in the registry the images already push to, where it does not count against the quota. Only push events export it, so pull request builds read the cache but cannot overwrite it.