### PR TITLE
EMT_Ph3_SSN_InductionMotor

### DIFF
--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -157,6 +157,7 @@
 #include <dpsim-models/EMT/EMT_Ph3_SSN_GFL.h>
 #include <dpsim-models/EMT/EMT_Ph3_SSN_GFL_Split.h>
 #include <dpsim-models/EMT/EMT_Ph3_SSN_GFM.h>
+#include <dpsim-models/EMT/EMT_Ph3_SSN_InductionMotor.h>
 #include <dpsim-models/EMT/EMT_Ph3_SSN_Inductor.h>
 #include <dpsim-models/EMT/EMT_Ph3_SeriesResistor.h>
 #include <dpsim-models/EMT/EMT_Ph3_SeriesSwitch.h>

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_InductionMotor.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_InductionMotor.h
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <memory>
+
+#include <dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeVariableSSNComp.h>
+
+namespace CPS {
+namespace EMT {
+namespace Ph3 {
+
+/// \brief Induction machine model formulated as a variable V-type SSN component.
+///
+/// Electrical model from Dufour:
+///
+///   psi_dot = (-R L^-1 + Omega) psi + v_dq
+///   i_dq    = (L^-1) psi
+///
+/// State vector:
+///   psi = [psi_sd, psi_sq, psi_rd', psi_rq', mechanical_speed, electrical_angle]^t
+///
+/// Primed/dashed quantities are reffered to stator.
+///
+class SSN_InductionMotor : public TwoTerminalVTypeVariableSSNComp {
+public:
+  using Ptr = std::shared_ptr<SSN_InductionMotor>;
+
+  static Ptr make(String uid, String name,
+                  Logger::Level logLevel = Logger::Level::off) {
+    return std::make_shared<SSN_InductionMotor>(uid, name, logLevel);
+  }
+
+  static Ptr make(String name, Logger::Level logLevel = Logger::Level::off) {
+    return std::make_shared<SSN_InductionMotor>(name, name, logLevel);
+  }
+
+  enum StateIndex {
+    PsiSd = 0,
+    PsiSq,
+    PsiRotorD,
+    PsiRotorQ,
+    MechanicalSpeed,
+    ElectricalAngle,
+    StateCount
+  };
+
+protected:
+  static constexpr Int mElectricalStateSize = 4;
+  static constexpr Int mStateSize = StateCount;
+  static constexpr Int mInputSize = 3;
+  static constexpr Int mOutputSize = 3;
+
+  Int mPolePairs;
+
+  Real mNominalFrequency;
+  Real mNominalMechanicalSpeed;
+
+  Real mStatorResistance;
+  Real mRotorResistance;
+
+  //rotor inductance
+  Real mLr_dash;
+  //mutual inductance
+  Real mLm;
+  //stator inductance
+  Real mLs;
+
+  Real mRotorInertia;
+  Real mMechanicalDamping;
+
+  Real mMechanicalTorque;
+  Real mInitialElectricalAngle;
+  Bool mAutoInitializeMechanicalTorque;
+
+  Matrix mInductanceMatrix;
+  Matrix mInverseInductanceMatrix;
+  Matrix mResistanceMatrix;
+
+  Real mJacobianRelativeStep;
+  Real mJacobianAbsoluteStep;
+
+  Attribute<Real>::Ptr mElectricalPower;
+  Attribute<Real>::Ptr mElectricalTorque;
+  Attribute<Real>::Ptr mMechanicalSpeedLog;
+  Attribute<Real>::Ptr mElectricalAngleLog;
+  Attribute<Real>::Ptr mStatorCurrentD;
+  Attribute<Real>::Ptr mStatorCurrentQ;
+  Attribute<Real>::Ptr mStatorVoltageD;
+  Attribute<Real>::Ptr mStatorVoltageQ;
+
+  Matrix getParkTransformMatrix(Real electricalAngle) const;
+  Matrix getInverseParkTransformMatrix(Real electricalAngle) const;
+  Matrix buildSpeedMatrix(Real electricalSpeed) const;
+
+  void rebuildMachineMatrices();
+
+  void evaluateStateDerivative(const Matrix &x, const Matrix &u,
+                               Matrix &stateDerivative) const;
+  void evaluateOutput(const Matrix &x, const Matrix &u, Matrix &output) const;
+
+  void calculateNumericalJacobians(const Matrix &x, const Matrix &u, Matrix &A,
+                                   Matrix &B, Matrix &C, Matrix &D) const;
+
+  void buildStateSpaceModel(const Matrix &x, const Matrix &u, Matrix &A,
+                            Matrix &B, Matrix &C, Matrix &D, Matrix &E,
+                            Matrix &F) const;
+
+  Bool updateComponentParameters() override;
+
+  std::vector<String> getLocalStateNames() const override;
+  void updateLogAttributes(const Matrix &u) const override;
+
+public:
+  SSN_InductionMotor(String uid, String name,
+                     Logger::Level logLevel = Logger::Level::off);
+
+  explicit SSN_InductionMotor(String name,
+                              Logger::Level logLevel = Logger::Level::off)
+      : SSN_InductionMotor(name, name, logLevel) {}
+
+  /// \brief Configure the sixth-order machine.
+  ///
+  /// Units:
+  /// - frequency: Hz
+  /// - resistances: ohm
+  /// - inductances: H
+  /// - inertia: kg m^2
+  /// - damping: N m s/rad
+  /// - field voltage: V, referred to stator
+  /// - mechanical torque: N m
+  void setParameters(Real nominalFrequency, Int polePairs,
+                     Real statorResistance, Real rotorResistance,
+                     Real statorInductance, Real rotorInductance,
+                     Real mutualInductance, Real rotorInertia,
+                     Real mechanicalDamping, Real mechanicalTorque,
+                     Real initialElectricalAngle = 0.0,
+                     Bool autoInitializeMechanicalTorque = true);
+
+  void setMechanicalTorque(Real mechanicalTorque);
+
+  void setNumericalLinearizationParameters(Real relativeStep,
+                                           Real absoluteStep);
+
+  void initializeFromNodesAndTerminals(Real frequency) override;
+
+  Matrix getState() const;
+  Matrix getStateDerivative() const;
+  Matrix getInterfaceVoltage() const;
+  Matrix getInterfaceCurrent() const;
+  std::vector<String> getStateNames() const { return getLocalStateNames(); }
+};
+
+} // namespace Ph3
+} // namespace EMT
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_InductionMotor.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_InductionMotor.h
@@ -82,13 +82,19 @@ protected:
   Real mJacobianAbsoluteStep;
 
   Attribute<Real>::Ptr mElectricalPower;
+  Attribute<Real>::Ptr mReactivePower;
   Attribute<Real>::Ptr mElectricalTorque;
+  Attribute<Real>::Ptr mMechanicalLoadTorque;
   Attribute<Real>::Ptr mMechanicalSpeedLog;
+  Attribute<Real>::Ptr mMechanicalSpeedPu;
   Attribute<Real>::Ptr mElectricalAngleLog;
+  Attribute<Real>::Ptr mSlip;
   Attribute<Real>::Ptr mStatorCurrentD;
   Attribute<Real>::Ptr mStatorCurrentQ;
   Attribute<Real>::Ptr mStatorVoltageD;
   Attribute<Real>::Ptr mStatorVoltageQ;
+  Attribute<Real>::Ptr mStatorCurrentMagnitude;
+  Attribute<Real>::Ptr mStatorVoltageMagnitude;
 
   Matrix getParkTransformMatrix(Real electricalAngle) const;
   Matrix getInverseParkTransformMatrix(Real electricalAngle) const;

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -164,6 +164,7 @@ list(APPEND MODELS_SOURCES
 	EMT/EMT_Ph3_TwoTerminalITypeSSNComp.cpp
 	EMT/EMT_Ph3_TwoTerminalVTypeVariableSSNComp.cpp
 	EMT/EMT_Ph3_FourTerminalVTypeSSNComp.cpp
+	EMT/EMT_Ph3_SSN_InductionMotor.cpp
 	EMT/EMT_Ph3_PiecewiseLinearInductor.cpp
 	EMT/EMT_Ph3_VSIVoltageControlVCO.cpp
 

--- a/dpsim-models/src/EMT/EMT_Ph3_SSN_InductionMotor.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SSN_InductionMotor.cpp
@@ -1,0 +1,416 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+#include <Eigen/Eigenvalues>
+#include <Eigen/LU>
+
+#include <dpsim-models/EMT/EMT_Ph3_SSN_InductionMotor.h>
+
+using namespace CPS;
+
+EMT::Ph3::SSN_InductionMotor::SSN_InductionMotor(String uid, String name,
+                                                 Logger::Level logLevel)
+    : TwoTerminalVTypeVariableSSNComp(uid, name, logLevel), mPolePairs(0),
+      mNominalFrequency(0.0), mNominalMechanicalSpeed(0.0),
+      mStatorResistance(0.0), mRotorResistance(0.0), mLs(0.0), mLr_dash(0.0),
+      mLm(0.0), mRotorInertia(0.0), mMechanicalDamping(0.0),
+      mMechanicalTorque(0.0), mInitialElectricalAngle(0.0),
+      mAutoInitializeMechanicalTorque(true),
+      mInductanceMatrix(
+          Matrix::Zero(mElectricalStateSize, mElectricalStateSize)),
+      mInverseInductanceMatrix(
+          Matrix::Zero(mElectricalStateSize, mElectricalStateSize)),
+      mResistanceMatrix(
+          Matrix::Zero(mElectricalStateSize, mElectricalStateSize)),
+      mJacobianRelativeStep(1e-6), mJacobianAbsoluteStep(1e-8),
+      mElectricalPower(mAttributes->create<Real>("electrical_power")),
+      mElectricalTorque(mAttributes->create<Real>("electrical_torque")),
+      mMechanicalSpeedLog(mAttributes->create<Real>("mechanical_speed")),
+      mElectricalAngleLog(mAttributes->create<Real>("electrical_angle")),
+      mStatorCurrentD(mAttributes->create<Real>("stator_current_d")),
+      mStatorCurrentQ(mAttributes->create<Real>("stator_current_q")),
+      mStatorVoltageD(mAttributes->create<Real>("stator_voltage_d")),
+      mStatorVoltageQ(mAttributes->create<Real>("stator_voltage_q")) {
+
+  **mIntfVoltage = Matrix::Zero(mInputSize, 1);
+  **mIntfCurrent = Matrix::Zero(mOutputSize, 1);
+
+  **mElectricalPower = 0.0;
+  **mElectricalTorque = 0.0;
+  **mMechanicalSpeedLog = 0.0;
+  **mElectricalAngleLog = 0.0;
+  **mStatorCurrentD = 0.0;
+  **mStatorCurrentQ = 0.0;
+  **mStatorVoltageD = 0.0;
+  **mStatorVoltageQ = 0.0;
+}
+
+std::vector<String> EMT::Ph3::SSN_InductionMotor::getLocalStateNames() const {
+  return {"psi_sd", "psi_sq",           "psi_dr",
+          "psi_qr", "mechanical_speed", "electrical_angle"};
+}
+
+void EMT::Ph3::SSN_InductionMotor::setParameters(
+    Real nominalFrequency, Int polePairs, Real statorResistance,
+    Real rotorResistance, Real statorInductance, Real rotorInductance,
+    Real mutualInductance, Real rotorInertia, Real mechanicalDamping,
+    Real mechanicalTorque, Real initialElectricalAngle,
+    Bool autoInitializeMechanicalTorque) {
+
+  if (nominalFrequency <= 0.0)
+    throw std::invalid_argument("Nominal frequency must be positive.");
+  if (polePairs <= 0)
+    throw std::invalid_argument("The number of pole pairs must be positive.");
+
+  if (statorResistance < 0.0)
+    throw std::invalid_argument("Stator resistance is invalid.");
+
+  if (statorInductance <= 0.0 || rotorInductance <= 0.0 ||
+      mutualInductance <= 0.0)
+    throw std::invalid_argument("Motor winding inductances must be positive.");
+
+  if (statorInductance <= mutualInductance ||
+      rotorInductance <= mutualInductance)
+    throw std::invalid_argument(
+        "Each total winding inductance must exceed its mutual inductance.");
+
+  if (rotorInertia <= 0.0)
+    throw std::invalid_argument("Rotor inertia must be positive.");
+  if (mechanicalDamping < 0.0)
+    throw std::invalid_argument("Mechanical damping must be non-negative.");
+
+  mNominalFrequency = nominalFrequency;
+  mPolePairs = polePairs;
+  mNominalMechanicalSpeed =
+      2.0 * PI * mNominalFrequency / static_cast<Real>(mPolePairs);
+
+  mLm = mutualInductance;
+  mLs = statorInductance;
+  mLr_dash = rotorInductance;
+
+  mRotorResistance = rotorResistance;
+  mStatorResistance = statorResistance;
+
+  mRotorInertia = rotorInertia;
+  mMechanicalDamping = mechanicalDamping;
+  mMechanicalTorque = mechanicalTorque;
+  mInitialElectricalAngle = initialElectricalAngle;
+  mAutoInitializeMechanicalTorque = autoInitializeMechanicalTorque;
+
+  rebuildMachineMatrices();
+
+  // Establish dimensions here. The actual local affine model is built after
+  // initialization at a physical operating point.
+  VTypeVariableSSNComp::setParameters(Matrix::Zero(mStateSize, mStateSize),
+                                      Matrix::Zero(mStateSize, mInputSize),
+                                      Matrix::Zero(mOutputSize, mStateSize),
+                                      Matrix::Zero(mOutputSize, mInputSize),
+                                      Matrix::Zero(mStateSize, 1),
+                                      Matrix::Zero(mOutputSize, 1));
+}
+
+void EMT::Ph3::SSN_InductionMotor::rebuildMachineMatrices() {
+  mInductanceMatrix.setZero();
+
+  Real denom = mLr_dash * mLs - mLm * mLm;
+  if (denom < DOUBLE_EPSILON)
+    throw std::invalid_argument(
+        "The induction motor inductance matrix is singular.");
+
+  // State order: [sd, sq, rd', kq'].
+  mInverseInductanceMatrix << mLr_dash, 0.0, -mLm, 0.0, 0.0, mLr_dash, 0.0,
+      -mLm, -mLm, 0.0, mLs, 0.0, 0.0, -mLm, 0.0, mLs;
+
+  mInverseInductanceMatrix *= 1. / denom;
+
+  Eigen::FullPivLU<Matrix> decomposition(mInverseInductanceMatrix);
+  if (!decomposition.isInvertible())
+    throw std::invalid_argument(
+        "The induction motor inverse inductance matrix is singular.");
+
+  mInductanceMatrix = decomposition.inverse();
+
+  Eigen::SelfAdjointEigenSolver<Matrix> eigenSolver(mInductanceMatrix);
+  if (eigenSolver.info() != Eigen::Success ||
+      eigenSolver.eigenvalues().minCoeff() <= 0.0)
+    throw std::invalid_argument(
+        "The induction motor inductance matrix is not positive definite.");
+
+  mResistanceMatrix.setZero();
+  mResistanceMatrix.diagonal() << mStatorResistance, mStatorResistance,
+      mRotorResistance, mRotorResistance;
+}
+
+void EMT::Ph3::SSN_InductionMotor::setMechanicalTorque(Real mechanicalTorque) {
+  mMechanicalTorque = mechanicalTorque;
+  mAutoInitializeMechanicalTorque = false;
+}
+
+void EMT::Ph3::SSN_InductionMotor::setNumericalLinearizationParameters(
+    Real relativeStep, Real absoluteStep) {
+  if (relativeStep <= 0.0)
+    throw std::invalid_argument(
+        "Relative finite-difference step must be positive.");
+  if (absoluteStep <= 0.0)
+    throw std::invalid_argument(
+        "Absolute finite-difference step must be positive.");
+
+  mJacobianRelativeStep = relativeStep;
+  mJacobianAbsoluteStep = absoluteStep;
+}
+
+Matrix EMT::Ph3::SSN_InductionMotor::getParkTransformMatrix(
+    Real electricalAngle) const {
+  electricalAngle = std::remainder(electricalAngle, 2.0 * PI);
+
+  Matrix transform(2, 3);
+  const Real scale = std::sqrt(2.0 / 3.0);
+
+  transform.row(0) << scale * std::cos(electricalAngle),
+      scale * std::cos(electricalAngle - 2.0 * PI / 3.0),
+      scale * std::cos(electricalAngle + 2.0 * PI / 3.0);
+
+  transform.row(1) << -scale * std::sin(electricalAngle),
+      -scale * std::sin(electricalAngle - 2.0 * PI / 3.0),
+      -scale * std::sin(electricalAngle + 2.0 * PI / 3.0);
+
+  return transform;
+}
+
+Matrix EMT::Ph3::SSN_InductionMotor::getInverseParkTransformMatrix(
+    Real electricalAngle) const {
+  // For balanced abc quantities, the inverse of the orthonormal two-axis
+  // transform is its transpose.
+  return getParkTransformMatrix(electricalAngle).transpose();
+}
+
+Matrix
+EMT::Ph3::SSN_InductionMotor::buildSpeedMatrix(Real electricalSpeed) const {
+  Matrix speedMatrix = Matrix::Zero(mElectricalStateSize, mElectricalStateSize);
+
+  speedMatrix(2, 3) = -electricalSpeed;
+  speedMatrix(3, 2) = electricalSpeed;
+
+  return speedMatrix;
+}
+
+void EMT::Ph3::SSN_InductionMotor::evaluateStateDerivative(
+    const Matrix &x, const Matrix &u, Matrix &stateDerivative) const {
+  if (x.rows() != mStateSize || x.cols() != 1)
+    throw std::invalid_argument(
+        "Induction motor state vector has an invalid dimension.");
+  if (u.rows() != mInputSize || u.cols() != 1)
+    throw std::invalid_argument(
+        "Induction motor input vector has an invalid dimension.");
+
+  stateDerivative.setZero(mStateSize, 1);
+
+  const Matrix flux = x.block(0, 0, mElectricalStateSize, 1);
+  const Real mechanicalSpeed = x(MechanicalSpeed, 0);
+  const Real electricalSpeed = static_cast<Real>(mPolePairs) * mechanicalSpeed;
+
+  const Matrix current = mInverseInductanceMatrix * flux;
+  const Real statorCurrentD = current(0, 0);
+  const Real statorCurrentQ = current(1, 0);
+
+  const Matrix voltageDq = getParkTransformMatrix(0.0) * u; //squirrel-cage
+
+  Matrix windingVoltage = Matrix::Zero(mElectricalStateSize, 1);
+  windingVoltage(0, 0) = voltageDq(0, 0);
+  windingVoltage(1, 0) = voltageDq(1, 0);
+  windingVoltage(2, 0) = 0.0; // rotor short-circuited
+  windingVoltage(3, 0) = 0.0;
+
+  const Matrix fluxDerivative = (-mResistanceMatrix * mInverseInductanceMatrix +
+                                 buildSpeedMatrix(electricalSpeed)) *
+                                    flux +
+                                windingVoltage;
+
+  stateDerivative.block(0, 0, mElectricalStateSize, 1) = fluxDerivative;
+
+  const Real electricalTorque =
+      static_cast<Real>(mPolePairs) *
+      (flux(PsiSd, 0) * statorCurrentQ - flux(PsiSq, 0) * statorCurrentD);
+
+  // Current is positive entering the machine. In generator operation the
+  // electromagnetic torque is therefore normally negative. The applied shaft
+  // torque is positive in the direction of rotation.
+  stateDerivative(MechanicalSpeed, 0) =
+      (mMechanicalTorque + electricalTorque -
+       mMechanicalDamping *
+           (mechanicalSpeed -
+            mNominalMechanicalSpeed)) / //steady state: synchronous speed as equilibrium point or slip?
+      mRotorInertia;
+
+  stateDerivative(ElectricalAngle, 0) = electricalSpeed;
+}
+
+void EMT::Ph3::SSN_InductionMotor::evaluateOutput(const Matrix &x,
+                                                  const Matrix &u,
+                                                  Matrix &output) const {
+  (void)u;
+
+  if (x.rows() != mStateSize || x.cols() != 1)
+    throw std::invalid_argument(
+        "Induction motor state vector has an invalid dimension.");
+
+  const Matrix flux = x.block(0, 0, mElectricalStateSize, 1);
+  const Matrix current = mInverseInductanceMatrix * flux;
+
+  Matrix statorCurrentDq(2, 1);
+  statorCurrentDq << current(0, 0), current(1, 0);
+
+  // Current entering the stator terminals, as required by the V-type stamp.
+  output = getInverseParkTransformMatrix(0.0) * statorCurrentDq;
+}
+
+void EMT::Ph3::SSN_InductionMotor::calculateNumericalJacobians(
+    const Matrix &x, const Matrix &u, Matrix &A, Matrix &B, Matrix &C,
+    Matrix &D) const {
+  A.setZero(mStateSize, mStateSize);
+  B.setZero(mStateSize, mInputSize);
+  C.setZero(mOutputSize, mStateSize);
+  D.setZero(mOutputSize, mInputSize);
+
+  Matrix fPlus = Matrix::Zero(mStateSize, 1);
+  Matrix fMinus = Matrix::Zero(mStateSize, 1);
+  Matrix gPlus = Matrix::Zero(mOutputSize, 1);
+  Matrix gMinus = Matrix::Zero(mOutputSize, 1);
+
+  for (Int column = 0; column < mStateSize; ++column) {
+    const Real step =
+        mJacobianAbsoluteStep +
+        mJacobianRelativeStep * std::max(1.0, std::abs(x(column, 0)));
+
+    Matrix xPlus = x;
+    Matrix xMinus = x;
+    xPlus(column, 0) += step;
+    xMinus(column, 0) -= step;
+
+    evaluateStateDerivative(xPlus, u, fPlus);
+    evaluateStateDerivative(xMinus, u, fMinus);
+    evaluateOutput(xPlus, u, gPlus);
+    evaluateOutput(xMinus, u, gMinus);
+
+    A.col(column) = (fPlus - fMinus) / (2.0 * step);
+    C.col(column) = (gPlus - gMinus) / (2.0 * step);
+  }
+
+  for (Int column = 0; column < mInputSize; ++column) {
+    const Real step =
+        mJacobianAbsoluteStep +
+        mJacobianRelativeStep * std::max(1.0, std::abs(u(column, 0)));
+
+    Matrix uPlus = u;
+    Matrix uMinus = u;
+    uPlus(column, 0) += step;
+    uMinus(column, 0) -= step;
+
+    evaluateStateDerivative(x, uPlus, fPlus);
+    evaluateStateDerivative(x, uMinus, fMinus);
+    evaluateOutput(x, uPlus, gPlus);
+    evaluateOutput(x, uMinus, gMinus);
+
+    B.col(column) = (fPlus - fMinus) / (2.0 * step);
+    D.col(column) = (gPlus - gMinus) / (2.0 * step);
+  }
+}
+
+void EMT::Ph3::SSN_InductionMotor::buildStateSpaceModel(
+    const Matrix &x, const Matrix &u, Matrix &A, Matrix &B, Matrix &C,
+    Matrix &D, Matrix &E, Matrix &F) const {
+  calculateNumericalJacobians(x, u, A, B, C, D);
+
+  Matrix stateDerivative = Matrix::Zero(mStateSize, 1);
+  Matrix output = Matrix::Zero(mOutputSize, 1);
+
+  evaluateStateDerivative(x, u, stateDerivative);
+  evaluateOutput(x, u, output);
+
+  E = stateDerivative - A * x - B * u;
+  F = output - C * x - D * u;
+}
+
+Bool EMT::Ph3::SSN_InductionMotor::updateComponentParameters() {
+  Matrix stateOffset;
+  Matrix outputOffset;
+
+  buildStateSpaceModel(**mX, **mIntfVoltage, mA, mB, mC, mD, stateOffset,
+                       outputOffset);
+
+  setStateOffset(stateOffset);
+  setOutputOffset(outputOffset);
+
+  return true;
+}
+
+void EMT::Ph3::SSN_InductionMotor::updateLogAttributes(const Matrix &u) const {
+  const Matrix &x = **mX;
+  const Matrix flux = x.block(0, 0, mElectricalStateSize, 1);
+  const Matrix current = mInverseInductanceMatrix * flux;
+  const Matrix voltageDq = getParkTransformMatrix(0.0) * u;
+
+  Matrix statorCurrentDq(2, 1);
+  statorCurrentDq << current(0, 0), current(1, 0);
+
+  const Real electricalTorque =
+      static_cast<Real>(mPolePairs) *
+      (flux(PsiSd, 0) * current(1, 0) - flux(PsiSq, 0) * current(0, 0));
+
+  const Real electricalPower = voltageDq(0, 0) * statorCurrentDq(0, 0) +
+                               voltageDq(1, 0) * statorCurrentDq(1, 0);
+
+  **mElectricalPower = electricalPower;
+  **mElectricalTorque = electricalTorque;
+  **mMechanicalSpeedLog = x(MechanicalSpeed, 0);
+  **mElectricalAngleLog = std::remainder(x(ElectricalAngle, 0), 2.0 * PI);
+  **mStatorCurrentD = current(0, 0);
+  **mStatorCurrentQ = current(1, 0);
+  **mStatorVoltageD = voltageDq(0, 0);
+  **mStatorVoltageQ = voltageDq(1, 0);
+}
+
+void EMT::Ph3::SSN_InductionMotor::initializeFromNodesAndTerminals(
+    Real frequency) {
+  if (!mParametersSet)
+    throw std::logic_error(
+        "setParameters() must be called before initialization.");
+
+  const MatrixComp initialVoltagePhasor = buildInitialInputFromNodes(frequency);
+  const Matrix initialVoltageAbc = initialVoltagePhasor.real();
+
+  Matrix x0 = Matrix::Zero(mStateSize, 1);
+  x0(MechanicalSpeed, 0) = 0.0;
+  x0(ElectricalAngle, 0) = mInitialElectricalAngle;
+
+  **mX = x0;
+  **mIntfVoltage = initialVoltageAbc;
+
+  updateStateSpaceModel();
+  mYHist = calculateHistoryVector();
+  **mIntfCurrent = mW * (**mIntfVoltage) + mYHist;
+  updateLogAttributes(**mIntfVoltage);
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "Cold-start initialization: standstill, zero flux.");
+}
+
+Matrix EMT::Ph3::SSN_InductionMotor::getState() const { return **mX; }
+
+Matrix EMT::Ph3::SSN_InductionMotor::getStateDerivative() const {
+  Matrix stateDerivative = Matrix::Zero(mStateSize, 1);
+  evaluateStateDerivative(**mX, **mIntfVoltage, stateDerivative);
+  return stateDerivative;
+}
+
+Matrix EMT::Ph3::SSN_InductionMotor::getInterfaceVoltage() const {
+  return **mIntfVoltage;
+}
+
+Matrix EMT::Ph3::SSN_InductionMotor::getInterfaceCurrent() const {
+  return **mIntfCurrent;
+}

--- a/dpsim-models/src/EMT/EMT_Ph3_SSN_InductionMotor.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SSN_InductionMotor.cpp
@@ -28,25 +28,40 @@ EMT::Ph3::SSN_InductionMotor::SSN_InductionMotor(String uid, String name,
           Matrix::Zero(mElectricalStateSize, mElectricalStateSize)),
       mJacobianRelativeStep(1e-6), mJacobianAbsoluteStep(1e-8),
       mElectricalPower(mAttributes->create<Real>("electrical_power")),
+      mReactivePower(mAttributes->create<Real>("reactive_power")),
       mElectricalTorque(mAttributes->create<Real>("electrical_torque")),
+      mMechanicalLoadTorque(
+          mAttributes->create<Real>("mechanical_load_torque")),
       mMechanicalSpeedLog(mAttributes->create<Real>("mechanical_speed")),
+      mMechanicalSpeedPu(mAttributes->create<Real>("mechanical_speed_pu")),
       mElectricalAngleLog(mAttributes->create<Real>("electrical_angle")),
+      mSlip(mAttributes->create<Real>("slip")),
       mStatorCurrentD(mAttributes->create<Real>("stator_current_d")),
       mStatorCurrentQ(mAttributes->create<Real>("stator_current_q")),
       mStatorVoltageD(mAttributes->create<Real>("stator_voltage_d")),
-      mStatorVoltageQ(mAttributes->create<Real>("stator_voltage_q")) {
+      mStatorVoltageQ(mAttributes->create<Real>("stator_voltage_q")),
+      mStatorCurrentMagnitude(
+          mAttributes->create<Real>("stator_current_magnitude")),
+      mStatorVoltageMagnitude(
+          mAttributes->create<Real>("stator_voltage_magnitude")) {
 
   **mIntfVoltage = Matrix::Zero(mInputSize, 1);
   **mIntfCurrent = Matrix::Zero(mOutputSize, 1);
 
   **mElectricalPower = 0.0;
+  **mReactivePower = 0.0;
   **mElectricalTorque = 0.0;
+  **mMechanicalLoadTorque = 0.0;
   **mMechanicalSpeedLog = 0.0;
+  **mMechanicalSpeedPu = 0.0;
   **mElectricalAngleLog = 0.0;
+  **mSlip = 0.0;
   **mStatorCurrentD = 0.0;
   **mStatorCurrentQ = 0.0;
   **mStatorVoltageD = 0.0;
   **mStatorVoltageQ = 0.0;
+  **mStatorCurrentMagnitude = 0.0;
+  **mStatorVoltageMagnitude = 0.0;
 }
 
 std::vector<String> EMT::Ph3::SSN_InductionMotor::getLocalStateNames() const {
@@ -68,6 +83,8 @@ void EMT::Ph3::SSN_InductionMotor::setParameters(
 
   if (statorResistance < 0.0)
     throw std::invalid_argument("Stator resistance is invalid.");
+  if (rotorResistance < 0.0)
+    throw std::invalid_argument("Rotor resistance is invalid.");
 
   if (statorInductance <= 0.0 || rotorInductance <= 0.0 ||
       mutualInductance <= 0.0)
@@ -363,15 +380,27 @@ void EMT::Ph3::SSN_InductionMotor::updateLogAttributes(const Matrix &u) const {
 
   const Real electricalPower = voltageDq(0, 0) * statorCurrentDq(0, 0) +
                                voltageDq(1, 0) * statorCurrentDq(1, 0);
+  const Real reactivePower = voltageDq(1, 0) * statorCurrentDq(0, 0) -
+                             voltageDq(0, 0) * statorCurrentDq(1, 0);
+  const Real mechanicalLoadTorque =
+      -mMechanicalTorque +
+      mMechanicalDamping * (x(MechanicalSpeed, 0) - mNominalMechanicalSpeed);
 
   **mElectricalPower = electricalPower;
+  **mReactivePower = reactivePower;
   **mElectricalTorque = electricalTorque;
+  **mMechanicalLoadTorque = mechanicalLoadTorque;
   **mMechanicalSpeedLog = x(MechanicalSpeed, 0);
+  **mMechanicalSpeedPu = x(MechanicalSpeed, 0) / mNominalMechanicalSpeed;
   **mElectricalAngleLog = std::remainder(x(ElectricalAngle, 0), 2.0 * PI);
+  **mSlip = (mNominalMechanicalSpeed - x(MechanicalSpeed, 0)) /
+            mNominalMechanicalSpeed;
   **mStatorCurrentD = current(0, 0);
   **mStatorCurrentQ = current(1, 0);
   **mStatorVoltageD = voltageDq(0, 0);
   **mStatorVoltageQ = voltageDq(1, 0);
+  **mStatorCurrentMagnitude = statorCurrentDq.norm();
+  **mStatorVoltageMagnitude = voltageDq.norm();
 }
 
 void EMT::Ph3::SSN_InductionMotor::initializeFromNodesAndTerminals(

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -155,6 +155,7 @@ Components/DP_Ph3_AvVoltSourceInverterStateSpace.cpp
 Components/EMT_SSN_GFM_Test.cpp
 Components/EMT_Ph3_SSN_GFM_JacobianCheck.cpp
 Components/EMT_Ph3_GFL_Comparison.cpp
+Components/EMT_Ph3_SSN_InductionMotor_LoadSwitch.cpp
 )
 
 set(STATE_SPACE_SOURCES
@@ -198,6 +199,7 @@ list(APPEND TEST_SOURCES
 	Circuits/SP_ITM_withPiLine_Ph1.cpp
 	Circuits/SP_Ph1_General2TerminalSSN.cpp
 	Circuits/EMT_DC_PiLine_SourceStep.cpp
+	Components/EMT_Ph3_SSN_InductionMotor_LoadSwitch.cpp
 )
 
 if(WITH_SUNDIALS)

--- a/dpsim/examples/cxx/Components/EMT_Ph3_SSN_InductionMotor_LoadSwitch.cpp
+++ b/dpsim/examples/cxx/Components/EMT_Ph3_SSN_InductionMotor_LoadSwitch.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS;
+
+class EMT_Ph3_SSN_InductionMotor_Circuits {
+public:
+  EMT_Ph3_SSN_InductionMotor_Circuits() = default;
+  ~EMT_Ph3_SSN_InductionMotor_Circuits() = default;
+
+  void ColdStart_LoadSwitch();
+
+private:
+  String simName_coldStart = "EMT_Ph3_SSN_InductionMotor_ColdStart_LoadSwitch";
+
+  static constexpr Real nominalFrequency = 50.0;
+  static constexpr Int polePairs = 2;
+
+  static constexpr Real Rs = 2.0; // stator resistance [ohm]
+  static constexpr Real Rr = 1.5; // rotor resistance, referred to stator [ohm]
+
+  static constexpr Real Lm = 0.15;     // mutual inductance [H]
+  static constexpr Real Lls = 0.01;    // stator leakage [H]
+  static constexpr Real Llr = 0.01;    // rotor leakage, referred to stator [H]
+  static constexpr Real Ls = Lm + Lls; // total stator inductance [H]
+  static constexpr Real Lr_dash =
+      Lm + Llr; // total rotor inductance, referred to stator [H]
+
+  static constexpr Real rotorInertia = 0.05;      // [kg m^2]
+  static constexpr Real mechanicalDamping = 0.01; // [N m s/rad]
+
+  static constexpr Real we = 2.0 * PI * nominalFrequency;
+  static constexpr Real synchronousSpeed = we / static_cast<Real>(polePairs);
+
+  static constexpr Real Vamp =
+      325.0; // peak phase voltage [V] (~230 V RMS line-to-neutral)
+
+  static constexpr Real stepTime = 1e-4;
+  static constexpr Real finalTime = 2.5;
+  static constexpr Real switchTime = 1.0;
+  static constexpr Real switchOpenRes = 1e6;
+  static constexpr Real switchClosedRes = 0.01;
+};
+
+void EMT_Ph3_SSN_InductionMotor_Circuits::ColdStart_LoadSwitch() {
+
+  //Comps and nodes
+  auto motor = EMT::Ph3::SSN_InductionMotor::make("motor_coldStart");
+  motor->setParameters(nominalFrequency, polePairs, Rs, Rr, Ls, Lr_dash, Lm,
+                       rotorInertia, mechanicalDamping, -1.0, 0.0, false);
+
+  auto vs = EMT::Ph3::VoltageSource::make("Vs");
+  vs->setParameters(Math::singlePhaseVariableToThreePhase(Complex(Vamp, 0.0)));
+
+  auto r_v = EMT::Ph3::Resistor::make("r_v");
+  r_v->setParameters(0.05 * Matrix::Identity(3, 3));
+
+  auto load1 = EMT::Ph3::Shunt::make("load");
+  load1->setParameters(1e6, 0.0);
+
+  auto load2 = EMT::Ph3::Shunt::make("load");
+  load2->setParameters(10, 0.0);
+
+  auto sw1 = EMT::Ph3::Switch::make("sw1");
+  sw1->setParameters(switchOpenRes * Matrix::Identity(3, 3),
+                     switchClosedRes * Matrix::Identity(3, 3), true);
+  sw1->closeSwitch();
+
+  auto sw2 = EMT::Ph3::Switch::make("sw2");
+  sw2->setParameters(switchOpenRes * Matrix::Identity(3, 3),
+                     switchClosedRes * Matrix::Identity(3, 3));
+  sw2->openSwitch();
+
+  auto n1 = SimNode<Real>::make("n1", PhaseType::ABC);
+  auto n2 = SimNode<Real>::make("n2", PhaseType::ABC);
+  auto n3 = SimNode<Real>::make("n3", PhaseType::ABC);
+  auto n4 = SimNode<Real>::make("n4", PhaseType::ABC);
+
+  //topology
+  vs->connect(SimNode<Real>::List{SimNode<Real>::GND, n1});
+  r_v->connect(SimNode<Real>::List{n1, n2});
+
+  motor->connect(SimNode<Real>::List{SimNode<Real>::GND, n2});
+
+  sw1->connect(SimNode<Real>::List{n2, n3});
+  load1->connect(SimNode<Real>::List{n3});
+
+  sw2->connect(SimNode<Real>::List{n2, n4});
+  load2->connect(SimNode<Real>::List{n4});
+
+  auto sys = SystemTopology(
+      nominalFrequency, SystemNodeList{n1, n2, n3, n4},
+      SystemComponentList{vs, motor, load1, load2, sw1, sw2, r_v});
+
+  //logging
+  Logger::setLogDir("logs/" + simName_coldStart);
+  auto logger = DataLogger::make(simName_coldStart);
+  logger->logAttribute("mechanical_speed",
+                       motor->attribute("mechanical_speed"));
+  logger->logAttribute("electrical_torque",
+                       motor->attribute("electrical_torque"));
+  logger->logAttribute("stator_current_d",
+                       motor->attribute("stator_current_d"));
+  logger->logAttribute("stator_current_q",
+                       motor->attribute("stator_current_q"));
+
+  //simulation setup
+  Simulation sim(simName_coldStart, Logger::Level::info);
+  sim.setSystem(sys);
+  sim.addLogger(logger);
+  sim.setDomain(Domain::EMT);
+  sim.setSolverType(Solver::Type::MNA);
+  sim.doSystemMatrixRecomputation(true);
+  sim.setTimeStep(stepTime);
+  sim.setFinalTime(finalTime);
+
+  //events
+  auto sw_ev1 = SwitchEvent3Ph::make(switchTime, sw1, false);
+  sim.addEvent(sw_ev1);
+  auto sw_ev2 = SwitchEvent3Ph::make(switchTime, sw2, true);
+  sim.addEvent(sw_ev2);
+
+  //run sim
+  sim.run();
+}
+
+int main(int argc, char *argv[]) {
+
+  EMT_Ph3_SSN_InductionMotor_Circuits InductionMotorCircuits;
+  InductionMotorCircuits.ColdStart_LoadSwitch();
+}

--- a/dpsim/examples/cxx/Components/EMT_Ph3_SSN_InductionMotor_LoadSwitch.cpp
+++ b/dpsim/examples/cxx/Components/EMT_Ph3_SSN_InductionMotor_LoadSwitch.cpp
@@ -29,11 +29,13 @@ private:
   static constexpr Real Lr_dash =
       Lm + Llr; // total rotor inductance, referred to stator [H]
 
-  static constexpr Real rotorInertia = 0.05;      // [kg m^2]
-  static constexpr Real mechanicalDamping = 0.01; // [N m s/rad]
-
   static constexpr Real we = 2.0 * PI * nominalFrequency;
   static constexpr Real synchronousSpeed = we / static_cast<Real>(polePairs);
+  static constexpr Real nominalMechanicalTorque = 1.0; // [N m]
+
+  static constexpr Real rotorInertia = 0.05; // [kg m^2]
+  static constexpr Real mechanicalDamping =
+      nominalMechanicalTorque / synchronousSpeed; // Tload = Tnom * wm / wm_nom
 
   static constexpr Real Vamp =
       325.0; // peak phase voltage [V] (~230 V RMS line-to-neutral)
@@ -42,7 +44,7 @@ private:
   static constexpr Real finalTime = 2.5;
   static constexpr Real switchTime = 1.0;
   static constexpr Real switchOpenRes = 1e6;
-  static constexpr Real switchClosedRes = 0.01;
+  static constexpr Real switchClosedRes = 1e-4;
 };
 
 void EMT_Ph3_SSN_InductionMotor_Circuits::ColdStart_LoadSwitch() {
@@ -50,7 +52,8 @@ void EMT_Ph3_SSN_InductionMotor_Circuits::ColdStart_LoadSwitch() {
   //Comps and nodes
   auto motor = EMT::Ph3::SSN_InductionMotor::make("motor_coldStart");
   motor->setParameters(nominalFrequency, polePairs, Rs, Rr, Ls, Lr_dash, Lm,
-                       rotorInertia, mechanicalDamping, -1.0, 0.0, false);
+                       rotorInertia, mechanicalDamping,
+                       -nominalMechanicalTorque, 0.0, false);
 
   auto vs = EMT::Ph3::VoltageSource::make("Vs");
   vs->setParameters(Math::singlePhaseVariableToThreePhase(Complex(Vamp, 0.0)));
@@ -59,7 +62,7 @@ void EMT_Ph3_SSN_InductionMotor_Circuits::ColdStart_LoadSwitch() {
   r_v->setParameters(0.05 * Matrix::Identity(3, 3));
 
   auto load1 = EMT::Ph3::Shunt::make("load");
-  load1->setParameters(1e6, 0.0);
+  load1->setParameters(1e9, 0.0);
 
   auto load2 = EMT::Ph3::Shunt::make("load");
   load2->setParameters(10, 0.0);
@@ -100,12 +103,28 @@ void EMT_Ph3_SSN_InductionMotor_Circuits::ColdStart_LoadSwitch() {
   auto logger = DataLogger::make(simName_coldStart);
   logger->logAttribute("mechanical_speed",
                        motor->attribute("mechanical_speed"));
+  logger->logAttribute("mechanical_speed_pu",
+                       motor->attribute("mechanical_speed_pu"));
+  logger->logAttribute("slip", motor->attribute("slip"));
+  logger->logAttribute("electrical_power",
+                       motor->attribute("electrical_power"));
+  logger->logAttribute("reactive_power", motor->attribute("reactive_power"));
   logger->logAttribute("electrical_torque",
                        motor->attribute("electrical_torque"));
+  logger->logAttribute("mechanical_load_torque",
+                       motor->attribute("mechanical_load_torque"));
   logger->logAttribute("stator_current_d",
                        motor->attribute("stator_current_d"));
   logger->logAttribute("stator_current_q",
                        motor->attribute("stator_current_q"));
+  logger->logAttribute("stator_current_magnitude",
+                       motor->attribute("stator_current_magnitude"));
+  logger->logAttribute("stator_voltage_d",
+                       motor->attribute("stator_voltage_d"));
+  logger->logAttribute("stator_voltage_q",
+                       motor->attribute("stator_voltage_q"));
+  logger->logAttribute("stator_voltage_magnitude",
+                       motor->attribute("stator_voltage_magnitude"));
 
   //simulation setup
   Simulation sim(simName_coldStart, Logger::Level::info);

--- a/examples/Notebooks/Components/EMT_Ph3_InductionMotor.ipynb
+++ b/examples/Notebooks/Components/EMT_Ph3_InductionMotor.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Run C++ examples: Induction Motor load switch"
+    "## Run C++ Example: Induction Motor Load Switch"
    ]
   },
   {
@@ -20,32 +20,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import subprocess\n",
-    "\n",
-    "# %matplotlib widget\n",
+    "from pathlib import Path\n",
     "\n",
     "name = \"EMT_Ph3_SSN_InductionMotor_LoadSwitch\"\n",
     "\n",
-    "dpsim_path = (\n",
-    "    subprocess.Popen([\"git\", \"rev-parse\", \"--show-toplevel\"], stdout=subprocess.PIPE)\n",
-    "    .communicate()[0]\n",
-    "    .rstrip()\n",
+    "dpsim_path = Path(\n",
+    "    subprocess.check_output([\"git\", \"rev-parse\", \"--show-toplevel\"])\n",
     "    .decode(\"utf-8\")\n",
+    "    .strip()\n",
     ")\n",
+    "path_exec = dpsim_path / \"build\" / \"dpsim\" / \"examples\" / \"cxx\" / name\n",
     "\n",
-    "path_exec = dpsim_path + \"/build/dpsim/examples/cxx/\"\n",
-    "sim = subprocess.Popen(\n",
-    "    [path_exec + name], stdout=subprocess.PIPE, stderr=subprocess.STDOUT\n",
+    "result = subprocess.run(\n",
+    "    [str(path_exec)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True\n",
     ")\n",
-    "print(sim.communicate()[0].decode())"
+    "print(result.stdout.decode())"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Load Results"
+    "## Load Results"
    ]
   },
   {
@@ -55,25 +52,19 @@
    "outputs": [],
    "source": [
     "from villas.dataprocessing.readtools import *\n",
-    "from villas.dataprocessing.timeseries import *\n",
-    "from villas.dataprocessing.timeseries import TimeSeries as ts\n",
     "import matplotlib.pyplot as plt\n",
-    "import re\n",
     "import numpy as np\n",
-    "import math\n",
     "\n",
-    "name = \"EMT_Ph3_SSN_InductionMotor_ColdStart_LoadSwitch\"\n",
-    "\n",
-    "work_dir = os.getcwd() + \"/logs/\"\n",
-    "path_logfile_ColdStart_LoadSwitch = work_dir + name + \"/\" + name + \".csv\"\n",
-    "ts_ColdStart_LoadSwitch = read_timeseries_dpsim(path_logfile_ColdStart_LoadSwitch)"
+    "sim_name = \"EMT_Ph3_SSN_InductionMotor_ColdStart_LoadSwitch\"\n",
+    "path_logfile = Path(\"logs\") / sim_name / f\"{sim_name}.csv\"\n",
+    "ts_motor = read_timeseries_dpsim(str(path_logfile))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plot results"
+    "## Plot Results"
    ]
   },
   {
@@ -82,18 +73,64 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.close(\"all\")\n",
-    "fig1 = plt.figure()\n",
+    "def values(name):\n",
+    "    return np.asarray(ts_motor[name].values, dtype=float)\n",
     "\n",
-    "plt.plot(\n",
-    "    ts_ColdStart_LoadSwitch[\"mechanical_speed\"].time,\n",
-    "    ts_ColdStart_LoadSwitch[\"mechanical_speed\"].values,\n",
-    "    \"r-\",\n",
-    "    markevery=1,\n",
-    "    label=\"mechanical_speed\",\n",
-    ")\n",
-    "plt.xlabel(\"simulation time [s]\")\n",
-    "plt.ylabel(\"mechanical speed [rad/s]\")"
+    "\n",
+    "time = ts_motor[\"mechanical_speed_pu\"].time\n",
+    "speed_pu = values(\"mechanical_speed_pu\")\n",
+    "slip = values(\"slip\")\n",
+    "torque_pu = values(\"mechanical_load_torque\")  # nominal torque is 1 Nm in the example\n",
+    "active_power = values(\"electrical_power\")\n",
+    "reactive_power = values(\"reactive_power\")\n",
+    "voltage_mag = values(\"stator_voltage_magnitude\")\n",
+    "current_mag = values(\"stator_current_magnitude\")\n",
+    "\n",
+    "voltage_base = np.nanmedian(voltage_mag[-max(1, len(voltage_mag) // 10) :])\n",
+    "current_base = np.nanmedian(current_mag[-max(1, len(current_mag) // 10) :])\n",
+    "voltage_pu = voltage_mag / voltage_base\n",
+    "current_pu = current_mag / current_base\n",
+    "\n",
+    "plt.close(\"all\")\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(12, 8))\n",
+    "\n",
+    "axes[0, 0].plot(time, active_power, label=\"Active power [W]\")\n",
+    "axes[0, 0].plot(time, reactive_power, label=\"Reactive power [VAr]\")\n",
+    "axes[0, 0].set_title(\"Active and reactive power\")\n",
+    "axes[0, 0].set_xlabel(\"Time [s]\")\n",
+    "axes[0, 0].grid(True)\n",
+    "axes[0, 0].legend()\n",
+    "\n",
+    "axes[0, 1].plot(time, torque_pu, label=\"Mechanical load torque [p.u.]\")\n",
+    "axes[0, 1].plot(time, speed_pu, label=\"Speed [p.u.]\")\n",
+    "axes[0, 1].plot(time, slip, \"--\", label=\"Slip [p.u.]\")\n",
+    "axes[0, 1].set_title(\"Mechanical torque, speed and slip\")\n",
+    "axes[0, 1].set_xlabel(\"Time [s]\")\n",
+    "axes[0, 1].grid(True)\n",
+    "axes[0, 1].legend()\n",
+    "\n",
+    "axes[1, 0].plot(time, voltage_pu, label=\"Voltage magnitude [p.u.]\")\n",
+    "axes[1, 0].plot(time, current_pu, \"--\", label=\"Stator current magnitude [p.u.]\")\n",
+    "axes[1, 0].set_title(\"Voltage magnitude and stator current\")\n",
+    "axes[1, 0].set_xlabel(\"Time [s]\")\n",
+    "axes[1, 0].grid(True)\n",
+    "axes[1, 0].legend()\n",
+    "\n",
+    "axes[1, 1].plot(speed_pu, active_power, label=\"Active power [W]\")\n",
+    "axes[1, 1].plot(speed_pu, reactive_power, label=\"Reactive power [VAr]\")\n",
+    "axes[1, 1].set_title(\"Active/reactive power vs. speed\")\n",
+    "axes[1, 1].set_xlabel(\"Speed [p.u.]\")\n",
+    "axes[1, 1].grid(True)\n",
+    "axes[1, 1].legend()\n",
+    "\n",
+    "fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Checks"
    ]
   },
   {
@@ -101,7 +138,21 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "for signal in [\n",
+    "    \"mechanical_speed_pu\",\n",
+    "    \"slip\",\n",
+    "    \"electrical_power\",\n",
+    "    \"reactive_power\",\n",
+    "    \"mechanical_load_torque\",\n",
+    "    \"stator_voltage_magnitude\",\n",
+    "    \"stator_current_magnitude\",\n",
+    "]:\n",
+    "    assert np.all(np.isfinite(values(signal))), f\"{signal} contains non-finite values\"\n",
+    "\n",
+    "assert np.nanmax(speed_pu) > 0.5\n",
+    "assert np.nanmax(current_pu) > 1.0"
+   ]
   }
  ],
  "metadata": {

--- a/examples/Notebooks/Components/EMT_Ph3_InductionMotor.ipynb
+++ b/examples/Notebooks/Components/EMT_Ph3_InductionMotor.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Induction Motor Tests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run C++ examples: Induction Motor load switch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "# %matplotlib widget\n",
+    "\n",
+    "name = \"EMT_Ph3_SSN_InductionMotor_LoadSwitch\"\n",
+    "\n",
+    "dpsim_path = (\n",
+    "    subprocess.Popen([\"git\", \"rev-parse\", \"--show-toplevel\"], stdout=subprocess.PIPE)\n",
+    "    .communicate()[0]\n",
+    "    .rstrip()\n",
+    "    .decode(\"utf-8\")\n",
+    ")\n",
+    "\n",
+    "path_exec = dpsim_path + \"/build/dpsim/examples/cxx/\"\n",
+    "sim = subprocess.Popen(\n",
+    "    [path_exec + name], stdout=subprocess.PIPE, stderr=subprocess.STDOUT\n",
+    ")\n",
+    "print(sim.communicate()[0].decode())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from villas.dataprocessing.readtools import *\n",
+    "from villas.dataprocessing.timeseries import *\n",
+    "from villas.dataprocessing.timeseries import TimeSeries as ts\n",
+    "import matplotlib.pyplot as plt\n",
+    "import re\n",
+    "import numpy as np\n",
+    "import math\n",
+    "\n",
+    "name = \"EMT_Ph3_SSN_InductionMotor_ColdStart_LoadSwitch\"\n",
+    "\n",
+    "work_dir = os.getcwd() + \"/logs/\"\n",
+    "path_logfile_ColdStart_LoadSwitch = work_dir + name + \"/\" + name + \".csv\"\n",
+    "ts_ColdStart_LoadSwitch = read_timeseries_dpsim(path_logfile_ColdStart_LoadSwitch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.close(\"all\")\n",
+    "fig1 = plt.figure()\n",
+    "\n",
+    "plt.plot(\n",
+    "    ts_ColdStart_LoadSwitch[\"mechanical_speed\"].time,\n",
+    "    ts_ColdStart_LoadSwitch[\"mechanical_speed\"].values,\n",
+    "    \"r-\",\n",
+    "    markevery=1,\n",
+    "    label=\"mechanical_speed\",\n",
+    ")\n",
+    "plt.xlabel(\"simulation time [s]\")\n",
+    "plt.ylabel(\"mechanical speed [rad/s]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "tests": {
+   "skip": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Implements an EMT_Ph3_SSN_InductionMotor model for use in the MNASolver/MNASolverDirect. Theory is based on Section 3. B. of https://ieeexplore.ieee.org/document/8536236.

As of now, a cold start load switch example exists as a first test. In the future, powerflow simulation by use of the power flow solver and powerflow initialization of the component are further implementation goals.