### PR TITLE
Add current-zero and exponential switching models for EMT and DP three-phase switches

### DIFF
--- a/dpsim-models/include/dpsim-models/Base/Base_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph3_Switch.h
@@ -10,10 +10,12 @@
 
 #include <dpsim-models/AttributeList.h>
 #include <dpsim-models/Definitions.h>
+
 namespace CPS {
 namespace Base {
 namespace Ph3 {
-/// Dynamic Phasor Three-Phase Switch
+
+/// Common base for three-phase switches.
 class Switch {
 protected:
   Bool mIsClosedPrev = false;
@@ -23,27 +25,39 @@ public:
   const CPS::Attribute<Matrix>::Ptr mOpenResistance;
   /// Resistance if switch is closed [ohm]
   const CPS::Attribute<Matrix>::Ptr mClosedResistance;
-  /// Defines if Switch is open or closed
+  /// Commanded/global switch state.
   const CPS::Attribute<Bool>::Ptr mIsClosed;
 
   explicit Switch(CPS::AttributeList::Ptr attributeList)
       : mOpenResistance(attributeList->create<Matrix>("R_open")),
         mClosedResistance(attributeList->create<Matrix>("R_closed")),
-        mIsClosed(attributeList->create<Bool>("is_closed")){};
+        mIsClosed(attributeList->create<Bool>("is_closed")) {}
 
-  ///
+  virtual ~Switch() = default;
+
   void setParameters(Matrix openResistance, Matrix closedResistance,
                      Bool closed = false) {
     **mOpenResistance = openResistance;
     **mClosedResistance = closedResistance;
     **mIsClosed = closed;
   }
-  void closeSwitch() { **mIsClosed = true; }
-  void openSwitch() { **mIsClosed = false; }
 
-  /// Check if switch is closed
+  /// Close command.
+  ///
+  /// Virtual so domain-specific breaker models can distinguish commanded
+  /// state from the physical pole state.
+  virtual void closeSwitch() { **mIsClosed = true; }
+
+  /// Open command.
+  ///
+  /// Virtual so EMT/DP current-zero breakers can remain physically conducting
+  /// after the command until the individual phase currents reach zero.
+  virtual void openSwitch() { **mIsClosed = false; }
+
+  /// Check commanded/global state.
   Bool isClosed() { return **mIsClosed; }
 };
+
 } // namespace Ph3
 } // namespace Base
 } // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_Inductor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_Inductor.h
@@ -15,76 +15,77 @@
 namespace CPS {
 namespace DP {
 namespace Ph3 {
-/// \brief Inductor
+
+/// \brief Three-phase dynamic-phasor inductor.
 ///
-/// The inductor is represented by a DC equivalent circuit which corresponds to
-/// one iteration of the trapezoidal integration method.
-/// The equivalent DC circuit is a resistance in parallel with a current source.
-/// The resistance is constant for a defined time step and system
-/// frequency and the current source changes for each iteration.
+/// The inductor is represented by the trapezoidal-integration companion model.
+/// Three-phase DP interface quantities use phase-peak complex envelopes.
+/// Power-flow node voltages are line-line RMS phasors and are converted to the
+/// DP phase-peak convention during initialization.
 class Inductor : public MNASimPowerComp<Complex>,
                  public Base::Ph3::Inductor,
                  public MNATearInterface,
                  public SharedFactory<Inductor> {
 protected:
-  /// DC equivalent current source [A]
+  /// Equivalent current source [A]
   MatrixComp mEquivCurrent;
   /// Equivalent conductance [S]
   MatrixComp mEquivCond;
-  /// Coefficient in front of previous current value
+  /// Coefficient multiplying the previous current value
   Complex mPrevCurrFac;
 
   void initVars(Real omega, Real timeStep);
 
 public:
-  /// Defines UID, name, component parameters and logging level
   Inductor(String uid, String name,
            Logger::Level logLevel = Logger::Level::off);
-  /// Defines name, component parameters and logging level
+
   Inductor(String name, Logger::Level logLevel = Logger::Level::off)
       : Inductor(name, name, logLevel) {}
-  /// Defines name, component parameters and logging level
+
   Inductor(String name, Real inductance,
            Logger::Level logLevel = Logger::Level::off);
 
   SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General ####
-  /// Initializes component from power flow data
+  /// Initialize DP phase-peak envelopes from line-line RMS PF node voltages.
   void initializeFromNodesAndTerminals(Real frequency) override;
+
   // #### MNA section ####
-  /// Initializes internal variables of the component
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
-  /// Stamps system matrix
+
   void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
-  /// Stamps right side (source) vector
+
   void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
-  /// Update interface voltage from MNA system result
+
   void mnaCompUpdateVoltage(const Matrix &leftVector) override;
-  /// Update interface current from MNA system result
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;
+
   void mnaCompPreStep(Real time, Int timeStepCount) override;
+
   void mnaCompPostStep(Real time, Int timeStepCount,
                        Attribute<Matrix>::Ptr &leftVector) override;
 
-  /// Add MNA pre step dependencies
   void mnaCompAddPreStepDependencies(
       AttributeBase::List &prevStepDependencies,
       AttributeBase::List &attributeDependencies,
       AttributeBase::List &modifiedAttributes) override;
-  /// Add MNA post step dependencies
+
   void
   mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
                                  AttributeBase::List &attributeDependencies,
                                  AttributeBase::List &modifiedAttributes,
                                  Attribute<Matrix>::Ptr &leftVector) override;
+
   // #### MNA Tear Section ####
   void mnaTearInitialize(Real omega, Real timestep) override;
   void mnaTearApplyMatrixStamp(SparseMatrixRow &tearMatrix) override;
   void mnaTearApplyVoltageStamp(Matrix &voltageVector) override;
   void mnaTearPostStep(MatrixComp voltage, MatrixComp current) override;
 };
+
 } // namespace Ph3
 } // namespace DP
 } // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_Resistor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_Resistor.h
@@ -17,48 +17,51 @@
 namespace CPS {
 namespace DP {
 namespace Ph3 {
+
+/// \brief Three-phase dynamic-phasor resistor.
 ///
+/// Three-phase DP interface quantities use phase-peak complex envelopes.
+/// Power-flow node voltages are converted from line-line RMS to phase peak
+/// during initialization.
 class Resistor : public MNASimPowerComp<Complex>,
                  public Base::Ph3::Resistor,
                  public MNATearInterface,
                  public SharedFactory<Resistor> {
-
 public:
-  /// Defines UID, name and logging level
   Resistor(String uid, String name,
            Logger::Level logLevel = Logger::Level::off);
-  /// Defines name and logging level
+
   Resistor(String name, Logger::Level logLevel = Logger::Level::off)
       : Resistor(name, name, logLevel) {}
 
   SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General ####
-  /// Initializes component from power flow data
+  /// Initialize DP phase-peak envelopes from line-line RMS PF node voltages.
   void initializeFromNodesAndTerminals(Real frequency) override;
+
   // #### MNA section ####
-  ///
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
-  /// Stamps system matrix
+
   void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
-  ///
+
   void mnaCompUpdateVoltage(const Matrix &leftVector) override;
-  ///
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;
 
-  /// Add MNA post step dependencies
   void
   mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
                                  AttributeBase::List &attributeDependencies,
                                  AttributeBase::List &modifiedAttributes,
                                  Attribute<Matrix>::Ptr &leftVector) override;
+
   void mnaCompPostStep(Real time, Int timeStepCount,
                        Attribute<Matrix>::Ptr &leftVector) override;
 
   // #### MNA Tear Section ####
   void mnaTearApplyMatrixStamp(SparseMatrixRow &tearMatrix) override;
 };
+
 } // namespace Ph3
 } // namespace DP
 } // namespace CPS

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_Switch.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <array>
+
 #include <dpsim-models/Base/Base_Ph3_Switch.h>
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Logger.h>
@@ -13,60 +15,170 @@
 namespace CPS {
 namespace DP {
 namespace Ph3 {
-/// \brief Dynamic phasor three-phase switch with per-phase resistance.
+
+/// Dynamic-phasor three-phase breaker.
 ///
-/// The switch can be opened and closed; each state has its own 3x3 resistance
-/// matrix. An asymmetric closed matrix (e.g. one low diagonal entry) models a
-/// single-phase fault. DP analogue of EMT::Ph3::Switch, driven by SwitchEvent3Ph.
+/// Switching modes:
+///
+/// - Ideal:
+///   conventional binary switch.
+///
+/// - CurrentZero:
+///   reconstruct the physical instantaneous phase currents from the phase-peak
+///   DP envelopes,
+///
+///       i_k(t) = Re{ I_k(t) exp(j omega_s t) },
+///
+///   and open each physical pole at its own current zero.
+///
+/// - ExponentialZCSEmulation:
+///   increase the switch resistance continuously according to
+///
+///       R(t) = R_closed * (R_open/R_closed)^alpha,
+///
+///   alpha in [0,1], over a user-defined switching duration. This is the
+///   variable-resistance ZCS-emulation approach and is not an arc model.
 class Switch : public MNASimPowerComp<Complex>,
                public Base::Ph3::Switch,
                public SharedFactory<Switch>,
                public MNAVariableCompInterface,
                public MNASwitchInterface {
 public:
-  /// Defines UID, name, component parameters and logging level
+  enum class SwitchingMode {
+    Ideal = 0,
+    CurrentZero = 1,
+    ExponentialZCSEmulation = 2,
+  };
+
+  const Attribute<Bool>::Ptr mOpeningRequested;
+
+  const Attribute<Bool>::Ptr mPoleClosedA;
+  const Attribute<Bool>::Ptr mPoleClosedB;
+  const Attribute<Bool>::Ptr mPoleClosedC;
+
+  /// Reconstructed physical instantaneous currents [A].
+  const Attribute<Real>::Ptr mInstantCurrentA;
+  const Attribute<Real>::Ptr mInstantCurrentB;
+  const Attribute<Real>::Ptr mInstantCurrentC;
+
+  const Attribute<Real>::Ptr mZeroCrossingTimeA;
+  const Attribute<Real>::Ptr mZeroCrossingTimeB;
+  const Attribute<Real>::Ptr mZeroCrossingTimeC;
+
+  /// Exponential-transition diagnostics.
+  const Attribute<Bool>::Ptr mExponentialTransitionActive;
+  const Attribute<Real>::Ptr mExponentialProgress;
+  const Attribute<Real>::Ptr mExponentialTransitionStartTime;
+  const Attribute<Real>::Ptr mExponentialTransitionEndTime;
+
+  /// Effective phase resistances currently stamped into the MNA matrix [ohm].
+  const Attribute<Real>::Ptr mEffectiveResistanceA;
+  const Attribute<Real>::Ptr mEffectiveResistanceB;
+  const Attribute<Real>::Ptr mEffectiveResistanceC;
+
   Switch(String uid, String name, Logger::Level loglevel = Logger::Level::off);
-  /// Defines name, component parameters and logging level
+
   Switch(String name, Logger::Level logLevel = Logger::Level::off)
       : Switch(name, name, logLevel) {}
 
   SimPowerComp<Complex>::Ptr clone(String name) override;
 
+  void setSwitchingMode(SwitchingMode mode);
+  SwitchingMode switchingMode() const { return mSwitchingMode; }
+
+  void setZeroCrossingTolerance(Real tolerance);
+
+  void setExponentialSwitchingTime(Real switchingTime);
+  Real exponentialSwitchingTime() const { return mExponentialSwitchingTime; }
+
+  void openSwitch() override;
+  void closeSwitch() override;
+
   // #### General ####
-  /// Initializes component from power flow data
   void initializeFromNodesAndTerminals(Real frequency) override;
 
-  // #### General MNA section ####
+  // #### General MNA ####
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
-  /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
-  /// Update interface voltage from MNA system result
-  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
-  /// Update interface current from MNA system result
-  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
 
-  // #### MNA section for switches ####
-  /// Check if switch is closed
-  Bool mnaIsClosed() override;
-  /// Stamps system matrix considering the defined switch position
-  void mnaCompApplySwitchSystemMatrixStamp(Bool closed,
-                                           SparseMatrixRow &systemMatrix,
-                                           Int freqIdx) override;
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
+
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
 
   void mnaCompPostStep(Real time, Int timeStepCount,
                        Attribute<Matrix>::Ptr &leftVector) override;
 
-  /// Add MNA post step dependencies
   void
   mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
                                  AttributeBase::List &attributeDependencies,
                                  AttributeBase::List &modifiedAttributes,
                                  Attribute<Matrix>::Ptr &leftVector) override;
 
-  // #### MNA section for variable component ####
+  // #### Switch interface ####
+  Bool mnaIsClosed() override;
+
+  void mnaCompApplySwitchSystemMatrixStamp(Bool closed,
+                                           SparseMatrixRow &systemMatrix,
+                                           Int freqIdx) override;
+
+  Bool supportsPrecomputedSystemMatrices() const override;
+
+  // #### Variable-component interface ####
   Bool hasParameterChanged() override;
+
+private:
+  SwitchingMode mSwitchingMode = SwitchingMode::Ideal;
+
+  Real mZeroCrossingTolerance = 1e-6;
+  Real mExponentialSwitchingTime = 0.01;
+  Real mTimeStep = 0.0;
+
+  /// Reference-frame angular frequency supplied by the solver [rad/s].
+  Real mShiftOmega = 0.0;
+
+  std::array<Bool, 3> mPoleClosedPrev{{false, false, false}};
+  std::array<Real, 3> mEffectiveResistancePrev{{0.0, 0.0, 0.0}};
+
+  Matrix mPreviousInstantaneousCurrent = Matrix::Zero(3, 1);
+  Real mPreviousCurrentTime = 0.0;
+  Bool mPreviousCurrentValid = false;
+
+  Bool mResetZeroCrossingHistory = false;
+  Bool mExponentialTransitionStarted = false;
+
+  Bool poleClosed(UInt phase) const;
+  void setPoleClosed(UInt phase, Bool closed);
+  void setAllPoles(Bool closed);
+
+  Bool allPolesClosed() const;
+  Bool allPolesOpen() const;
+
+  void resetZeroCrossingTimes();
+
+  Real effectiveResistance(UInt phase) const;
+  void setEffectiveResistance(UInt phase, Real resistance);
+  void synchronizeEffectiveResistance(Bool closed);
+
+  void resetExponentialTransition();
+  void validateExponentialResistanceParameters() const;
+  Real exponentialResistance(UInt phase, Real alpha) const;
+  void updateExponentialTransition(Real time);
+
+  MatrixFixedSizeComp<3, 3> currentConductanceMatrix() const;
+
+  Matrix reconstructInstantaneousCurrent(Real time) const;
+  void setInstantaneousCurrentAttributes(const Matrix &current);
+
+  Bool currentCrossedZero(Real previousCurrent, Real current) const;
+
+  Real interpolateZeroCrossingTime(Real previousCurrent, Real current,
+                                   Real previousTime, Real currentTime) const;
+
+  void setZeroCrossingTime(UInt phase, Real time);
+  void updateZeroCrossingState(Real time);
 };
+
 } // namespace Ph3
 } // namespace DP
 } // namespace CPS

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Switch.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <array>
+
 #include <dpsim-models/Base/Base_Ph3_Switch.h>
 #include <dpsim-models/Definitions.h>
 #include <dpsim-models/Logger.h>
@@ -18,44 +20,116 @@
 namespace CPS {
 namespace EMT {
 namespace Ph3 {
-/// \brief Dynamic phasor switch
+
+/// \brief Three-phase EMT switch / circuit breaker.
 ///
-/// The switch can be opened and closed.
-/// Each state has a specific resistance value.
+/// Switching modes:
+///
+/// - Ideal:
+///   Conventional binary DPsim switch. All three phases open immediately.
+///
+/// - CurrentZero:
+///   An opening command is armed and each physical pole remains conducting
+///   until its own instantaneous EMT phase current reaches/crosses zero.
+///
+/// - ExponentialZCSEmulation:
+///   The phase resistance is increased continuously from R_closed to R_open
+///   according to an exponential trajectory over a prescribed switching time:
+///
+///       R(t) = R_closed * (R_open / R_closed)^alpha
+///
+///   with alpha in [0,1]. This reproduces the variable-resistance ZCS
+///   emulation described by Wirtz et al. and is not an arc model.
 class Switch : public MNASimPowerComp<Real>,
                public Base::Ph3::Switch,
                public SharedFactory<Switch>,
                public MNAVariableCompInterface,
                public MNASwitchInterface {
 public:
-  /// Defines UID, name, component parameters and logging level
-  Switch(String uid, String name, Logger::Level loglevel = Logger::Level::off);
-  /// Defines name, component parameters and logging level
+  enum class SwitchingMode {
+    Ideal = 0,
+    CurrentZero = 1,
+    ExponentialZCSEmulation = 2,
+  };
+
+  /// Opening request is active while a CurrentZero or exponential opening
+  /// process has not yet completed.
+  const Attribute<Bool>::Ptr mOpeningRequested;
+
+  /// Physical pole states.
+  const Attribute<Bool>::Ptr mPoleClosedA;
+  const Attribute<Bool>::Ptr mPoleClosedB;
+  const Attribute<Bool>::Ptr mPoleClosedC;
+
+  /// Estimated physical zero-crossing times [s], -1 if none has been detected.
+  const Attribute<Real>::Ptr mZeroCrossingTimeA;
+  const Attribute<Real>::Ptr mZeroCrossingTimeB;
+  const Attribute<Real>::Ptr mZeroCrossingTimeC;
+
+  /// Exponential-transition diagnostics.
+  const Attribute<Bool>::Ptr mExponentialTransitionActive;
+  const Attribute<Real>::Ptr mExponentialProgress;
+  const Attribute<Real>::Ptr mExponentialTransitionStartTime;
+  const Attribute<Real>::Ptr mExponentialTransitionEndTime;
+
+  /// Effective phase resistances currently stamped into the MNA matrix [ohm].
+  const Attribute<Real>::Ptr mEffectiveResistanceA;
+  const Attribute<Real>::Ptr mEffectiveResistanceB;
+  const Attribute<Real>::Ptr mEffectiveResistanceC;
+
+  Switch(String uid, String name, Logger::Level logLevel = Logger::Level::off);
+
   Switch(String name, Logger::Level logLevel = Logger::Level::off)
       : Switch(name, name, logLevel) {}
 
   SimPowerComp<Real>::Ptr clone(String name) override;
 
+  /// Select switching model. Configure before simulation initialization.
+  void setSwitchingMode(SwitchingMode mode);
+  SwitchingMode switchingMode() const { return mSwitchingMode; }
+
+  /// Absolute current tolerance used by CurrentZero mode [A].
+  void setZeroCrossingTolerance(Real tolerance);
+  Real zeroCrossingTolerance() const { return mZeroCrossingTolerance; }
+
+  /// Set total opening transition time for ExponentialZCSEmulation [s].
+  void setExponentialSwitchingTime(Real switchingTime);
+  Real exponentialSwitchingTime() const { return mExponentialSwitchingTime; }
+
+  /// Open command.
+  ///
+  /// Ideal:
+  ///   all poles open immediately.
+  ///
+  /// CurrentZero:
+  ///   wait for individual phase-current zeros.
+  ///
+  /// ExponentialZCSEmulation:
+  ///   arm a simultaneous three-phase exponential resistance increase.
+  void openSwitch() override;
+
+  /// Closing is instantaneous for all modes in this implementation.
+  void closeSwitch() override;
+
   // #### General ####
-  /// Initializes component from power flow data
   void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### General MNA section ####
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
-  /// Stamps system matrix
+
   void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
-  /// Stamps right side (source) vector
   void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
-  /// Update interface voltage from MNA system result
+
   void mnaCompUpdateVoltage(const Matrix &leftVector) override;
-  /// Update interface current from MNA system result
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;
 
-  // #### MNA section for switches ####
-  /// Check if switch is closed
+  // #### MNA switch interface ####
   Bool mnaIsClosed() override;
-  /// Stamps system matrix considering the defined switch position
+
+  /// Only Ideal is representable by the conventional two precomputed matrices.
+  Bool supportsPrecomputedSystemMatrices() const override;
+
   void mnaCompApplySwitchSystemMatrixStamp(Bool closed,
                                            SparseMatrixRow &systemMatrix,
                                            Int freqIdx) override;
@@ -63,16 +137,68 @@ public:
   void mnaCompPostStep(Real time, Int timeStepCount,
                        Attribute<Matrix>::Ptr &leftVector) override;
 
-  /// Add MNA post step dependencies
   void
   mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
                                  AttributeBase::List &attributeDependencies,
                                  AttributeBase::List &modifiedAttributes,
                                  Attribute<Matrix>::Ptr &leftVector) override;
 
-  // #### MNA section for variable component ####
+  // #### Variable component interface ####
   Bool hasParameterChanged() override;
+
+private:
+  SwitchingMode mSwitchingMode = SwitchingMode::Ideal;
+
+  Real mZeroCrossingTolerance = 1e-6;
+
+  /// Default matches the 10 ms switching duration used in the benchmark of
+  /// the referenced DP ZCS-emulation paper.
+  Real mExponentialSwitchingTime = 0.01;
+
+  /// Simulation timestep stored so post-step can prepare R(t+dt), which is
+  /// the conductance required by the next MNA solve.
+  Real mTimeStep = 0.0;
+
+  std::array<Bool, 3> mPoleClosedPrev{{false, false, false}};
+  std::array<Real, 3> mEffectiveResistancePrev{{0.0, 0.0, 0.0}};
+
+  Matrix mPreviousCurrent = Matrix::Zero(3, 1);
+  Real mPreviousCurrentTime = 0.0;
+  Bool mPreviousCurrentValid = false;
+
+  Bool mResetZeroCrossingHistory = false;
+
+  Bool mExponentialTransitionStarted = false;
+
+  Bool poleClosed(UInt phase) const;
+  void setPoleClosed(UInt phase, Bool closed);
+  void setAllPoles(Bool closed);
+
+  Bool allPolesClosed() const;
+  Bool allPolesOpen() const;
+
+  void resetZeroCrossingTimes();
+
+  Real effectiveResistance(UInt phase) const;
+  void setEffectiveResistance(UInt phase, Real resistance);
+  void synchronizeEffectiveResistance(Bool closed);
+
+  void resetExponentialTransition();
+  void validateExponentialResistanceParameters() const;
+  Real exponentialResistance(UInt phase, Real alpha) const;
+  void updateExponentialTransition(Real time);
+
+  MatrixFixedSize<3, 3> currentConductanceMatrix() const;
+
+  Bool currentCrossedZero(Real previousCurrent, Real current) const;
+
+  Real interpolateZeroCrossingTime(Real previousCurrent, Real current,
+                                   Real previousTime, Real currentTime) const;
+
+  void setZeroCrossingTime(UInt phase, Real time);
+  void updateZeroCrossingState(Real time);
 };
+
 } // namespace Ph3
 } // namespace EMT
 } // namespace CPS

--- a/dpsim-models/src/DP/DP_Ph3_Inductor.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_Inductor.cpp
@@ -15,6 +15,7 @@ DP::Ph3::Inductor::Inductor(String uid, String name, Logger::Level logLevel)
       Base::Ph3::Inductor(mAttributes) {
   mPhaseType = PhaseType::ABC;
   setTerminalNumber(2);
+
   mEquivCurrent = MatrixComp::Zero(3, 1);
   **mIntfVoltage = MatrixComp::Zero(3, 1);
   **mIntfCurrent = MatrixComp::Zero(3, 1);
@@ -27,57 +28,83 @@ SimPowerComp<Complex>::Ptr DP::Ph3::Inductor::clone(String name) {
 }
 
 void DP::Ph3::Inductor::initializeFromNodesAndTerminals(Real frequency) {
-
-  Real omega = 2 * PI * frequency;
+  const Real omega = 2.0 * PI * frequency;
 
   MatrixComp reactance = MatrixComp::Zero(3, 3);
-  reactance << Complex(0, omega * (**mInductance)(0, 0)),
-      Complex(0, omega * (**mInductance)(0, 1)),
-      Complex(0, omega * (**mInductance)(0, 2)),
-      Complex(0, omega * (**mInductance)(1, 0)),
-      Complex(0, omega * (**mInductance)(1, 1)),
-      Complex(0, omega * (**mInductance)(1, 2)),
-      Complex(0, omega * (**mInductance)(2, 0)),
-      Complex(0, omega * (**mInductance)(2, 1)),
-      Complex(0, omega * (**mInductance)(2, 2));
-  MatrixComp susceptance = reactance.inverse();
-  // IntfVoltage initialization for each phase
-  (**mIntfVoltage)(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
-  Real voltMag = Math::abs((**mIntfVoltage)(0, 0));
-  Real voltPhase = Math::phase((**mIntfVoltage)(0, 0));
-  (**mIntfVoltage)(1, 0) = Complex(voltMag * cos(voltPhase - 2. / 3. * M_PI),
-                                   voltMag * sin(voltPhase - 2. / 3. * M_PI));
-  (**mIntfVoltage)(2, 0) = Complex(voltMag * cos(voltPhase + 2. / 3. * M_PI),
-                                   voltMag * sin(voltPhase + 2. / 3. * M_PI));
 
-  **mIntfCurrent = susceptance * **mIntfVoltage;
+  for (UInt row = 0; row < 3; ++row) {
+    for (UInt col = 0; col < 3; ++col) {
+      reactance(row, col) = Complex(0.0, omega * (**mInductance)(row, col));
+    }
+  }
 
-  //TODO
-  SPDLOG_LOGGER_INFO(mSLog, "--- Initialize according to power flow ---");
+  // ---------------------------------------------------------------------------
+  // IMPORTANT DP / PF CONVENTION CONVERSION
+  // ---------------------------------------------------------------------------
+  // Power-flow node voltages are line-line RMS phasors.
+  // DP::Ph3 electrical states use phase-peak complex envelopes.
+  //
+  // This conversion is already used by DP::Ph3::PiLine and must also be used
+  // by the primitive inductor. The previous implementation omitted the
+  // RMS3PH_TO_PEAK1PH factor here, which initialized the inductor state too
+  // small by sqrt(3/2) and produced a startup transient after PF initialization.
+  // ---------------------------------------------------------------------------
+
+  MatrixComp vInitABC = MatrixComp::Zero(3, 1);
+
+  vInitABC(0, 0) =
+      RMS3PH_TO_PEAK1PH * (initialSingleVoltage(1) - initialSingleVoltage(0));
+
+  vInitABC(1, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_B;
+
+  vInitABC(2, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_C;
+
+  **mIntfVoltage = vInitABC;
+  **mIntfCurrent = reactance.inverse() * vInitABC;
+
+  SPDLOG_LOGGER_INFO(
+      mSLog,
+      "\n--- Initialization from powerflow ---"
+      "\nDP convention: phase-peak complex envelopes"
+      "\nVoltage across:"
+      "\n{:s}"
+      "\nCurrent:"
+      "\n{:s}"
+      "\nTerminal 0 PF voltage converted to phase peak: {:s}"
+      "\nTerminal 1 PF voltage converted to phase peak: {:s}"
+      "\n--- Initialization from powerflow finished ---",
+      Logger::matrixCompToString(**mIntfVoltage),
+      Logger::matrixCompToString(**mIntfCurrent),
+      Logger::phasorToString(RMS3PH_TO_PEAK1PH * initialSingleVoltage(0)),
+      Logger::phasorToString(RMS3PH_TO_PEAK1PH * initialSingleVoltage(1)));
 }
 
 void DP::Ph3::Inductor::initVars(Real omega, Real timeStep) {
-  Matrix a = timeStep / 2. * (**mInductance).inverse();
-  Real b = timeStep * omega / 2.;
+  Matrix a = timeStep / 2.0 * (**mInductance).inverse();
 
-  Matrix equivCondReal = a / (1. + b * b);
-  Matrix equivCondImag = -a * b / (Real(1.) + b * b);
+  const Real b = timeStep * omega / 2.0;
+
+  Matrix equivCondReal = a / (1.0 + b * b);
+
+  Matrix equivCondImag = -a * b / (1.0 + b * b);
+
   mEquivCond = MatrixComp::Zero(3, 3);
-  mEquivCond << Complex(equivCondReal(0, 0), equivCondImag(0, 0)),
-      Complex(equivCondReal(0, 1), equivCondImag(0, 1)),
-      Complex(equivCondReal(0, 2), equivCondImag(0, 2)),
-      Complex(equivCondReal(1, 0), equivCondImag(1, 0)),
-      Complex(equivCondReal(1, 1), equivCondImag(1, 1)),
-      Complex(equivCondReal(1, 2), equivCondImag(1, 2)),
-      Complex(equivCondReal(2, 0), equivCondImag(2, 0)),
-      Complex(equivCondReal(2, 1), equivCondImag(2, 1)),
-      Complex(equivCondReal(2, 2), equivCondImag(2, 2));
 
-  Real preCurrFracReal = (1. - b * b) / (1. + b * b);
-  Real preCurrFracImag = (-2. * b) / (1. + b * b);
+  for (UInt row = 0; row < 3; ++row) {
+    for (UInt col = 0; col < 3; ++col) {
+      mEquivCond(row, col) =
+          Complex(equivCondReal(row, col), equivCondImag(row, col));
+    }
+  }
+
+  const Real preCurrFracReal = (1.0 - b * b) / (1.0 + b * b);
+
+  const Real preCurrFracImag = (-2.0 * b) / (1.0 + b * b);
+
   mPrevCurrFac = Complex(preCurrFracReal, preCurrFracImag);
 
-  // TODO: check if this is correct or if it should be only computed before the step
+  // Initialize the history source consistently with the initialized
+  // phase-peak DP voltage/current envelopes.
   mEquivCurrent = mEquivCond * **mIntfVoltage + mPrevCurrFac * **mIntfCurrent;
 }
 
@@ -86,8 +113,13 @@ void DP::Ph3::Inductor::mnaCompInitialize(Real omega, Real timeStep,
   updateMatrixNodeIndices();
   initVars(omega, timeStep);
 
-  SPDLOG_LOGGER_INFO(mSLog, "Initial voltage {}",
-                     Math::abs((**mIntfVoltage)(0, 0)));
+  SPDLOG_LOGGER_INFO(mSLog, "Initial phase-A DP voltage envelope: {} < {} rad",
+                     Math::abs((**mIntfVoltage)(0, 0)),
+                     Math::phase((**mIntfVoltage)(0, 0)));
+
+  SPDLOG_LOGGER_INFO(mSLog, "Initial phase-A DP current envelope: {} < {} rad",
+                     Math::abs((**mIntfCurrent)(0, 0)),
+                     Math::phase((**mIntfCurrent)(0, 0)));
 }
 
 void DP::Ph3::Inductor::mnaCompApplySystemMatrixStamp(
@@ -98,23 +130,27 @@ void DP::Ph3::Inductor::mnaCompApplySystemMatrixStamp(
 }
 
 void DP::Ph3::Inductor::mnaCompApplyRightSideVectorStamp(Matrix &rightVector) {
-
-  // Calculate equivalent current source for next time step
+  // Companion-model history source for the next time step.
   mEquivCurrent = mEquivCond * **mIntfVoltage + mPrevCurrFac * **mIntfCurrent;
 
   if (terminalNotGrounded(0)) {
     Math::setVectorElement(rightVector, matrixNodeIndex(0, 0),
                            mEquivCurrent(0, 0));
+
     Math::setVectorElement(rightVector, matrixNodeIndex(0, 1),
                            mEquivCurrent(1, 0));
+
     Math::setVectorElement(rightVector, matrixNodeIndex(0, 2),
                            mEquivCurrent(2, 0));
   }
+
   if (terminalNotGrounded(1)) {
     Math::setVectorElement(rightVector, matrixNodeIndex(1, 0),
                            -mEquivCurrent(0, 0));
+
     Math::setVectorElement(rightVector, matrixNodeIndex(1, 1),
                            -mEquivCurrent(1, 0));
+
     Math::setVectorElement(rightVector, matrixNodeIndex(1, 2),
                            -mEquivCurrent(2, 0));
   }
@@ -124,7 +160,6 @@ void DP::Ph3::Inductor::mnaCompAddPreStepDependencies(
     AttributeBase::List &prevStepDependencies,
     AttributeBase::List &attributeDependencies,
     AttributeBase::List &modifiedAttributes) {
-  // actually depends on L, but then we'd have to modify the system matrix anyway
   modifiedAttributes.push_back(mRightVector);
   prevStepDependencies.push_back(mIntfVoltage);
   prevStepDependencies.push_back(mIntfCurrent);
@@ -151,25 +186,27 @@ void DP::Ph3::Inductor::mnaCompPostStep(Real time, Int timeStepCount,
 }
 
 void DP::Ph3::Inductor::mnaCompUpdateVoltage(const Matrix &leftVector) {
-  // v1 - v0
-  **mIntfVoltage = Matrix::Zero(3, 1);
+  **mIntfVoltage = MatrixComp::Zero(3, 1);
+
   if (terminalNotGrounded(1)) {
     (**mIntfVoltage)(0, 0) =
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 0));
+
     (**mIntfVoltage)(1, 0) =
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 1));
+
     (**mIntfVoltage)(2, 0) =
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 2));
   }
+
   if (terminalNotGrounded(0)) {
-    (**mIntfVoltage)(0, 0) =
-        (**mIntfVoltage)(0, 0) -
+    (**mIntfVoltage)(0, 0) -=
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 0));
-    (**mIntfVoltage)(1, 0) =
-        (**mIntfVoltage)(1, 0) -
+
+    (**mIntfVoltage)(1, 0) -=
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 1));
-    (**mIntfVoltage)(2, 0) =
-        (**mIntfVoltage)(2, 0) -
+
+    (**mIntfVoltage)(2, 0) -=
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 2));
   }
 }
@@ -179,33 +216,37 @@ void DP::Ph3::Inductor::mnaCompUpdateCurrent(const Matrix &leftVector) {
 }
 
 // #### Tear Methods ####
+
 void DP::Ph3::Inductor::mnaTearInitialize(Real omega, Real timeStep) {
   initVars(omega, timeStep);
 }
 
 void DP::Ph3::Inductor::mnaTearApplyMatrixStamp(SparseMatrixRow &tearMatrix) {
-  // Set diagonal entries
   Math::addToMatrixElement(tearMatrix, mTearIdx * 3, mTearIdx * 3,
-                           1. / mEquivCond(0, 0)); // 1 /
+                           1.0 / mEquivCond(0, 0));
+
   Math::addToMatrixElement(tearMatrix, mTearIdx * 3 + 1, mTearIdx * 3 + 1,
-                           1. / mEquivCond(1, 1));
+                           1.0 / mEquivCond(1, 1));
+
   Math::addToMatrixElement(tearMatrix, mTearIdx * 3 + 2, mTearIdx * 3 + 2,
-                           1. / mEquivCond(2, 2));
+                           1.0 / mEquivCond(2, 2));
 }
 
 void DP::Ph3::Inductor::mnaTearApplyVoltageStamp(Matrix &voltageVector) {
-  mEquivCurrent =
-      mEquivCond * (**mIntfVoltage) + mPrevCurrFac * (**mIntfCurrent);
+  mEquivCurrent = mEquivCond * **mIntfVoltage + mPrevCurrFac * **mIntfCurrent;
+
   Math::addToVectorElement(voltageVector, mTearIdx * 3,
                            mEquivCurrent(0, 0) / mEquivCond(0, 0));
+
   Math::addToVectorElement(voltageVector, mTearIdx * 3 + 1,
                            mEquivCurrent(1, 0) / mEquivCond(1, 1));
+
   Math::addToVectorElement(voltageVector, mTearIdx * 3 + 2,
                            mEquivCurrent(2, 0) / mEquivCond(2, 2));
 }
 
 void DP::Ph3::Inductor::mnaTearPostStep(MatrixComp voltage,
                                         MatrixComp current) {
-  (**mIntfVoltage) = voltage;
-  (**mIntfCurrent) = mEquivCond * voltage + mEquivCurrent;
+  **mIntfVoltage = voltage;
+  **mIntfCurrent = mEquivCond * voltage + mEquivCurrent;
 }

--- a/dpsim-models/src/DP/DP_Ph3_Resistor.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_Resistor.cpp
@@ -15,6 +15,7 @@ DP::Ph3::Resistor::Resistor(String uid, String name, Logger::Level logLevel)
       Base::Ph3::Resistor(mAttributes) {
   mPhaseType = PhaseType::ABC;
   setTerminalNumber(2);
+
   **mIntfVoltage = MatrixComp::Zero(3, 1);
   **mIntfCurrent = MatrixComp::Zero(3, 1);
 }
@@ -26,26 +27,45 @@ SimPowerComp<Complex>::Ptr DP::Ph3::Resistor::clone(String name) {
 }
 
 void DP::Ph3::Resistor::initializeFromNodesAndTerminals(Real frequency) {
+  // ---------------------------------------------------------------------------
+  // DP / PF CONVENTION CONVERSION
+  // ---------------------------------------------------------------------------
+  // Power-flow node voltages are line-line RMS phasors.
+  // DP::Ph3 states use phase-peak complex envelopes.
+  //
+  // The previous implementation constructed B/C from mIntfVoltage(A) without
+  // first assigning phase A from the PF terminal voltages. This made standalone
+  // resistor initialization dependent on stale/default interface state.
+  // ---------------------------------------------------------------------------
 
-  Real voltMag = Math::abs((**mIntfVoltage)(0, 0));
-  Real voltPhase = Math::phase((**mIntfVoltage)(0, 0));
-  (**mIntfVoltage)(1, 0) = Complex(voltMag * cos(voltPhase - 2. / 3. * M_PI),
-                                   voltMag * sin(voltPhase - 2. / 3. * M_PI));
-  (**mIntfVoltage)(2, 0) = Complex(voltMag * cos(voltPhase + 2. / 3. * M_PI),
-                                   voltMag * sin(voltPhase + 2. / 3. * M_PI));
+  MatrixComp vInitABC = MatrixComp::Zero(3, 1);
+
+  vInitABC(0, 0) =
+      RMS3PH_TO_PEAK1PH * (initialSingleVoltage(1) - initialSingleVoltage(0));
+
+  vInitABC(1, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_B;
+
+  vInitABC(2, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_C;
+
+  **mIntfVoltage = vInitABC;
+
   **mIntfCurrent = (**mResistance).inverse() * **mIntfVoltage;
 
-  SPDLOG_LOGGER_INFO(mSLog,
-                     "\n--- Initialization from powerflow ---"
-                     "\nVoltage across amplitude and phase: \n{:s}"
-                     "\nCurrent amplitude and phase: \n{:s}"
-                     "\nTerminal 0 voltage amplitude and phase: \n{:s}"
-                     "\nTerminal 1 voltage amplitude and phase: \n{:s}"
-                     "\n--- Initialization from powerflow finished ---",
-                     Logger::phasorMatrixToString(**mIntfVoltage),
-                     Logger::phasorMatrixToString(**mIntfCurrent),
-                     Logger::phasorMatrixToString(initialVoltage(0)),
-                     Logger::phasorMatrixToString(initialVoltage(1)));
+  SPDLOG_LOGGER_INFO(
+      mSLog,
+      "\n--- Initialization from powerflow ---"
+      "\nDP convention: phase-peak complex envelopes"
+      "\nVoltage across:"
+      "\n{:s}"
+      "\nCurrent:"
+      "\n{:s}"
+      "\nTerminal 0 PF voltage converted to phase peak: {:s}"
+      "\nTerminal 1 PF voltage converted to phase peak: {:s}"
+      "\n--- Initialization from powerflow finished ---",
+      Logger::matrixCompToString(**mIntfVoltage),
+      Logger::matrixCompToString(**mIntfCurrent),
+      Logger::phasorToString(RMS3PH_TO_PEAK1PH * initialSingleVoltage(0)),
+      Logger::phasorToString(RMS3PH_TO_PEAK1PH * initialSingleVoltage(1)));
 }
 
 void DP::Ph3::Resistor::mnaCompInitialize(Real omega, Real timeStep,
@@ -56,7 +76,8 @@ void DP::Ph3::Resistor::mnaCompInitialize(Real omega, Real timeStep,
 
 void DP::Ph3::Resistor::mnaCompApplySystemMatrixStamp(
     SparseMatrixRow &systemMatrix) {
-  MatrixFixedSizeComp<3, 3> conductance = Matrix::Zero(3, 3);
+  MatrixFixedSizeComp<3, 3> conductance = MatrixFixedSizeComp<3, 3>::Zero();
+
   conductance.real() = (**mResistance).inverse();
 
   MNAStampUtils::stampAdmittanceMatrix(
@@ -81,25 +102,27 @@ void DP::Ph3::Resistor::mnaCompPostStep(Real time, Int timeStepCount,
 }
 
 void DP::Ph3::Resistor::mnaCompUpdateVoltage(const Matrix &leftVector) {
-  // Voltage across component is defined as V1 - V0
   **mIntfVoltage = MatrixComp::Zero(3, 1);
+
   if (terminalNotGrounded(1)) {
     (**mIntfVoltage)(0, 0) =
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 0));
+
     (**mIntfVoltage)(1, 0) =
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 1));
+
     (**mIntfVoltage)(2, 0) =
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 2));
   }
+
   if (terminalNotGrounded(0)) {
-    (**mIntfVoltage)(0, 0) =
-        (**mIntfVoltage)(0, 0) -
+    (**mIntfVoltage)(0, 0) -=
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 0));
-    (**mIntfVoltage)(1, 0) =
-        (**mIntfVoltage)(1, 0) -
+
+    (**mIntfVoltage)(1, 0) -=
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 1));
-    (**mIntfVoltage)(2, 0) =
-        (**mIntfVoltage)(2, 0) -
+
+    (**mIntfVoltage)(2, 0) -=
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 2));
   }
 
@@ -110,21 +133,25 @@ void DP::Ph3::Resistor::mnaCompUpdateVoltage(const Matrix &leftVector) {
 
 void DP::Ph3::Resistor::mnaCompUpdateCurrent(const Matrix &leftVector) {
   **mIntfCurrent = (**mResistance).inverse() * **mIntfVoltage;
-  SPDLOG_LOGGER_DEBUG(mSLog, "Current A: {} < {}",
 
+  SPDLOG_LOGGER_DEBUG(mSLog, "Current A: {} < {}",
                       std::abs((**mIntfCurrent)(0, 0)),
                       std::arg((**mIntfCurrent)(0, 0)));
 }
 
 // #### Tear Methods ####
+
 void DP::Ph3::Resistor::mnaTearApplyMatrixStamp(SparseMatrixRow &tearMatrix) {
-  MatrixFixedSizeComp<3, 3> conductance = Matrix::Zero(3, 3);
+  MatrixFixedSizeComp<3, 3> conductance = MatrixFixedSizeComp<3, 3>::Zero();
+
   conductance.real() = (**mResistance).inverse();
-  // Set diagonal entries
+
   Math::addToMatrixElement(tearMatrix, mTearIdx * 3, mTearIdx * 3,
-                           1. / conductance(0, 0).real()); // 1 /
+                           1.0 / conductance(0, 0).real());
+
   Math::addToMatrixElement(tearMatrix, mTearIdx * 3 + 1, mTearIdx * 3 + 1,
-                           1. / conductance(1, 1).real());
+                           1.0 / conductance(1, 1).real());
+
   Math::addToMatrixElement(tearMatrix, mTearIdx * 3 + 2, mTearIdx * 3 + 2,
-                           1. / conductance(2, 2).real());
+                           1.0 / conductance(2, 2).real());
 }

--- a/dpsim-models/src/DP/DP_Ph3_Switch.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_Switch.cpp
@@ -1,23 +1,161 @@
 // SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
 // SPDX-License-Identifier: MPL-2.0
 
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
 #include <dpsim-models/DP/DP_Ph3_Switch.h>
 
 using namespace CPS;
 
 DP::Ph3::Switch::Switch(String uid, String name, Logger::Level logLevel)
     : MNASimPowerComp<Complex>(uid, name, false, true, logLevel),
-      Base::Ph3::Switch(mAttributes) {
+      Base::Ph3::Switch(mAttributes),
+      mOpeningRequested(mAttributes->create<Bool>("opening_requested")),
+      mPoleClosedA(mAttributes->create<Bool>("pole_closed_a")),
+      mPoleClosedB(mAttributes->create<Bool>("pole_closed_b")),
+      mPoleClosedC(mAttributes->create<Bool>("pole_closed_c")),
+      mInstantCurrentA(mAttributes->create<Real>("i_instantaneous_a")),
+      mInstantCurrentB(mAttributes->create<Real>("i_instantaneous_b")),
+      mInstantCurrentC(mAttributes->create<Real>("i_instantaneous_c")),
+      mZeroCrossingTimeA(mAttributes->create<Real>("zero_crossing_time_a")),
+      mZeroCrossingTimeB(mAttributes->create<Real>("zero_crossing_time_b")),
+      mZeroCrossingTimeC(mAttributes->create<Real>("zero_crossing_time_c")),
+      mExponentialTransitionActive(
+          mAttributes->create<Bool>("exponential_transition_active")),
+      mExponentialProgress(mAttributes->create<Real>("exponential_progress")),
+      mExponentialTransitionStartTime(
+          mAttributes->create<Real>("exponential_transition_start_time")),
+      mExponentialTransitionEndTime(
+          mAttributes->create<Real>("exponential_transition_end_time")),
+      mEffectiveResistanceA(
+          mAttributes->create<Real>("effective_resistance_a")),
+      mEffectiveResistanceB(
+          mAttributes->create<Real>("effective_resistance_b")),
+      mEffectiveResistanceC(
+          mAttributes->create<Real>("effective_resistance_c")) {
   mPhaseType = PhaseType::ABC;
   setTerminalNumber(2);
+
   **mIntfVoltage = MatrixComp::Zero(3, 1);
   **mIntfCurrent = MatrixComp::Zero(3, 1);
+
+  **mOpeningRequested = false;
+  setAllPoles(false);
+
+  **mInstantCurrentA = 0.0;
+  **mInstantCurrentB = 0.0;
+  **mInstantCurrentC = 0.0;
+
+  resetZeroCrossingTimes();
+
+  **mExponentialTransitionActive = false;
+  **mExponentialProgress = 0.0;
+  **mExponentialTransitionStartTime = -1.0;
+  **mExponentialTransitionEndTime = -1.0;
+  **mEffectiveResistanceA = 0.0;
+  **mEffectiveResistanceB = 0.0;
+  **mEffectiveResistanceC = 0.0;
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph3::Switch::clone(String name) {
   auto copy = Switch::make(name, mLogLevel);
   copy->setParameters(**mOpenResistance, **mClosedResistance, **mIsClosed);
+  copy->setSwitchingMode(mSwitchingMode);
+  copy->setZeroCrossingTolerance(mZeroCrossingTolerance);
+  copy->setExponentialSwitchingTime(mExponentialSwitchingTime);
   return copy;
+}
+
+void DP::Ph3::Switch::setSwitchingMode(SwitchingMode mode) {
+  mSwitchingMode = mode;
+
+  setAllPoles(**mIsClosed);
+  **mOpeningRequested = false;
+  resetZeroCrossingTimes();
+
+  mPreviousCurrentValid = false;
+  mResetZeroCrossingHistory = false;
+
+  resetExponentialTransition();
+  synchronizeEffectiveResistance(**mIsClosed);
+}
+
+void DP::Ph3::Switch::setZeroCrossingTolerance(Real tolerance) {
+  if (tolerance < 0.0) {
+    throw std::invalid_argument(
+        "DP::Ph3::Switch zero-crossing tolerance must be non-negative.");
+  }
+
+  mZeroCrossingTolerance = tolerance;
+}
+
+void DP::Ph3::Switch::setExponentialSwitchingTime(Real switchingTime) {
+  if (switchingTime <= 0.0) {
+    throw std::invalid_argument(
+        "DP::Ph3::Switch exponential switching time must be positive.");
+  }
+
+  mExponentialSwitchingTime = switchingTime;
+}
+
+void DP::Ph3::Switch::openSwitch() {
+  Base::Ph3::Switch::openSwitch();
+
+  if (mSwitchingMode == SwitchingMode::Ideal) {
+    **mOpeningRequested = false;
+    setAllPoles(false);
+    resetZeroCrossingTimes();
+    resetExponentialTransition();
+    synchronizeEffectiveResistance(false);
+    return;
+  }
+
+  if (allPolesOpen()) {
+    **mOpeningRequested = false;
+    return;
+  }
+
+  if (mSwitchingMode == SwitchingMode::CurrentZero) {
+    **mOpeningRequested = true;
+    resetZeroCrossingTimes();
+    resetExponentialTransition();
+    mResetZeroCrossingHistory = true;
+
+    SPDLOG_LOGGER_INFO(
+        mSLog, "DP current-zero opening command received. "
+               "Waiting for reconstructed physical phase-current zeros.");
+    return;
+  }
+
+  validateExponentialResistanceParameters();
+  **mOpeningRequested = true;
+  resetZeroCrossingTimes();
+  resetExponentialTransition();
+  **mExponentialTransitionActive = true;
+  synchronizeEffectiveResistance(true);
+  setAllPoles(true);
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "DP exponential ZCS-emulation opening command received. "
+                     "Switching duration={:.6e}s.",
+                     mExponentialSwitchingTime);
+}
+
+void DP::Ph3::Switch::closeSwitch() {
+  Base::Ph3::Switch::closeSwitch();
+
+  **mOpeningRequested = false;
+  setAllPoles(true);
+  resetZeroCrossingTimes();
+  mResetZeroCrossingHistory = false;
+
+  resetExponentialTransition();
+  synchronizeEffectiveResistance(true);
+
+  SPDLOG_LOGGER_INFO(
+      mSLog, "DP switch closing command: all three physical poles closed.");
 }
 
 void DP::Ph3::Switch::initializeFromNodesAndTerminals(Real frequency) {
@@ -25,36 +163,102 @@ void DP::Ph3::Switch::initializeFromNodesAndTerminals(Real frequency) {
   mTerminals[1]->setPhaseType(PhaseType::ABC);
 
   Matrix impedance = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
-  // Voltage across component is defined as V1 - V0.
-  **mIntfVoltage = initialVoltage(1) - initialVoltage(0);
-  **mIntfCurrent = impedance.inverse() * **mIntfVoltage;
+
+  // DP::Ph3 MNA quantities are phase-peak complex envelopes. Power-flow
+  // node voltages are line-line RMS, so convert the A-phase voltage to
+  // phase peak and construct the balanced B/C envelopes explicitly.
+  MatrixComp vInitABC = MatrixComp::Zero(3, 1);
+  vInitABC(0, 0) =
+      RMS3PH_TO_PEAK1PH * (initialSingleVoltage(1) - initialSingleVoltage(0));
+  vInitABC(1, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_B;
+  vInitABC(2, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_C;
+
+  **mIntfVoltage = vInitABC;
+  **mIntfCurrent = impedance.inverse() * vInitABC;
+
+  setAllPoles(**mIsClosed);
+  **mOpeningRequested = false;
+  resetZeroCrossingTimes();
+  resetExponentialTransition();
+  synchronizeEffectiveResistance(**mIsClosed);
 
   SPDLOG_LOGGER_INFO(mSLog,
                      "\n--- Initialization from powerflow ---"
-                     "\nVoltage across phasor: \n{:s}"
-                     "\nCurrent phasor: \n{:s}"
-                     "\nTerminal 0 voltage phasor: \n{:s}"
-                     "\nTerminal 1 voltage phasor: \n{:s}"
+                     "\nVoltage envelope:"
+                     "\n{:s}"
+                     "\nCurrent envelope:"
+                     "\n{:s}"
+                     "\nTerminal 0 voltage envelope:"
+                     "\n{:s}"
+                     "\nTerminal 1 voltage envelope:"
+                     "\n{:s}"
+                     "\nSwitching mode: {:s}"
+                     "\nInitial breaker state: {:s}"
                      "\n--- Initialization from powerflow finished ---",
                      Logger::phasorMatrixToString(**mIntfVoltage),
                      Logger::phasorMatrixToString(**mIntfCurrent),
                      Logger::phasorMatrixToString(initialVoltage(0)),
-                     Logger::phasorMatrixToString(initialVoltage(1)));
+                     Logger::phasorMatrixToString(initialVoltage(1)),
+                     mSwitchingMode == SwitchingMode::Ideal
+                         ? "Ideal"
+                         : (mSwitchingMode == SwitchingMode::CurrentZero
+                                ? "CurrentZero"
+                                : "ExponentialZCSEmulation"),
+                     **mIsClosed ? "closed" : "open");
 }
 
 void DP::Ph3::Switch::mnaCompInitialize(Real omega, Real timeStep,
                                         Attribute<Matrix>::Ptr leftVector) {
   updateMatrixNodeIndices();
+  mTimeStep = timeStep;
   **mRightVector = Matrix::Zero(0, 0);
+
+  // omega is the DP reference-frame angular frequency supplied by the solver.
+  mShiftOmega = omega;
+
+  // Final safeguard in case setSwitchingMode() was called before setParameters().
+  setAllPoles(**mIsClosed);
+  synchronizeEffectiveResistance(**mIsClosed);
+  resetExponentialTransition();
+
+  mPoleClosedPrev = {{
+      **mPoleClosedA,
+      **mPoleClosedB,
+      **mPoleClosedC,
+  }};
+
+  mIsClosedPrev = **mIsClosed;
+
+  const Matrix instantaneous = reconstructInstantaneousCurrent(0.0);
+
+  setInstantaneousCurrentAttributes(instantaneous);
+
+  mPreviousInstantaneousCurrent = instantaneous;
+  mEffectiveResistancePrev = {{
+      **mEffectiveResistanceA,
+      **mEffectiveResistanceB,
+      **mEffectiveResistanceC,
+  }};
+
+  mPreviousCurrentTime = 0.0;
+  mPreviousCurrentValid = true;
+  mResetZeroCrossingHistory = false;
 }
 
-Bool DP::Ph3::Switch::mnaIsClosed() { return **mIsClosed; }
+Bool DP::Ph3::Switch::mnaIsClosed() {
+  if (mSwitchingMode == SwitchingMode::Ideal)
+    return **mIsClosed;
+
+  return allPolesClosed();
+}
+
+Bool DP::Ph3::Switch::supportsPrecomputedSystemMatrices() const {
+  return mSwitchingMode == SwitchingMode::Ideal;
+}
 
 void DP::Ph3::Switch::mnaCompApplySystemMatrixStamp(
     SparseMatrixRow &systemMatrix) {
-  MatrixFixedSizeComp<3, 3> conductance = Matrix::Zero(3, 3);
-  conductance.real() = (**mIsClosed) ? (**mClosedResistance).inverse()
-                                     : (**mOpenResistance).inverse();
+  const MatrixFixedSizeComp<3, 3> conductance = currentConductanceMatrix();
 
   MNAStampUtils::stampAdmittanceMatrix(
       conductance, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
@@ -63,9 +267,12 @@ void DP::Ph3::Switch::mnaCompApplySystemMatrixStamp(
 
 void DP::Ph3::Switch::mnaCompApplySwitchSystemMatrixStamp(
     Bool closed, SparseMatrixRow &systemMatrix, Int freqIdx) {
-  MatrixFixedSizeComp<3, 3> conductance = Matrix::Zero(3, 3);
-  conductance.real() = (closed) ? (**mClosedResistance).inverse()
-                                : (**mOpenResistance).inverse();
+  // Conventional precomputed two-state path. CurrentZero mode bypasses this
+  // by returning supportsPrecomputedSystemMatrices() == false.
+  MatrixFixedSizeComp<3, 3> conductance = MatrixFixedSizeComp<3, 3>::Zero();
+
+  conductance.real() =
+      closed ? (**mClosedResistance).inverse() : (**mOpenResistance).inverse();
 
   MNAStampUtils::stampAdmittanceMatrix(
       conductance, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
@@ -78,19 +285,51 @@ void DP::Ph3::Switch::mnaCompAddPostStepDependencies(
     AttributeBase::List &modifiedAttributes,
     Attribute<Matrix>::Ptr &leftVector) {
   attributeDependencies.push_back(leftVector);
+
   modifiedAttributes.push_back(mIntfVoltage);
   modifiedAttributes.push_back(mIntfCurrent);
+
+  modifiedAttributes.push_back(mOpeningRequested);
+  modifiedAttributes.push_back(mPoleClosedA);
+  modifiedAttributes.push_back(mPoleClosedB);
+  modifiedAttributes.push_back(mPoleClosedC);
+
+  modifiedAttributes.push_back(mInstantCurrentA);
+  modifiedAttributes.push_back(mInstantCurrentB);
+  modifiedAttributes.push_back(mInstantCurrentC);
+
+  modifiedAttributes.push_back(mZeroCrossingTimeA);
+  modifiedAttributes.push_back(mZeroCrossingTimeB);
+  modifiedAttributes.push_back(mZeroCrossingTimeC);
+
+  modifiedAttributes.push_back(mExponentialTransitionActive);
+  modifiedAttributes.push_back(mExponentialProgress);
+  modifiedAttributes.push_back(mExponentialTransitionStartTime);
+  modifiedAttributes.push_back(mExponentialTransitionEndTime);
+  modifiedAttributes.push_back(mEffectiveResistanceA);
+  modifiedAttributes.push_back(mEffectiveResistanceB);
+  modifiedAttributes.push_back(mEffectiveResistanceC);
 }
 
 void DP::Ph3::Switch::mnaCompPostStep(Real time, Int timeStepCount,
                                       Attribute<Matrix>::Ptr &leftVector) {
   mnaCompUpdateVoltage(**leftVector);
   mnaCompUpdateCurrent(**leftVector);
+
+  const Matrix instantaneous = reconstructInstantaneousCurrent(time);
+
+  setInstantaneousCurrentAttributes(instantaneous);
+
+  if (mSwitchingMode == SwitchingMode::CurrentZero) {
+    updateZeroCrossingState(time);
+  } else if (mSwitchingMode == SwitchingMode::ExponentialZCSEmulation) {
+    updateExponentialTransition(time);
+  }
 }
 
 void DP::Ph3::Switch::mnaCompUpdateVoltage(const Matrix &leftVector) {
-  // Voltage across component is defined as V1 - V0.
   **mIntfVoltage = MatrixComp::Zero(3, 1);
+
   if (terminalNotGrounded(1)) {
     (**mIntfVoltage)(0, 0) =
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 0));
@@ -99,33 +338,392 @@ void DP::Ph3::Switch::mnaCompUpdateVoltage(const Matrix &leftVector) {
     (**mIntfVoltage)(2, 0) =
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(1, 2));
   }
+
   if (terminalNotGrounded(0)) {
-    (**mIntfVoltage)(0, 0) =
-        (**mIntfVoltage)(0, 0) -
+    (**mIntfVoltage)(0, 0) -=
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 0));
-    (**mIntfVoltage)(1, 0) =
-        (**mIntfVoltage)(1, 0) -
+    (**mIntfVoltage)(1, 0) -=
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 1));
-    (**mIntfVoltage)(2, 0) =
-        (**mIntfVoltage)(2, 0) -
+    (**mIntfVoltage)(2, 0) -=
         Math::complexFromVectorElement(leftVector, matrixNodeIndex(0, 2));
   }
 }
 
 void DP::Ph3::Switch::mnaCompUpdateCurrent(const Matrix &leftVector) {
-  MatrixFixedSizeComp<3, 3> conductance = Matrix::Zero(3, 3);
-  conductance.real() = (**mIsClosed) ? (**mClosedResistance).inverse()
-                                     : (**mOpenResistance).inverse();
-
-  **mIntfCurrent = conductance * **mIntfVoltage;
+  **mIntfCurrent = currentConductanceMatrix() * **mIntfVoltage;
 }
 
 Bool DP::Ph3::Switch::hasParameterChanged() {
-  // Recompute the system matrix only when the switch state changed.
-  if (!(mIsClosedPrev == this->mnaIsClosed())) {
-    mIsClosedPrev = this->mnaIsClosed();
-    return 1;
-  } else {
-    return 0;
+  if (mSwitchingMode == SwitchingMode::Ideal) {
+    if (mIsClosedPrev != **mIsClosed) {
+      mIsClosedPrev = **mIsClosed;
+      return true;
+    }
+
+    return false;
+  }
+
+  if (mSwitchingMode == SwitchingMode::ExponentialZCSEmulation) {
+    const std::array<Real, 3> resistanceNow{{
+        **mEffectiveResistanceA,
+        **mEffectiveResistanceB,
+        **mEffectiveResistanceC,
+    }};
+
+    Bool changed = false;
+    for (UInt phase = 0; phase < 3; ++phase) {
+      if (resistanceNow[phase] != mEffectiveResistancePrev[phase]) {
+        mEffectiveResistancePrev[phase] = resistanceNow[phase];
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  const std::array<Bool, 3> poleClosedNow{{
+      **mPoleClosedA,
+      **mPoleClosedB,
+      **mPoleClosedC,
+  }};
+
+  Bool changed = false;
+
+  for (UInt phase = 0; phase < 3; ++phase) {
+    if (poleClosedNow[phase] != mPoleClosedPrev[phase]) {
+      mPoleClosedPrev[phase] = poleClosedNow[phase];
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+Bool DP::Ph3::Switch::poleClosed(UInt phase) const {
+  switch (phase) {
+  case 0:
+    return **mPoleClosedA;
+  case 1:
+    return **mPoleClosedB;
+  case 2:
+    return **mPoleClosedC;
+  default:
+    throw std::out_of_range("DP::Ph3::Switch phase index must be 0, 1, or 2.");
+  }
+}
+
+void DP::Ph3::Switch::setPoleClosed(UInt phase, Bool closed) {
+  switch (phase) {
+  case 0:
+    **mPoleClosedA = closed;
+    break;
+  case 1:
+    **mPoleClosedB = closed;
+    break;
+  case 2:
+    **mPoleClosedC = closed;
+    break;
+  default:
+    throw std::out_of_range("DP::Ph3::Switch phase index must be 0, 1, or 2.");
+  }
+
+  // Keep the resistance diagnostics synchronized with the discrete
+  // CurrentZero pole state. Exponential mode manages R(t) independently.
+  if (mSwitchingMode == SwitchingMode::CurrentZero &&
+      (**mClosedResistance).rows() >= 3 && (**mOpenResistance).rows() >= 3) {
+    setEffectiveResistance(phase, closed ? (**mClosedResistance)(phase, phase)
+                                         : (**mOpenResistance)(phase, phase));
+  }
+}
+
+void DP::Ph3::Switch::setAllPoles(Bool closed) {
+  **mPoleClosedA = closed;
+  **mPoleClosedB = closed;
+  **mPoleClosedC = closed;
+}
+
+Bool DP::Ph3::Switch::allPolesClosed() const {
+  return **mPoleClosedA && **mPoleClosedB && **mPoleClosedC;
+}
+
+Bool DP::Ph3::Switch::allPolesOpen() const {
+  return !**mPoleClosedA && !**mPoleClosedB && !**mPoleClosedC;
+}
+
+void DP::Ph3::Switch::resetZeroCrossingTimes() {
+  **mZeroCrossingTimeA = -1.0;
+  **mZeroCrossingTimeB = -1.0;
+  **mZeroCrossingTimeC = -1.0;
+}
+
+Real DP::Ph3::Switch::effectiveResistance(UInt phase) const {
+  switch (phase) {
+  case 0:
+    return **mEffectiveResistanceA;
+  case 1:
+    return **mEffectiveResistanceB;
+  case 2:
+    return **mEffectiveResistanceC;
+  default:
+    throw std::out_of_range("DP::Ph3::Switch phase index must be 0, 1, or 2.");
+  }
+}
+
+void DP::Ph3::Switch::setEffectiveResistance(UInt phase, Real resistance) {
+  switch (phase) {
+  case 0:
+    **mEffectiveResistanceA = resistance;
+    return;
+  case 1:
+    **mEffectiveResistanceB = resistance;
+    return;
+  case 2:
+    **mEffectiveResistanceC = resistance;
+    return;
+  default:
+    throw std::out_of_range("DP::Ph3::Switch phase index must be 0, 1, or 2.");
+  }
+}
+
+void DP::Ph3::Switch::synchronizeEffectiveResistance(Bool closed) {
+  if ((**mClosedResistance).rows() < 3 || (**mOpenResistance).rows() < 3)
+    return;
+
+  for (UInt phase = 0; phase < 3; ++phase) {
+    setEffectiveResistance(phase, closed ? (**mClosedResistance)(phase, phase)
+                                         : (**mOpenResistance)(phase, phase));
+  }
+}
+
+void DP::Ph3::Switch::resetExponentialTransition() {
+  **mExponentialTransitionActive = false;
+  **mExponentialProgress = 0.0;
+  **mExponentialTransitionStartTime = -1.0;
+  **mExponentialTransitionEndTime = -1.0;
+  mExponentialTransitionStarted = false;
+}
+
+void DP::Ph3::Switch::validateExponentialResistanceParameters() const {
+  if ((**mClosedResistance).rows() < 3 || (**mOpenResistance).rows() < 3) {
+    throw std::invalid_argument(
+        "DP::Ph3::Switch exponential mode requires 3x3 resistance matrices.");
+  }
+
+  if (mExponentialSwitchingTime <= 0.0) {
+    throw std::invalid_argument(
+        "DP::Ph3::Switch exponential switching time must be positive.");
+  }
+
+  for (UInt phase = 0; phase < 3; ++phase) {
+    const Real rClosed = (**mClosedResistance)(phase, phase);
+    const Real rOpen = (**mOpenResistance)(phase, phase);
+
+    if (rClosed <= 0.0 || rOpen <= 0.0) {
+      throw std::invalid_argument(
+          "DP::Ph3::Switch exponential mode requires positive diagonal "
+          "open and closed resistances.");
+    }
+  }
+}
+
+Real DP::Ph3::Switch::exponentialResistance(UInt phase, Real alpha) const {
+  const Real rClosed = (**mClosedResistance)(phase, phase);
+  const Real rOpen = (**mOpenResistance)(phase, phase);
+  const Real boundedAlpha = std::max(0.0, std::min(1.0, alpha));
+
+  return std::exp(std::log(rClosed) +
+                  boundedAlpha * (std::log(rOpen) - std::log(rClosed)));
+}
+
+void DP::Ph3::Switch::updateExponentialTransition(Real time) {
+  if (!**mExponentialTransitionActive)
+    return;
+
+  if (!mExponentialTransitionStarted) {
+    mExponentialTransitionStarted = true;
+    **mExponentialTransitionStartTime = time;
+    **mExponentialTransitionEndTime = time + mExponentialSwitchingTime;
+  }
+
+  const Real targetTime = time + mTimeStep;
+  const Real alpha = (targetTime - **mExponentialTransitionStartTime) /
+                     mExponentialSwitchingTime;
+  const Real boundedAlpha = std::max(0.0, std::min(1.0, alpha));
+
+  **mExponentialProgress = boundedAlpha;
+
+  for (UInt phase = 0; phase < 3; ++phase)
+    setEffectiveResistance(phase, exponentialResistance(phase, boundedAlpha));
+
+  if (boundedAlpha >= 1.0) {
+    synchronizeEffectiveResistance(false);
+    setAllPoles(false);
+    **mOpeningRequested = false;
+    **mExponentialTransitionActive = false;
+
+    SPDLOG_LOGGER_INFO(
+        mSLog,
+        "DP exponential ZCS-emulation opening completed: start={:.9f}s, "
+        "end={:.9f}s, duration={:.6e}s.",
+        **mExponentialTransitionStartTime, **mExponentialTransitionEndTime,
+        mExponentialSwitchingTime);
+  }
+}
+
+MatrixFixedSizeComp<3, 3> DP::Ph3::Switch::currentConductanceMatrix() const {
+  MatrixFixedSizeComp<3, 3> conductance = MatrixFixedSizeComp<3, 3>::Zero();
+
+  if (mSwitchingMode == SwitchingMode::Ideal) {
+    conductance.real() = (**mIsClosed) ? (**mClosedResistance).inverse()
+                                       : (**mOpenResistance).inverse();
+    return conductance;
+  }
+
+  for (UInt phase = 0; phase < 3; ++phase) {
+    Real resistance = 0.0;
+
+    if (mSwitchingMode == SwitchingMode::CurrentZero) {
+      resistance = poleClosed(phase) ? (**mClosedResistance)(phase, phase)
+                                     : (**mOpenResistance)(phase, phase);
+    } else {
+      resistance = effectiveResistance(phase);
+    }
+
+    conductance(phase, phase) = Complex(1.0 / resistance, 0.0);
+  }
+
+  return conductance;
+}
+
+Matrix DP::Ph3::Switch::reconstructInstantaneousCurrent(Real time) const {
+  Matrix instantaneous = Matrix::Zero(3, 1);
+
+  // DP::Ph3 quantities are phase-peak complex envelopes. Restore the removed
+  // reference-frequency carrier; no additional RMS-to-peak scaling is needed.
+  const Complex carrier = std::polar<Real>(1.0, mShiftOmega * time);
+
+  for (UInt phase = 0; phase < 3; ++phase) {
+    instantaneous(phase, 0) = std::real((**mIntfCurrent)(phase, 0) * carrier);
+  }
+
+  return instantaneous;
+}
+
+void DP::Ph3::Switch::setInstantaneousCurrentAttributes(const Matrix &current) {
+  **mInstantCurrentA = current(0, 0);
+  **mInstantCurrentB = current(1, 0);
+  **mInstantCurrentC = current(2, 0);
+}
+
+Bool DP::Ph3::Switch::currentCrossedZero(Real previousCurrent,
+                                         Real current) const {
+  if (std::abs(current) <= mZeroCrossingTolerance)
+    return true;
+
+  return (previousCurrent > mZeroCrossingTolerance &&
+          current < -mZeroCrossingTolerance) ||
+         (previousCurrent < -mZeroCrossingTolerance &&
+          current > mZeroCrossingTolerance);
+}
+
+Real DP::Ph3::Switch::interpolateZeroCrossingTime(Real previousCurrent,
+                                                  Real current,
+                                                  Real previousTime,
+                                                  Real currentTime) const {
+  const Real denominator = std::abs(previousCurrent) + std::abs(current);
+
+  if (denominator <= mZeroCrossingTolerance)
+    return currentTime;
+
+  const Real fraction = std::abs(previousCurrent) / denominator;
+
+  return previousTime + fraction * (currentTime - previousTime);
+}
+
+void DP::Ph3::Switch::setZeroCrossingTime(UInt phase, Real time) {
+  switch (phase) {
+  case 0:
+    **mZeroCrossingTimeA = time;
+    return;
+  case 1:
+    **mZeroCrossingTimeB = time;
+    return;
+  case 2:
+    **mZeroCrossingTimeC = time;
+    return;
+  default:
+    throw std::out_of_range("DP::Ph3::Switch phase index must be 0, 1, or 2.");
+  }
+}
+
+void DP::Ph3::Switch::updateZeroCrossingState(Real time) {
+  const Matrix current = reconstructInstantaneousCurrent(time);
+
+  // Keep a current history while no opening command is active.
+  if (!**mOpeningRequested) {
+    mPreviousInstantaneousCurrent = current;
+    mPreviousCurrentTime = time;
+    mPreviousCurrentValid = true;
+    return;
+  }
+
+  // First post-command sample: do not compare against the pre-command sample.
+  if (mResetZeroCrossingHistory || !mPreviousCurrentValid) {
+    for (UInt phase = 0; phase < 3; ++phase) {
+      if (poleClosed(phase) &&
+          std::abs(current(phase, 0)) <= mZeroCrossingTolerance) {
+        setPoleClosed(phase, false);
+        setZeroCrossingTime(phase, time);
+
+        SPDLOG_LOGGER_INFO(
+            mSLog,
+            "DP phase {} opened at sampled physical current zero: "
+            "t={:.9f}s, i={:.6e}A",
+            phase, time, current(phase, 0));
+      }
+    }
+
+    mPreviousInstantaneousCurrent = current;
+    mPreviousCurrentTime = time;
+    mPreviousCurrentValid = true;
+    mResetZeroCrossingHistory = false;
+
+    if (allPolesOpen())
+      **mOpeningRequested = false;
+
+    return;
+  }
+
+  for (UInt phase = 0; phase < 3; ++phase) {
+    if (!poleClosed(phase))
+      continue;
+
+    const Real previous = mPreviousInstantaneousCurrent(phase, 0);
+    const Real present = current(phase, 0);
+
+    if (!currentCrossedZero(previous, present))
+      continue;
+
+    const Real zeroTime = interpolateZeroCrossingTime(
+        previous, present, mPreviousCurrentTime, time);
+
+    setPoleClosed(phase, false);
+    setZeroCrossingTime(phase, zeroTime);
+
+    SPDLOG_LOGGER_INFO(mSLog,
+                       "DP phase {} physical current zero detected: "
+                       "t_z={:.9f}s, i_prev={:.6e}A, i={:.6e}A. "
+                       "Pole opened.",
+                       phase, zeroTime, previous, present);
+  }
+
+  mPreviousInstantaneousCurrent = current;
+  mPreviousCurrentTime = time;
+  mPreviousCurrentValid = true;
+
+  if (allPolesOpen()) {
+    **mOpeningRequested = false;
+
+    SPDLOG_LOGGER_INFO(mSLog, "DP current-zero interruption completed: "
+                              "all three physical breaker poles are open.");
   }
 }

--- a/dpsim-models/src/EMT/EMT_Ph3_Switch.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Switch.cpp
@@ -6,36 +6,174 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *********************************************************************************/
 
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
 #include <dpsim-models/EMT/EMT_Ph3_Switch.h>
 
 using namespace CPS;
 
-// !!! TODO: 	Adaptions to use in EMT_Ph3 models phase-to-ground peak variables
-// !!! 			with initialization from phase-to-phase RMS variables
-
 EMT::Ph3::Switch::Switch(String uid, String name, Logger::Level logLevel)
     : MNASimPowerComp<Real>(uid, name, false, true, logLevel),
-      Base::Ph3::Switch(mAttributes) {
+      Base::Ph3::Switch(mAttributes),
+      mOpeningRequested(mAttributes->create<Bool>("opening_requested")),
+      mPoleClosedA(mAttributes->create<Bool>("pole_closed_a")),
+      mPoleClosedB(mAttributes->create<Bool>("pole_closed_b")),
+      mPoleClosedC(mAttributes->create<Bool>("pole_closed_c")),
+      mZeroCrossingTimeA(mAttributes->create<Real>("zero_crossing_time_a")),
+      mZeroCrossingTimeB(mAttributes->create<Real>("zero_crossing_time_b")),
+      mZeroCrossingTimeC(mAttributes->create<Real>("zero_crossing_time_c")),
+      mExponentialTransitionActive(
+          mAttributes->create<Bool>("exponential_transition_active")),
+      mExponentialProgress(mAttributes->create<Real>("exponential_progress")),
+      mExponentialTransitionStartTime(
+          mAttributes->create<Real>("exponential_transition_start_time")),
+      mExponentialTransitionEndTime(
+          mAttributes->create<Real>("exponential_transition_end_time")),
+      mEffectiveResistanceA(
+          mAttributes->create<Real>("effective_resistance_a")),
+      mEffectiveResistanceB(
+          mAttributes->create<Real>("effective_resistance_b")),
+      mEffectiveResistanceC(
+          mAttributes->create<Real>("effective_resistance_c")) {
   setTerminalNumber(2);
-  **mIntfVoltage = Matrix::Zero(1, 1);
-  **mIntfCurrent = Matrix::Zero(1, 1);
+
+  // IMPORTANT:
+  // Keep the three-phase interface dimensions fixed from construction.
+  // DataLogger inspects matrix dimensions when attributes are registered,
+  // before the simulation starts.
+  **mIntfVoltage = Matrix::Zero(3, 1);
+  **mIntfCurrent = Matrix::Zero(3, 1);
+
+  **mOpeningRequested = false;
+  setAllPoles(false);
+  resetZeroCrossingTimes();
+
+  **mExponentialTransitionActive = false;
+  **mExponentialProgress = 0.0;
+  **mExponentialTransitionStartTime = -1.0;
+  **mExponentialTransitionEndTime = -1.0;
+  **mEffectiveResistanceA = 0.0;
+  **mEffectiveResistanceB = 0.0;
+  **mEffectiveResistanceC = 0.0;
 }
 
 SimPowerComp<Real>::Ptr EMT::Ph3::Switch::clone(String name) {
   auto copy = Switch::make(name, mLogLevel);
   copy->setParameters(**mOpenResistance, **mClosedResistance, **mIsClosed);
+  copy->setSwitchingMode(mSwitchingMode);
+  copy->setZeroCrossingTolerance(mZeroCrossingTolerance);
+  copy->setExponentialSwitchingTime(mExponentialSwitchingTime);
   return copy;
 }
 
-void EMT::Ph3::Switch::initializeFromNodesAndTerminals(Real frequency) {
+void EMT::Ph3::Switch::setSwitchingMode(SwitchingMode mode) {
+  mSwitchingMode = mode;
 
+  // Synchronize physical poles with the configured initial command state.
+  setAllPoles(**mIsClosed);
+  **mOpeningRequested = false;
+  resetZeroCrossingTimes();
+
+  mPreviousCurrentValid = false;
+  mResetZeroCrossingHistory = false;
+
+  resetExponentialTransition();
+  synchronizeEffectiveResistance(**mIsClosed);
+}
+
+void EMT::Ph3::Switch::setZeroCrossingTolerance(Real tolerance) {
+  if (tolerance < 0.0) {
+    throw std::invalid_argument(
+        "EMT::Ph3::Switch zero-crossing tolerance must be non-negative.");
+  }
+
+  mZeroCrossingTolerance = tolerance;
+}
+
+void EMT::Ph3::Switch::setExponentialSwitchingTime(Real switchingTime) {
+  if (switchingTime <= 0.0) {
+    throw std::invalid_argument(
+        "EMT::Ph3::Switch exponential switching time must be positive.");
+  }
+
+  mExponentialSwitchingTime = switchingTime;
+}
+
+void EMT::Ph3::Switch::openSwitch() {
+  Base::Ph3::Switch::openSwitch();
+
+  if (mSwitchingMode == SwitchingMode::Ideal) {
+    **mOpeningRequested = false;
+    setAllPoles(false);
+    resetZeroCrossingTimes();
+    resetExponentialTransition();
+    synchronizeEffectiveResistance(false);
+    return;
+  }
+
+  if (allPolesOpen()) {
+    **mOpeningRequested = false;
+    return;
+  }
+
+  if (mSwitchingMode == SwitchingMode::CurrentZero) {
+    **mOpeningRequested = true;
+    resetZeroCrossingTimes();
+    resetExponentialTransition();
+    mResetZeroCrossingHistory = true;
+
+    SPDLOG_LOGGER_INFO(mSLog, "Current-zero opening command received. Waiting "
+                              "for phase-current zeros.");
+    return;
+  }
+
+  validateExponentialResistanceParameters();
+  **mOpeningRequested = true;
+  resetZeroCrossingTimes();
+  resetExponentialTransition();
+  **mExponentialTransitionActive = true;
+  synchronizeEffectiveResistance(true);
+  setAllPoles(true);
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "Exponential ZCS-emulation opening command received. "
+                     "Switching duration={:.6e}s.",
+                     mExponentialSwitchingTime);
+}
+
+void EMT::Ph3::Switch::closeSwitch() {
+  Base::Ph3::Switch::closeSwitch();
+
+  **mOpeningRequested = false;
+  setAllPoles(true);
+  resetZeroCrossingTimes();
+  mResetZeroCrossingHistory = false;
+
+  resetExponentialTransition();
+  synchronizeEffectiveResistance(true);
+
+  SPDLOG_LOGGER_INFO(mSLog, "Switch closing command: all three poles closed.");
+}
+
+void EMT::Ph3::Switch::initializeFromNodesAndTerminals(Real frequency) {
   Matrix impedance = (**mIsClosed) ? **mClosedResistance : **mOpenResistance;
+
   MatrixComp vInitABC = MatrixComp::Zero(3, 1);
   vInitABC(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
   vInitABC(1, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_B;
   vInitABC(2, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_C;
+
   **mIntfVoltage = vInitABC.real();
   **mIntfCurrent = (impedance.inverse() * vInitABC).real();
+
+  // Power-flow initialization defines the initial physical breaker state.
+  setAllPoles(**mIsClosed);
+  **mOpeningRequested = false;
+  resetZeroCrossingTimes();
+  resetExponentialTransition();
+  synchronizeEffectiveResistance(**mIsClosed);
 
   SPDLOG_LOGGER_INFO(mSLog,
                      "\n--- Initialization from powerflow ---"
@@ -43,26 +181,71 @@ void EMT::Ph3::Switch::initializeFromNodesAndTerminals(Real frequency) {
                      "\nCurrent: {:s}"
                      "\nTerminal 0 voltage: {:s}"
                      "\nTerminal 1 voltage: {:s}"
+                     "\nSwitching mode: {:s}"
+                     "\nInitial breaker state: {:s}"
                      "\n--- Initialization from powerflow finished ---",
                      Logger::matrixToString(**mIntfVoltage),
                      Logger::matrixToString(**mIntfCurrent),
                      Logger::phasorToString(initialSingleVoltage(0)),
-                     Logger::phasorToString(initialSingleVoltage(1)));
+                     Logger::phasorToString(initialSingleVoltage(1)),
+                     mSwitchingMode == SwitchingMode::Ideal
+                         ? "Ideal"
+                         : (mSwitchingMode == SwitchingMode::CurrentZero
+                                ? "CurrentZero"
+                                : "ExponentialZCSEmulation"),
+                     **mIsClosed ? "closed" : "open");
 }
 
 void EMT::Ph3::Switch::mnaCompInitialize(Real omega, Real timeStep,
                                          Attribute<Matrix>::Ptr leftVector) {
   updateMatrixNodeIndices();
+  mTimeStep = timeStep;
   **mRightVector = Matrix::Zero(0, 0);
+
+  // setParameters() belongs to the shared base class. Synchronize here as a
+  // final safeguard in case setSwitchingMode() was called before setParameters().
+  setAllPoles(**mIsClosed);
+  synchronizeEffectiveResistance(**mIsClosed);
+  resetExponentialTransition();
+
+  mPoleClosedPrev = {
+      **mPoleClosedA,
+      **mPoleClosedB,
+      **mPoleClosedC,
+  };
+
+  if ((**mIntfCurrent).rows() == 3) {
+    mPreviousCurrent = **mIntfCurrent;
+    mPreviousCurrentValid = true;
+  } else {
+    mPreviousCurrent = Matrix::Zero(3, 1);
+    mPreviousCurrentValid = false;
+  }
+
+  mEffectiveResistancePrev = {{
+      **mEffectiveResistanceA,
+      **mEffectiveResistanceB,
+      **mEffectiveResistanceC,
+  }};
+
+  mPreviousCurrentTime = 0.0;
+  mResetZeroCrossingHistory = false;
 }
 
-Bool EMT::Ph3::Switch::mnaIsClosed() { return **mIsClosed; }
+Bool EMT::Ph3::Switch::mnaIsClosed() {
+  if (mSwitchingMode == SwitchingMode::Ideal)
+    return **mIsClosed;
+
+  return allPolesClosed();
+}
+
+Bool EMT::Ph3::Switch::supportsPrecomputedSystemMatrices() const {
+  return mSwitchingMode == SwitchingMode::Ideal;
+}
 
 void EMT::Ph3::Switch::mnaCompApplySystemMatrixStamp(
     SparseMatrixRow &systemMatrix) {
-  MatrixFixedSize<3, 3> conductance = (**mIsClosed)
-                                          ? (**mClosedResistance).inverse()
-                                          : (**mOpenResistance).inverse();
+  const MatrixFixedSize<3, 3> conductance = currentConductanceMatrix();
 
   MNAStampUtils::stampConductanceMatrix(
       conductance, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
@@ -74,8 +257,12 @@ void EMT::Ph3::Switch::mnaCompApplySystemMatrixStamp(
 
 void EMT::Ph3::Switch::mnaCompApplySwitchSystemMatrixStamp(
     Bool closed, SparseMatrixRow &systemMatrix, Int freqIdx) {
-  MatrixFixedSize<3, 3> conductance = (closed) ? (**mClosedResistance).inverse()
-                                               : (**mOpenResistance).inverse();
+  // This method is used by the conventional precomputed two-state switch path.
+  // CurrentZero mode advertises supportsPrecomputedSystemMatrices() == false
+  // and therefore uses mnaCompApplySystemMatrixStamp() through the variable
+  // matrix recomputation path instead.
+  MatrixFixedSize<3, 3> conductance =
+      closed ? (**mClosedResistance).inverse() : (**mOpenResistance).inverse();
 
   MNAStampUtils::stampConductanceMatrix(
       conductance, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
@@ -93,19 +280,43 @@ void EMT::Ph3::Switch::mnaCompAddPostStepDependencies(
     AttributeBase::List &modifiedAttributes,
     Attribute<Matrix>::Ptr &leftVector) {
   attributeDependencies.push_back(leftVector);
+
   modifiedAttributes.push_back(mIntfVoltage);
   modifiedAttributes.push_back(mIntfCurrent);
+
+  modifiedAttributes.push_back(mOpeningRequested);
+  modifiedAttributes.push_back(mPoleClosedA);
+  modifiedAttributes.push_back(mPoleClosedB);
+  modifiedAttributes.push_back(mPoleClosedC);
+  modifiedAttributes.push_back(mZeroCrossingTimeA);
+  modifiedAttributes.push_back(mZeroCrossingTimeB);
+  modifiedAttributes.push_back(mZeroCrossingTimeC);
+
+  modifiedAttributes.push_back(mExponentialTransitionActive);
+  modifiedAttributes.push_back(mExponentialProgress);
+  modifiedAttributes.push_back(mExponentialTransitionStartTime);
+  modifiedAttributes.push_back(mExponentialTransitionEndTime);
+  modifiedAttributes.push_back(mEffectiveResistanceA);
+  modifiedAttributes.push_back(mEffectiveResistanceB);
+  modifiedAttributes.push_back(mEffectiveResistanceC);
 }
 
 void EMT::Ph3::Switch::mnaCompPostStep(Real time, Int timeStepCount,
                                        Attribute<Matrix>::Ptr &leftVector) {
   mnaCompUpdateVoltage(**leftVector);
   mnaCompUpdateCurrent(**leftVector);
+
+  if (mSwitchingMode == SwitchingMode::CurrentZero) {
+    updateZeroCrossingState(time);
+  } else if (mSwitchingMode == SwitchingMode::ExponentialZCSEmulation) {
+    updateExponentialTransition(time);
+  }
 }
 
 void EMT::Ph3::Switch::mnaCompUpdateVoltage(const Matrix &leftVector) {
-  // Voltage across component is defined as V1 - V0
+  // Voltage across component is defined as V1 - V0.
   **mIntfVoltage = Matrix::Zero(3, 1);
+
   if (terminalNotGrounded(1)) {
     (**mIntfVoltage)(0, 0) =
         Math::realFromVectorElement(leftVector, matrixNodeIndex(1, 0));
@@ -114,33 +325,381 @@ void EMT::Ph3::Switch::mnaCompUpdateVoltage(const Matrix &leftVector) {
     (**mIntfVoltage)(2, 0) =
         Math::realFromVectorElement(leftVector, matrixNodeIndex(1, 2));
   }
+
   if (terminalNotGrounded(0)) {
-    (**mIntfVoltage)(0, 0) =
-        (**mIntfVoltage)(0, 0) -
+    (**mIntfVoltage)(0, 0) -=
         Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 0));
-    (**mIntfVoltage)(1, 0) =
-        (**mIntfVoltage)(1, 0) -
+    (**mIntfVoltage)(1, 0) -=
         Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 1));
-    (**mIntfVoltage)(2, 0) =
-        (**mIntfVoltage)(2, 0) -
+    (**mIntfVoltage)(2, 0) -=
         Math::realFromVectorElement(leftVector, matrixNodeIndex(0, 2));
   }
 }
 
 void EMT::Ph3::Switch::mnaCompUpdateCurrent(const Matrix &leftVector) {
-  Matrix conductance = Matrix::Zero(3, 3);
-  (**mIsClosed) ? Math::invertMatrix(**mClosedResistance, conductance)
-                : Math::invertMatrix(**mOpenResistance, conductance);
-
-  **mIntfCurrent = conductance * **mIntfVoltage;
+  **mIntfCurrent = currentConductanceMatrix() * **mIntfVoltage;
 }
 
 Bool EMT::Ph3::Switch::hasParameterChanged() {
-  // Check if state of switch changed
-  if (!(mIsClosedPrev == this->mnaIsClosed())) {
-    mIsClosedPrev = this->mnaIsClosed();
-    return 1; //recompute system matrix
-  } else {
-    return 0; // do not recompute system matrix
+  if (mSwitchingMode == SwitchingMode::Ideal) {
+    // Preserve the previous DPsim switch behavior.
+    if (mIsClosedPrev != mnaIsClosed()) {
+      mIsClosedPrev = mnaIsClosed();
+      return true;
+    }
+
+    return false;
   }
-};
+
+  if (mSwitchingMode == SwitchingMode::ExponentialZCSEmulation) {
+    const std::array<Real, 3> resistanceNow{{
+        **mEffectiveResistanceA,
+        **mEffectiveResistanceB,
+        **mEffectiveResistanceC,
+    }};
+
+    Bool changed = false;
+    for (UInt phase = 0; phase < 3; ++phase) {
+      if (resistanceNow[phase] != mEffectiveResistancePrev[phase]) {
+        mEffectiveResistancePrev[phase] = resistanceNow[phase];
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  const std::array<Bool, 3> poleClosedNow{{
+      **mPoleClosedA,
+      **mPoleClosedB,
+      **mPoleClosedC,
+  }};
+
+  Bool changed = false;
+
+  for (UInt phase = 0; phase < 3; ++phase) {
+    if (poleClosedNow[phase] != mPoleClosedPrev[phase]) {
+      changed = true;
+      mPoleClosedPrev[phase] = poleClosedNow[phase];
+    }
+  }
+
+  return changed;
+}
+
+Bool EMT::Ph3::Switch::poleClosed(UInt phase) const {
+  switch (phase) {
+  case 0:
+    return **mPoleClosedA;
+  case 1:
+    return **mPoleClosedB;
+  case 2:
+    return **mPoleClosedC;
+  default:
+    throw std::out_of_range("EMT::Ph3::Switch phase index must be 0, 1, or 2.");
+  }
+}
+
+void EMT::Ph3::Switch::setPoleClosed(UInt phase, Bool closed) {
+  switch (phase) {
+  case 0:
+    **mPoleClosedA = closed;
+    break;
+  case 1:
+    **mPoleClosedB = closed;
+    break;
+  case 2:
+    **mPoleClosedC = closed;
+    break;
+  default:
+    throw std::out_of_range("EMT::Ph3::Switch phase index must be 0, 1, or 2.");
+  }
+
+  // Keep the resistance diagnostics synchronized with the discrete
+  // CurrentZero pole state. Exponential mode manages R(t) independently.
+  if (mSwitchingMode == SwitchingMode::CurrentZero &&
+      (**mClosedResistance).rows() >= 3 && (**mOpenResistance).rows() >= 3) {
+    setEffectiveResistance(phase, closed ? (**mClosedResistance)(phase, phase)
+                                         : (**mOpenResistance)(phase, phase));
+  }
+}
+
+void EMT::Ph3::Switch::setAllPoles(Bool closed) {
+  **mPoleClosedA = closed;
+  **mPoleClosedB = closed;
+  **mPoleClosedC = closed;
+}
+
+Bool EMT::Ph3::Switch::allPolesClosed() const {
+  return **mPoleClosedA && **mPoleClosedB && **mPoleClosedC;
+}
+
+Bool EMT::Ph3::Switch::allPolesOpen() const {
+  return !**mPoleClosedA && !**mPoleClosedB && !**mPoleClosedC;
+}
+
+void EMT::Ph3::Switch::resetZeroCrossingTimes() {
+  **mZeroCrossingTimeA = -1.0;
+  **mZeroCrossingTimeB = -1.0;
+  **mZeroCrossingTimeC = -1.0;
+}
+
+Real EMT::Ph3::Switch::effectiveResistance(UInt phase) const {
+  switch (phase) {
+  case 0:
+    return **mEffectiveResistanceA;
+  case 1:
+    return **mEffectiveResistanceB;
+  case 2:
+    return **mEffectiveResistanceC;
+  default:
+    throw std::out_of_range("EMT::Ph3::Switch phase index must be 0, 1, or 2.");
+  }
+}
+
+void EMT::Ph3::Switch::setEffectiveResistance(UInt phase, Real resistance) {
+  switch (phase) {
+  case 0:
+    **mEffectiveResistanceA = resistance;
+    return;
+  case 1:
+    **mEffectiveResistanceB = resistance;
+    return;
+  case 2:
+    **mEffectiveResistanceC = resistance;
+    return;
+  default:
+    throw std::out_of_range("EMT::Ph3::Switch phase index must be 0, 1, or 2.");
+  }
+}
+
+void EMT::Ph3::Switch::synchronizeEffectiveResistance(Bool closed) {
+  if ((**mClosedResistance).rows() < 3 || (**mOpenResistance).rows() < 3)
+    return;
+
+  for (UInt phase = 0; phase < 3; ++phase) {
+    setEffectiveResistance(phase, closed ? (**mClosedResistance)(phase, phase)
+                                         : (**mOpenResistance)(phase, phase));
+  }
+}
+
+void EMT::Ph3::Switch::resetExponentialTransition() {
+  **mExponentialTransitionActive = false;
+  **mExponentialProgress = 0.0;
+  **mExponentialTransitionStartTime = -1.0;
+  **mExponentialTransitionEndTime = -1.0;
+  mExponentialTransitionStarted = false;
+}
+
+void EMT::Ph3::Switch::validateExponentialResistanceParameters() const {
+  if ((**mClosedResistance).rows() < 3 || (**mOpenResistance).rows() < 3) {
+    throw std::invalid_argument(
+        "EMT::Ph3::Switch exponential mode requires 3x3 resistance matrices.");
+  }
+
+  if (mExponentialSwitchingTime <= 0.0) {
+    throw std::invalid_argument(
+        "EMT::Ph3::Switch exponential switching time must be positive.");
+  }
+
+  for (UInt phase = 0; phase < 3; ++phase) {
+    const Real rClosed = (**mClosedResistance)(phase, phase);
+    const Real rOpen = (**mOpenResistance)(phase, phase);
+
+    if (rClosed <= 0.0 || rOpen <= 0.0) {
+      throw std::invalid_argument(
+          "EMT::Ph3::Switch exponential mode requires positive diagonal "
+          "open and closed resistances.");
+    }
+  }
+}
+
+Real EMT::Ph3::Switch::exponentialResistance(UInt phase, Real alpha) const {
+  const Real rClosed = (**mClosedResistance)(phase, phase);
+  const Real rOpen = (**mOpenResistance)(phase, phase);
+  const Real boundedAlpha = std::max(0.0, std::min(1.0, alpha));
+
+  return std::exp(std::log(rClosed) +
+                  boundedAlpha * (std::log(rOpen) - std::log(rClosed)));
+}
+
+void EMT::Ph3::Switch::updateExponentialTransition(Real time) {
+  if (!**mExponentialTransitionActive)
+    return;
+
+  if (!mExponentialTransitionStarted) {
+    mExponentialTransitionStarted = true;
+    **mExponentialTransitionStartTime = time;
+    **mExponentialTransitionEndTime = time + mExponentialSwitchingTime;
+  }
+
+  // Prepare R(t+dt) in post-step so that the next MNA solve at t+dt stamps
+  // the intended resistance trajectory without requiring a time-aware event API.
+  const Real targetTime = time + mTimeStep;
+  const Real alpha = (targetTime - **mExponentialTransitionStartTime) /
+                     mExponentialSwitchingTime;
+  const Real boundedAlpha = std::max(0.0, std::min(1.0, alpha));
+
+  **mExponentialProgress = boundedAlpha;
+
+  for (UInt phase = 0; phase < 3; ++phase)
+    setEffectiveResistance(phase, exponentialResistance(phase, boundedAlpha));
+
+  if (boundedAlpha >= 1.0) {
+    synchronizeEffectiveResistance(false);
+    setAllPoles(false);
+    **mOpeningRequested = false;
+    **mExponentialTransitionActive = false;
+
+    SPDLOG_LOGGER_INFO(
+        mSLog,
+        "Exponential ZCS-emulation opening completed: start={:.9f}s, "
+        "end={:.9f}s, duration={:.6e}s.",
+        **mExponentialTransitionStartTime, **mExponentialTransitionEndTime,
+        mExponentialSwitchingTime);
+  }
+}
+
+MatrixFixedSize<3, 3> EMT::Ph3::Switch::currentConductanceMatrix() const {
+  if (mSwitchingMode == SwitchingMode::Ideal) {
+    MatrixFixedSize<3, 3> conductance = (**mIsClosed)
+                                            ? (**mClosedResistance).inverse()
+                                            : (**mOpenResistance).inverse();
+    return conductance;
+  }
+
+  MatrixFixedSize<3, 3> conductance = MatrixFixedSize<3, 3>::Zero();
+
+  for (UInt phase = 0; phase < 3; ++phase) {
+    Real resistance = 0.0;
+
+    if (mSwitchingMode == SwitchingMode::CurrentZero) {
+      resistance = poleClosed(phase) ? (**mClosedResistance)(phase, phase)
+                                     : (**mOpenResistance)(phase, phase);
+    } else {
+      resistance = effectiveResistance(phase);
+    }
+
+    conductance(phase, phase) = 1.0 / resistance;
+  }
+
+  return conductance;
+}
+
+Bool EMT::Ph3::Switch::currentCrossedZero(Real previousCurrent,
+                                          Real current) const {
+  if (std::abs(current) <= mZeroCrossingTolerance)
+    return true;
+
+  return (previousCurrent > mZeroCrossingTolerance &&
+          current < -mZeroCrossingTolerance) ||
+         (previousCurrent < -mZeroCrossingTolerance &&
+          current > mZeroCrossingTolerance);
+}
+
+Real EMT::Ph3::Switch::interpolateZeroCrossingTime(Real previousCurrent,
+                                                   Real current,
+                                                   Real previousTime,
+                                                   Real currentTime) const {
+  const Real denominator = std::abs(previousCurrent) + std::abs(current);
+
+  if (denominator <= mZeroCrossingTolerance)
+    return currentTime;
+
+  const Real fraction = std::abs(previousCurrent) / denominator;
+
+  return previousTime + fraction * (currentTime - previousTime);
+}
+
+void EMT::Ph3::Switch::setZeroCrossingTime(UInt phase, Real time) {
+  switch (phase) {
+  case 0:
+    **mZeroCrossingTimeA = time;
+    return;
+  case 1:
+    **mZeroCrossingTimeB = time;
+    return;
+  case 2:
+    **mZeroCrossingTimeC = time;
+    return;
+  default:
+    throw std::out_of_range("EMT::Ph3::Switch phase index must be 0, 1, or 2.");
+  }
+}
+
+void EMT::Ph3::Switch::updateZeroCrossingState(Real time) {
+  const Matrix current = **mIntfCurrent;
+
+  if (current.rows() != 3)
+    return;
+
+  // While no opening request is active, continuously maintain a clean
+  // current history for diagnostics and for a later opening command.
+  if (!**mOpeningRequested) {
+    mPreviousCurrent = current;
+    mPreviousCurrentTime = time;
+    mPreviousCurrentValid = true;
+    return;
+  }
+
+  // The first sample after the opening command must not use a sample from
+  // before the command for a sign-change test. It may still open a pole if
+  // that first post-command sample itself is already at zero.
+  if (mResetZeroCrossingHistory || !mPreviousCurrentValid) {
+    for (UInt phase = 0; phase < 3; ++phase) {
+      if (poleClosed(phase) &&
+          std::abs(current(phase, 0)) <= mZeroCrossingTolerance) {
+        setPoleClosed(phase, false);
+        setZeroCrossingTime(phase, time);
+
+        SPDLOG_LOGGER_INFO(mSLog,
+                           "Phase {} opened at sampled current zero: "
+                           "t={:.9f}s, i={:.6e}A",
+                           phase, time, current(phase, 0));
+      }
+    }
+
+    mPreviousCurrent = current;
+    mPreviousCurrentTime = time;
+    mPreviousCurrentValid = true;
+    mResetZeroCrossingHistory = false;
+
+    if (allPolesOpen())
+      **mOpeningRequested = false;
+
+    return;
+  }
+
+  for (UInt phase = 0; phase < 3; ++phase) {
+    if (!poleClosed(phase))
+      continue;
+
+    const Real previous = mPreviousCurrent(phase, 0);
+    const Real present = current(phase, 0);
+
+    if (!currentCrossedZero(previous, present))
+      continue;
+
+    const Real zeroTime = interpolateZeroCrossingTime(
+        previous, present, mPreviousCurrentTime, time);
+
+    setPoleClosed(phase, false);
+    setZeroCrossingTime(phase, zeroTime);
+
+    SPDLOG_LOGGER_INFO(mSLog,
+                       "Phase {} current zero detected: "
+                       "t_z={:.9f}s, i_prev={:.6e}A, i={:.6e}A. "
+                       "Pole opened.",
+                       phase, zeroTime, previous, present);
+  }
+
+  mPreviousCurrent = current;
+  mPreviousCurrentTime = time;
+  mPreviousCurrentValid = true;
+
+  if (allPolesOpen()) {
+    **mOpeningRequested = false;
+
+    SPDLOG_LOGGER_INFO(mSLog, "Current-zero interruption completed: "
+                              "all three breaker poles are open.");
+  }
+}

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -135,6 +135,7 @@ set(SYNCGEN_SOURCES
 	Components/DP_SP_SynGenTrStab_testModels_doubleLine.cpp
 	Components/EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter.cpp
 	Components/EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter.cpp
+	Components/EMT_DP_Ph3_Switch_3Mode_Benchmark.cpp
 )
 
 set(INVERTER_SOURCES

--- a/dpsim/examples/cxx/Components/EMT_DP_Ph3_Switch_3Mode_Benchmark.cpp
+++ b/dpsim/examples/cxx/Components/EMT_DP_Ph3_Switch_3Mode_Benchmark.cpp
@@ -1,0 +1,972 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+#include <DPsim.h>
+#include <dpsim-models/DP/DP_Ph3_Switch.h>
+#include <dpsim-models/EMT/EMT_Ph3_Switch.h>
+#include <dpsim-models/Filesystem.h>
+
+using namespace DPsim;
+using namespace CPS;
+
+enum class BenchmarkMode {
+  Ideal,
+  CurrentZero,
+  ExponentialZCSEmulation,
+};
+
+enum class SwitchingDirection {
+  CloseToOpen,
+  OpenToClose,
+};
+
+struct Parameters {
+  Real frequency = 50.0;
+  Real nominalVoltage = 20e3;
+
+  Real loadP = 1.0e6;
+  Real loadQ = 0.3e6;
+
+  Real pathAResistance = 0.20;
+  Real pathAInductance = 1.0e-3;
+
+  Real pathBResistance = 0.40;
+  Real pathBInductance = 2.0e-3;
+
+  Real switchOpenResistance = 1e9;
+  Real switchClosedResistance = 1e-3;
+
+  Real zeroCrossingTolerance = 1e-6;
+
+  Real exponentialSwitchingTime = 0.010;
+
+  Real timeStep = 20e-6;
+
+  Real openCommandTime = 0.0437;
+
+  Real closeCommandTime = 0.0437;
+
+  Real finalTime = 0.070;
+};
+
+struct RunResult {
+  String domain;
+  String mode;
+  String direction;
+
+  Bool initialClosed = false;
+  Bool targetClosed = false;
+
+  Real commandTime = 0.0;
+  Real runtimeSeconds = 0.0;
+
+  Real zeroA = -1.0;
+  Real zeroB = -1.0;
+  Real zeroC = -1.0;
+
+  Real exponentialStart = -1.0;
+  Real exponentialEnd = -1.0;
+  Real exponentialProgress = 0.0;
+  Bool exponentialActiveFinal = false;
+
+  Real finalResistanceA = -1.0;
+  Real finalResistanceB = -1.0;
+  Real finalResistanceC = -1.0;
+
+  Bool finalCommandedClosed = false;
+  Bool finalPoleA = false;
+  Bool finalPoleB = false;
+  Bool finalPoleC = false;
+
+  Int expectedMatrixRecomputations = 0;
+
+  Bool passCommandState = false;
+  Bool passPoleState = false;
+  Bool passResistanceState = false;
+  Bool passTransitionState = false;
+  Bool passOverall = false;
+};
+
+String modeName(BenchmarkMode mode) {
+  switch (mode) {
+  case BenchmarkMode::Ideal:
+    return "Ideal";
+  case BenchmarkMode::CurrentZero:
+    return "CurrentZero";
+  case BenchmarkMode::ExponentialZCSEmulation:
+    return "ExponentialZCSEmulation";
+  }
+
+  return "Unknown";
+}
+
+String directionName(SwitchingDirection direction) {
+  switch (direction) {
+  case SwitchingDirection::CloseToOpen:
+    return "CloseToOpen";
+  case SwitchingDirection::OpenToClose:
+    return "OpenToClose";
+  }
+
+  return "Unknown";
+}
+
+Bool initialClosed(SwitchingDirection direction) {
+  return direction == SwitchingDirection::CloseToOpen;
+}
+
+Bool targetClosed(SwitchingDirection direction) {
+  return direction == SwitchingDirection::OpenToClose;
+}
+
+Real commandTime(const Parameters &p, SwitchingDirection direction) {
+  return direction == SwitchingDirection::CloseToOpen ? p.openCommandTime
+                                                      : p.closeCommandTime;
+}
+
+Int expectedMatrixRecomputations(const Parameters &p, BenchmarkMode mode,
+                                 SwitchingDirection direction) {
+  if (mode == BenchmarkMode::Ideal) {
+    return 0;
+  }
+
+  if (direction == SwitchingDirection::OpenToClose) {
+    return 1;
+  }
+
+  if (mode == BenchmarkMode::CurrentZero) {
+    return 3;
+  }
+
+  return static_cast<Int>(std::ceil(p.exponentialSwitchingTime / p.timeStep)) +
+         1;
+}
+
+Bool nearlyEqual(Real a, Real b, Real relTol = 1e-9, Real absTol = 1e-12) {
+  const Real scale = std::max(std::abs(a), std::abs(b));
+
+  return std::abs(a - b) <= std::max(absTol, relTol * scale);
+}
+
+void evaluateRunResult(const Parameters &p, RunResult &result) {
+  const Bool expectedClosed = result.targetClosed;
+
+  result.passCommandState = result.finalCommandedClosed == expectedClosed;
+
+  result.passPoleState = result.finalPoleA == expectedClosed &&
+                         result.finalPoleB == expectedClosed &&
+                         result.finalPoleC == expectedClosed;
+
+  const Real expectedResistance =
+      expectedClosed ? p.switchClosedResistance : p.switchOpenResistance;
+
+  result.passResistanceState =
+      nearlyEqual(result.finalResistanceA, expectedResistance) &&
+      nearlyEqual(result.finalResistanceB, expectedResistance) &&
+      nearlyEqual(result.finalResistanceC, expectedResistance);
+
+  if (result.mode == "ExponentialZCSEmulation") {
+    if (expectedClosed) {
+      result.passTransitionState =
+          !result.exponentialActiveFinal &&
+          nearlyEqual(result.exponentialProgress, 0.0, 0.0, 1e-12);
+    } else {
+      result.passTransitionState =
+          !result.exponentialActiveFinal &&
+          nearlyEqual(result.exponentialProgress, 1.0, 0.0, 1e-12) &&
+          result.exponentialStart >= 0.0 &&
+          result.exponentialEnd >= result.exponentialStart;
+    }
+  } else {
+    result.passTransitionState = !result.exponentialActiveFinal;
+  }
+
+  result.passOverall = result.passCommandState && result.passPoleState &&
+                       result.passResistanceState && result.passTransitionState;
+}
+
+String makeRunTimestamp() {
+  const auto now = std::chrono::system_clock::now();
+
+  const std::time_t nowTime = std::chrono::system_clock::to_time_t(now);
+
+  std::tm localTime{};
+
+#ifdef _WIN32
+  localtime_s(&localTime, &nowTime);
+#else
+  localtime_r(&nowTime, &localTime);
+#endif
+
+  std::ostringstream stream;
+  stream << std::put_time(&localTime, "%Y%m%d_%H%M%S");
+
+  return stream.str();
+}
+
+String makeResultsDirectory() {
+  return "logs/"
+         "EMT_DP_Ph3_Switch_3Mode_Bidirectional_Benchmark_results_" +
+         makeRunTimestamp();
+}
+
+void writeSummary(const String &resultsDir,
+                  const std::vector<RunResult> &results) {
+  const String path = resultsDir + "/benchmark_summary.csv";
+
+  std::ofstream csv(path, std::ios::out | std::ios::trunc);
+
+  if (!csv.is_open()) {
+    throw std::runtime_error("Could not open benchmark summary: " + path);
+  }
+
+  csv << std::scientific << std::setprecision(12);
+
+  csv << "domain,"
+      << "mode,"
+      << "direction,"
+      << "initial_closed,"
+      << "target_closed,"
+      << "command_time_s,"
+      << "runtime_s,"
+      << "zero_a_s,"
+      << "zero_b_s,"
+      << "zero_c_s,"
+      << "exponential_start_s,"
+      << "exponential_end_s,"
+      << "exponential_progress_final,"
+      << "exponential_active_final,"
+      << "final_R_a_ohm,"
+      << "final_R_b_ohm,"
+      << "final_R_c_ohm,"
+      << "final_commanded_closed,"
+      << "final_pole_a_closed,"
+      << "final_pole_b_closed,"
+      << "final_pole_c_closed,"
+      << "expected_matrix_recomputations,"
+      << "pass_command_state,"
+      << "pass_pole_state,"
+      << "pass_resistance_state,"
+      << "pass_transition_state,"
+      << "pass_overall\n";
+
+  for (const auto &r : results) {
+    csv << r.domain << "," << r.mode << "," << r.direction << ","
+        << static_cast<Int>(r.initialClosed) << ","
+        << static_cast<Int>(r.targetClosed) << "," << r.commandTime << ","
+        << r.runtimeSeconds << "," << r.zeroA << "," << r.zeroB << ","
+        << r.zeroC << "," << r.exponentialStart << "," << r.exponentialEnd
+        << "," << r.exponentialProgress << ","
+        << static_cast<Int>(r.exponentialActiveFinal) << ","
+        << r.finalResistanceA << "," << r.finalResistanceB << ","
+        << r.finalResistanceC << "," << static_cast<Int>(r.finalCommandedClosed)
+        << "," << static_cast<Int>(r.finalPoleA) << ","
+        << static_cast<Int>(r.finalPoleB) << ","
+        << static_cast<Int>(r.finalPoleC) << ","
+        << r.expectedMatrixRecomputations << ","
+        << static_cast<Int>(r.passCommandState) << ","
+        << static_cast<Int>(r.passPoleState) << ","
+        << static_cast<Int>(r.passResistanceState) << ","
+        << static_cast<Int>(r.passTransitionState) << ","
+        << static_cast<Int>(r.passOverall) << "\n";
+  }
+}
+
+SystemTopology runPowerFlow(const Parameters &p, Bool breakerClosed) {
+  const String stateName = breakerClosed ? "Closed" : "Open";
+
+  const String simName =
+      "EMT_DP_Ph3_Switch_3Mode_Bidirectional_Benchmark_PF_" + stateName;
+
+  auto n1 = SimNode<Complex>::make("n1", PhaseType::Single);
+
+  auto n2 = SimNode<Complex>::make("n2", PhaseType::Single);
+
+  auto n3 = SimNode<Complex>::make("n3", PhaseType::Single);
+
+  auto slack = SP::Ph1::NetworkInjection::make("Slack", Logger::Level::info);
+
+  slack->setParameters(p.nominalVoltage);
+
+  slack->setBaseVoltage(p.nominalVoltage);
+
+  slack->modifyPowerFlowBusType(PowerflowBusType::VD);
+
+  auto pathA = SP::Ph1::PiLine::make("PathA", Logger::Level::info);
+
+  pathA->setParameters(p.pathAResistance, p.pathAInductance, 0.0);
+
+  pathA->setBaseVoltage(p.nominalVoltage);
+
+  auto pathB = SP::Ph1::PiLine::make("PathB", Logger::Level::info);
+
+  pathB->setParameters(p.pathBResistance, p.pathBInductance, 0.0);
+
+  pathB->setBaseVoltage(p.nominalVoltage);
+
+  auto load = SP::Ph1::Shunt::make("LoadPF", Logger::Level::info);
+
+  load->setParameters(p.loadP / std::pow(p.nominalVoltage, 2),
+                      -p.loadQ / std::pow(p.nominalVoltage, 2));
+
+  load->setBaseVoltage(p.nominalVoltage);
+
+  slack->connect({n1});
+  pathA->connect({n1, n2});
+  pathB->connect({n1, n3});
+  load->connect({n3});
+
+  SystemComponentList components{
+      slack,
+      pathA,
+      pathB,
+      load,
+  };
+
+  if (breakerClosed) {
+    auto breakerPF = SP::Ph1::PiLine::make("BreakerPF", Logger::Level::info);
+
+    breakerPF->setParameters(p.switchClosedResistance, 0.0, 0.0);
+
+    breakerPF->setBaseVoltage(p.nominalVoltage);
+
+    breakerPF->connect({n2, n3});
+
+    components.push_back(breakerPF);
+  }
+
+  auto systemPF = SystemTopology(p.frequency,
+                                 SystemNodeList{
+                                     n1,
+                                     n2,
+                                     n3,
+                                 },
+                                 components);
+
+  auto logger = DataLogger::make(simName);
+
+  logger->logAttribute("v_n1", n1->attribute("v"));
+
+  logger->logAttribute("v_n2", n2->attribute("v"));
+
+  logger->logAttribute("v_n3", n3->attribute("v"));
+
+  Simulation sim(simName, Logger::Level::info);
+
+  sim.setSystem(systemPF);
+
+  sim.setTimeStep(1.0);
+
+  sim.setFinalTime(2.0);
+
+  sim.setDomain(Domain::SP);
+
+  sim.setSolverType(Solver::Type::NRP);
+
+  sim.setSolverAndComponentBehaviour(Solver::Behaviour::Initialization);
+
+  sim.doInitFromNodesAndTerminals(false);
+
+  sim.addLogger(logger);
+
+  sim.run();
+
+  return systemPF;
+}
+
+EMT::Ph3::Switch::SwitchingMode toEMTMode(BenchmarkMode mode) {
+  switch (mode) {
+  case BenchmarkMode::Ideal:
+    return EMT::Ph3::Switch::SwitchingMode::Ideal;
+
+  case BenchmarkMode::CurrentZero:
+    return EMT::Ph3::Switch::SwitchingMode::CurrentZero;
+
+  case BenchmarkMode::ExponentialZCSEmulation:
+    return EMT::Ph3::Switch::SwitchingMode::ExponentialZCSEmulation;
+  }
+
+  return EMT::Ph3::Switch::SwitchingMode::Ideal;
+}
+
+RunResult runEMT(const Parameters &p, const SystemTopology &systemPF,
+                 BenchmarkMode mode, SwitchingDirection direction) {
+  const Bool startsClosed = initialClosed(direction);
+
+  const Bool endsClosed = targetClosed(direction);
+
+  const Real eventTime = commandTime(p, direction);
+
+  const String simName =
+      "EMT_DP_Ph3_Switch_3Mode_Bidirectional_Benchmark_EMT_" + modeName(mode) +
+      "_" + directionName(direction);
+
+  auto n1 = SimNode<Real>::make("n1", PhaseType::ABC);
+
+  auto n2 = SimNode<Real>::make("n2", PhaseType::ABC);
+
+  auto n3 = SimNode<Real>::make("n3", PhaseType::ABC);
+
+  auto slack = EMT::Ph3::NetworkInjection::make("Slack", Logger::Level::info);
+
+  slack->setParameters(Math::singlePhaseVariableToThreePhase(p.nominalVoltage),
+                       p.frequency);
+
+  auto pathA = EMT::Ph3::PiLine::make("PathA", Logger::Level::info);
+
+  pathA->setParameters(
+      Math::singlePhaseParameterToThreePhase(p.pathAResistance),
+      Math::singlePhaseParameterToThreePhase(p.pathAInductance),
+      Math::singlePhaseParameterToThreePhase(0.0));
+
+  auto pathB = EMT::Ph3::PiLine::make("PathB", Logger::Level::info);
+
+  pathB->setParameters(
+      Math::singlePhaseParameterToThreePhase(p.pathBResistance),
+      Math::singlePhaseParameterToThreePhase(p.pathBInductance),
+      Math::singlePhaseParameterToThreePhase(0.0));
+
+  auto breaker = EMT::Ph3::Switch::make("Breaker", Logger::Level::info);
+
+  breaker->setParameters(
+      Math::singlePhaseParameterToThreePhase(p.switchOpenResistance),
+      Math::singlePhaseParameterToThreePhase(p.switchClosedResistance),
+      startsClosed);
+
+  breaker->setSwitchingMode(toEMTMode(mode));
+
+  breaker->setZeroCrossingTolerance(p.zeroCrossingTolerance);
+
+  breaker->setExponentialSwitchingTime(p.exponentialSwitchingTime);
+
+  auto load = EMT::Ph3::RXLoad::make("Load", Logger::Level::info);
+
+  load->setParameters(Math::singlePhasePowerToThreePhase(p.loadP),
+                      Math::singlePhasePowerToThreePhase(p.loadQ),
+                      p.nominalVoltage);
+
+  slack->connect({n1});
+  pathA->connect({n1, n2});
+  breaker->connect({n2, n3});
+  pathB->connect({n1, n3});
+  load->connect({n3});
+
+  auto system = SystemTopology(p.frequency,
+                               SystemNodeList{
+                                   n1,
+                                   n2,
+                                   n3,
+                               },
+                               SystemComponentList{
+                                   slack,
+                                   pathA,
+                                   breaker,
+                                   pathB,
+                                   load,
+                               });
+
+  system.initWithPowerflow(systemPF, Domain::EMT);
+
+  auto logger = DataLogger::make(simName);
+
+  const auto breakerCurrent = breaker->attributeTyped<Matrix>("i_intf");
+
+  logger->logAttribute("i_breaker_a", breakerCurrent->deriveCoeff<Real>(0, 0));
+
+  logger->logAttribute("i_breaker_b", breakerCurrent->deriveCoeff<Real>(1, 0));
+
+  logger->logAttribute("i_breaker_c", breakerCurrent->deriveCoeff<Real>(2, 0));
+
+  const auto breakerVoltage = breaker->attributeTyped<Matrix>("v_intf");
+
+  logger->logAttribute("v_breaker_a", breakerVoltage->deriveCoeff<Real>(0, 0));
+
+  logger->logAttribute("v_breaker_b", breakerVoltage->deriveCoeff<Real>(1, 0));
+
+  logger->logAttribute("v_breaker_c", breakerVoltage->deriveCoeff<Real>(2, 0));
+
+  const auto loadBusVoltage = n3->attributeTyped<Matrix>("v");
+
+  logger->logAttribute("v_n3_a", loadBusVoltage->deriveCoeff<Real>(0, 0));
+
+  logger->logAttribute("v_n3_b", loadBusVoltage->deriveCoeff<Real>(1, 0));
+
+  logger->logAttribute("v_n3_c", loadBusVoltage->deriveCoeff<Real>(2, 0));
+
+  logger->logAttribute("commanded_closed", breaker->attribute("is_closed"));
+
+  logger->logAttribute("opening_requested",
+                       breaker->attribute("opening_requested"));
+
+  logger->logAttribute("pole_closed_a", breaker->attribute("pole_closed_a"));
+
+  logger->logAttribute("pole_closed_b", breaker->attribute("pole_closed_b"));
+
+  logger->logAttribute("pole_closed_c", breaker->attribute("pole_closed_c"));
+
+  logger->logAttribute("zero_crossing_time_a",
+                       breaker->attribute("zero_crossing_time_a"));
+
+  logger->logAttribute("zero_crossing_time_b",
+                       breaker->attribute("zero_crossing_time_b"));
+
+  logger->logAttribute("zero_crossing_time_c",
+                       breaker->attribute("zero_crossing_time_c"));
+
+  logger->logAttribute("exponential_transition_active",
+                       breaker->attribute("exponential_transition_active"));
+
+  logger->logAttribute("exponential_progress",
+                       breaker->attribute("exponential_progress"));
+
+  logger->logAttribute("exponential_transition_start_time",
+                       breaker->attribute("exponential_transition_start_time"));
+
+  logger->logAttribute("exponential_transition_end_time",
+                       breaker->attribute("exponential_transition_end_time"));
+
+  logger->logAttribute("effective_resistance_a",
+                       breaker->attribute("effective_resistance_a"));
+
+  logger->logAttribute("effective_resistance_b",
+                       breaker->attribute("effective_resistance_b"));
+
+  logger->logAttribute("effective_resistance_c",
+                       breaker->attribute("effective_resistance_c"));
+
+  Simulation sim(simName, Logger::Level::info);
+
+  sim.setSystem(system);
+
+  sim.setTimeStep(p.timeStep);
+
+  sim.setFinalTime(p.finalTime);
+
+  sim.setDomain(Domain::EMT);
+
+  sim.setSolverType(Solver::Type::MNA);
+
+  sim.addLogger(logger);
+
+  auto event = SwitchEvent3Ph::make(eventTime, breaker, endsClosed);
+
+  sim.addEvent(event);
+
+  const auto wallStart = std::chrono::steady_clock::now();
+
+  sim.run();
+
+  const auto wallEnd = std::chrono::steady_clock::now();
+
+  RunResult result;
+
+  result.domain = "EMT";
+
+  result.mode = modeName(mode);
+
+  result.direction = directionName(direction);
+
+  result.initialClosed = startsClosed;
+
+  result.targetClosed = endsClosed;
+
+  result.commandTime = eventTime;
+
+  result.runtimeSeconds =
+      std::chrono::duration<Real>(wallEnd - wallStart).count();
+
+  result.zeroA = **breaker->attributeTyped<Real>("zero_crossing_time_a");
+
+  result.zeroB = **breaker->attributeTyped<Real>("zero_crossing_time_b");
+
+  result.zeroC = **breaker->attributeTyped<Real>("zero_crossing_time_c");
+
+  result.exponentialStart =
+      **breaker->attributeTyped<Real>("exponential_transition_start_time");
+
+  result.exponentialEnd =
+      **breaker->attributeTyped<Real>("exponential_transition_end_time");
+
+  result.exponentialProgress =
+      **breaker->attributeTyped<Real>("exponential_progress");
+
+  result.exponentialActiveFinal =
+      **breaker->attributeTyped<Bool>("exponential_transition_active");
+
+  result.finalResistanceA =
+      **breaker->attributeTyped<Real>("effective_resistance_a");
+
+  result.finalResistanceB =
+      **breaker->attributeTyped<Real>("effective_resistance_b");
+
+  result.finalResistanceC =
+      **breaker->attributeTyped<Real>("effective_resistance_c");
+
+  result.finalCommandedClosed = **breaker->attributeTyped<Bool>("is_closed");
+
+  result.finalPoleA = **breaker->attributeTyped<Bool>("pole_closed_a");
+
+  result.finalPoleB = **breaker->attributeTyped<Bool>("pole_closed_b");
+
+  result.finalPoleC = **breaker->attributeTyped<Bool>("pole_closed_c");
+
+  result.expectedMatrixRecomputations =
+      expectedMatrixRecomputations(p, mode, direction);
+
+  evaluateRunResult(p, result);
+
+  return result;
+}
+
+DP::Ph3::Switch::SwitchingMode toDPMode(BenchmarkMode mode) {
+  switch (mode) {
+  case BenchmarkMode::Ideal:
+    return DP::Ph3::Switch::SwitchingMode::Ideal;
+
+  case BenchmarkMode::CurrentZero:
+    return DP::Ph3::Switch::SwitchingMode::CurrentZero;
+
+  case BenchmarkMode::ExponentialZCSEmulation:
+    return DP::Ph3::Switch::SwitchingMode::ExponentialZCSEmulation;
+  }
+
+  return DP::Ph3::Switch::SwitchingMode::Ideal;
+}
+
+RunResult runDP(const Parameters &p, const SystemTopology &systemPF,
+                BenchmarkMode mode, SwitchingDirection direction) {
+  const Bool startsClosed = initialClosed(direction);
+
+  const Bool endsClosed = targetClosed(direction);
+
+  const Real eventTime = commandTime(p, direction);
+
+  const String simName = "EMT_DP_Ph3_Switch_3Mode_Bidirectional_Benchmark_DP_" +
+                         modeName(mode) + "_" + directionName(direction);
+
+  auto n1 = DP::SimNode::make("n1", PhaseType::ABC);
+
+  auto n2 = DP::SimNode::make("n2", PhaseType::ABC);
+
+  auto n3 = DP::SimNode::make("n3", PhaseType::ABC);
+
+  auto slack = DP::Ph3::NetworkInjection::make("Slack", Logger::Level::info);
+
+  auto pathA = DP::Ph3::PiLine::make("PathA", Logger::Level::info);
+
+  pathA->setParameters(
+      Math::singlePhaseParameterToThreePhase(p.pathAResistance),
+      Math::singlePhaseParameterToThreePhase(p.pathAInductance),
+      Matrix::Zero(3, 3), Matrix::Zero(3, 3));
+
+  auto pathB = DP::Ph3::PiLine::make("PathB", Logger::Level::info);
+
+  pathB->setParameters(
+      Math::singlePhaseParameterToThreePhase(p.pathBResistance),
+      Math::singlePhaseParameterToThreePhase(p.pathBInductance),
+      Matrix::Zero(3, 3), Matrix::Zero(3, 3));
+
+  auto breaker = DP::Ph3::Switch::make("Breaker", Logger::Level::info);
+
+  breaker->setParameters(
+      Math::singlePhaseParameterToThreePhase(p.switchOpenResistance),
+      Math::singlePhaseParameterToThreePhase(p.switchClosedResistance),
+      startsClosed);
+
+  breaker->setSwitchingMode(toDPMode(mode));
+
+  breaker->setZeroCrossingTolerance(p.zeroCrossingTolerance);
+
+  breaker->setExponentialSwitchingTime(p.exponentialSwitchingTime);
+
+  const Real denominator = p.loadP * p.loadP + p.loadQ * p.loadQ;
+
+  const Real loadResistance =
+      p.nominalVoltage * p.nominalVoltage * p.loadP / denominator;
+
+  const Real loadReactance =
+      p.nominalVoltage * p.nominalVoltage * p.loadQ / denominator;
+
+  const Real loadInductance = loadReactance / (2.0 * PI * p.frequency);
+
+  auto load = DP::Ph3::PiLine::make("Load", Logger::Level::info);
+
+  load->setParameters(Math::singlePhaseParameterToThreePhase(loadResistance),
+                      Math::singlePhaseParameterToThreePhase(loadInductance),
+                      Matrix::Zero(3, 3), Matrix::Zero(3, 3));
+
+  slack->connect({n1});
+  pathA->connect({n1, n2});
+  breaker->connect({n2, n3});
+  pathB->connect({n1, n3});
+
+  load->connect({
+      DP::SimNode::GND,
+      n3,
+  });
+
+  auto system = SystemTopology(p.frequency,
+                               SystemNodeList{
+                                   n1,
+                                   n2,
+                                   n3,
+                               },
+                               SystemComponentList{
+                                   slack,
+                                   pathA,
+                                   breaker,
+                                   pathB,
+                                   load,
+                               });
+
+  system.initWithPowerflow(systemPF, Domain::DP);
+
+  const Complex slackPhasePeak = RMS3PH_TO_PEAK1PH * n1->initialSingleVoltage();
+
+  slack->setParameters(Math::singlePhaseVariableToThreePhase(slackPhasePeak),
+                       0.0);
+
+  auto logger = DataLogger::make(simName);
+
+  const auto breakerCurrent = breaker->attributeTyped<MatrixComp>("i_intf");
+
+  logger->logAttribute("i_breaker_a_env",
+                       breakerCurrent->deriveCoeff<Complex>(0, 0));
+
+  logger->logAttribute("i_breaker_b_env",
+                       breakerCurrent->deriveCoeff<Complex>(1, 0));
+
+  logger->logAttribute("i_breaker_c_env",
+                       breakerCurrent->deriveCoeff<Complex>(2, 0));
+
+  logger->logAttribute("i_instantaneous_a",
+                       breaker->attribute("i_instantaneous_a"));
+
+  logger->logAttribute("i_instantaneous_b",
+                       breaker->attribute("i_instantaneous_b"));
+
+  logger->logAttribute("i_instantaneous_c",
+                       breaker->attribute("i_instantaneous_c"));
+
+  const auto breakerVoltage = breaker->attributeTyped<MatrixComp>("v_intf");
+
+  logger->logAttribute("v_breaker_a_env",
+                       breakerVoltage->deriveCoeff<Complex>(0, 0));
+
+  logger->logAttribute("v_breaker_b_env",
+                       breakerVoltage->deriveCoeff<Complex>(1, 0));
+
+  logger->logAttribute("v_breaker_c_env",
+                       breakerVoltage->deriveCoeff<Complex>(2, 0));
+
+  const auto loadBusVoltage = n3->attributeTyped<MatrixComp>("v");
+
+  logger->logAttribute("v_n3_a_env",
+                       loadBusVoltage->deriveCoeff<Complex>(0, 0));
+
+  logger->logAttribute("v_n3_b_env",
+                       loadBusVoltage->deriveCoeff<Complex>(1, 0));
+
+  logger->logAttribute("v_n3_c_env",
+                       loadBusVoltage->deriveCoeff<Complex>(2, 0));
+
+  logger->logAttribute("commanded_closed", breaker->attribute("is_closed"));
+
+  logger->logAttribute("opening_requested",
+                       breaker->attribute("opening_requested"));
+
+  logger->logAttribute("pole_closed_a", breaker->attribute("pole_closed_a"));
+
+  logger->logAttribute("pole_closed_b", breaker->attribute("pole_closed_b"));
+
+  logger->logAttribute("pole_closed_c", breaker->attribute("pole_closed_c"));
+
+  logger->logAttribute("zero_crossing_time_a",
+                       breaker->attribute("zero_crossing_time_a"));
+
+  logger->logAttribute("zero_crossing_time_b",
+                       breaker->attribute("zero_crossing_time_b"));
+
+  logger->logAttribute("zero_crossing_time_c",
+                       breaker->attribute("zero_crossing_time_c"));
+
+  logger->logAttribute("exponential_transition_active",
+                       breaker->attribute("exponential_transition_active"));
+
+  logger->logAttribute("exponential_progress",
+                       breaker->attribute("exponential_progress"));
+
+  logger->logAttribute("exponential_transition_start_time",
+                       breaker->attribute("exponential_transition_start_time"));
+
+  logger->logAttribute("exponential_transition_end_time",
+                       breaker->attribute("exponential_transition_end_time"));
+
+  logger->logAttribute("effective_resistance_a",
+                       breaker->attribute("effective_resistance_a"));
+
+  logger->logAttribute("effective_resistance_b",
+                       breaker->attribute("effective_resistance_b"));
+
+  logger->logAttribute("effective_resistance_c",
+                       breaker->attribute("effective_resistance_c"));
+
+  Simulation sim(simName, Logger::Level::info);
+
+  sim.setSystem(system);
+
+  sim.setTimeStep(p.timeStep);
+
+  sim.setFinalTime(p.finalTime);
+
+  sim.setDomain(Domain::DP);
+
+  sim.setSolverType(Solver::Type::MNA);
+
+  sim.addLogger(logger);
+
+  auto event = SwitchEvent3Ph::make(eventTime, breaker, endsClosed);
+
+  sim.addEvent(event);
+
+  const auto wallStart = std::chrono::steady_clock::now();
+
+  sim.run();
+
+  const auto wallEnd = std::chrono::steady_clock::now();
+
+  RunResult result;
+
+  result.domain = "DP";
+
+  result.mode = modeName(mode);
+
+  result.direction = directionName(direction);
+
+  result.initialClosed = startsClosed;
+
+  result.targetClosed = endsClosed;
+
+  result.commandTime = eventTime;
+
+  result.runtimeSeconds =
+      std::chrono::duration<Real>(wallEnd - wallStart).count();
+
+  result.zeroA = **breaker->attributeTyped<Real>("zero_crossing_time_a");
+
+  result.zeroB = **breaker->attributeTyped<Real>("zero_crossing_time_b");
+
+  result.zeroC = **breaker->attributeTyped<Real>("zero_crossing_time_c");
+
+  result.exponentialStart =
+      **breaker->attributeTyped<Real>("exponential_transition_start_time");
+
+  result.exponentialEnd =
+      **breaker->attributeTyped<Real>("exponential_transition_end_time");
+
+  result.exponentialProgress =
+      **breaker->attributeTyped<Real>("exponential_progress");
+
+  result.exponentialActiveFinal =
+      **breaker->attributeTyped<Bool>("exponential_transition_active");
+
+  result.finalResistanceA =
+      **breaker->attributeTyped<Real>("effective_resistance_a");
+
+  result.finalResistanceB =
+      **breaker->attributeTyped<Real>("effective_resistance_b");
+
+  result.finalResistanceC =
+      **breaker->attributeTyped<Real>("effective_resistance_c");
+
+  result.finalCommandedClosed = **breaker->attributeTyped<Bool>("is_closed");
+
+  result.finalPoleA = **breaker->attributeTyped<Bool>("pole_closed_a");
+
+  result.finalPoleB = **breaker->attributeTyped<Bool>("pole_closed_b");
+
+  result.finalPoleC = **breaker->attributeTyped<Bool>("pole_closed_c");
+
+  result.expectedMatrixRecomputations =
+      expectedMatrixRecomputations(p, mode, direction);
+
+  evaluateRunResult(p, result);
+
+  return result;
+}
+
+int main() {
+  const Parameters p;
+
+  const String resultsDir = makeResultsDirectory();
+
+  fs::create_directories(resultsDir);
+
+  Logger::setLogDir(resultsDir);
+
+  const auto systemPFClosed = runPowerFlow(p, true);
+
+  const auto systemPFOpen = runPowerFlow(p, false);
+
+  const std::vector<BenchmarkMode> modes{
+      BenchmarkMode::Ideal,
+      BenchmarkMode::CurrentZero,
+      BenchmarkMode::ExponentialZCSEmulation,
+  };
+
+  const std::vector<SwitchingDirection> directions{
+      SwitchingDirection::CloseToOpen,
+      SwitchingDirection::OpenToClose,
+  };
+
+  std::vector<RunResult> results;
+  results.reserve(12);
+
+  for (const auto mode : modes) {
+    for (const auto direction : directions) {
+
+      const auto &systemPF =
+          initialClosed(direction) ? systemPFClosed : systemPFOpen;
+
+      results.push_back(runEMT(p, systemPF, mode, direction));
+    }
+  }
+
+  for (const auto mode : modes) {
+    for (const auto direction : directions) {
+
+      const auto &systemPF =
+          initialClosed(direction) ? systemPFClosed : systemPFOpen;
+
+      results.push_back(runDP(p, systemPF, mode, direction));
+    }
+  }
+
+  writeSummary(resultsDir, results);
+
+  UInt passed = 0;
+
+  for (const auto &r : results) {
+    if (r.passOverall)
+      ++passed;
+
+    std::cout << r.domain << " " << r.mode << " " << r.direction << ": "
+              << (r.passOverall ? "PASS" : "FAIL") << "\n";
+  }
+
+  std::cout << "Regression: " << passed << "/" << results.size()
+            << " passed. Results: " << resultsDir << std::endl;
+
+  return passed == results.size() ? 0 : 1;
+}

--- a/dpsim/include/dpsim/DataLoggerInterface.h
+++ b/dpsim/include/dpsim/DataLoggerInterface.h
@@ -48,6 +48,9 @@ public:
     } else if (auto attrInt = std::dynamic_pointer_cast<CPS::Attribute<Int>>(
                    attr.getPtr())) {
       mAttributes[name] = attrInt;
+    } else if (auto attrBool = std::dynamic_pointer_cast<CPS::Attribute<Bool>>(
+                   attr.getPtr())) {
+      mAttributes[name] = attrBool;
     } else if (auto attrMatrix =
                    std::dynamic_pointer_cast<CPS::Attribute<Matrix>>(
                        attr.getPtr())) {


### PR DESCRIPTION
## Description

This PR extends the three-phase switch models in the EMT and dynamic phasor
(DP) domains with more realistic opening behavior.

The existing binary switch behavior is retained as the default. Two additional
switching modes are introduced:

- `CurrentZero`
- `ExponentialZCSEmulation` (Approach from Wirtz: https://ieeexplore.ieee.org/abstract/document/10408527) 

The implementation supports independent phase opening for current-zero
switching and variable switch conductances during the exponential switching
process.

In addition, this PR fixes the initialization of three-phase DP passive
components used by the benchmark example, so that the DP simulation starts from
a consistent power-flow operating point.

## Motivation

The existing switch model changes directly between the closed and open
resistance states. For breaker opening, this can interrupt a non-zero current
instantaneously and produce unrealistic transients.

In EMT simulations, a more realistic approximation is to keep each breaker pole
closed until the corresponding phase current reaches its next natural zero.

For dynamic phasor simulations, the physical fundamental-frequency zero crossing
is not directly visible in the complex envelope. This PR therefore adds two
different approaches:

1. reconstruction of the physical instantaneous phase current and detection of
   its zero crossing;
2. an exponential variable-resistance transition that emulates zero-current
   switching behavior without explicit zero-crossing detection.

## Switching modes

The following modes are available for both `EMT::Ph3::Switch` and
`DP::Ph3::Switch`:

```cpp
enum class SwitchingMode {
  Ideal = 0,
  CurrentZero = 1,
  ExponentialZCSEmulation = 2,
};