### PR TITLE
fix(ci): stop building the images against the RWTH GitLab

### DIFF
--- a/packaging/Docker/Dockerfile.dev-rocky
+++ b/packaging/Docker/Dockerfile.dev-rocky
@@ -83,7 +83,7 @@ RUN dnf install -y \
 	rpcgen texinfo bison flex
 
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
-RUN git clone --branch 3.0 --recurse-submodules --depth 1 https://git.rwth-aachen.de/acs/public/virtualization/cricket.git && \
+RUN git clone --branch 3.0 --recurse-submodules --depth 1 https://github.com/RWTH-ACS/cricket.git && \
 	cd cricket && \
 	make ${MAKE_OPTS} libtirpc && \
 	make ${MAKE_OPTS} bin/libtirpc.so && \

--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -106,7 +106,7 @@ RUN cd /tmp && \
 	git clone --recurse-submodules https://github.com/VILLASframework/node.git villas-node && \
 	cd villas-node && \
 	git checkout ${VILLAS_VERSION} && \
-	DEPS_SKIP=criterion,ethercat \
+	DEPS_SKIP=criterion,ethercat,libxil \
 	MAKE_OPTS="" \
 	CMAKE_OPTS=-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 	NINJA=/usr/bin/ninja-build \


### PR DESCRIPTION
git.rwth-aachen.de is returning 502, which fails the Rocky image on the cricket clone and the manylinux image on libxil.

Clones cricket from github.com/RWTH-ACS/cricket and adds libxil to the manylinux DEPS_SKIP as dev-rocky already does. No FPGA support is lost, since VILLAS gates that on its libxil submodule.