### PR TITLE
Support state space extraction for EMT split SSN components

### DIFF
--- a/dpsim-models/include/dpsim-models/Components.h
+++ b/dpsim-models/include/dpsim-models/Components.h
@@ -123,6 +123,7 @@
 #include <dpsim-models/EMT/EMT_ITypeSSNComp.h>
 #include <dpsim-models/EMT/EMT_SSNComp.h>
 #include <dpsim-models/EMT/EMT_VTypeSSNComp.h>
+#include <dpsim-models/EMT/EMT_VTypeSplitSSNComp.h>
 #include <dpsim-models/EMT/EMT_VTypeVariableSSNComp.h>
 
 #include <dpsim-models/EMT/EMT_Ph1_Capacitor.h>
@@ -171,6 +172,7 @@
 #include <dpsim-models/EMT/EMT_Ph3_SynchronGeneratorDQTrapez.h>
 #include <dpsim-models/EMT/EMT_Ph3_TwoTerminalITypeSSNComp.h>
 #include <dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeSSNComp.h>
+#include <dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeSplitSSNComp.h>
 #include <dpsim-models/EMT/EMT_Ph3_VoltageSource.h>
 #include <dpsim-models/EMT/EMT_Ph3_VoltageSourceNorton.h>
 #ifdef WITH_SUNDIALS

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_GFL_Split.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_SSN_GFL_Split.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 
-#include <dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeSSNComp.h>
+#include <dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeSplitSSNComp.h>
 
 namespace CPS {
 namespace EMT {
@@ -44,7 +44,7 @@ namespace Ph3 {
 /// known forcing term and therefore contributes only to the SSN history
 /// current. Consequently, the Norton conductance mW remains constant for the
 /// complete simulation.
-class SSN_GFL_Split final : public TwoTerminalVTypeSSNComp,
+class SSN_GFL_Split final : public TwoTerminalVTypeSplitSSNComp,
                             public SharedFactory<SSN_GFL_Split> {
 private:
   static constexpr Int mNetworkStateSize = 6;
@@ -99,40 +99,6 @@ private:
   Real mKiCurrCtrl;
 
   // -------------------------------------------------------------------------
-  // Fixed electrical plant
-  //
-  // The inherited matrices mA, mB, mC, mD contain the SSN-facing plant with
-  // terminal voltage u as the only nodal input.
-  //
-  // mBConverter contains the additional known converter-voltage input:
-  //
-  //   x_n_dot = mA x_n + mB u + mBConverter v_inv_delayed
-  // -------------------------------------------------------------------------
-  Matrix mBConverter;
-  Matrix mdBConverter;
-
-  // -------------------------------------------------------------------------
-  // Time-varying controller subsystem
-  // -------------------------------------------------------------------------
-  Matrix mControllerState;
-  Matrix mControllerMeasurementOld;
-
-  Matrix mControllerA;
-  Matrix mControllerB;
-  Matrix mControllerC;
-  Matrix mControllerD;
-  Matrix mControllerE;
-  Matrix mControllerF;
-
-  Matrix mControllerAd;
-  Matrix mControllerBd;
-  Matrix mControllerEd;
-
-  // Controller output and z^-1 output.
-  Matrix mConverterVoltageReference;
-  Matrix mConverterVoltageDelayed;
-
-  // -------------------------------------------------------------------------
   // Logging attributes
   // -------------------------------------------------------------------------
   const Attribute<Real>::Ptr mVcD;
@@ -162,7 +128,7 @@ private:
 
   void evaluateControllerOutput(const Matrix &xController,
                                 const Matrix &measurement,
-                                Matrix &output) const;
+                                Matrix &output) const override final;
 
   void calculateControllerAnalyticalJacobians(const Matrix &xController,
                                               const Matrix &measurement,
@@ -172,30 +138,8 @@ private:
   void buildControllerStateSpaceModel(const Matrix &xController,
                                       const Matrix &measurement, Matrix &A,
                                       Matrix &B, Matrix &C, Matrix &D,
-                                      Matrix &E, Matrix &F) const;
-
-  void recomputeControllerDiscreteModel();
-
-  Matrix buildControllerMeasurement(const Matrix &networkState,
-                                    const Matrix &terminalVoltage) const;
-
-  // -------------------------------------------------------------------------
-  // Fixed SSN plant hooks
-  // -------------------------------------------------------------------------
-
-  /// \brief Add the delayed converter-voltage forcing to the Norton history
-  /// current while leaving mW unchanged.
-  Matrix calculateHistoryVector() const override final;
-
-  /// \brief Update the fixed plant state and then the separate controller.
-  ///
-  /// The newly calculated converter reference is stored in the z^-1 buffer and
-  /// is therefore used only during the following simulation step.
-  void updateState(const Matrix &uOld, const Matrix &uNew) override final;
-
-  /// \brief Discretize the fixed plant once and form the constant Norton
-  /// conductance. Also initializes the controller discretization.
-  void recomputeDiscreteModel() override final;
+                                      Matrix &E,
+                                      Matrix &F) const override final;
 
   void updateLogAttributes(const Matrix &u) const override final;
 
@@ -212,6 +156,11 @@ public:
 
   std::vector<SSNComp::LocalAbcStateBlock>
   getLocalAbcStateBlocks() const override final;
+
+  std::vector<String> getSplitLocalStateNames() const override final;
+
+  std::vector<SSNComp::LocalAbcStateBlock>
+  getSplitLocalAbcStateBlocks() const override final;
 
   /// \brief Configure the filter, PLL, power controller and current controller.
   ///

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeSplitSSNComp.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeSplitSSNComp.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <dpsim-models/EMT/EMT_VTypeSplitSSNComp.h>
+
+namespace CPS {
+namespace EMT {
+namespace Ph3 {
+
+/// \brief Abstract base class for three-phase, two-terminal split V-type SSN
+/// components.
+///
+/// This class implements the common three-phase/two-terminal logic:
+/// - reconstruction of the initial input voltage from terminal phasors
+/// - conductance matrix stamp
+/// - right-side history current stamp
+/// - interface voltage update from the MNA solution
+///
+/// It does not prescribe a particular controller or electrical plant.
+class TwoTerminalVTypeSplitSSNComp : public VTypeSplitSSNComp {
+protected:
+  TwoTerminalVTypeSplitSSNComp(String uid, String name, Int controllerStateSize,
+                               Int controllerInputSize,
+                               Int controllerOutputSize,
+                               Logger::Level logLevel = Logger::Level::off);
+
+  MatrixComp buildInitialInputFromNodes(Real frequency) override final;
+
+public:
+  void
+  mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override final;
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override final;
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override final;
+};
+
+} // namespace Ph3
+} // namespace EMT
+} // namespace CPS

--- a/dpsim-models/include/dpsim-models/EMT/EMT_VTypeSplitSSNComp.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_VTypeSplitSSNComp.h
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <vector>
+
+#include <dpsim-models/EMT/EMT_VTypeSSNComp.h>
+
+namespace CPS {
+namespace EMT {
+
+/// \brief Abstract base class for partitioned EMT V-type SSN components.
+///
+/// The inherited SSN model represents a fixed LTI electrical plant. A
+/// separately linearized controller drives an additional plant input through
+/// a one-step output delay. Controller measurements are linear combinations of
+/// the plant state and terminal voltage. The MNA Norton conductance therefore
+/// remains constant even if the controller matrices change at every step.
+class VTypeSplitSSNComp : public VTypeSSNComp {
+private:
+  const Int mControllerStateSize;
+  const Int mControllerInputSize;
+  const Int mControllerOutputSize;
+
+  Matrix mMeasurementState;
+  Matrix mMeasurementTerminal;
+
+  Matrix mSplitDiscreteA;
+  Matrix mSplitDiscreteB;
+  Matrix mSplitHistoryC;
+  Matrix mControllerBdUsed;
+
+  void recomputeControllerDiscreteModel();
+  void rebuildSplitDiscreteModel(const Matrix &controllerBdUsed);
+
+protected:
+  Matrix mBControllerOutput;
+  Matrix mdBControllerOutput;
+
+  Matrix mControllerState;
+  Matrix mControllerMeasurementOld;
+
+  Matrix mControllerA;
+  Matrix mControllerB;
+  Matrix mControllerC;
+  Matrix mControllerD;
+  Matrix mControllerE;
+  Matrix mControllerF;
+
+  Matrix mControllerAd;
+  Matrix mControllerBd;
+  Matrix mControllerEd;
+
+  Matrix mControllerOutput;
+  Matrix mDelayedControllerOutput;
+
+  VTypeSplitSSNComp(String uid, String name, Int inputSize, Int outputSize,
+                    Int controllerStateSize, Int controllerInputSize,
+                    Int controllerOutputSize,
+                    Logger::Level logLevel = Logger::Level::off);
+
+  /// Configure the fixed plant model, delayed controller input and
+  /// measurement maps m = Hx*xPlant + Hu*uTerminal.
+  void setSplitParameters(const Matrix &plantA, const Matrix &plantB,
+                          const Matrix &plantC, const Matrix &plantD,
+                          const Matrix &controllerOutputB,
+                          const Matrix &measurementState,
+                          const Matrix &measurementTerminal);
+
+  Matrix buildControllerMeasurement(const Matrix &plantState,
+                                    const Matrix &terminalVoltage) const;
+
+  /// Build the affine controller model at the supplied local operating point.
+  virtual void buildControllerStateSpaceModel(const Matrix &controllerState,
+                                              const Matrix &measurement,
+                                              Matrix &A, Matrix &B, Matrix &C,
+                                              Matrix &D, Matrix &E,
+                                              Matrix &F) const = 0;
+
+  /// Evaluate the nonlinear controller output at the supplied local operating
+  /// point.
+  virtual void evaluateControllerOutput(const Matrix &controllerState,
+                                        const Matrix &measurement,
+                                        Matrix &output) const = 0;
+
+  Matrix calculateHistoryVector() const override final;
+  void updateState(const Matrix &uOld, const Matrix &uNew) override final;
+  void recomputeDiscreteModel() override final;
+
+public:
+  /// Number of states in the augmented controller/plant/delay model.
+  UInt getSplitStateCount() const;
+
+  /// Augmented local transition matrix for the completed simulation step.
+  const Matrix &getSplitDiscreteA() const;
+
+  /// Augmented local input matrix for the terminal-voltage input.
+  const Matrix &getSplitDiscreteB() const;
+
+  /// Map from augmented states to the Norton history current.
+  const Matrix &getSplitHistoryC() const;
+
+  const Matrix &getControllerDiscreteA() const;
+  const Matrix &getControllerDiscreteB() const;
+  const Matrix &getControllerDiscreteBUsed() const;
+  const Matrix &getDiscreteControllerOutputB() const;
+
+  /// Whether the local matrices exposed for extraction change at each step.
+  virtual Bool requiresStateSpaceMatrixUpdate() const { return true; }
+
+  /// State attribute updated by the component post-step task.
+  Attribute<Matrix>::Ptr getSplitStateAttribute() const;
+
+  /// Local names in augmented controller/plant/delay state order.
+  virtual std::vector<String> getSplitLocalStateNames() const = 0;
+
+  /// Local abc blocks in augmented controller/plant/delay state order.
+  virtual std::vector<SSNComp::LocalAbcStateBlock>
+  getSplitLocalAbcStateBlocks() const = 0;
+};
+
+} // namespace EMT
+} // namespace CPS

--- a/dpsim-models/src/CMakeLists.txt
+++ b/dpsim-models/src/CMakeLists.txt
@@ -91,6 +91,7 @@ list(APPEND MODELS_SOURCES
 
 	EMT/EMT_SSNComp.cpp
 	EMT/EMT_VTypeSSNComp.cpp
+	EMT/EMT_VTypeSplitSSNComp.cpp
 	EMT/EMT_VTypeVariableSSNComp.cpp
 	EMT/EMT_ITypeSSNComp.cpp
 
@@ -162,6 +163,7 @@ list(APPEND MODELS_SOURCES
 	EMT/EMT_Ph3_GenericFourTerminalVTypeSSN.cpp
 	EMT/EMT_Ph3_TwoTerminalVTypeSSNComp.cpp
 	EMT/EMT_Ph3_TwoTerminalITypeSSNComp.cpp
+	EMT/EMT_Ph3_TwoTerminalVTypeSplitSSNComp.cpp
 	EMT/EMT_Ph3_TwoTerminalVTypeVariableSSNComp.cpp
 	EMT/EMT_Ph3_FourTerminalVTypeSSNComp.cpp
 	EMT/EMT_Ph3_SSN_InductionMotor.cpp

--- a/dpsim-models/src/EMT/EMT_Ph3_SSN_GFL_Split.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_SSN_GFL_Split.cpp
@@ -11,25 +11,12 @@ using namespace CPS;
 
 EMT::Ph3::SSN_GFL_Split::SSN_GFL_Split(String uid, String name,
                                        Logger::Level logLevel)
-    : TwoTerminalVTypeSSNComp(uid, name, logLevel), mLf(0.0), mCf(0.0),
-      mRf(0.0), mRc(0.0), mOmegaN(0.0), mKpPLL(0.0), mKiPLL(0.0),
-      mOmegaCutoff(0.0), mPRef(0.0), mQRef(0.0), mKpPowerCtrl(0.0),
+    : TwoTerminalVTypeSplitSSNComp(uid, name, mControllerStateSize,
+                                   mControllerInputSize, mControllerOutputSize,
+                                   logLevel),
+      mLf(0.0), mCf(0.0), mRf(0.0), mRc(0.0), mOmegaN(0.0), mKpPLL(0.0),
+      mKiPLL(0.0), mOmegaCutoff(0.0), mPRef(0.0), mQRef(0.0), mKpPowerCtrl(0.0),
       mKiPowerCtrl(0.0), mKpCurrCtrl(0.0), mKiCurrCtrl(0.0),
-      mBConverter(Matrix::Zero(mNetworkStateSize, 3)),
-      mdBConverter(Matrix::Zero(mNetworkStateSize, 3)),
-      mControllerState(Matrix::Zero(mControllerStateSize, 1)),
-      mControllerMeasurementOld(Matrix::Zero(mControllerInputSize, 1)),
-      mControllerA(Matrix::Zero(mControllerStateSize, mControllerStateSize)),
-      mControllerB(Matrix::Zero(mControllerStateSize, mControllerInputSize)),
-      mControllerC(Matrix::Zero(mControllerOutputSize, mControllerStateSize)),
-      mControllerD(Matrix::Zero(mControllerOutputSize, mControllerInputSize)),
-      mControllerE(Matrix::Zero(mControllerStateSize, 1)),
-      mControllerF(Matrix::Zero(mControllerOutputSize, 1)),
-      mControllerAd(Matrix::Zero(mControllerStateSize, mControllerStateSize)),
-      mControllerBd(Matrix::Zero(mControllerStateSize, mControllerInputSize)),
-      mControllerEd(Matrix::Zero(mControllerStateSize, 1)),
-      mConverterVoltageReference(Matrix::Zero(3, 1)),
-      mConverterVoltageDelayed(Matrix::Zero(3, 1)),
       mVcD(mAttributes->create<Real>("vc_d")),
       mVcQ(mAttributes->create<Real>("vc_q")),
       mIrcD(mAttributes->create<Real>("irc_d")),
@@ -68,6 +55,32 @@ EMT::Ph3::SSN_GFL_Split::getLocalAbcStateBlocks() const {
        "vc"},
       {{static_cast<UInt>(IfA), static_cast<UInt>(IfB), static_cast<UInt>(IfC)},
        "if"},
+  };
+}
+
+std::vector<String> EMT::Ph3::SSN_GFL_Split::getSplitLocalStateNames() const {
+  return {"theta_pll",    "phi_pll", "p_filtered",    "q_filtered",
+          "phi_d",        "phi_q",   "gamma_d",       "gamma_q",
+          "vc_a",         "vc_b",    "vc_c",          "if_a",
+          "if_b",         "if_c",    "v_inv_delay_a", "v_inv_delay_b",
+          "v_inv_delay_c"};
+}
+
+std::vector<EMT::SSNComp::LocalAbcStateBlock>
+EMT::Ph3::SSN_GFL_Split::getSplitLocalAbcStateBlocks() const {
+  const UInt networkOffset = static_cast<UInt>(mControllerStateSize);
+  const UInt delayOffset = networkOffset + static_cast<UInt>(mNetworkStateSize);
+
+  return {
+      {{networkOffset + static_cast<UInt>(VcA),
+        networkOffset + static_cast<UInt>(VcB),
+        networkOffset + static_cast<UInt>(VcC)},
+       "vc"},
+      {{networkOffset + static_cast<UInt>(IfA),
+        networkOffset + static_cast<UInt>(IfB),
+        networkOffset + static_cast<UInt>(IfC)},
+       "if"},
+      {{delayOffset, delayOffset + 1, delayOffset + 2}, "v_inv_delay"},
   };
 }
 
@@ -151,24 +164,24 @@ void EMT::Ph3::SSN_GFL_Split::setParameters(Real lf, Real cf, Real rf, Real rc,
 
   bTerminal.block(VcA, 0, 3, 3) = 1.0 / (mCf * mRc) * identity3;
 
-  mBConverter.setZero(mNetworkStateSize, 3);
-  mBConverter.block(IfA, 0, 3, 3) = 1.0 / mLf * identity3;
+  Matrix bControllerOutput = Matrix::Zero(mNetworkStateSize, 3);
+  bControllerOutput.block(IfA, 0, 3, 3) = 1.0 / mLf * identity3;
 
   cNetwork.block(0, VcA, 3, 3) = -1.0 / mRc * identity3;
   dTerminal = 1.0 / mRc * identity3;
 
-  // This fixed SSN plant is not changed after setParameters().
-  SSNComp::setParameters(aNetwork, bTerminal, cNetwork, dTerminal);
+  Matrix measurementState =
+      Matrix::Zero(mControllerInputSize, mNetworkStateSize);
+  measurementState.block(0, VcA, 3, 3) = identity3;
+  measurementState.block(3, VcA, 3, 3) = (1.0 / mRc) * identity3;
 
-  mControllerState.setZero();
-  mControllerMeasurementOld.setZero();
-  mConverterVoltageReference.setZero();
-  mConverterVoltageDelayed.setZero();
+  Matrix measurementTerminal =
+      Matrix::Zero(mControllerInputSize, mTerminalInputSize);
+  measurementTerminal.block(3, 0, 3, 3) = (-1.0 / mRc) * identity3;
 
-  // Initialize controller matrix dimensions and a valid operating-point model.
-  buildControllerStateSpaceModel(mControllerState, mControllerMeasurementOld,
-                                 mControllerA, mControllerB, mControllerC,
-                                 mControllerD, mControllerE, mControllerF);
+  // The fixed network stamp is not changed by controller re-linearization.
+  setSplitParameters(aNetwork, bTerminal, cNetwork, dTerminal,
+                     bControllerOutput, measurementState, measurementTerminal);
 }
 
 Matrix EMT::Ph3::SSN_GFL_Split::getParkTransformMatrix(Real theta) const {
@@ -198,30 +211,6 @@ EMT::Ph3::SSN_GFL_Split::getInverseParkTransformMatrix(Real theta) const {
       -scale * std::sin(theta + 2.0 * PI / 3.0);
 
   return transform;
-}
-
-Matrix EMT::Ph3::SSN_GFL_Split::buildControllerMeasurement(
-    const Matrix &networkState, const Matrix &terminalVoltage) const {
-
-  if (networkState.rows() != mNetworkStateSize || networkState.cols() != 1)
-    throw std::invalid_argument(
-        "SSN_GFL_Split network state has an invalid dimension.");
-
-  if (terminalVoltage.rows() != mTerminalInputSize ||
-      terminalVoltage.cols() != 1)
-    throw std::invalid_argument(
-        "SSN_GFL_Split terminal voltage has an invalid dimension.");
-
-  const Matrix vcAbc = networkState.block(VcA, 0, 3, 1);
-
-  // Positive current is physical inverter injection into the grid.
-  const Matrix iGridAbc = (vcAbc - terminalVoltage) / mRc;
-
-  Matrix measurement = Matrix::Zero(mControllerInputSize, 1);
-  measurement.block(0, 0, 3, 1) = vcAbc;
-  measurement.block(3, 0, 3, 1) = iGridAbc;
-
-  return measurement;
 }
 
 void EMT::Ph3::SSN_GFL_Split::evaluateControllerStateDerivative(
@@ -484,70 +473,6 @@ void EMT::Ph3::SSN_GFL_Split::buildControllerStateSpaceModel(
   F = output - C * xController - D * measurement;
 }
 
-void EMT::Ph3::SSN_GFL_Split::recomputeControllerDiscreteModel() {
-  if (mTimeStep <= 0.0)
-    return;
-
-  Math::calculateStateSpaceTrapezoidalMatrices(
-      mControllerA, mControllerB, mControllerE, mTimeStep, mControllerAd,
-      mControllerBd, mControllerEd);
-}
-
-void EMT::Ph3::SSN_GFL_Split::recomputeDiscreteModel() {
-  // Fixed electrical plant.
-  SSNComp::recomputeDiscreteModel();
-
-  // Additional trapezoidal input matrix for the delayed converter command.
-  const Matrix identity =
-      Matrix::Identity(mNetworkStateSize, mNetworkStateSize);
-  const Matrix lhs = identity - 0.5 * mTimeStep * mA;
-
-  mdBConverter = lhs.fullPivLu().solve(0.5 * mTimeStep * mBConverter);
-
-  // The controller is the only time-varying local subsystem.
-  recomputeControllerDiscreteModel();
-}
-
-Matrix EMT::Ph3::SSN_GFL_Split::calculateHistoryVector() const {
-  // The delayed converter voltage only enters the history vector.
-  return mC * (mdA * (**mX) + mdB * (**mIntfVoltage) +
-               2.0 * mdBConverter * mConverterVoltageDelayed);
-}
-
-void EMT::Ph3::SSN_GFL_Split::updateState(const Matrix &uOld,
-                                          const Matrix &uNew) {
-  // Use the converter command available before this network solve.
-  const Matrix delayedVoltageUsedThisStep = mConverterVoltageDelayed;
-
-  **mX = mdA * (**mX) + mdB * (uNew + uOld) +
-         2.0 * mdBConverter * delayedVoltageUsedThisStep;
-
-  // Form new measurements from the solved network state.
-  const Matrix measurementNew = buildControllerMeasurement(**mX, uNew);
-
-  // Advance the controller with the previous local affine model.
-  mControllerState =
-      mControllerAd * mControllerState +
-      mControllerBd * (measurementNew + mControllerMeasurementOld) +
-      mControllerEd;
-
-  mControllerMeasurementOld = measurementNew;
-
-  // Re-linearize only the controller at the new operating point.
-  buildControllerStateSpaceModel(mControllerState, measurementNew, mControllerA,
-                                 mControllerB, mControllerC, mControllerD,
-                                 mControllerE, mControllerF);
-
-  recomputeControllerDiscreteModel();
-
-  // Calculate controller output at sample k.
-  evaluateControllerOutput(mControllerState, measurementNew,
-                           mConverterVoltageReference);
-
-  // Store the command for the next simulation interval.
-  mConverterVoltageDelayed = mConverterVoltageReference;
-}
-
 void EMT::Ph3::SSN_GFL_Split::updateLogAttributes(const Matrix &u) const {
   const Matrix measurement = buildControllerMeasurement(**mX, u);
 
@@ -568,9 +493,9 @@ void EMT::Ph3::SSN_GFL_Split::updateLogAttributes(const Matrix &u) const {
   **mOmegaPLL =
       mOmegaN + mKpPLL * **mVcQ + mKiPLL * mControllerState(PhiPLL, 0);
 
-  **mVInvRefA = mConverterVoltageReference(0, 0);
-  **mVInvRefB = mConverterVoltageReference(1, 0);
-  **mVInvRefC = mConverterVoltageReference(2, 0);
+  **mVInvRefA = mControllerOutput(0, 0);
+  **mVInvRefB = mControllerOutput(1, 0);
+  **mVInvRefC = mControllerOutput(2, 0);
 }
 
 void EMT::Ph3::SSN_GFL_Split::initializeFromNodesAndTerminals(Real frequency) {
@@ -698,8 +623,8 @@ void EMT::Ph3::SSN_GFL_Split::initializeFromNodesAndTerminals(Real frequency) {
   mControllerMeasurementOld = buildControllerMeasurement(**mX, **mIntfVoltage);
 
   // Avoid an artificial one-step zero command at t = 0.
-  mConverterVoltageReference = converterVoltageReferenceAbc0;
-  mConverterVoltageDelayed = converterVoltageReferenceAbc0;
+  mControllerOutput = converterVoltageReferenceAbc0;
+  mDelayedControllerOutput = converterVoltageReferenceAbc0;
 
   // Build the controller model at the initialized operating point.
   buildControllerStateSpaceModel(mControllerState, mControllerMeasurementOld,
@@ -710,7 +635,7 @@ void EMT::Ph3::SSN_GFL_Split::initializeFromNodesAndTerminals(Real frequency) {
   // recomputeDiscreteModel(). This also makes re-initialization robust if a
   // timestep is already known.
   if (mTimeStep > 0.0)
-    recomputeControllerDiscreteModel();
+    recomputeDiscreteModel();
 
   updateLogAttributes(**mIntfVoltage);
 
@@ -729,7 +654,7 @@ void EMT::Ph3::SSN_GFL_Split::initializeFromNodesAndTerminals(Real frequency) {
       Logger::matrixToString(**mIntfVoltage),
       Logger::matrixToString(**mIntfCurrent), Logger::matrixToString(**mX),
       Logger::matrixToString(mControllerState), pInitial, qInitial, vcD0, vcQ0,
-      iGridD0, iGridQ0, Logger::matrixToString(mConverterVoltageDelayed));
+      iGridD0, iGridQ0, Logger::matrixToString(mDelayedControllerOutput));
 }
 
 Matrix EMT::Ph3::SSN_GFL_Split::getState() const {
@@ -754,8 +679,9 @@ Matrix EMT::Ph3::SSN_GFL_Split::getStateDerivative() const {
   evaluateControllerStateDerivative(mControllerState, measurement,
                                     controllerDerivative);
 
-  const Matrix networkDerivative = mA * (**mX) + mB * (**mIntfVoltage) +
-                                   mBConverter * mConverterVoltageDelayed;
+  const Matrix networkDerivative =
+      mA * (**mX) + mB * (**mIntfVoltage) +
+      mBControllerOutput * mDelayedControllerOutput;
 
   Matrix derivative = Matrix::Zero(mControllerStateSize + mNetworkStateSize, 1);
 
@@ -775,11 +701,11 @@ Matrix EMT::Ph3::SSN_GFL_Split::getInterfaceCurrent() const {
 }
 
 Matrix EMT::Ph3::SSN_GFL_Split::getConverterVoltageReference() const {
-  return mConverterVoltageReference;
+  return mControllerOutput;
 }
 
 Matrix EMT::Ph3::SSN_GFL_Split::getDelayedConverterVoltage() const {
-  return mConverterVoltageDelayed;
+  return mDelayedControllerOutput;
 }
 
 Matrix EMT::Ph3::SSN_GFL_Split::getControllerA() const { return mControllerA; }
@@ -800,7 +726,7 @@ Matrix EMT::Ph3::SSN_GFL_Split::getNetworkB() const {
   Matrix bFull = Matrix::Zero(mNetworkStateSize, 6);
 
   bFull.block(0, 0, mNetworkStateSize, 3) = mB;
-  bFull.block(0, 3, mNetworkStateSize, 3) = mBConverter;
+  bFull.block(0, 3, mNetworkStateSize, 3) = mBControllerOutput;
 
   return bFull;
 }

--- a/dpsim-models/src/EMT/EMT_Ph3_TwoTerminalVTypeSplitSSNComp.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_TwoTerminalVTypeSplitSSNComp.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeSplitSSNComp.h>
+
+using namespace CPS;
+
+EMT::Ph3::TwoTerminalVTypeSplitSSNComp::TwoTerminalVTypeSplitSSNComp(
+    String uid, String name, Int controllerStateSize, Int controllerInputSize,
+    Int controllerOutputSize, Logger::Level logLevel)
+    : VTypeSplitSSNComp(uid, name, 3, 3, controllerStateSize,
+                        controllerInputSize, controllerOutputSize, logLevel) {
+  mPhaseType = PhaseType::ABC;
+  setTerminalNumber(2);
+}
+
+MatrixComp
+EMT::Ph3::TwoTerminalVTypeSplitSSNComp::buildInitialInputFromNodes(Real) {
+  MatrixComp vInitABC = MatrixComp::Zero(3, 1);
+
+  // Interface voltage convention: v = v_terminal1 - v_terminal0
+  vInitABC(0, 0) = RMS3PH_TO_PEAK1PH * initialSingleVoltage(1) -
+                   RMS3PH_TO_PEAK1PH * initialSingleVoltage(0);
+  vInitABC(1, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_B;
+  vInitABC(2, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_C;
+
+  return vInitABC;
+}
+
+void EMT::Ph3::TwoTerminalVTypeSplitSSNComp::mnaCompApplySystemMatrixStamp(
+    SparseMatrixRow &systemMatrix) {
+  MNAStampUtils::stampConductanceMatrix(
+      mW, systemMatrix, matrixNodeIndex(0), matrixNodeIndex(1),
+      terminalNotGrounded(0), terminalNotGrounded(1), mSLog);
+}
+
+void EMT::Ph3::TwoTerminalVTypeSplitSSNComp::mnaCompApplyRightSideVectorStamp(
+    Matrix &rightVector) {
+  if (terminalNotGrounded(0)) {
+    for (Int phase = 0; phase < 3; ++phase) {
+      Math::setVectorElement(rightVector, matrixNodeIndex(0, phase),
+                             mYHist(phase, 0));
+    }
+  }
+
+  if (terminalNotGrounded(1)) {
+    for (Int phase = 0; phase < 3; ++phase) {
+      Math::setVectorElement(rightVector, matrixNodeIndex(1, phase),
+                             -mYHist(phase, 0));
+    }
+  }
+}
+
+void EMT::Ph3::TwoTerminalVTypeSplitSSNComp::mnaCompUpdateVoltage(
+    const Matrix &leftVector) {
+  // Interface voltage convention: v = v_terminal1 - v_terminal0
+  **mIntfVoltage = Matrix::Zero(3, 1);
+
+  if (terminalNotGrounded(1)) {
+    for (Int phase = 0; phase < 3; ++phase) {
+      (**mIntfVoltage)(phase, 0) =
+          Math::realFromVectorElement(leftVector, matrixNodeIndex(1, phase));
+    }
+  }
+
+  if (terminalNotGrounded(0)) {
+    for (Int phase = 0; phase < 3; ++phase) {
+      (**mIntfVoltage)(phase, 0) -=
+          Math::realFromVectorElement(leftVector, matrixNodeIndex(0, phase));
+    }
+  }
+}

--- a/dpsim-models/src/EMT/EMT_VTypeSplitSSNComp.cpp
+++ b/dpsim-models/src/EMT/EMT_VTypeSplitSSNComp.cpp
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dpsim-models/EMT/EMT_VTypeSplitSSNComp.h>
+
+#include <stdexcept>
+
+using namespace CPS;
+
+EMT::VTypeSplitSSNComp::VTypeSplitSSNComp(String uid, String name,
+                                          Int inputSize, Int outputSize,
+                                          Int controllerStateSize,
+                                          Int controllerInputSize,
+                                          Int controllerOutputSize,
+                                          Logger::Level logLevel)
+    : VTypeSSNComp(uid, name, inputSize, outputSize, logLevel),
+      mControllerStateSize(controllerStateSize),
+      mControllerInputSize(controllerInputSize),
+      mControllerOutputSize(controllerOutputSize),
+      mMeasurementState(Matrix::Zero(controllerInputSize, 0)),
+      mMeasurementTerminal(Matrix::Zero(controllerInputSize, inputSize)),
+      mSplitDiscreteA(Matrix::Zero(0, 0)),
+      mSplitDiscreteB(Matrix::Zero(0, inputSize)),
+      mSplitHistoryC(Matrix::Zero(outputSize, 0)),
+      mControllerBdUsed(Matrix::Zero(controllerStateSize, controllerInputSize)),
+      mBControllerOutput(Matrix::Zero(0, controllerOutputSize)),
+      mdBControllerOutput(Matrix::Zero(0, controllerOutputSize)),
+      mControllerState(Matrix::Zero(controllerStateSize, 1)),
+      mControllerMeasurementOld(Matrix::Zero(controllerInputSize, 1)),
+      mControllerA(Matrix::Zero(controllerStateSize, controllerStateSize)),
+      mControllerB(Matrix::Zero(controllerStateSize, controllerInputSize)),
+      mControllerC(Matrix::Zero(controllerOutputSize, controllerStateSize)),
+      mControllerD(Matrix::Zero(controllerOutputSize, controllerInputSize)),
+      mControllerE(Matrix::Zero(controllerStateSize, 1)),
+      mControllerF(Matrix::Zero(controllerOutputSize, 1)),
+      mControllerAd(Matrix::Zero(controllerStateSize, controllerStateSize)),
+      mControllerBd(Matrix::Zero(controllerStateSize, controllerInputSize)),
+      mControllerEd(Matrix::Zero(controllerStateSize, 1)),
+      mControllerOutput(Matrix::Zero(controllerOutputSize, 1)),
+      mDelayedControllerOutput(Matrix::Zero(controllerOutputSize, 1)) {
+  if (controllerStateSize < 0 || controllerInputSize < 0 ||
+      controllerOutputSize <= 0)
+    throw std::invalid_argument("Invalid split SSN controller dimensions.");
+}
+
+void EMT::VTypeSplitSSNComp::setSplitParameters(
+    const Matrix &plantA, const Matrix &plantB, const Matrix &plantC,
+    const Matrix &plantD, const Matrix &controllerOutputB,
+    const Matrix &measurementState, const Matrix &measurementTerminal) {
+  const Int plantStateSize = plantA.rows();
+
+  if (controllerOutputB.rows() != plantStateSize ||
+      controllerOutputB.cols() != mControllerOutputSize)
+    throw std::invalid_argument(
+        "Controller-output input matrix has invalid dimensions.");
+
+  if (measurementState.rows() != mControllerInputSize ||
+      measurementState.cols() != plantStateSize)
+    throw std::invalid_argument(
+        "Measurement state matrix has invalid dimensions.");
+
+  if (measurementTerminal.rows() != mControllerInputSize ||
+      measurementTerminal.cols() != plantB.cols())
+    throw std::invalid_argument(
+        "Measurement terminal matrix has invalid dimensions.");
+
+  SSNComp::setParameters(plantA, plantB, plantC, plantD);
+
+  mBControllerOutput = controllerOutputB;
+  mdBControllerOutput = Matrix::Zero(plantStateSize, mControllerOutputSize);
+  mMeasurementState = measurementState;
+  mMeasurementTerminal = measurementTerminal;
+
+  mControllerState.setZero();
+  mControllerMeasurementOld.setZero();
+  mControllerOutput.setZero();
+  mDelayedControllerOutput.setZero();
+
+  buildControllerStateSpaceModel(mControllerState, mControllerMeasurementOld,
+                                 mControllerA, mControllerB, mControllerC,
+                                 mControllerD, mControllerE, mControllerF);
+
+  const Int splitStateSize =
+      mControllerStateSize + plantStateSize + mControllerOutputSize;
+  mSplitDiscreteA = Matrix::Zero(splitStateSize, splitStateSize);
+  mSplitDiscreteB = Matrix::Zero(splitStateSize, plantB.cols());
+  mSplitHistoryC = Matrix::Zero(plantC.rows(), splitStateSize);
+}
+
+Matrix EMT::VTypeSplitSSNComp::buildControllerMeasurement(
+    const Matrix &plantState, const Matrix &terminalVoltage) const {
+  if (plantState.rows() != mA.rows() || plantState.cols() != 1)
+    throw std::invalid_argument(
+        "Split SSN plant state has invalid dimensions.");
+
+  if (terminalVoltage.rows() != mB.cols() || terminalVoltage.cols() != 1)
+    throw std::invalid_argument(
+        "Split SSN terminal voltage has invalid dimensions.");
+
+  return mMeasurementState * plantState +
+         mMeasurementTerminal * terminalVoltage;
+}
+
+void EMT::VTypeSplitSSNComp::recomputeControllerDiscreteModel() {
+  if (mTimeStep <= 0.0)
+    return;
+
+  Math::calculateStateSpaceTrapezoidalMatrices(
+      mControllerA, mControllerB, mControllerE, mTimeStep, mControllerAd,
+      mControllerBd, mControllerEd);
+}
+
+void EMT::VTypeSplitSSNComp::rebuildSplitDiscreteModel(
+    const Matrix &controllerBdUsed) {
+  mControllerBdUsed = controllerBdUsed;
+
+  const UInt controllerOffset = 0;
+  const UInt plantOffset = static_cast<UInt>(mControllerStateSize);
+  const UInt delayOffset = plantOffset + static_cast<UInt>(mA.rows());
+
+  mSplitDiscreteA.setZero();
+  mSplitDiscreteB.setZero();
+  mSplitHistoryC.setZero();
+
+  const Matrix controllerInputUpdate =
+      mControllerAd * controllerBdUsed + mControllerBd;
+
+  const Matrix measurementFromPlantHistory = mMeasurementState;
+  const Matrix measurementFromDelay =
+      2.0 * mMeasurementState * mdBControllerOutput;
+  const Matrix measurementFromTerminal =
+      mMeasurementState * mdB + mMeasurementTerminal;
+
+  const Matrix delayedOutputFromMeasurement =
+      mControllerC * controllerBdUsed + mControllerD;
+
+  mSplitDiscreteA.block(controllerOffset, controllerOffset,
+                        mControllerStateSize, mControllerStateSize) =
+      mControllerAd;
+  mSplitDiscreteA.block(controllerOffset, plantOffset, mControllerStateSize,
+                        mA.rows()) =
+      controllerInputUpdate * measurementFromPlantHistory;
+  mSplitDiscreteA.block(controllerOffset, delayOffset, mControllerStateSize,
+                        mControllerOutputSize) =
+      controllerInputUpdate * measurementFromDelay;
+  mSplitDiscreteB.block(controllerOffset, 0, mControllerStateSize, mB.cols()) =
+      controllerInputUpdate * measurementFromTerminal;
+
+  mSplitDiscreteA.block(plantOffset, plantOffset, mA.rows(), mA.cols()) = mdA;
+  mSplitDiscreteA.block(plantOffset, delayOffset, mA.rows(),
+                        mControllerOutputSize) =
+      2.0 * mdA * mdBControllerOutput;
+  mSplitDiscreteB.block(plantOffset, 0, mA.rows(), mB.cols()) =
+      (mdA + Matrix::Identity(mA.rows(), mA.cols())) * mdB;
+
+  mSplitDiscreteA.block(delayOffset, controllerOffset, mControllerOutputSize,
+                        mControllerStateSize) = mControllerC;
+  mSplitDiscreteA.block(delayOffset, plantOffset, mControllerOutputSize,
+                        mA.rows()) =
+      delayedOutputFromMeasurement * measurementFromPlantHistory;
+  mSplitDiscreteA.block(delayOffset, delayOffset, mControllerOutputSize,
+                        mControllerOutputSize) =
+      delayedOutputFromMeasurement * measurementFromDelay;
+  mSplitDiscreteB.block(delayOffset, 0, mControllerOutputSize, mB.cols()) =
+      delayedOutputFromMeasurement * measurementFromTerminal;
+
+  mSplitHistoryC.block(0, plantOffset, mC.rows(), mC.cols()) = mC;
+  mSplitHistoryC.block(0, delayOffset, mC.rows(), mControllerOutputSize) =
+      2.0 * mC * mdBControllerOutput;
+}
+
+void EMT::VTypeSplitSSNComp::recomputeDiscreteModel() {
+  SSNComp::recomputeDiscreteModel();
+
+  const Matrix identity = Matrix::Identity(mA.rows(), mA.cols());
+  const Matrix lhs = identity - 0.5 * mTimeStep * mA;
+  mdBControllerOutput =
+      lhs.fullPivLu().solve(0.5 * mTimeStep * mBControllerOutput);
+
+  recomputeControllerDiscreteModel();
+  rebuildSplitDiscreteModel(mControllerBd);
+}
+
+Matrix EMT::VTypeSplitSSNComp::calculateHistoryVector() const {
+  return mC * (mdA * (**mX) + mdB * (**mIntfVoltage) +
+               2.0 * mdBControllerOutput * mDelayedControllerOutput);
+}
+
+void EMT::VTypeSplitSSNComp::updateState(const Matrix &uOld,
+                                         const Matrix &uNew) {
+  const Matrix delayedControllerOutputUsedThisStep = mDelayedControllerOutput;
+  const Matrix controllerBdUsedThisStep = mControllerBd;
+
+  **mX = mdA * (**mX) + mdB * (uNew + uOld) +
+         2.0 * mdBControllerOutput * delayedControllerOutputUsedThisStep;
+
+  const Matrix measurementNew = buildControllerMeasurement(**mX, uNew);
+
+  mControllerState =
+      mControllerAd * mControllerState +
+      mControllerBd * (measurementNew + mControllerMeasurementOld) +
+      mControllerEd;
+  mControllerMeasurementOld = measurementNew;
+
+  buildControllerStateSpaceModel(mControllerState, measurementNew, mControllerA,
+                                 mControllerB, mControllerC, mControllerD,
+                                 mControllerE, mControllerF);
+  recomputeControllerDiscreteModel();
+
+  rebuildSplitDiscreteModel(controllerBdUsedThisStep);
+
+  evaluateControllerOutput(mControllerState, measurementNew, mControllerOutput);
+  mDelayedControllerOutput = mControllerOutput;
+}
+
+UInt EMT::VTypeSplitSSNComp::getSplitStateCount() const {
+  return static_cast<UInt>(mSplitDiscreteA.rows());
+}
+
+const Matrix &EMT::VTypeSplitSSNComp::getSplitDiscreteA() const {
+  return mSplitDiscreteA;
+}
+
+const Matrix &EMT::VTypeSplitSSNComp::getSplitDiscreteB() const {
+  return mSplitDiscreteB;
+}
+
+const Matrix &EMT::VTypeSplitSSNComp::getSplitHistoryC() const {
+  return mSplitHistoryC;
+}
+
+const Matrix &EMT::VTypeSplitSSNComp::getControllerDiscreteA() const {
+  return mControllerAd;
+}
+
+const Matrix &EMT::VTypeSplitSSNComp::getControllerDiscreteB() const {
+  return mControllerBd;
+}
+
+const Matrix &EMT::VTypeSplitSSNComp::getControllerDiscreteBUsed() const {
+  return mControllerBdUsed;
+}
+
+const Matrix &EMT::VTypeSplitSSNComp::getDiscreteControllerOutputB() const {
+  return mdBControllerOutput;
+}
+
+Attribute<Matrix>::Ptr EMT::VTypeSplitSSNComp::getSplitStateAttribute() const {
+  return mX;
+}

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -163,6 +163,7 @@ set(STATE_SPACE_SOURCES
 StateSpace/EMT_Ph3_RLC_StateSpaceExtraction.cpp
 StateSpace/EMT_Ph3_Composite_StateSpaceExtraction.cpp
 StateSpace/EMT_Ph3_Switch_StateSpaceExtraction.cpp
+StateSpace/EMT_Ph3_GFL_Split_StateSpaceExtraction.cpp
 StateSpace/DP_Ph1_RLC_StateSpaceExtraction.cpp
 StateSpace/DP_Ph1_Inverter_StateSpaceExtraction.cpp
 StateSpace/DP_Ph1_Composite_StateSpaceExtraction.cpp

--- a/dpsim/examples/cxx/StateSpace/EMT_Ph3_GFL_Split_StateSpaceExtraction.cpp
+++ b/dpsim/examples/cxx/StateSpace/EMT_Ph3_GFL_Split_StateSpaceExtraction.cpp
@@ -1,0 +1,529 @@
+// SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
+// SPDX-License-Identifier: MPL-2.0
+
+#include <DPsim.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+#include <dpsim-models/EMT/EMT_Ph3_SSN_GFL.h>
+#include <dpsim-models/EMT/EMT_Ph3_SSN_GFL_Split.h>
+
+using namespace CPS;
+using namespace DPsim;
+
+namespace {
+
+constexpr UInt ControllerStateCount = 8;
+constexpr UInt NetworkStateCount = 6;
+constexpr UInt GridStateCount = 3;
+constexpr UInt DelayStateCount = 3;
+constexpr UInt DelayedStateCount =
+    ControllerStateCount + NetworkStateCount + GridStateCount + DelayStateCount;
+constexpr UInt NoDelayStateCount =
+    ControllerStateCount + NetworkStateCount + GridStateCount;
+
+struct ExtractionResult {
+  VectorComp discreteEigenvalues;
+  Real extractionTime;
+  UInt stateCount;
+};
+
+struct EigenvalueRecord {
+  Real timeStep;
+  String model;
+  String representation;
+  VectorComp values;
+};
+
+VectorComp eigenvalues(const Matrix &matrix) {
+  Eigen::EigenSolver<Matrix> solver(matrix);
+  if (solver.info() != Eigen::Success)
+    throw std::runtime_error("Eigenvalue computation failed.");
+  return solver.eigenvalues();
+}
+
+Complex mapContinuousToDiscrete(const Complex &lambda, Real timeStep) {
+  const Complex two(2.0, 0.0);
+  return (two + timeStep * lambda) / (two - timeStep * lambda);
+}
+
+VectorComp mapContinuousToDiscrete(const VectorComp &lambda, Real timeStep) {
+  VectorComp result(lambda.rows());
+  for (Eigen::Index idx = 0; idx < lambda.rows(); ++idx)
+    result(idx) = mapContinuousToDiscrete(lambda(idx), timeStep);
+  return result;
+}
+
+Real maxNearestDistance(const VectorComp &reference, const VectorComp &actual) {
+  Real maximum = 0.0;
+
+  for (Eigen::Index refIdx = 0; refIdx < reference.rows(); ++refIdx) {
+    Real nearest = std::numeric_limits<Real>::max();
+    for (Eigen::Index actualIdx = 0; actualIdx < actual.rows(); ++actualIdx)
+      nearest =
+          std::min(nearest, std::abs(reference(refIdx) - actual(actualIdx)));
+    maximum = std::max(maximum, nearest);
+  }
+
+  return maximum;
+}
+
+void appendEigenvaluesToCsv(std::ofstream &stream,
+                            const EigenvalueRecord &record) {
+  for (Eigen::Index idx = 0; idx < record.values.rows(); ++idx) {
+    stream << record.timeStep << ',' << 1e6 * record.timeStep << ','
+           << record.model << ',' << record.representation << ',' << idx << ','
+           << record.values(idx).real() << ',' << record.values(idx).imag()
+           << '\n';
+  }
+}
+
+void writeEigenvaluesCsv(const std::filesystem::path &path,
+                         const std::vector<EigenvalueRecord> &records) {
+  std::filesystem::create_directories(path.parent_path());
+
+  std::ofstream stream(path);
+  if (!stream.is_open())
+    throw std::runtime_error("Could not open eigenvalue CSV output: " +
+                             path.string());
+
+  stream << std::setprecision(std::numeric_limits<Real>::max_digits10);
+  stream << "time_step_s,time_step_us,model,representation,index,real,imag\n";
+
+  for (const auto &record : records)
+    appendEigenvaluesToCsv(stream, record);
+
+  if (!stream)
+    throw std::runtime_error("Could not write eigenvalue CSV output: " +
+                             path.string());
+}
+
+Matrix parkTransformDq0(Real theta) {
+  const Real k = std::sqrt(2.0 / 3.0);
+  const Real k0 = 1.0 / std::sqrt(3.0);
+
+  Matrix transform(3, 3);
+  transform.row(0) << k * std::cos(theta), k * std::cos(theta - 2.0 * PI / 3.0),
+      k * std::cos(theta + 2.0 * PI / 3.0);
+  transform.row(1) << -k * std::sin(theta),
+      -k * std::sin(theta - 2.0 * PI / 3.0),
+      -k * std::sin(theta + 2.0 * PI / 3.0);
+  transform.row(2) << k0, k0, k0;
+  return transform;
+}
+
+void stampParkBlock(Matrix &transform, UInt offset, Real theta) {
+  transform.block(offset, offset, 3, 3) = parkTransformDq0(theta);
+}
+
+void stampFrameDerivative(Matrix &matrix, UInt offset, Real omega) {
+  matrix(offset, offset + 1) += omega;
+  matrix(offset + 1, offset) -= omega;
+}
+
+} // namespace
+
+class EMTPh3SplitGFLStateSpaceExtractionExample {
+public:
+  EMTPh3SplitGFLStateSpaceExtractionExample()
+      : mFrequency(50.0), mOmega(2.0 * PI * mFrequency),
+        mGridVoltageRmsLineToLine(400.0), mGridResistance(0.3),
+        mGridInductance(0.1e-3), mLf(2e-3), mCf(10e-6), mRf(0.2), mRc(0.2),
+        mKpPLL(0.25), mKiPLL(0.2), mOmegaCutoff(mOmega), mPRef(10000.0),
+        mQRef(5000.0), mKpPowerCtrl(0.05), mKiPowerCtrl(0.2), mKpCurrCtrl(0.25),
+        mKiCurrCtrl(1.0) {}
+
+  void run() const {
+    const String simName = "EMT_Ph3_GFL_Split_StateSpaceExtraction";
+    const SystemTopology powerFlow = runPowerFlow(simName + "_PF");
+
+    const std::array<Real, 4> timeSteps{1e-6, 10e-6, 100e-6, 1e-3};
+    const std::array<String, 4> timeStepLabels{"1us", "10us", "100us", "1ms"};
+    std::vector<EigenvalueRecord> records;
+
+    std::cout
+        << "\n============================================================\n"
+        << "EMT Ph3 GFL state-space extraction comparison\n"
+        << "============================================================\n"
+        << "Topology: ideal source -> R/L grid -> SSN GFL\n"
+        << "Analysis frame: global dq0\n"
+        << "Time steps: 1 us, 10 us, 100 us, 1 ms\n";
+
+    for (UInt caseIdx = 0; caseIdx < timeSteps.size(); ++caseIdx) {
+      const Real timeStep = timeSteps[caseIdx];
+      const String suffix = "_dt_" + timeStepLabels[caseIdx];
+
+      auto splitInverter =
+          EMT::Ph3::SSN_GFL_Split::make("InverterSplit", Logger::Level::warn);
+      setInverterParameters(splitInverter);
+      const ExtractionResult extractedSplit =
+          runExtraction(powerFlow, splitInverter, simName + "_Split" + suffix,
+                        timeStep, DelayedStateCount);
+
+      auto noDelayInverter =
+          EMT::Ph3::SSN_GFL::make("InverterNoDelay", Logger::Level::warn);
+      setInverterParameters(noDelayInverter);
+      const ExtractionResult extractedNoDelay = runExtraction(
+          powerFlow, noDelayInverter, simName + "_NoDelay" + suffix, timeStep,
+          NoDelayStateCount);
+
+      const Matrix analyticalDelayedAd = buildAnalyticalDelayedDiscreteMatrix(
+          *splitInverter, extractedSplit.extractionTime, timeStep);
+      const VectorComp analyticalDelayedZ = eigenvalues(analyticalDelayedAd);
+
+      const Matrix analyticalNoDelayA = buildAnalyticalNoDelayContinuousMatrix(
+          *splitInverter, extractedSplit.extractionTime + timeStep);
+      const VectorComp analyticalNoDelayLambda =
+          eigenvalues(analyticalNoDelayA);
+      const VectorComp analyticalNoDelayZ =
+          mapContinuousToDiscrete(analyticalNoDelayLambda, timeStep);
+
+      records.push_back({timeStep, "extracted_ssn_gfl_split", "discrete_z",
+                         extractedSplit.discreteEigenvalues});
+      records.push_back({timeStep, "extracted_ssn_gfl", "discrete_z",
+                         extractedNoDelay.discreteEigenvalues});
+      records.push_back(
+          {timeStep, "analytical_delayed", "discrete_z", analyticalDelayedZ});
+      records.push_back(
+          {timeStep, "analytical_no_delay", "discrete_z", analyticalNoDelayZ});
+      records.push_back({timeStep, "analytical_no_delay", "continuous_exact",
+                         analyticalNoDelayLambda});
+
+      const Real delayedDifference =
+          std::max(maxNearestDistance(analyticalDelayedZ,
+                                      extractedSplit.discreteEigenvalues),
+                   maxNearestDistance(extractedSplit.discreteEigenvalues,
+                                      analyticalDelayedZ));
+      const Real noDelayDifference =
+          std::max(maxNearestDistance(analyticalNoDelayZ,
+                                      extractedNoDelay.discreteEigenvalues),
+                   maxNearestDistance(extractedNoDelay.discreteEigenvalues,
+                                      analyticalNoDelayZ));
+
+      std::cout << "\nDelta t = " << 1e6 * timeStep << " us\n"
+                << "  split states: " << extractedSplit.stateCount
+                << " (8 controller + 6 plant + 3 grid + 3 delay)\n"
+                << "  no-delay states: " << extractedNoDelay.stateCount
+                << " (8 controller + 6 plant + 3 grid)\n"
+                << "  split extraction vs analytical delayed max error: "
+                << delayedDifference << "\n"
+                << "  no-delay extraction vs analytical no-delay max error: "
+                << noDelayDifference << "\n";
+
+      if (delayedDifference > 1e-7)
+        throw std::runtime_error(
+            "Split-GFL extraction does not match the analytical delayed "
+            "model at time step " +
+            timeStepLabels[caseIdx] + ".");
+    }
+
+    const std::filesystem::path eigenvalueCsvPath =
+        std::filesystem::path("logs") / simName / "eigenvalues.csv";
+    writeEigenvaluesCsv(eigenvalueCsvPath, records);
+    std::cout << "\nEigenvalue CSV: " << eigenvalueCsvPath.string() << "\n";
+  }
+
+private:
+  template <typename InverterType>
+  void
+  setInverterParameters(const std::shared_ptr<InverterType> &inverter) const {
+    inverter->setParameters(mLf, mCf, mRf, mRc, mOmega, mKpPLL, mKiPLL,
+                            mOmegaCutoff, mPRef, mQRef, mKpPowerCtrl,
+                            mKiPowerCtrl, mKpCurrCtrl, mKiCurrCtrl);
+  }
+
+  template <typename InverterType>
+  ExtractionResult runExtraction(const SystemTopology &powerFlow,
+                                 const std::shared_ptr<InverterType> &inverter,
+                                 const String &simName, Real timeStep,
+                                 UInt expectedStateCount) const {
+    Simulation simulation(simName, Logger::Level::warn);
+    simulation.setSystem(createEmtSystem(powerFlow, inverter));
+    simulation.setDomain(Domain::EMT);
+    simulation.setSolverType(Solver::Type::MNA);
+    simulation.setTimeStep(timeStep);
+    // Extract the first-step map at the power-flow initialized operating point.
+    // This keeps the delayed and no-delay cases comparable across time steps.
+    simulation.setFinalTime(timeStep);
+    simulation.doStateSpaceExtraction(true);
+    simulation.doInitFromNodesAndTerminals(true);
+    simulation.run();
+
+    const auto &extractor = simulation.getStateSpaceExtractor();
+    if (extractor.getStateCount() != expectedStateCount)
+      throw std::runtime_error("Unexpected extracted state count in " +
+                               simName + ".");
+
+    StateSpaceModalAnalysis modalAnalysis(extractor);
+    modalAnalysis.setAnalysisFrame(StateSpaceAnalysisFrame::GlobalDQ0);
+    modalAnalysis.setGlobalDq0Frame(mOmega);
+    modalAnalysis.update();
+
+    return {modalAnalysis.getDiscreteEigenvalues(),
+            extractor.getLastExtractionTime(), extractor.getStateCount()};
+  }
+
+  SystemTopology runPowerFlow(const String &simName) const {
+    auto nGrid = SimNode<Complex>::make("nGrid", PhaseType::Single);
+    auto nSeries = SimNode<Complex>::make("nSeries", PhaseType::Single);
+    auto nPcc = SimNode<Complex>::make("nPcc", PhaseType::Single);
+
+    auto slack = SP::Ph1::NetworkInjection::make("Slack");
+    slack->setParameters(mGridVoltageRmsLineToLine);
+    slack->setBaseVoltage(mGridVoltageRmsLineToLine);
+    slack->modifyPowerFlowBusType(PowerflowBusType::VD);
+
+    auto resistance = SP::Ph1::PiLine::make("GridResistancePF");
+    resistance->setParameters(mGridResistance, 0.0, 0.0, 0.0);
+    resistance->setBaseVoltage(mGridVoltageRmsLineToLine);
+
+    auto inductance = SP::Ph1::PiLine::make("GridInductancePF");
+    inductance->setParameters(0.0, mGridInductance, 0.0, 0.0);
+    inductance->setBaseVoltage(mGridVoltageRmsLineToLine);
+
+    auto inverterInjection = SP::Ph1::Load::make("InverterPF");
+    inverterInjection->setParameters(-mPRef, -mQRef, mGridVoltageRmsLineToLine);
+    inverterInjection->modifyPowerFlowBusType(PowerflowBusType::PQ);
+
+    slack->connect({nGrid});
+    resistance->connect({nPcc, nSeries});
+    inductance->connect({nSeries, nGrid});
+    inverterInjection->connect({nPcc});
+
+    SystemTopology system(
+        mFrequency, SystemNodeList{nGrid, nSeries, nPcc},
+        SystemComponentList{slack, resistance, inductance, inverterInjection});
+
+    Simulation simulation(simName, Logger::Level::warn);
+    simulation.setSystem(system);
+    simulation.setDomain(Domain::SP);
+    simulation.setSolverType(Solver::Type::NRP);
+    simulation.setSolverAndComponentBehaviour(
+        Solver::Behaviour::Initialization);
+    simulation.setTimeStep(1.0);
+    simulation.setFinalTime(2.0);
+    simulation.doInitFromNodesAndTerminals(false);
+    simulation.run();
+
+    return system;
+  }
+
+  template <typename InverterType>
+  SystemTopology
+  createEmtSystem(const SystemTopology &powerFlow,
+                  const std::shared_ptr<InverterType> &inverter) const {
+    auto nGrid = SimNode<Real>::make("nGrid", PhaseType::ABC);
+    auto nSeries = SimNode<Real>::make("nSeries", PhaseType::ABC);
+    auto nPcc = SimNode<Real>::make("nPcc", PhaseType::ABC);
+
+    auto slack = EMT::Ph3::NetworkInjection::make("Slack");
+    auto resistance = EMT::Ph3::Resistor::make("GridResistance");
+    resistance->setParameters(
+        Math::singlePhaseParameterToThreePhase(mGridResistance));
+    auto inductance = EMT::Ph3::Inductor::make("GridInductance");
+    inductance->setParameters(
+        Math::singlePhaseParameterToThreePhase(mGridInductance));
+
+    slack->connect({nGrid});
+    inductance->connect({nGrid, nSeries});
+    resistance->connect({nSeries, nPcc});
+    inverter->connect({EMT::SimNode::GND, nPcc});
+
+    SystemTopology system(
+        mFrequency, SystemNodeList{nGrid, nSeries, nPcc},
+        SystemComponentList{slack, inductance, resistance, inverter});
+    system.initWithPowerflow(powerFlow, Domain::EMT);
+    return system;
+  }
+
+  Matrix
+  buildAnalyticalDelayedDiscreteMatrix(const EMT::Ph3::SSN_GFL_Split &inverter,
+                                       Real timeStart, Real timeStep) const {
+    const Matrix controllerAdNext = inverter.getControllerDiscreteA();
+    const Matrix controllerBdNext = inverter.getControllerDiscreteB();
+    const Matrix controllerBdUsed = inverter.getControllerDiscreteBUsed();
+    const Matrix controllerC = inverter.getControllerC();
+    const Matrix controllerD = inverter.getControllerD();
+    const Matrix networkAd = inverter.getDiscreteA();
+    const Matrix networkBd = inverter.getDiscreteB();
+    const Matrix networkBvd = inverter.getDiscreteControllerOutputB();
+
+    Matrix terminalFromPlant = Matrix::Zero(3, 9);
+    terminalFromPlant.block(0, 0, 3, 3) = Matrix::Identity(3, 3);
+    terminalFromPlant.block(0, 6, 3, 3) = -mRc * Matrix::Identity(3, 3);
+
+    Matrix measurementFromPlant = Matrix::Zero(6, 9);
+    measurementFromPlant.block(0, 0, 3, 3) = Matrix::Identity(3, 3);
+    measurementFromPlant.block(3, 6, 3, 3) = Matrix::Identity(3, 3);
+
+    const Real denominator =
+        1.0 + 0.5 * timeStep * mGridResistance / mGridInductance;
+    const Real gridAdScalar =
+        (1.0 - 0.5 * timeStep * mGridResistance / mGridInductance) /
+        denominator;
+    const Real gridBdScalar = (0.5 * timeStep / mGridInductance) / denominator;
+
+    Matrix terminalInput = Matrix::Zero(9, 3);
+    terminalInput.block(0, 0, 6, 3) = networkBd;
+    terminalInput.block(6, 0, 3, 3) = gridBdScalar * Matrix::Identity(3, 3);
+
+    Matrix delayedInput = Matrix::Zero(9, 3);
+    delayedInput.block(0, 0, 6, 3) = 2.0 * networkBvd;
+
+    const Matrix lhs =
+        Matrix::Identity(9, 9) - terminalInput * terminalFromPlant;
+    const Matrix physicalFromHistory =
+        lhs.fullPivLu().solve(Matrix::Identity(9, 9));
+    const Matrix physicalFromDelay = lhs.fullPivLu().solve(delayedInput);
+
+    Matrix historyAd = Matrix::Zero(9, 9);
+    historyAd.block(0, 0, 6, 6) = networkAd;
+    historyAd.block(6, 6, 3, 3) = gridAdScalar * Matrix::Identity(3, 3);
+
+    Matrix historyTerminalInput = Matrix::Zero(9, 3);
+    historyTerminalInput.block(0, 0, 6, 3) =
+        (networkAd + Matrix::Identity(6, 6)) * networkBd;
+    historyTerminalInput.block(6, 0, 3, 3) =
+        (gridAdScalar + 1.0) * gridBdScalar * Matrix::Identity(3, 3);
+
+    Matrix historyDelayDirect = Matrix::Zero(9, 3);
+    historyDelayDirect.block(0, 0, 6, 3) = 2.0 * networkAd * networkBvd;
+
+    const Matrix terminalFromHistory = terminalFromPlant * physicalFromHistory;
+    const Matrix terminalFromDelay = terminalFromPlant * physicalFromDelay;
+    const Matrix historyClosedAd =
+        historyAd + historyTerminalInput * terminalFromHistory;
+    const Matrix historyClosedDelay =
+        historyDelayDirect + historyTerminalInput * terminalFromDelay;
+
+    const Matrix measurementFromHistory =
+        measurementFromPlant * physicalFromHistory;
+    const Matrix measurementFromDelay =
+        measurementFromPlant * physicalFromDelay;
+    const Matrix controllerInputUpdate =
+        controllerAdNext * controllerBdUsed + controllerBdNext;
+
+    Matrix result = Matrix::Zero(DelayedStateCount, DelayedStateCount);
+    const UInt controllerOffset = 0;
+    const UInt plantOffset = ControllerStateCount;
+    const UInt delayOffset = ControllerStateCount + 9;
+
+    result.block(plantOffset, plantOffset, 9, 9) = historyClosedAd;
+    result.block(plantOffset, delayOffset, 9, 3) = historyClosedDelay;
+
+    result.block(controllerOffset, controllerOffset, 8, 8) = controllerAdNext;
+    result.block(controllerOffset, plantOffset, 8, 9) =
+        controllerInputUpdate * measurementFromHistory;
+    result.block(controllerOffset, delayOffset, 8, 3) =
+        controllerInputUpdate * measurementFromDelay;
+
+    const Matrix delayMeasurementGain =
+        controllerC * controllerBdUsed + controllerD;
+    result.block(delayOffset, controllerOffset, 3, 8) = controllerC;
+    result.block(delayOffset, plantOffset, 3, 9) =
+        delayMeasurementGain * measurementFromHistory;
+    result.block(delayOffset, delayOffset, 3, 3) =
+        delayMeasurementGain * measurementFromDelay;
+
+    Matrix transformStart =
+        Matrix::Identity(DelayedStateCount, DelayedStateCount);
+    Matrix transformEnd = transformStart;
+    const Real thetaStart = mOmega * timeStart;
+    const Real thetaEnd = thetaStart + mOmega * timeStep;
+
+    for (const UInt offset :
+         {ControllerStateCount, ControllerStateCount + 3,
+          ControllerStateCount + 6, ControllerStateCount + 9}) {
+      stampParkBlock(transformStart, offset, thetaStart);
+      stampParkBlock(transformEnd, offset, thetaEnd);
+    }
+
+    return transformEnd * result * transformStart.transpose();
+  }
+
+  Matrix buildAnalyticalNoDelayContinuousMatrix(
+      const EMT::Ph3::SSN_GFL_Split &inverter, Real time) const {
+    const Matrix controllerA = inverter.getControllerA();
+    const Matrix controllerB = inverter.getControllerB();
+    const Matrix controllerC = inverter.getControllerC();
+    const Matrix controllerD = inverter.getControllerD();
+    const Matrix networkA = inverter.getNetworkA();
+    const Matrix networkBFull = inverter.getNetworkB();
+    const Matrix networkB = networkBFull.leftCols(3);
+    const Matrix networkBv = networkBFull.rightCols(3);
+
+    Matrix terminalFromPlant = Matrix::Zero(3, 9);
+    terminalFromPlant.block(0, 0, 3, 3) = Matrix::Identity(3, 3);
+    terminalFromPlant.block(0, 6, 3, 3) = -mRc * Matrix::Identity(3, 3);
+
+    Matrix measurementFromPlant = Matrix::Zero(6, 9);
+    measurementFromPlant.block(0, 0, 3, 3) = Matrix::Identity(3, 3);
+    measurementFromPlant.block(3, 6, 3, 3) = Matrix::Identity(3, 3);
+
+    Matrix result = Matrix::Zero(NoDelayStateCount, NoDelayStateCount);
+    const UInt controllerOffset = 0;
+    const UInt plantOffset = ControllerStateCount;
+
+    result.block(controllerOffset, controllerOffset, 8, 8) = controllerA;
+    result.block(controllerOffset, plantOffset, 8, 9) =
+        controllerB * measurementFromPlant;
+
+    result.block(plantOffset, controllerOffset, 6, 8) = networkBv * controllerC;
+    result.block(plantOffset, plantOffset, 6, 6) = networkA;
+    result.block(plantOffset, plantOffset, 6, 9) +=
+        networkB * terminalFromPlant +
+        networkBv * controllerD * measurementFromPlant;
+
+    result.block(plantOffset + 6, plantOffset, 3, 9) =
+        (1.0 / mGridInductance) * terminalFromPlant;
+    result.block(plantOffset + 6, plantOffset + 6, 3, 3) +=
+        (-mGridResistance / mGridInductance) * Matrix::Identity(3, 3);
+
+    Matrix transform = Matrix::Identity(NoDelayStateCount, NoDelayStateCount);
+    const Real theta = mOmega * time;
+    for (const UInt offset : {ControllerStateCount, ControllerStateCount + 3,
+                              ControllerStateCount + 6})
+      stampParkBlock(transform, offset, theta);
+
+    Matrix transformed = transform * result * transform.transpose();
+    for (const UInt offset : {ControllerStateCount, ControllerStateCount + 3,
+                              ControllerStateCount + 6})
+      stampFrameDerivative(transformed, offset, mOmega);
+
+    return transformed;
+  }
+
+  Real mFrequency;
+  Real mOmega;
+  Real mGridVoltageRmsLineToLine;
+  Real mGridResistance;
+  Real mGridInductance;
+  Real mLf;
+  Real mCf;
+  Real mRf;
+  Real mRc;
+  Real mKpPLL;
+  Real mKiPLL;
+  Real mOmegaCutoff;
+  Real mPRef;
+  Real mQRef;
+  Real mKpPowerCtrl;
+  Real mKiPowerCtrl;
+  Real mKpCurrCtrl;
+  Real mKiCurrCtrl;
+};
+
+int main() {
+  EMTPh3SplitGFLStateSpaceExtractionExample example;
+  example.run();
+  return 0;
+}

--- a/dpsim/include/dpsim/MNASolverDirect.h
+++ b/dpsim/include/dpsim/MNASolverDirect.h
@@ -277,6 +277,13 @@ public:
     StateSpaceExtractionTask(MnaSolverDirect<VarType> &solver)
         : Task(solver.mName + ".StateSpaceExtraction"), mSolver(solver) {
       mAttributeDependencies.push_back(solver.mLeftSideVector);
+      if (solver.mStateSpaceExtractor) {
+        // Some contributors update their matrices in post-step;
+        // these dependencies prevent extraction from reading not updated matrices.
+        for (const auto &dependency :
+             solver.mStateSpaceExtractor->getAttributeDependencies())
+          mAttributeDependencies.push_back(dependency);
+      }
       mModifiedAttributes.push_back(Scheduler::external);
     }
 

--- a/dpsim/include/dpsim/MNAStateSpaceContributor.h
+++ b/dpsim/include/dpsim/MNAStateSpaceContributor.h
@@ -53,8 +53,16 @@ public:
   /// Number of local extraction states contributed by this component.
   virtual UInt getStateCount() const = 0;
 
-  /// Returns true if the local matrices may change during simulation.
-  virtual Bool isVariable() const { return false; }
+  /// Whether this contributor belongs to the updated matrix group.
+  virtual Bool contributesToUpdatedMatrices() const { return false; }
+
+  /// Whether this contributor requests its matrices to be refreshed.
+  virtual Bool requiresUpdate() const { return false; }
+
+  /// Attributes that must be up to date before this contribution is stamped.
+  virtual CPS::AttributeBase::List getAttributeDependencies() const {
+    return {};
+  }
 
   /// Stamp this component's current local state-space contribution.
   virtual void stamp(Matrix &AdLocal, Matrix &BdMna, Matrix &CdMna,

--- a/dpsim/include/dpsim/MNAStateSpaceExtractor.h
+++ b/dpsim/include/dpsim/MNAStateSpaceExtractor.h
@@ -47,6 +47,10 @@ public:
 
   const StateSpaceMetadata &getMetadata() const { return mMetadata; }
 
+  const CPS::AttributeBase::List &getAttributeDependencies() const {
+    return mAttributeDependencies;
+  }
+
   Bool hasExtractionTime() const { return mHasExtractionTime; }
 
   Real getLastExtractionTime() const { return mLastExtractionTime; }
@@ -63,9 +67,9 @@ private:
 
   void collectMetadata();
 
-  void stampStaticMatrices();
+  void stampConstantMatrices();
 
-  void restampVariableMatrices();
+  void restampUpdatedMatrices();
 
   void rebuildCombinedMatrices();
 
@@ -79,7 +83,7 @@ private:
 
   Real mTimeStep = 0.0;
 
-  Bool mHasVariableContributors = false;
+  Bool mHasUpdatedContributors = false;
 
   Bool mStateMatrixValid = false;
 
@@ -91,13 +95,15 @@ private:
 
   std::vector<ContributorEntry> mContributorEntries;
 
-  Matrix mAdLocalStatic;
-  Matrix mBdMnaStatic;
-  Matrix mCdMnaStatic;
+  CPS::AttributeBase::List mAttributeDependencies;
 
-  Matrix mAdLocalVariable;
-  Matrix mBdMnaVariable;
-  Matrix mCdMnaVariable;
+  Matrix mAdLocalConstant;
+  Matrix mBdMnaConstant;
+  Matrix mCdMnaConstant;
+
+  Matrix mAdLocalUpdated;
+  Matrix mBdMnaUpdated;
+  Matrix mCdMnaUpdated;
 
   Matrix mAdLocal;
   Matrix mBdMna;

--- a/dpsim/include/dpsim/StateSpaceModalAnalysis.h
+++ b/dpsim/include/dpsim/StateSpaceModalAnalysis.h
@@ -14,13 +14,21 @@ enum class StateSpaceAnalysisFrame {
   GlobalDQ0,
 };
 
+enum class StateSpacePoleMapping {
+  /// Inverse trapezoidal (bilinear) mapping. Use when the complete model was
+  /// discretized with the trapezoidal rule and contains no explicit delays.
+  Bilinear,
+
+  /// Sampled-data mapping lambda = log(z) / dt. Use for models containing
+  /// explicit discrete delays or other non-trapezoidal update operations.
+  Logarithmic,
+};
+
 /// Performs modal analysis of an extracted discrete-time state-space model.
 ///
 /// The analysis uses the state matrix provided by MNAStateSpaceExtractor and
 /// maps discrete-time eigenvalues to continuous-time equivalent eigenvalues
-/// with the trapezoidal-rule relation:
-///
-///   lambda = 2 / dt * (z - 1) / (z + 1)
+/// using a selectable pole mapping.
 class StateSpaceModalAnalysis {
 public:
   explicit StateSpaceModalAnalysis(const MNAStateSpaceExtractor &extractor);
@@ -42,6 +50,8 @@ public:
     mGlobalTheta0 = theta0;
   }
 
+  void setPoleMapping(StateSpacePoleMapping mapping) { mPoleMapping = mapping; }
+
   /// Update modal quantities from the current extracted state matrix.
   void update();
 
@@ -50,7 +60,8 @@ public:
     return mDiscreteEigenvalues;
   }
 
-  /// Continuous-time equivalent eigenvalues reconstructed from discrete eigenvalues.
+  /// Continuous-time equivalent eigenvalues reconstructed with the selected
+  /// pole mapping.
   const CPS::VectorComp &getContinuousEigenvalues() const {
     return mContinuousEigenvalues;
   }
@@ -100,6 +111,8 @@ private:
   const MNAStateSpaceExtractor &mExtractor;
 
   StateSpaceAnalysisFrame mAnalysisFrame = StateSpaceAnalysisFrame::Native;
+
+  StateSpacePoleMapping mPoleMapping = StateSpacePoleMapping::Bilinear;
 
   Real mGlobalOmega = 0.0;
 

--- a/dpsim/src/MNAStateSpaceContributor.cpp
+++ b/dpsim/src/MNAStateSpaceContributor.cpp
@@ -28,6 +28,7 @@
 #include <dpsim-models/EMT/EMT_Ph3_Switch.h>
 #include <dpsim-models/EMT/EMT_Ph3_Transformer.h>
 #include <dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeSSNComp.h>
+#include <dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeSplitSSNComp.h>
 #include <dpsim-models/EMT/EMT_Ph3_TwoTerminalVTypeVariableSSNComp.h>
 #include <dpsim-models/EMT/EMT_Ph3_VoltageSource.h>
 #include <dpsim-models/EMT/EMT_VTypeSSNComp.h>
@@ -313,7 +314,7 @@ public:
 
   UInt getStateCount() const override { return mComponent->getStateCount(); }
 
-  Bool isVariable() const override { return mIsVariable; }
+  Bool contributesToUpdatedMatrices() const override { return mIsVariable; }
 
   void stamp(Matrix &AdLocal, Matrix &BdMna, Matrix &CdMna, UInt stateOffset,
              UInt mnaVectorSize) const override {
@@ -386,6 +387,90 @@ public:
 private:
   std::shared_ptr<EMT::VTypeSSNComp> mComponent;
   Bool mIsVariable = false;
+};
+
+class EMTPh3TwoTerminalVTypeSplitSSNStateSpaceContributor final
+    : public MNAStateSpaceContributor {
+public:
+  explicit EMTPh3TwoTerminalVTypeSplitSSNStateSpaceContributor(
+      std::shared_ptr<EMT::Ph3::TwoTerminalVTypeSplitSSNComp> component)
+      : mComponent(std::move(component)) {}
+
+  UInt getStateCount() const override {
+    return mComponent->getSplitStateCount();
+  }
+
+  Bool contributesToUpdatedMatrices() const override {
+    return mComponent->requiresStateSpaceMatrixUpdate();
+  }
+
+  Bool requiresUpdate() const override {
+    return mComponent->requiresStateSpaceMatrixUpdate();
+  }
+
+  CPS::AttributeBase::List getAttributeDependencies() const override {
+    if (requiresUpdate())
+      return {mComponent->getSplitStateAttribute()};
+
+    return {};
+  }
+
+  void stamp(Matrix &AdLocal, Matrix &BdMna, Matrix &CdMna, UInt stateOffset,
+             UInt mnaVectorSize) const override {
+    const UInt localStateCount = getStateCount();
+    const Matrix &discreteA = mComponent->getSplitDiscreteA();
+    const Matrix &discreteB = mComponent->getSplitDiscreteB();
+    const Matrix &historyC = mComponent->getSplitHistoryC();
+    const Matrix K =
+        buildTwoTerminalInterfaceVoltageMapping(*mComponent, mnaVectorSize);
+
+    AdLocal.block(stateOffset, stateOffset, localStateCount, localStateCount) +=
+        discreteA;
+    BdMna.block(stateOffset, 0, localStateCount, mnaVectorSize) +=
+        discreteB * K;
+    stampTwoTerminalCurrentInjectionMapping(K, CdMna, stateOffset, historyC);
+  }
+
+  void contributeMetadata(StateSpaceMetadata &metadata,
+                          UInt stateOffset) const override {
+    const UInt localStateCount = getStateCount();
+    const String componentName = mComponent->name();
+    const auto localStateNames = mComponent->getSplitLocalStateNames();
+
+    if (!localStateNames.empty() && localStateNames.size() != localStateCount) {
+      throw std::runtime_error(
+          "Split SSN component returned an invalid number of local state "
+          "names.");
+    }
+
+    for (UInt idx = 0; idx < localStateCount; ++idx) {
+      if (!localStateNames.empty())
+        setStateName(metadata, stateOffset + idx,
+                     componentName + "." + localStateNames[idx]);
+    }
+
+    for (auto abcBlock : mComponent->getSplitLocalAbcStateBlocks()) {
+      if (abcBlock.name.empty()) {
+        throw std::runtime_error(
+            "Split SSN component returned an abc state block with an empty "
+            "name.");
+      }
+
+      for (auto &idx : abcBlock.indices) {
+        if (idx >= localStateCount) {
+          throw std::runtime_error(
+              "Split SSN component returned an invalid abc state index.");
+        }
+        idx += stateOffset;
+      }
+
+      metadata.abcStateBlocks.push_back(
+          {abcBlock.indices, componentName + "." + abcBlock.name});
+    }
+  }
+
+private:
+  std::shared_ptr<EMT::Ph3::TwoTerminalVTypeSplitSSNComp> mComponent;
 };
 
 class DPPh1InductorStateSpaceContributor final
@@ -533,7 +618,7 @@ public:
 
   UInt getStateCount() const override { return mComponent->getStateCount(); }
 
-  Bool isVariable() const override { return true; }
+  Bool contributesToUpdatedMatrices() const override { return true; }
 
   void stamp(Matrix &AdLocal, Matrix &BdMna, Matrix &CdMna, UInt stateOffset,
              UInt mnaVectorSize) const override {
@@ -596,6 +681,13 @@ MNAStateSpaceContributorFactory::create(const MNAInterface::Ptr &component) {
               component)) {
     return std::make_shared<EMTPh3TwoTerminalVTypeSSNStateSpaceContributor>(
         variableSsn, true);
+  }
+
+  if (auto splitSsn =
+          std::dynamic_pointer_cast<EMT::Ph3::TwoTerminalVTypeSplitSSNComp>(
+              component)) {
+    return std::make_shared<
+        EMTPh3TwoTerminalVTypeSplitSSNStateSpaceContributor>(splitSsn);
   }
 
   if (auto ssn = std::dynamic_pointer_cast<EMT::Ph3::TwoTerminalVTypeSSNComp>(

--- a/dpsim/src/MNAStateSpaceExtractor.cpp
+++ b/dpsim/src/MNAStateSpaceExtractor.cpp
@@ -36,8 +36,12 @@ void MNAStateSpaceExtractor::initialize(
 
     nextStateOffset += localStateCount;
 
-    if (contributor->isVariable())
-      mHasVariableContributors = true;
+    if (contributor->contributesToUpdatedMatrices())
+      mHasUpdatedContributors = true;
+
+    const auto dependencies = contributor->getAttributeDependencies();
+    mAttributeDependencies.insert(mAttributeDependencies.end(),
+                                  dependencies.begin(), dependencies.end());
   }
 
   mStateCount = nextStateOffset;
@@ -45,8 +49,8 @@ void MNAStateSpaceExtractor::initialize(
   allocateMatrices();
   collectMetadata();
 
-  stampStaticMatrices();
-  restampVariableMatrices();
+  stampConstantMatrices();
+  restampUpdatedMatrices();
   rebuildCombinedMatrices();
 
   mStateMatrixValid = false;
@@ -60,21 +64,22 @@ void MNAStateSpaceExtractor::reset() {
   mStateCount = 0;
   mTimeStep = 0.0;
 
-  mHasVariableContributors = false;
+  mHasUpdatedContributors = false;
   mStateMatrixValid = false;
   mMetadata = StateSpaceMetadata{};
   mLastExtractionTime = 0.0;
   mHasExtractionTime = false;
 
   mContributorEntries.clear();
+  mAttributeDependencies.clear();
 
-  mAdLocalStatic.resize(0, 0);
-  mBdMnaStatic.resize(0, 0);
-  mCdMnaStatic.resize(0, 0);
+  mAdLocalConstant.resize(0, 0);
+  mBdMnaConstant.resize(0, 0);
+  mCdMnaConstant.resize(0, 0);
 
-  mAdLocalVariable.resize(0, 0);
-  mBdMnaVariable.resize(0, 0);
-  mCdMnaVariable.resize(0, 0);
+  mAdLocalUpdated.resize(0, 0);
+  mBdMnaUpdated.resize(0, 0);
+  mCdMnaUpdated.resize(0, 0);
 
   mAdLocal.resize(0, 0);
   mBdMna.resize(0, 0);
@@ -98,8 +103,20 @@ void MNAStateSpaceExtractor::extract(DirectLinearSolver &linearSolver,
     return;
   }
 
-  if (variableModelChanged && mHasVariableContributors) {
-    restampVariableMatrices();
+  Bool updatedMatricesChanged = variableModelChanged;
+
+  if (!updatedMatricesChanged) {
+    for (const auto &entry : mContributorEntries) {
+      if (entry.contributor->contributesToUpdatedMatrices() &&
+          entry.contributor->requiresUpdate()) {
+        updatedMatricesChanged = true;
+        break;
+      }
+    }
+  }
+
+  if (updatedMatricesChanged && mHasUpdatedContributors) {
+    restampUpdatedMatrices();
     rebuildCombinedMatrices();
     mStateMatrixValid = false;
   }
@@ -112,13 +129,13 @@ void MNAStateSpaceExtractor::extract(DirectLinearSolver &linearSolver,
 }
 
 void MNAStateSpaceExtractor::allocateMatrices() {
-  mAdLocalStatic = Matrix::Zero(mStateCount, mStateCount);
-  mBdMnaStatic = Matrix::Zero(mStateCount, mMnaVectorSize);
-  mCdMnaStatic = Matrix::Zero(mMnaVectorSize, mStateCount);
+  mAdLocalConstant = Matrix::Zero(mStateCount, mStateCount);
+  mBdMnaConstant = Matrix::Zero(mStateCount, mMnaVectorSize);
+  mCdMnaConstant = Matrix::Zero(mMnaVectorSize, mStateCount);
 
-  mAdLocalVariable = Matrix::Zero(mStateCount, mStateCount);
-  mBdMnaVariable = Matrix::Zero(mStateCount, mMnaVectorSize);
-  mCdMnaVariable = Matrix::Zero(mMnaVectorSize, mStateCount);
+  mAdLocalUpdated = Matrix::Zero(mStateCount, mStateCount);
+  mBdMnaUpdated = Matrix::Zero(mStateCount, mMnaVectorSize);
+  mCdMnaUpdated = Matrix::Zero(mMnaVectorSize, mStateCount);
 
   mAdLocal = Matrix::Zero(mStateCount, mStateCount);
   mBdMna = Matrix::Zero(mStateCount, mMnaVectorSize);
@@ -156,36 +173,36 @@ void MNAStateSpaceExtractor::collectMetadata() {
   }
 }
 
-void MNAStateSpaceExtractor::stampStaticMatrices() {
-  mAdLocalStatic.setZero();
-  mBdMnaStatic.setZero();
-  mCdMnaStatic.setZero();
+void MNAStateSpaceExtractor::stampConstantMatrices() {
+  mAdLocalConstant.setZero();
+  mBdMnaConstant.setZero();
+  mCdMnaConstant.setZero();
 
   for (const auto &entry : mContributorEntries) {
-    if (!entry.contributor->isVariable()) {
-      entry.contributor->stamp(mAdLocalStatic, mBdMnaStatic, mCdMnaStatic,
+    if (!entry.contributor->contributesToUpdatedMatrices()) {
+      entry.contributor->stamp(mAdLocalConstant, mBdMnaConstant, mCdMnaConstant,
                                entry.stateOffset, mMnaVectorSize);
     }
   }
 }
 
-void MNAStateSpaceExtractor::restampVariableMatrices() {
-  mAdLocalVariable.setZero();
-  mBdMnaVariable.setZero();
-  mCdMnaVariable.setZero();
+void MNAStateSpaceExtractor::restampUpdatedMatrices() {
+  mAdLocalUpdated.setZero();
+  mBdMnaUpdated.setZero();
+  mCdMnaUpdated.setZero();
 
   for (const auto &entry : mContributorEntries) {
-    if (entry.contributor->isVariable()) {
-      entry.contributor->stamp(mAdLocalVariable, mBdMnaVariable, mCdMnaVariable,
+    if (entry.contributor->contributesToUpdatedMatrices()) {
+      entry.contributor->stamp(mAdLocalUpdated, mBdMnaUpdated, mCdMnaUpdated,
                                entry.stateOffset, mMnaVectorSize);
     }
   }
 }
 
 void MNAStateSpaceExtractor::rebuildCombinedMatrices() {
-  mAdLocal = mAdLocalStatic + mAdLocalVariable;
-  mBdMna = mBdMnaStatic + mBdMnaVariable;
-  mCdMna = mCdMnaStatic + mCdMnaVariable;
+  mAdLocal = mAdLocalConstant + mAdLocalUpdated;
+  mBdMna = mBdMnaConstant + mBdMnaUpdated;
+  mCdMna = mCdMnaConstant + mCdMnaUpdated;
 }
 
 void MNAStateSpaceExtractor::computeStateMatrix(

--- a/dpsim/src/StateSpaceModalAnalysis.cpp
+++ b/dpsim/src/StateSpaceModalAnalysis.cpp
@@ -190,6 +190,9 @@ StateSpaceModalAnalysis::buildStateNamesInAnalysisFrame() const {
 
 CPS::Complex
 StateSpaceModalAnalysis::mapDiscreteToContinuous(const CPS::Complex &z) const {
+  if (mPoleMapping == StateSpacePoleMapping::Logarithmic)
+    return std::log(z) / mExtractor.getTimeStep();
+
   const CPS::Complex one(1.0, 0.0);
   const CPS::Complex denominator = z + one;
 

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -164,6 +164,10 @@ PYBIND11_MODULE(dpsimpy, m) {
       .value("Native", DPsim::StateSpaceAnalysisFrame::Native)
       .value("GlobalDQ0", DPsim::StateSpaceAnalysisFrame::GlobalDQ0);
 
+  py::enum_<DPsim::StateSpacePoleMapping>(m, "StateSpacePoleMapping")
+      .value("Bilinear", DPsim::StateSpacePoleMapping::Bilinear)
+      .value("Logarithmic", DPsim::StateSpacePoleMapping::Logarithmic);
+
   m.attr("RMS3PH_TO_PEAK1PH") = RMS3PH_TO_PEAK1PH;
   m.attr("PEAK1PH_TO_RMS3PH") = PEAK1PH_TO_RMS3PH;
   m.attr("P_SNUB_TRANSFORMER") = P_SNUB_TRANSFORMER;
@@ -208,6 +212,7 @@ PYBIND11_MODULE(dpsimpy, m) {
       .def("set_global_dq0_frame",
            &DPsim::StateSpaceModalAnalysis::setGlobalDq0Frame, "omega"_a,
            "theta0"_a = 0.0)
+      .def("set_pole_mapping", &DPsim::StateSpaceModalAnalysis::setPoleMapping)
       .def("update", &DPsim::StateSpaceModalAnalysis::update)
       .def("get_discrete_eigenvalues",
            &DPsim::StateSpaceModalAnalysis::getDiscreteEigenvalues,


### PR DESCRIPTION
## Description

This PR adds state-space extraction support for split SSN components whose electrical plant and controller are evaluated separately with a one-step interface delay.

It introduces reusable split V-type SSN base classes and refactors `EMT::Ph3::SSN_GFL_Split` to use them. The extractor now maintains constant and updated contribution matrices, allowing both variable components and split SSN components to refresh their contributions when required.

A logarithmic discrete-to-continuous pole mapping is added for models containing explicit discrete delays.

The included C++ example compares the split and no-delay GFL models with analytical references for time steps from 1 µs to 1 ms.