### PR TITLE
restore github hosted runners in workflows

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -111,7 +111,7 @@ jobs:
     name: Publish sogno/dpsim:${{ matrix.image }}
     needs: [changes]
     if: needs.changes.outputs.base != '[]'
-    runs-on: sogno-platform-dpsim-runner
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -139,7 +139,7 @@ jobs:
     name: Publish sogno/dpsim:${{ matrix.image }}
     needs: [changes, base]
     if: ${{ always() && needs.base.result != 'failure' && needs.changes.outputs.derived != '[]' }}
-    runs-on: sogno-platform-dpsim-runner
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Self hosted is violently out of sync right now