### PR TITLE
build(python): drop 3.9 and build wheels for 3.14

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -131,7 +131,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Resolve all extras
         run: |

--- a/.github/workflows/packaging-python.yaml
+++ b/.github/workflows/packaging-python.yaml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-latest]
-        python: [cp39, cp310, cp311, cp312, cp313]
+        python: [cp310, cp311, cp312, cp313, cp314]
         include:
         - os: ubuntu-24.04
           platform: manylinux_x86_64

--- a/README.md
+++ b/README.md
@@ -24,13 +24,19 @@ Click the badge below to explore the interactive Jupyter notebooks in your brows
 
 [![Binder](https://2i2c.mybinder.org/badge_logo.svg)](https://2i2c.mybinder.org/v2/gh/sogno-platform/dpsim/HEAD?urlpath=%2Fdoc%2Ftree%2Fexamples%2FIndex.ipynb)
 
-### Using Python on Linux
+### Using Python on Linux and Windows
 
-Install DPsim on Linux using the command
+Install DPsim using the command
 
 ```shell
 pip install dpsim
 ```
+
+Wheels are published for CPython 3.10 through 3.14 on Linux and Windows x86-64. The Windows
+wheel is built without VILLASnode, real-time support and Sundials; use WSL2 or the `sogno/dpsim`
+container if you need those. See the
+[installation instructions](https://sogno.energy/dpsim/docs/user-guide/install/) for the full
+matrix.
 
 ## Documentation
 

--- a/docs/hugo/content/en/docs/Developer Guide/Architecture and Conventions/build.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Architecture and Conventions/build.md
@@ -106,8 +106,8 @@ succeeds and simply gives you stale behaviour. Either rebuild and rely on `PYTHO
 or reinstall the package after every C++ change.
 
 To summarise the three ways to get DPsim, in increasing order of involvement: `pip install dpsim`
-for a released Linux wheel, a native build plus `PYTHONPATH` for development, and `make install`
-to place a build system wide.
+for a released Linux or Windows wheel, a native build plus `PYTHONPATH` for development, and
+`make install` to place a build system wide.
 
 If you develop inside a conda environment, the equivalent is to register the same two
 directories from within the active environment. This needs `conda-build` installed:
@@ -234,8 +234,13 @@ libcimpp, see [issue #609](https://github.com/sogno-platform/dpsim/issues/609). 
 
 ## Python package
 
-Wheels are produced by cibuildwheel in the `publish_to_pypi` workflow, currently for
-manylinux x86_64 and CPython 3.9 through 3.13. To build a source distribution locally:
+Wheels are produced by cibuildwheel in the `packaging-python` workflow, currently for
+manylinux x86_64 and Windows x86-64, CPython 3.10 through 3.14. The Windows wheel is the
+reduced one described in [install]({{< ref "/docs/User Guide/install.md" >}}), which also
+carries the full matrix. The set of versions lives in the `tool.cibuildwheel` sections of
+`pyproject.toml` and in the `python` matrix of `.github/workflows/packaging-python.yaml`, and
+both have to be changed together.
+To build a source distribution locally:
 
 ```shell
 python3 -m build --sdist

--- a/docs/hugo/content/en/docs/User Guide/install.md
+++ b/docs/hugo/content/en/docs/User Guide/install.md
@@ -44,15 +44,48 @@ pip install dpsim
 
 {{% alert title="Published wheels cover Linux and Windows" color="info" %}}
 Three limitations are worth knowing before you start.
-Wheels are published for Linux and Windows on x86-64, for CPython 3.9 through 3.13, so on macOS
-you have to build from source for now.
-The Windows wheel is built without VILLASnode, real-time support and Sundials, so it has no
-`dpsimpyvillas` module, no `RealTimeSimulation` and `RealTimeDataLogger`, and no
-`SynchronGeneratorDQODE` in `dpsimpy.dp.ph3` and `dpsimpy.emt.ph3`; the solvers, the models and
-the CIM/CGMES reader are all available.
+Wheels are published for Linux and Windows on x86-64 only, so on macOS you have to build from
+source for now.
+The Windows wheel is a reduced build and does not carry every feature; see
+[supported versions](#supported-versions) below.
 The package also contains only the simulation core; the example notebooks additionally need
 plotting and data handling packages, which are listed in the import section of each notebook.
 {{% /alert %}}
+
+## Supported versions
+
+DPsim needs CPython 3.10 or newer, both for the wheels and for a source build. One wheel is
+published per platform and CPython version:
+
+| Platform | Architecture | CPython | Modules in the wheel |
+| --- | --- | --- | --- |
+| Linux, `manylinux_2_28` | x86-64 | 3.10, 3.11, 3.12, 3.13, 3.14 | `dpsim`, `dpsimpy`, `dpsimpyvillas` |
+| Windows | x86-64 | 3.10, 3.11, 3.12, 3.13, 3.14 | `dpsim`, `dpsimpy` |
+| macOS | any | none | build from source |
+
+Free-threaded interpreters (`cp3XXt`) and PyPy are not built, and neither are 32-bit or Arm
+wheels. Older DPsim releases additionally ship CPython 3.9 wheels.
+
+The two wheels are not equivalent. The Windows one is built without VILLASnode, real-time
+support and Sundials, because those do not build there, so co-simulation, real-time execution
+and the ODE-based generator are missing from it:
+
+| Feature | Linux wheel | Windows wheel |
+| --- | --- | --- |
+| MNA, power flow and SSN solvers | yes | yes |
+| CIM/CGMES reader | yes | yes |
+| Component models | all | all but `SynchronGeneratorDQODE` in `dpsimpy.dp.ph3` and `dpsimpy.emt.ph3` |
+| `dpsimpyvillas`, VILLASnode co-simulation | yes | no |
+| `RealTimeSimulation`, `RealTimeDataLogger` | yes | no |
+| MNA solver plugins | yes | no |
+
+Do not build from source to close that gap; on Windows there are two easier routes to the full
+package. Either run the Linux wheel inside
+[WSL2](https://learn.microsoft.com/windows/wsl/install), where a plain `pip install dpsim` gives
+you everything, or use the `sogno/dpsim` container described below, which ships the same
+complete build.
+
+The wheel pulls in NumPy 2.0 or newer, pandas 2.0 or newer and SciPy 1.10 or newer.
 
 If you prefer conda, the equivalent is:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11>=2.10.3", "pybind11-stubgen>=2.5", "numpy>=2.0.0"]
+requires = ["setuptools>=42", "wheel", "pybind11>=3.0.0", "pybind11-stubgen>=2.5", "numpy>=2.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,8 +13,13 @@ readme = {file = "README.md", content-type = "text/markdown"}
 license = "MPL-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy>=2.0.0",
     "pandas>=2.0.0",
@@ -67,12 +72,12 @@ build-verbosity = 3
 test-command = "python -c \"import dpsimpy; import dpsim\""
 
 [tool.cibuildwheel.linux]
-build = "cp3{9,10,11,12,13}-manylinux_x86_64"
+build = "cp3{10,11,12,13,14}-manylinux_x86_64"
 manylinux-x86_64-image = "sogno/dpsim:manylinux"
 test-command = "python -c \"import dpsimpy; import dpsimpyvillas; import dpsim\""
 
 [tool.cibuildwheel.windows]
-build = "cp3{9,10,11,12,13}-win_amd64"
+build = "cp3{10,11,12,13,14}-win_amd64"
 before-build = "pip install delvewheel"
 repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.cfamily.analysisCache.path=sonar-cache
 sonar.cfamily.analysisCache.mode=fs
 
 # Sonar Python Version
-sonar.python.version=3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+sonar.python.version=3.10, 3.11, 3.12, 3.13, 3.14
 
 # Patterns excluded from duplication detection
 sonar.cpd.exclusions=dpsim/examples/**/*,examples/**/*


### PR DESCRIPTION
Drops CPython 3.9 and adds 3.14 in pyproject, both cibuildwheel matrices and the CI checks. The published manylinux image already carries cp314, so no image rebuild is needed.

The install page gains a version matrix and a table of what the Windows wheel lacks; README and the build page no longer claim wheels are Linux only.

Succesful runs:
https://github.com/leonardocarreras/dpsim/actions/runs/31490363600/job/93785444971
https://github.com/leonardocarreras/dpsim/actions/runs/31490363600/job/93785444971