### PR TITLE
ci(llm-review): stop repeating findings on every push

### DIFF
--- a/.github/llm-review/review.py
+++ b/.github/llm-review/review.py
@@ -55,6 +55,9 @@ SUGGESTION_MIN_CONF = 80
 MAX_INLINE = 8
 MAX_REFUTED_SHOWN = 5
 
+REVIEW_HEADING = "### DPsim LLM review"
+RECHECK_RE = re.compile(r"^<sub>Re-checked at .*$\n?", re.M)
+
 # Finder calls run serially by default: the gateway caps concurrent requests per
 # key (429 too_many_concurrent_requests), so parallelism isn't reliably available.
 # Raise LLM_FINDER_CONCURRENCY if your gateway allows it; 429s back off and retry.
@@ -1198,6 +1201,51 @@ def build_review(
     return payload
 
 
+def latest_own_review(pr_number):
+    """The runner's most recent review on this PR, as (id, body), so a run with
+    nothing new can refresh it instead of posting again. (None, "") if there is
+    none, or if it cannot be read."""
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    token = os.environ.get("GITHUB_TOKEN")
+    if not (repo and token):
+        return None, ""
+    url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews?per_page=100"
+    try:
+        reviews = gh_get_json(url, token)
+    except (urllib.error.URLError, ValueError) as e:
+        print(f"could not read earlier reviews: {e}", file=sys.stderr)
+        return None, ""
+    found = (None, "")
+    for r in reviews if isinstance(reviews, list) else []:
+        body = r.get("body") or ""
+        if REVIEW_HEADING in body:
+            found = (r.get("id"), body)
+    return found
+
+
+def refreshed_body(body, head_sha):
+    note = f"<sub>Re-checked at {head_sha[:7]}: nothing new.</sub>"
+    return f"{RECHECK_RE.sub('', body).rstrip()}\n\n{note}"
+
+
+def gh_update_review(pr_number, review_id, body):
+    repo = env("GITHUB_REPOSITORY", required=True)
+    token = env("GITHUB_TOKEN", required=True)
+    url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews/{review_id}"
+    req = urllib.request.Request(
+        url,
+        data=json.dumps({"body": body}).encode(),
+        method="PUT",
+        headers={
+            "Authorization": "Bearer " + token,
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return resp.status
+
+
 def gh_post_review(pr_number, payload):
     repo = env("GITHUB_REPOSITORY", required=True)
     token = env("GITHUB_TOKEN", required=True)
@@ -1333,11 +1381,24 @@ def main():
         return
 
     if not [f for f in findings if bucket(f) != "optional"]:
-        print(
-            "nothing worth posting; leaving the pull request alone",
-            file=sys.stderr,
-        )
-        return
+        review_id, body = latest_own_review(pr_number)
+        if review_id:
+            try:
+                status = gh_update_review(
+                    pr_number, review_id, refreshed_body(body, head_sha)
+                )
+                print(
+                    f"nothing new; refreshed review {review_id} in place, "
+                    f"HTTP {status}",
+                    file=sys.stderr,
+                )
+                return
+            except urllib.error.HTTPError as e:
+                print(
+                    f"could not refresh review {review_id}, HTTP {e.code}: "
+                    f"{e.read().decode(errors='replace')[:200]}",
+                    file=sys.stderr,
+                )
 
     gh_post_review(pr_number, payload)
 

--- a/.github/llm-review/review.py
+++ b/.github/llm-review/review.py
@@ -53,6 +53,7 @@ SEV_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
 # a bad run cannot carpet a PR.
 SUGGESTION_MIN_CONF = 80
 MAX_INLINE = 8
+MAX_REFUTED_SHOWN = 5
 
 # Finder calls run serially by default: the gateway caps concurrent requests per
 # key (429 too_many_concurrent_requests), so parallelism isn't reliably available.
@@ -986,11 +987,10 @@ def render_body(f):
 
 # Severity buckets for the summary body, in display order. Critical/high always
 # land in the top bucket regardless of confidence; among the rest, a low-
-# confidence finding is a tentative "worth a glance" rather than an action item.
+# confidence finding is tentative and is not posted at all, only logged.
 SECTIONS = [
     ("critical", "\U0001f534 Critical & high"),
     ("suggestion", "\U0001f7e1 Suggestions"),
-    ("optional", "\U0001f535 Optional / low-confidence"),
 ]
 
 
@@ -1068,9 +1068,14 @@ def methodology_block(stats, claim=None):
     refuted = stats.get("refuted_list") or []
     if refuted:
         out += ["", "Refuted by verification:"]
-        for r in refuted:
+        for r in refuted[:MAX_REFUTED_SHOWN]:
             loc = f" ({r['file']})" if r.get("file") else ""
             out.append(f"- {r.get('title', '')}{loc}: {r.get('note', '')}")
+        if len(refuted) > MAX_REFUTED_SHOWN:
+            out.append(
+                f"- ... and {len(refuted) - MAX_REFUTED_SHOWN} more, in the "
+                "workflow log."
+            )
     out.append("</details>")
     return out
 
@@ -1083,7 +1088,16 @@ def build_review(
     Body: a one-line TL;DR, a claim-vs-code note, a severity tally, findings
     grouped into buckets, and a collapsible methodology note. Findings that
     anchor to a diff line are also emitted as inline comments with the detail.
+    Tentative findings are counted, not printed: they go to the workflow log.
     """
+    tentative = [f for f in findings if bucket(f) == "optional"]
+    findings = [f for f in findings if bucket(f) != "optional"]
+    for f in tentative:
+        print(
+            f"tentative, not posted: {f.get('file')}:{f.get('line')} "
+            f"{f.get('title', '')} [{confidence_display(f) or '?'}]",
+            file=sys.stderr,
+        )
     findings.sort(
         key=lambda f: (SEV_RANK.get(f.get("severity"), 9), confidence_sort_key(f))
     )
@@ -1148,19 +1162,15 @@ def build_review(
             items = [f for f in findings if bucket(f) == key]
             if not items:
                 continue
-            # Collapse the tentative bucket into a compact, foldable block so it
-            # does not crowd the actionable findings.
-            if key == "optional":
-                lines += [
-                    "",
-                    f"<details><summary>{header} ({len(items)})</summary>",
-                    "",
-                ]
-                lines += [summary_line(f, f["_anchored"], compact=True) for f in items]
-                lines += ["", "</details>"]
-            else:
-                lines += ["", f"#### {header}"]
-                lines += [summary_line(f, f["_anchored"]) for f in items]
+            lines += ["", f"#### {header}"]
+            lines += [summary_line(f, f["_anchored"]) for f in items]
+
+    if tentative:
+        lines += [
+            "",
+            f"<sub>Not shown: {len(tentative)} tentative. All are in the "
+            "workflow log.</sub>",
+        ]
 
     lines += methodology_block(stats, claim)
     finders = [os.environ.get("LLM_MODEL", "LLM")]
@@ -1304,6 +1314,11 @@ def main():
         vstats = merge_vstats(vstats, vstats2)
 
     overview, findings = synthesize(verified, pr_ctx, model=verify_model)
+    for r in (vstats or {}).get("refuted_list") or []:
+        print(
+            f"refuted: {r.get('file')} {r.get('title', '')}: {r.get('note', '')}",
+            file=sys.stderr,
+        )
     payload = build_review(
         findings, head_sha, valid_files, overview, vstats, claim, diff=diff
     )
@@ -1315,6 +1330,13 @@ def main():
         for c in payload["comments"]:
             print(f"\n--- {c['path']}:{c['line']} ---")
             print(c["body"])
+        return
+
+    if not [f for f in findings if bucket(f) != "optional"]:
+        print(
+            "nothing worth posting; leaving the pull request alone",
+            file=sys.stderr,
+        )
         return
 
     gh_post_review(pr_number, payload)

--- a/docs/hugo/content/en/docs/Contributing/llm-pr-review.md
+++ b/docs/hugo/content/en/docs/Contributing/llm-pr-review.md
@@ -40,6 +40,22 @@ The prompts encode DPsim's documented conventions (see
 [Guidelines]({{< ref "/docs/Contributing" >}})) and the recurring points raised in
 past reviews, so the feedback stays specific to this project rather than generic.
 
+## What gets posted
+
+Not every finding the passes raise reaches the pull request.
+
+**Tentative findings are not posted.** A finding that verification could not
+confirm against the source, or that carries a confidence below 50 %, is written
+to the workflow log only. Over the review history of a merged pull request this
+was the large majority of everything raised, and effectively none of it was
+actionable; posting it buried the findings that were.
+
+**A run with nothing to say posts nothing at all.** The runner reviews again on
+every push, and a run whose findings are all tentative leaves the pull request
+untouched rather than adding an empty review. The workflow log records what it
+found either way, so a silent run is a run that found nothing worth your time,
+not a run that failed.
+
 ## Configuration
 
 The workflow requires one repository secret:

--- a/docs/hugo/content/en/docs/Contributing/llm-pr-review.md
+++ b/docs/hugo/content/en/docs/Contributing/llm-pr-review.md
@@ -50,11 +50,12 @@ to the workflow log only. Over the review history of a merged pull request this
 was the large majority of everything raised, and effectively none of it was
 actionable; posting it buried the findings that were.
 
-**A run with nothing to say posts nothing at all.** The runner reviews again on
-every push, and a run whose findings are all tentative leaves the pull request
-untouched rather than adding an empty review. The workflow log records what it
-found either way, so a silent run is a run that found nothing worth your time,
-not a run that failed.
+**A run with nothing to say does not post a second review.** The runner reviews
+again on every push. When a run has nothing left after the rule above, it edits
+its previous review instead, appending a line recording that the head commit was
+re-checked and nothing new was found. Editing a review body sends no
+notification, so those runs are visible on the pull request but silent in your
+inbox; only a run with something to say posts, and only that one mails you.
 
 ## Configuration
 


### PR DESCRIPTION
Unconfirmed and sub-50 findings go to the log, not the PR. A run with nothing new edits its previous review instead of posting again, which sends no mail. On PR #581 history: 12 findings instead of 171, 4 mails instead of 10.