### PR TITLE
fix(ci): install libxil in the manylinux image from GitHub

### DIFF
--- a/packaging/Docker/Dockerfile.manylinux
+++ b/packaging/Docker/Dockerfile.manylinux
@@ -101,6 +101,14 @@ RUN dnf install -y \
 	subversion-perl \
 	perl-Memoize
 
+# Install libxil from source, VILLASnode links it for fpga support
+RUN cd /tmp && \
+	git clone --branch master --depth 1 https://github.com/VILLASframework/libxil.git && \
+	mkdir -p libxil/build && cd libxil/build && \
+	cmake ${CMAKE_OPTS} .. && \
+	make ${MAKE_OPTS} install && \
+	rm -rf /tmp/libxil
+
 # Install VILLASnode from source
 RUN cd /tmp && \
 	git clone --recurse-submodules https://github.com/VILLASframework/node.git villas-node && \


### PR DESCRIPTION
Skipping libxil in the VILLASnode installer removed the shared library that dpsimpy links for fpga support, so every wheel build fails at stub generation with ImportError: libxil.so once sogno/dpsim:manylinux was republished.

Installs it from github.com/VILLASframework/libxil with the same recipe deps.sh uses, keeping it in DEPS_SKIP so the installer never reaches for git.rwth-aachen.de. The wheel checks on this pull request cannot pass, because cibuildwheel pins the published image rather than the one built here.
