### PR TITLE
Further enhancement of switch model

### DIFF
--- a/docs/hugo/content/en/docs/Concepts/Models/switches.md
+++ b/docs/hugo/content/en/docs/Concepts/Models/switches.md
@@ -48,8 +48,9 @@ asks the network to move the capacitor voltage discontinuously, and the trapezoi
 of the capacitor answers with the same alternating error.
 
 This is a property of the discretisation, not of the physical circuit. A real breaker interrupts at a
-current zero and closes at a voltage zero, and the arc across real contacts dissipates what is left;
-a two-valued resistance switched at an arbitrary instant has neither mechanism.
+current zero, while controlled switching can aim to close at a favourable voltage instant. The arc
+across real contacts dissipates what is left; a two-valued resistance switched at an arbitrary
+instant has neither mechanism.
 
 ## What a current zero means per domain
 
@@ -58,7 +59,8 @@ Whether that is available depends on what the domain represents.
 
 In EMT the state variables are instantaneous quantities, so the current zero is directly visible.
 Waiting for it means the interrupted current is zero to within one time step and there is nothing
-left for the companion model to disagree about. This is physically and numerically correct.
+left for the companion model to disagree about. This is consistent with the intended ideal
+current-zero interruption model.
 
 In DP the state variables are complex envelopes of a carrier at the reference frequency
 $\omega_s$, and the instantaneous current can be reconstructed from them,
@@ -104,14 +106,14 @@ physical arc voltage, no energy balance and no reignition. The parameter to choo
 it should be long enough that the ramp covers several time steps and short enough to stay
 insignificant on the timescale being studied.
 
-The cost is that the system matrix changes on every step of the transition rather than once, so each
+The cost is that the system matrix changes at every step of the transition rather than once, so each
 of those steps requires a refactorisation. Both non-ideal modes therefore report
 `supportsPrecomputedSystemMatrices() == false` and take the variable-component path through the
 solver, while `Ideal` keeps the cheap precomputed two-state path.
 
-On closing, DP ZCS suppresses unrealistic transients, also based on companion models history
-terms. This also suppresses physically real closing inrush, so we still have only an
-approximation. EMT closing inrush is real, not an artifact.
+On closing, DP ZCS suppresses unrealistic transients that are also related to companion-model history
+terms. This can also suppress physically real closing inrush, so the result is still only an
+approximation. EMT closing inrush is real, not an artefact.
 
 ## Choosing a mode
 
@@ -122,7 +124,7 @@ approximation. EMT closing inrush is real, not an artifact.
 | `ExponentialZCSEmulation` | ramped over $T_{sw}$ | ramped over $T_{sw}$ | the transient has to be absent, in particular for DP in either direction |
 
 The modes are available in `EMT::Ph3::Switch`, `DP::Ph3::Switch` and `DP::Ph1::Switch`. Every switch
-defaults to `Ideal`
+defaults to `Ideal`.
 
 ## The variable-resistance switch
 

--- a/docs/hugo/content/en/docs/Concepts/Models/switches.md
+++ b/docs/hugo/content/en/docs/Concepts/Models/switches.md
@@ -1,9 +1,10 @@
 ---
 title: "Switches"
 linkTitle: "Switches"
-date: 2026-07-31
+date: 2026-08-19
 description: >
-  Two-resistance switching and the variable-resistance switch used for faults.
+  Two-resistance switching, why a step change in resistance is a problem, and the current-zero and
+  exponential ZCS-emulation modes that avoid it.
 weight: 5
 ---
 
@@ -42,32 +43,104 @@ one time step. The inductor opposes it, and with the trapezoidal companion model
 numerical oscillation across the switch: the current alternates sign at the step frequency and
 decays slowly, contaminating the solution for many steps after the event.
 
-This is a property of the discretisation, not of the physical circuit. The physical arc that would
-form across real contacts dissipates that energy; a two-valued resistance has no equivalent
-mechanism.
+Closing has the mirror image of the same problem. Energising a path that terminates in capacitance
+asks the network to move the capacitor voltage discontinuously, and the trapezoidal companion model
+of the capacitor answers with the same alternating error.
+
+This is a property of the discretisation, not of the physical circuit. A real breaker interrupts at a
+current zero and closes at a voltage zero, and the arc across real contacts dissipates what is left;
+a two-valued resistance switched at an arbitrary instant has neither mechanism.
+
+## What a current zero means per domain
+
+The remedy a real breaker uses is to switch where the discontinuity is not there in the first place.
+Whether that is available depends on what the domain represents.
+
+In EMT the state variables are instantaneous quantities, so the current zero is directly visible.
+Waiting for it means the interrupted current is zero to within one time step and there is nothing
+left for the companion model to disagree about. This is physically and numerically correct.
+
+In DP the state variables are complex envelopes of a carrier at the reference frequency
+$\omega_s$, and the instantaneous current can be reconstructed from them,
+
+```math
+i_k(t) = \mathrm{Re}\{ I_k(t) \, e^{j \omega_s t} \},
+```
+
+per phase for `DP::Ph3` and for the single envelope of `DP::Ph1`. This locates the current zero
+correctly. What it does not do is remove the transient: the history terms of the neighbouring
+inductors are expressed in the envelope, not in the instantaneous quantity, and they are not zero at
+that instant. The envelope itself still has to jump, and the trapezoidal companion model cannot
+follow it.
+
+{{% alert title="CurrentZero in DP is not EMT-like behaviour" color="warning" %}}
+The `CurrentZero` mode exists in DP and does find the correct instant, which is useful when the
+switching time itself is the quantity of interest. It does not deliver the continuity that the same
+mode gives in EMT, and the name invites that expectation. If you need continuous behaviour in DP,
+use the exponential mode below.
+{{% /alert %}}
+
+## Exponential ZCS emulation
+
+The alternative is to stop asking for a discontinuity at all. The switch resistance is moved
+continuously between its two values along a geometric path,
+
+```math
+R(\alpha) = R_{closed} \left( \frac{R_{open}}{R_{closed}} \right)^{\alpha}
+= \exp\!\big( \ln R_{closed} + \alpha \, ( \ln R_{open} - \ln R_{closed} ) \big),
+```
+
+with $\alpha$ advancing linearly in time over a switching duration $T_{sw}$ that is a model
+parameter. Opening runs $\alpha$ from $0$ to $1$, closing runs it from $1$ to $0$; both directions
+use the same law, so a switch configured this way is symmetric. Because the resistance stamped in a
+step is the one the *next* solve uses, $\alpha$ is evaluated at $t + \Delta t$.
+
+A geometric path rather than a linear one is what makes this work over nine decades of resistance: it
+spends comparable numbers of steps in each decade, so the change per step stays a bounded ratio
+instead of being negligible at first and violent at the end.
+
+As the name suggests, this is an emulation of zero-current switching, not an arc model. There is no
+physical arc voltage, no energy balance and no reignition. The parameter to choose is $T_{sw}$, and
+it should be long enough that the ramp covers several time steps and short enough to stay
+insignificant on the timescale being studied.
+
+The cost is that the system matrix changes on every step of the transition rather than once, so each
+of those steps requires a refactorisation. Both non-ideal modes therefore report
+`supportsPrecomputedSystemMatrices() == false` and take the variable-component path through the
+solver, while `Ideal` keeps the cheap precomputed two-state path.
+
+On closing, DP ZCS suppresses unrealistic transients, also based on companion models history
+terms. This also suppresses physically real closing inrush, so we still have only an
+approximation. EMT closing inrush is real, not an artifact.
+
+## Choosing a mode
+
+| Mode | Opening | Closing | Use it when |
+| --- | --- | --- | --- |
+| `Ideal` | immediate | immediate | the switching transient does not matter, or the branch carries no inductive current and feeds no capacitance |
+| `CurrentZero` | at the current zero | immediate | EMT, where it is the physically correct interruption; in DP only when the instant matters and the transient does not |
+| `ExponentialZCSEmulation` | ramped over $T_{sw}$ | ramped over $T_{sw}$ | the transient has to be absent, in particular for DP in either direction |
+
+The modes are available in `EMT::Ph3::Switch`, `DP::Ph3::Switch` and `DP::Ph1::Switch`. Every switch
+defaults to `Ideal`
 
 ## The variable-resistance switch
 
-The variable-resistance switch removes the oscillation by refusing to make the change in a single
-step. On opening, the resistance is multiplied by a fixed factor each step,
+`varResSwitch` (`DP::Ph1` and `SP::Ph1`) is the older, narrower form of the same idea. On opening it
+multiplies the resistance by a fixed factor each step,
 
 ```math
 R[k+1] = \alpha \, R[k], \qquad \alpha > 1,
 ```
 
-until it reaches the target open value, after which it is held there. The current therefore decays
-geometrically over several steps rather than being interrupted at once, which is close to what an
-arc does and which the trapezoidal companion model can follow without ringing.
+until it passes the target open value, after which it is held there. Closing is immediate by construction. The
+growth factor is derived from the step size, and the transition rewrites the configured
+$R_{open}$ / $R_{closed}$ attributes as it runs, so the duration is whatever the factor happens to
+produce rather than a value that is set.
 
-The growth factor is tied to the step size so that the transition covers a comparable interval of
-time rather than a comparable number of steps. Closing is not ramped: the resistance is taken
-straight to its closed value, because energising a path through a small resistance does not produce
-the same interruption problem.
-
-The cost is that the system matrix changes on every step of the transition rather than once, so each
-of those steps requires a refactorisation. The switch is worth its cost where the interruption is
-severe, typically a fault applied at a machine terminal or a transformer winding, and unnecessary
-for ordinary load switching.
+`ExponentialZCSEmulation` supersedes it: same geometric path, but with an explicit switching
+duration, without mutating the configured resistances, in both switching directions, and available
+in three-phase and EMT variants.
 
 ## Series switching
 

--- a/docs/hugo/content/en/docs/Developer Guide/Model Implementations/switches-and-loads.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Model Implementations/switches-and-loads.md
@@ -14,11 +14,47 @@ code. Availability per domain is in
 
 ## Switches
 
-`Switch` implements `Base::Ph1::Switch` and stamps one admittance chosen by `mIsClosed`, using
-`MNAStampUtils::stampAdmittance` so the grounded-terminal cases are handled centrally.
-`SeriesSwitch` folds a series resistance into the same branch.
+`Switch` implements `Base::Ph1::Switch` (or `Base::Ph3::Switch`) and stamps one admittance chosen by
+`mIsClosed`, using `MNAStampUtils::stampAdmittance` so the grounded-terminal cases are handled
+centrally. `SeriesSwitch` folds a series resistance into the same branch.
 
-`varResSwitch` additionally implements `MNAVariableCompInterface`, which is what allows it to change
+### Switching modes
+
+`EMT::Ph3::Switch`, `DP::Ph3::Switch` and `DP::Ph1::Switch` carry a `SwitchingMode` enum — `Ideal`,
+`CurrentZero`, `ExponentialZCSEmulation` — set through `setSwitchingMode()`, with
+`setZeroCrossingTolerance()` and `setExponentialSwitchingTime()` for the two non-ideal modes. The
+behaviour behind them is derived under [switches]({{< ref "/docs/Concepts/Models/switches.md" >}}).
+
+The distinction that runs through the implementation is **commanded state versus physical state**.
+`mIsClosed` is what the command asked for; `pole_closed_a/b/c` (`pole_closed` in `DP::Ph1`) is what
+the poles are actually doing, and `mnaIsClosed()` reports the commanded state only in `Ideal` mode
+and the pole state otherwise. `Base::Ph{1,3}::Switch::closeSwitch()` / `openSwitch()` are virtual for
+exactly this reason: the override records the command and lets the post-step decide when the poles
+follow. `Base::Ph1::Switch::close()` / `open()` are non-virtual delegates to them, so `SwitchEvent`
+and the Python bindings need no change.
+
+The non-ideal modes return `supportsPrecomputedSystemMatrices() == false` and drive the matrix
+through `MNAVariableCompInterface::hasParameterChanged()` instead — per pole in `CurrentZero`, per
+resistance value in `ExponentialZCSEmulation`, which means one refactorisation per step of the ramp.
+`effective_resistance_*` is the value actually stamped and is the attribute to log when debugging a
+transition; `exponential_progress`, `exponential_transition_active` and the start/end times are the
+rest of the diagnostics.
+
+{{% alert title="Watch out: the stamped resistance is one step ahead" color="warning" %}}
+`updateExponentialTransition()` evaluates the ramp at `time + mTimeStep`, because the resistance it
+writes is the one the *next* solve uses. `mTimeStep` is captured in `mnaCompInitialize`, so a switch
+that never went through MNA initialisation would ramp against a zero step size.
+{{% /alert %}}
+
+In DP, `reconstructInstantaneousCurrent()` restores the carrier removed by the DP formulation. Note
+the scaling asymmetry between the two DP variants: `DP::Ph3` envelopes are phase-peak and are built
+from power flow with `RMS3PH_TO_PEAK1PH`, while `DP::Ph1` keeps the power-flow scaling, so the
+reconstructed `i_instantaneous` of `DP::Ph1` is in envelope scaling. The zero-crossing instant does
+not depend on it, which is why the detection is shared.
+
+### varResSwitch
+
+`varResSwitch` also implements `MNAVariableCompInterface`, which is what allows it to change
 the system matrix during a run. Its `hasParameterChanged` is called each step and drives the
 transition:
 
@@ -37,6 +73,9 @@ wrong for any other.
 {{% /alert %}}
 
 Its `initializeFromNodesAndTerminals` carries a comment saying it is not used.
+
+New models should prefer `ExponentialZCSEmulation` on the plain `Switch`, which covers the same
+ground with a parameterised duration and without rewriting its own resistance attributes.
 
 ## Loads
 

--- a/dpsim-models/include/dpsim-models/Base/Base_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/Base/Base_Ph1_Switch.h
@@ -32,6 +32,8 @@ public:
         mClosedResistance(attributeList->create<Real>("R_closed")),
         mIsClosed(attributeList->create<Bool>("is_closed")){};
 
+  virtual ~Switch() = default;
+
   ///
   void setParameters(Real openResistance, Real closedResistance,
                      Bool closed = false) {
@@ -40,10 +42,22 @@ public:
     **mIsClosed = closed;
   }
 
+  /// Close command.
+  ///
+  /// Virtual so domain-specific breaker models can distinguish commanded
+  /// state from the physical pole state.
+  virtual void closeSwitch() { **mIsClosed = true; }
+
+  /// Open command.
+  ///
+  /// Virtual so current-zero breakers can remain physically conducting after
+  /// the command until the current reaches zero.
+  virtual void openSwitch() { **mIsClosed = false; }
+
   /// Close switch
-  void close() { **mIsClosed = true; }
+  void close() { closeSwitch(); }
   /// Open switch
-  void open() { **mIsClosed = false; }
+  void open() { openSwitch(); }
   /// Check if switch is closed
   Bool isClosed() { return **mIsClosed; }
 };

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Switch.h
@@ -22,55 +22,154 @@ namespace Ph1 {
 ///
 /// The switch can be opened and closed.
 /// Each state has a specific resistance value.
+///
+/// Switching modes:
+///
+/// - Ideal:
+///   conventional binary switch.
+///
+/// - CurrentZero:
+///   reconstruct the physical instantaneous current from the DP envelope,
+///
+///       i(t) = Re{ I(t) exp(j omega_s t) },
+///
+///   and open at its current zero.
+///
+/// - ExponentialZCSEmulation:
+///   increase the switch resistance continuously according to
+///
+///       R(t) = R_closed * (R_open/R_closed)^alpha,
+///
+///   alpha in [0,1], over a user-defined switching duration. This is the
+///   variable-resistance ZCS-emulation approach and is not an arc model.
 class Switch : public MNASimPowerComp<Complex>,
                public Base::Ph1::Switch,
                public SharedFactory<Switch>,
                public MNASwitchInterface,
                public MNAVariableCompInterface {
 public:
+  enum class SwitchingMode {
+    Ideal = 0,
+    CurrentZero = 1,
+    ExponentialZCSEmulation = 2,
+  };
+
+  const Attribute<Bool>::Ptr mOpeningRequested;
+
+  const Attribute<Bool>::Ptr mPoleClosed;
+
+  /// Reconstructed physical instantaneous current [A].
+  const Attribute<Real>::Ptr mInstantCurrent;
+
+  const Attribute<Real>::Ptr mZeroCrossingTime;
+
+  /// Exponential-transition diagnostics.
+  const Attribute<Bool>::Ptr mExponentialTransitionActive;
+  const Attribute<Real>::Ptr mExponentialProgress;
+  const Attribute<Real>::Ptr mExponentialTransitionStartTime;
+  const Attribute<Real>::Ptr mExponentialTransitionEndTime;
+
+  /// Effective resistance currently stamped into the MNA matrix [ohm].
+  const Attribute<Real>::Ptr mEffectiveResistance;
+
   /// Defines UID, name, component parameters and logging level
   Switch(String uid, String name, Logger::Level loglevel = Logger::Level::off);
   /// Defines name, component parameters and logging level
   Switch(String name, Logger::Level logLevel = Logger::Level::off)
       : Switch(name, name, logLevel) {}
 
-  SimPowerComp<Complex>::Ptr clone(String name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
+
+  void setSwitchingMode(SwitchingMode mode);
+  SwitchingMode switchingMode() const { return mSwitchingMode; }
+
+  void setZeroCrossingTolerance(Real tolerance);
+
+  void setExponentialSwitchingTime(Real switchingTime);
+  Real exponentialSwitchingTime() const { return mExponentialSwitchingTime; }
+
+  void openSwitch() override;
+  void closeSwitch() override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### General MNA section ####
   void mnaCompInitialize(Real omega, Real timeStep,
-                         Attribute<Matrix>::Ptr leftVector);
+                         Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix);
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   /// Stamps right side (source) vector
-  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector);
+  void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
   /// Update interface voltage from MNA system result
-  void mnaCompUpdateVoltage(const Matrix &leftVector);
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
   /// Update interface current from MNA system result
-  void mnaCompUpdateCurrent(const Matrix &leftVector);
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
   /// MNA post step operations
   void mnaCompPostStep(Real time, Int timeStepCount,
-                       Attribute<Matrix>::Ptr &leftVector);
+                       Attribute<Matrix>::Ptr &leftVector) override;
   /// Add MNA post step dependencies
   void
   mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
                                  AttributeBase::List &attributeDependencies,
                                  AttributeBase::List &modifiedAttributes,
-                                 Attribute<Matrix>::Ptr &leftVector);
+                                 Attribute<Matrix>::Ptr &leftVector) override;
 
   // #### MNA section for switch ####
   /// Check if switch is closed
-  Bool mnaIsClosed();
+  Bool mnaIsClosed() override;
   /// Stamps system matrix considering the defined switch position
   void mnaCompApplySwitchSystemMatrixStamp(Bool closed,
                                            SparseMatrixRow &systemMatrix,
-                                           Int freqIdx);
+                                           Int freqIdx) override;
+
+  Bool supportsPrecomputedSystemMatrices() const override;
 
   // #### MNA section for variable component ####
-  Bool hasParameterChanged();
+  Bool hasParameterChanged() override;
+
+private:
+  SwitchingMode mSwitchingMode = SwitchingMode::Ideal;
+
+  Real mZeroCrossingTolerance = 1e-6;
+  Real mExponentialSwitchingTime = 0.01;
+  Real mTimeStep = 0.0;
+
+  /// Reference-frame angular frequency supplied by the solver [rad/s].
+  Real mShiftOmega = 0.0;
+
+  Bool mPoleClosedPrev = false;
+  Real mEffectiveResistancePrev = 0.0;
+
+  Real mPreviousInstantaneousCurrent = 0.0;
+  Real mPreviousCurrentTime = 0.0;
+  Bool mPreviousCurrentValid = false;
+
+  Bool mResetZeroCrossingHistory = false;
+  Bool mExponentialTransitionStarted = false;
+
+  void setPoleClosed(Bool closed);
+
+  void resetZeroCrossingTime();
+
+  void synchronizeEffectiveResistance(Bool closed);
+
+  void resetExponentialTransition();
+  void validateExponentialResistanceParameters() const;
+  Real exponentialResistance(Real alpha) const;
+  void updateExponentialTransition(Real time);
+
+  Complex currentConductance() const;
+
+  Real reconstructInstantaneousCurrent(Real time) const;
+
+  Bool currentCrossedZero(Real previousCurrent, Real current) const;
+
+  Real interpolateZeroCrossingTime(Real previousCurrent, Real current,
+                                   Real previousTime, Real currentTime) const;
+
+  void updateZeroCrossingState(Real time);
 };
 } // namespace Ph1
 } // namespace DP

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Switch.h
@@ -40,7 +40,9 @@ namespace Ph1 {
 ///
 ///       R(t) = R_closed * (R_open/R_closed)^alpha,
 ///
-///   alpha in [0,1], over a user-defined switching duration. This is the
+///   alpha in [0,1], over a user-defined switching duration. Opening runs
+///   alpha from 0 to 1, closing runs it from 1 to 0, since the envelope
+///   cannot represent a discontinuity in either direction. This is the
 ///   variable-resistance ZCS-emulation approach and is not an arc model.
 class Switch : public MNASimPowerComp<Complex>,
                public Base::Ph1::Switch,
@@ -65,6 +67,10 @@ public:
 
   /// Exponential-transition diagnostics.
   const Attribute<Bool>::Ptr mExponentialTransitionActive;
+  /// True while the active exponential transition is a closing transition.
+  const Attribute<Bool>::Ptr mExponentialTransitionClosing;
+  /// Position on the resistance path, 0 at R_closed and 1 at R_open. Runs
+  /// 0 -> 1 while opening and 1 -> 0 while closing.
   const Attribute<Real>::Ptr mExponentialProgress;
   const Attribute<Real>::Ptr mExponentialTransitionStartTime;
   const Attribute<Real>::Ptr mExponentialTransitionEndTime;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_Switch.h
@@ -36,7 +36,9 @@ namespace Ph3 {
 ///
 ///       R(t) = R_closed * (R_open/R_closed)^alpha,
 ///
-///   alpha in [0,1], over a user-defined switching duration. This is the
+///   alpha in [0,1], over a user-defined switching duration. Opening runs
+///   alpha from 0 to 1, closing runs it from 1 to 0, since the envelope
+///   cannot represent a discontinuity in either direction. This is the
 ///   variable-resistance ZCS-emulation approach and is not an arc model.
 class Switch : public MNASimPowerComp<Complex>,
                public Base::Ph3::Switch,
@@ -67,6 +69,10 @@ public:
 
   /// Exponential-transition diagnostics.
   const Attribute<Bool>::Ptr mExponentialTransitionActive;
+  /// True while the active exponential transition is a closing transition.
+  const Attribute<Bool>::Ptr mExponentialTransitionClosing;
+  /// Position on the resistance path, 0 at R_closed and 1 at R_open. Runs
+  /// 0 -> 1 while opening and 1 -> 0 while closing.
   const Attribute<Real>::Ptr mExponentialProgress;
   const Attribute<Real>::Ptr mExponentialTransitionStartTime;
   const Attribute<Real>::Ptr mExponentialTransitionEndTime;

--- a/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/EMT/EMT_Ph3_Switch.h
@@ -68,6 +68,10 @@ public:
 
   /// Exponential-transition diagnostics.
   const Attribute<Bool>::Ptr mExponentialTransitionActive;
+  /// True while the active exponential transition is a closing transition.
+  const Attribute<Bool>::Ptr mExponentialTransitionClosing;
+  /// Position on the resistance path, 0 at R_closed and 1 at R_open. Runs
+  /// 0 -> 1 while opening and 1 -> 0 while closing.
   const Attribute<Real>::Ptr mExponentialProgress;
   const Attribute<Real>::Ptr mExponentialTransitionStartTime;
   const Attribute<Real>::Ptr mExponentialTransitionEndTime;
@@ -92,7 +96,7 @@ public:
   void setZeroCrossingTolerance(Real tolerance);
   Real zeroCrossingTolerance() const { return mZeroCrossingTolerance; }
 
-  /// Set total opening transition time for ExponentialZCSEmulation [s].
+  /// Set total transition time for ExponentialZCSEmulation [s].
   void setExponentialSwitchingTime(Real switchingTime);
   Real exponentialSwitchingTime() const { return mExponentialSwitchingTime; }
 
@@ -108,7 +112,14 @@ public:
   ///   arm a simultaneous three-phase exponential resistance increase.
   void openSwitch() override;
 
-  /// Closing is instantaneous for all modes in this implementation.
+  /// Close command.
+  ///
+  /// Ideal and CurrentZero:
+  ///   all poles close immediately. There is no current zero to wait for when
+  ///   energising a branch.
+  ///
+  /// ExponentialZCSEmulation:
+  ///   arm a simultaneous three-phase exponential resistance decrease.
   void closeSwitch() override;
 
   // #### General ####

--- a/dpsim-models/src/DP/DP_Ph1_Switch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Switch.cpp
@@ -6,22 +6,143 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *********************************************************************************/
 
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
 #include <dpsim-models/DP/DP_Ph1_Switch.h>
 
 using namespace CPS;
 
 DP::Ph1::Switch::Switch(String uid, String name, Logger::Level logLevel)
     : MNASimPowerComp<Complex>(uid, name, false, true, logLevel),
-      Base::Ph1::Switch(mAttributes) {
+      Base::Ph1::Switch(mAttributes),
+      mOpeningRequested(mAttributes->create<Bool>("opening_requested")),
+      mPoleClosed(mAttributes->create<Bool>("pole_closed")),
+      mInstantCurrent(mAttributes->create<Real>("i_instantaneous")),
+      mZeroCrossingTime(mAttributes->create<Real>("zero_crossing_time")),
+      mExponentialTransitionActive(
+          mAttributes->create<Bool>("exponential_transition_active")),
+      mExponentialProgress(mAttributes->create<Real>("exponential_progress")),
+      mExponentialTransitionStartTime(
+          mAttributes->create<Real>("exponential_transition_start_time")),
+      mExponentialTransitionEndTime(
+          mAttributes->create<Real>("exponential_transition_end_time")),
+      mEffectiveResistance(mAttributes->create<Real>("effective_resistance")) {
   setTerminalNumber(2);
   **mIntfVoltage = MatrixComp::Zero(1, 1);
   **mIntfCurrent = MatrixComp::Zero(1, 1);
+
+  **mOpeningRequested = false;
+  **mPoleClosed = false;
+
+  **mInstantCurrent = 0.0;
+
+  resetZeroCrossingTime();
+
+  **mExponentialTransitionActive = false;
+  **mExponentialProgress = 0.0;
+  **mExponentialTransitionStartTime = -1.0;
+  **mExponentialTransitionEndTime = -1.0;
+  **mEffectiveResistance = 0.0;
 }
 
 SimPowerComp<Complex>::Ptr DP::Ph1::Switch::clone(String name) {
   auto copy = Switch::make(name, mLogLevel);
   copy->setParameters(**mOpenResistance, **mClosedResistance, **mIsClosed);
+  copy->setSwitchingMode(mSwitchingMode);
+  copy->setZeroCrossingTolerance(mZeroCrossingTolerance);
+  copy->setExponentialSwitchingTime(mExponentialSwitchingTime);
   return copy;
+}
+
+void DP::Ph1::Switch::setSwitchingMode(SwitchingMode mode) {
+  mSwitchingMode = mode;
+
+  **mPoleClosed = **mIsClosed;
+  **mOpeningRequested = false;
+  resetZeroCrossingTime();
+
+  mPreviousCurrentValid = false;
+  mResetZeroCrossingHistory = false;
+
+  resetExponentialTransition();
+  synchronizeEffectiveResistance(**mIsClosed);
+}
+
+void DP::Ph1::Switch::setZeroCrossingTolerance(Real tolerance) {
+  if (tolerance < 0.0) {
+    throw std::invalid_argument(
+        "DP::Ph1::Switch zero-crossing tolerance must be non-negative.");
+  }
+
+  mZeroCrossingTolerance = tolerance;
+}
+
+void DP::Ph1::Switch::setExponentialSwitchingTime(Real switchingTime) {
+  if (switchingTime <= 0.0) {
+    throw std::invalid_argument(
+        "DP::Ph1::Switch exponential switching time must be positive.");
+  }
+
+  mExponentialSwitchingTime = switchingTime;
+}
+
+void DP::Ph1::Switch::openSwitch() {
+  Base::Ph1::Switch::openSwitch();
+
+  if (mSwitchingMode == SwitchingMode::Ideal) {
+    **mOpeningRequested = false;
+    **mPoleClosed = false;
+    resetZeroCrossingTime();
+    resetExponentialTransition();
+    synchronizeEffectiveResistance(false);
+    return;
+  }
+
+  if (!**mPoleClosed) {
+    **mOpeningRequested = false;
+    return;
+  }
+
+  if (mSwitchingMode == SwitchingMode::CurrentZero) {
+    **mOpeningRequested = true;
+    resetZeroCrossingTime();
+    resetExponentialTransition();
+    mResetZeroCrossingHistory = true;
+
+    SPDLOG_LOGGER_INFO(mSLog,
+                       "DP current-zero opening command received. "
+                       "Waiting for the reconstructed physical current zero.");
+    return;
+  }
+
+  validateExponentialResistanceParameters();
+  **mOpeningRequested = true;
+  resetZeroCrossingTime();
+  resetExponentialTransition();
+  **mExponentialTransitionActive = true;
+  synchronizeEffectiveResistance(true);
+  **mPoleClosed = true;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "DP exponential ZCS-emulation opening command received. "
+                     "Switching duration={:.6e}s.",
+                     mExponentialSwitchingTime);
+}
+
+void DP::Ph1::Switch::closeSwitch() {
+  Base::Ph1::Switch::closeSwitch();
+
+  **mOpeningRequested = false;
+  **mPoleClosed = true;
+  resetZeroCrossingTime();
+  mResetZeroCrossingHistory = false;
+
+  resetExponentialTransition();
+  synchronizeEffectiveResistance(true);
+
+  SPDLOG_LOGGER_INFO(mSLog, "DP switch closing command: pole closed.");
 }
 
 void DP::Ph1::Switch::initializeFromNodesAndTerminals(Real frequency) {
@@ -30,37 +151,73 @@ void DP::Ph1::Switch::initializeFromNodesAndTerminals(Real frequency) {
   (**mIntfVoltage)(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
   (**mIntfCurrent)(0, 0) = (**mIntfVoltage)(0, 0) / impedance;
 
+  // Power-flow initialization defines the initial physical breaker state.
+  **mPoleClosed = **mIsClosed;
+  **mOpeningRequested = false;
+  resetZeroCrossingTime();
+  resetExponentialTransition();
+  synchronizeEffectiveResistance(**mIsClosed);
+
   SPDLOG_LOGGER_INFO(mSLog,
                      "\n--- Initialization from powerflow ---"
                      "\nVoltage across: {:s}"
                      "\nCurrent: {:s}"
                      "\nTerminal 0 voltage: {:s}"
                      "\nTerminal 1 voltage: {:s}"
+                     "\nSwitching mode: {:s}"
+                     "\nInitial breaker state: {:s}"
                      "\n--- Initialization from powerflow finished ---",
                      Logger::phasorToString((**mIntfVoltage)(0, 0)),
                      Logger::phasorToString((**mIntfCurrent)(0, 0)),
                      Logger::phasorToString(initialSingleVoltage(0)),
-                     Logger::phasorToString(initialSingleVoltage(1)));
+                     Logger::phasorToString(initialSingleVoltage(1)),
+                     mSwitchingMode == SwitchingMode::Ideal
+                         ? "Ideal"
+                         : (mSwitchingMode == SwitchingMode::CurrentZero
+                                ? "CurrentZero"
+                                : "ExponentialZCSEmulation"),
+                     **mIsClosed ? "closed" : "open");
 }
 
 void DP::Ph1::Switch::mnaCompInitialize(Real omega, Real timeStep,
                                         Attribute<Matrix>::Ptr leftVector) {
   updateMatrixNodeIndices();
+  mTimeStep = timeStep;
   **mRightVector = Matrix::Zero(0, 0);
+
+  // omega is the DP reference-frame angular frequency supplied by the solver.
+  mShiftOmega = omega;
+
+  // Final safeguard in case setSwitchingMode() was called before setParameters().
+  **mPoleClosed = **mIsClosed;
+  synchronizeEffectiveResistance(**mIsClosed);
+  resetExponentialTransition();
+
+  mPoleClosedPrev = **mPoleClosed;
+  mIsClosedPrev = **mIsClosed;
+
+  **mInstantCurrent = reconstructInstantaneousCurrent(0.0);
+
+  mPreviousInstantaneousCurrent = **mInstantCurrent;
+  mEffectiveResistancePrev = **mEffectiveResistance;
+
+  mPreviousCurrentTime = 0.0;
+  mPreviousCurrentValid = true;
+  mResetZeroCrossingHistory = false;
 }
 
 void DP::Ph1::Switch::mnaCompApplySystemMatrixStamp(
     SparseMatrixRow &systemMatrix) {
-  Complex conductance = (**mIsClosed) ? Complex(1. / **mClosedResistance, 0)
-                                      : Complex(1. / **mOpenResistance, 0);
-
-  MNAStampUtils::stampAdmittance(conductance, systemMatrix, matrixNodeIndex(0),
-                                 matrixNodeIndex(1), terminalNotGrounded(0),
-                                 terminalNotGrounded(1), mSLog);
+  MNAStampUtils::stampAdmittance(currentConductance(), systemMatrix,
+                                 matrixNodeIndex(0), matrixNodeIndex(1),
+                                 terminalNotGrounded(0), terminalNotGrounded(1),
+                                 mSLog);
 }
 
 void DP::Ph1::Switch::mnaCompApplySwitchSystemMatrixStamp(
     Bool closed, SparseMatrixRow &systemMatrix, Int freqIdx) {
+  // Conventional precomputed two-state path. The CurrentZero and exponential
+  // modes bypass this by returning supportsPrecomputedSystemMatrices() == false.
   Complex conductance = (closed) ? Complex(1. / **mClosedResistance, 0)
                                  : Complex(1. / **mOpenResistance, 0);
 
@@ -71,7 +228,16 @@ void DP::Ph1::Switch::mnaCompApplySwitchSystemMatrixStamp(
 
 void DP::Ph1::Switch::mnaCompApplyRightSideVectorStamp(Matrix &rightVector) {}
 
-Bool DP::Ph1::Switch::mnaIsClosed() { return isClosed(); }
+Bool DP::Ph1::Switch::mnaIsClosed() {
+  if (mSwitchingMode == SwitchingMode::Ideal)
+    return **mIsClosed;
+
+  return **mPoleClosed;
+}
+
+Bool DP::Ph1::Switch::supportsPrecomputedSystemMatrices() const {
+  return mSwitchingMode == SwitchingMode::Ideal;
+}
 
 void DP::Ph1::Switch::mnaCompUpdateVoltage(const Matrix &leftVector) {
   // Voltage across component is defined as V1 - V0
@@ -86,9 +252,7 @@ void DP::Ph1::Switch::mnaCompUpdateVoltage(const Matrix &leftVector) {
 }
 
 void DP::Ph1::Switch::mnaCompUpdateCurrent(const Matrix &leftVector) {
-  (**mIntfCurrent)(0, 0) = (**mIsClosed)
-                               ? (**mIntfVoltage)(0, 0) / **mClosedResistance
-                               : (**mIntfVoltage)(0, 0) / **mOpenResistance;
+  (**mIntfCurrent)(0, 0) = currentConductance() * (**mIntfVoltage)(0, 0);
 }
 
 void DP::Ph1::Switch::mnaCompAddPostStepDependencies(
@@ -100,20 +264,243 @@ void DP::Ph1::Switch::mnaCompAddPostStepDependencies(
   attributeDependencies.push_back(leftVector);
   modifiedAttributes.push_back(mIntfVoltage);
   modifiedAttributes.push_back(mIntfCurrent);
+
+  modifiedAttributes.push_back(mOpeningRequested);
+  modifiedAttributes.push_back(mPoleClosed);
+
+  modifiedAttributes.push_back(mInstantCurrent);
+  modifiedAttributes.push_back(mZeroCrossingTime);
+
+  modifiedAttributes.push_back(mExponentialTransitionActive);
+  modifiedAttributes.push_back(mExponentialProgress);
+  modifiedAttributes.push_back(mExponentialTransitionStartTime);
+  modifiedAttributes.push_back(mExponentialTransitionEndTime);
+  modifiedAttributes.push_back(mEffectiveResistance);
 }
 
 void DP::Ph1::Switch::mnaCompPostStep(Real time, Int timeStepCount,
                                       Attribute<Matrix>::Ptr &leftVector) {
   mnaCompUpdateVoltage(**leftVector);
   mnaCompUpdateCurrent(**leftVector);
+
+  **mInstantCurrent = reconstructInstantaneousCurrent(time);
+
+  if (mSwitchingMode == SwitchingMode::CurrentZero) {
+    updateZeroCrossingState(time);
+  } else if (mSwitchingMode == SwitchingMode::ExponentialZCSEmulation) {
+    updateExponentialTransition(time);
+  }
 }
 
 Bool DP::Ph1::Switch::hasParameterChanged() {
-  // Check if state of switch changed
-  if (!(mIsClosedPrev == this->mnaIsClosed())) {
-    mIsClosedPrev = this->mnaIsClosed();
-    return 1; //recompute system matrix
-  } else {
-    return 0; // do not recompute system matrix
+  if (mSwitchingMode == SwitchingMode::Ideal) {
+    // Check if state of switch changed
+    if (mIsClosedPrev != **mIsClosed) {
+      mIsClosedPrev = **mIsClosed;
+      return true; //recompute system matrix
+    }
+
+    return false; // do not recompute system matrix
   }
-};
+
+  if (mSwitchingMode == SwitchingMode::ExponentialZCSEmulation) {
+    if (**mEffectiveResistance != mEffectiveResistancePrev) {
+      mEffectiveResistancePrev = **mEffectiveResistance;
+      return true;
+    }
+
+    return false;
+  }
+
+  if (**mPoleClosed != mPoleClosedPrev) {
+    mPoleClosedPrev = **mPoleClosed;
+    return true;
+  }
+
+  return false;
+}
+
+void DP::Ph1::Switch::setPoleClosed(Bool closed) {
+  **mPoleClosed = closed;
+
+  // Keep the resistance diagnostics synchronized with the discrete
+  // CurrentZero pole state. Exponential mode manages R(t) independently.
+  if (mSwitchingMode == SwitchingMode::CurrentZero)
+    synchronizeEffectiveResistance(closed);
+}
+
+void DP::Ph1::Switch::resetZeroCrossingTime() { **mZeroCrossingTime = -1.0; }
+
+void DP::Ph1::Switch::synchronizeEffectiveResistance(Bool closed) {
+  **mEffectiveResistance = closed ? **mClosedResistance : **mOpenResistance;
+}
+
+void DP::Ph1::Switch::resetExponentialTransition() {
+  **mExponentialTransitionActive = false;
+  **mExponentialProgress = 0.0;
+  **mExponentialTransitionStartTime = -1.0;
+  **mExponentialTransitionEndTime = -1.0;
+  mExponentialTransitionStarted = false;
+}
+
+void DP::Ph1::Switch::validateExponentialResistanceParameters() const {
+  if (mExponentialSwitchingTime <= 0.0) {
+    throw std::invalid_argument(
+        "DP::Ph1::Switch exponential switching time must be positive.");
+  }
+
+  if (**mClosedResistance <= 0.0 || **mOpenResistance <= 0.0) {
+    throw std::invalid_argument("DP::Ph1::Switch exponential mode requires "
+                                "positive open and closed resistances.");
+  }
+}
+
+Real DP::Ph1::Switch::exponentialResistance(Real alpha) const {
+  const Real rClosed = **mClosedResistance;
+  const Real rOpen = **mOpenResistance;
+  const Real boundedAlpha = std::max(0.0, std::min(1.0, alpha));
+
+  return std::exp(std::log(rClosed) +
+                  boundedAlpha * (std::log(rOpen) - std::log(rClosed)));
+}
+
+void DP::Ph1::Switch::updateExponentialTransition(Real time) {
+  if (!**mExponentialTransitionActive)
+    return;
+
+  if (!mExponentialTransitionStarted) {
+    mExponentialTransitionStarted = true;
+    **mExponentialTransitionStartTime = time;
+    **mExponentialTransitionEndTime = time + mExponentialSwitchingTime;
+  }
+
+  const Real targetTime = time + mTimeStep;
+  const Real alpha = (targetTime - **mExponentialTransitionStartTime) /
+                     mExponentialSwitchingTime;
+  const Real boundedAlpha = std::max(0.0, std::min(1.0, alpha));
+
+  **mExponentialProgress = boundedAlpha;
+  **mEffectiveResistance = exponentialResistance(boundedAlpha);
+
+  if (boundedAlpha >= 1.0) {
+    synchronizeEffectiveResistance(false);
+    **mPoleClosed = false;
+    **mOpeningRequested = false;
+    **mExponentialTransitionActive = false;
+
+    SPDLOG_LOGGER_INFO(
+        mSLog,
+        "DP exponential ZCS-emulation opening completed: start={:.9f}s, "
+        "end={:.9f}s, duration={:.6e}s.",
+        **mExponentialTransitionStartTime, **mExponentialTransitionEndTime,
+        mExponentialSwitchingTime);
+  }
+}
+
+Complex DP::Ph1::Switch::currentConductance() const {
+  if (mSwitchingMode == SwitchingMode::Ideal) {
+    return (**mIsClosed) ? Complex(1. / **mClosedResistance, 0)
+                         : Complex(1. / **mOpenResistance, 0);
+  }
+
+  if (mSwitchingMode == SwitchingMode::CurrentZero) {
+    return (**mPoleClosed) ? Complex(1. / **mClosedResistance, 0)
+                           : Complex(1. / **mOpenResistance, 0);
+  }
+
+  return Complex(1. / **mEffectiveResistance, 0);
+}
+
+Real DP::Ph1::Switch::reconstructInstantaneousCurrent(Real time) const {
+  // Restore the reference-frequency carrier removed by the DP formulation.
+  // DP::Ph1 envelopes keep the power-flow amplitude scaling, so no RMS-to-peak
+  // conversion is applied here; the zero crossing instant does not depend on it.
+  const Complex carrier = std::polar<Real>(1.0, mShiftOmega * time);
+
+  return std::real((**mIntfCurrent)(0, 0) * carrier);
+}
+
+Bool DP::Ph1::Switch::currentCrossedZero(Real previousCurrent,
+                                         Real current) const {
+  if (std::abs(current) <= mZeroCrossingTolerance)
+    return true;
+
+  return (previousCurrent > mZeroCrossingTolerance &&
+          current < -mZeroCrossingTolerance) ||
+         (previousCurrent < -mZeroCrossingTolerance &&
+          current > mZeroCrossingTolerance);
+}
+
+Real DP::Ph1::Switch::interpolateZeroCrossingTime(Real previousCurrent,
+                                                  Real current,
+                                                  Real previousTime,
+                                                  Real currentTime) const {
+  const Real denominator = std::abs(previousCurrent) + std::abs(current);
+
+  if (denominator <= mZeroCrossingTolerance)
+    return currentTime;
+
+  const Real fraction = std::abs(previousCurrent) / denominator;
+
+  return previousTime + fraction * (currentTime - previousTime);
+}
+
+void DP::Ph1::Switch::updateZeroCrossingState(Real time) {
+  const Real current = **mInstantCurrent;
+
+  // Keep a current history while no opening command is active.
+  if (!**mOpeningRequested) {
+    mPreviousInstantaneousCurrent = current;
+    mPreviousCurrentTime = time;
+    mPreviousCurrentValid = true;
+    return;
+  }
+
+  // First post-command sample: do not compare against the pre-command sample.
+  if (mResetZeroCrossingHistory || !mPreviousCurrentValid) {
+    if (**mPoleClosed && std::abs(current) <= mZeroCrossingTolerance) {
+      setPoleClosed(false);
+      **mZeroCrossingTime = time;
+
+      SPDLOG_LOGGER_INFO(mSLog,
+                         "DP pole opened at sampled physical current zero: "
+                         "t={:.9f}s, i={:.6e}A",
+                         time, current);
+    }
+
+    mPreviousInstantaneousCurrent = current;
+    mPreviousCurrentTime = time;
+    mPreviousCurrentValid = true;
+    mResetZeroCrossingHistory = false;
+
+    if (!**mPoleClosed)
+      **mOpeningRequested = false;
+
+    return;
+  }
+
+  if (**mPoleClosed &&
+      currentCrossedZero(mPreviousInstantaneousCurrent, current)) {
+    const Real zeroTime = interpolateZeroCrossingTime(
+        mPreviousInstantaneousCurrent, current, mPreviousCurrentTime, time);
+
+    setPoleClosed(false);
+    **mZeroCrossingTime = zeroTime;
+
+    SPDLOG_LOGGER_INFO(mSLog,
+                       "DP physical current zero detected: "
+                       "t_z={:.9f}s, i_prev={:.6e}A, i={:.6e}A. Pole opened.",
+                       zeroTime, mPreviousInstantaneousCurrent, current);
+  }
+
+  mPreviousInstantaneousCurrent = current;
+  mPreviousCurrentTime = time;
+  mPreviousCurrentValid = true;
+
+  if (!**mPoleClosed) {
+    **mOpeningRequested = false;
+
+    SPDLOG_LOGGER_INFO(mSLog, "DP current-zero interruption completed: "
+                              "the breaker pole is open.");
+  }
+}

--- a/dpsim-models/src/DP/DP_Ph1_Switch.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Switch.cpp
@@ -23,6 +23,8 @@ DP::Ph1::Switch::Switch(String uid, String name, Logger::Level logLevel)
       mZeroCrossingTime(mAttributes->create<Real>("zero_crossing_time")),
       mExponentialTransitionActive(
           mAttributes->create<Bool>("exponential_transition_active")),
+      mExponentialTransitionClosing(
+          mAttributes->create<Bool>("exponential_transition_closing")),
       mExponentialProgress(mAttributes->create<Real>("exponential_progress")),
       mExponentialTransitionStartTime(
           mAttributes->create<Real>("exponential_transition_start_time")),
@@ -41,6 +43,7 @@ DP::Ph1::Switch::Switch(String uid, String name, Logger::Level logLevel)
   resetZeroCrossingTime();
 
   **mExponentialTransitionActive = false;
+  **mExponentialTransitionClosing = false;
   **mExponentialProgress = 0.0;
   **mExponentialTransitionStartTime = -1.0;
   **mExponentialTransitionEndTime = -1.0;
@@ -91,6 +94,20 @@ void DP::Ph1::Switch::setExponentialSwitchingTime(Real switchingTime) {
 void DP::Ph1::Switch::openSwitch() {
   Base::Ph1::Switch::openSwitch();
 
+  // An opening command during a closing ramp abandons that ramp. The pole is
+  // still open at that point, so the switch simply stays open.
+  if (**mExponentialTransitionActive && **mExponentialTransitionClosing) {
+    resetExponentialTransition();
+    **mPoleClosed = false;
+    synchronizeEffectiveResistance(false);
+    **mOpeningRequested = false;
+
+    SPDLOG_LOGGER_INFO(mSLog,
+                       "DP opening command received during an exponential "
+                       "closing transition. Transition abandoned.");
+    return;
+  }
+
   if (mSwitchingMode == SwitchingMode::Ideal) {
     **mOpeningRequested = false;
     **mPoleClosed = false;
@@ -135,14 +152,40 @@ void DP::Ph1::Switch::closeSwitch() {
   Base::Ph1::Switch::closeSwitch();
 
   **mOpeningRequested = false;
-  **mPoleClosed = true;
   resetZeroCrossingTime();
   mResetZeroCrossingHistory = false;
 
-  resetExponentialTransition();
-  synchronizeEffectiveResistance(true);
+  if (mSwitchingMode != SwitchingMode::ExponentialZCSEmulation) {
+    **mPoleClosed = true;
+    resetExponentialTransition();
+    synchronizeEffectiveResistance(true);
 
-  SPDLOG_LOGGER_INFO(mSLog, "DP switch closing command: pole closed.");
+    SPDLOG_LOGGER_INFO(mSLog, "DP switch closing command: pole closed.");
+    return;
+  }
+
+  if (**mPoleClosed && !**mExponentialTransitionActive) {
+    resetExponentialTransition();
+    synchronizeEffectiveResistance(true);
+    return;
+  }
+
+  // Energising a branch is the mirror image of interrupting it: the same
+  // resistance path is traversed from R_open towards R_closed. The DP envelope
+  // cannot represent the voltage step across a capacitance any more than it can
+  // represent an interrupted inductive current, so closing is ramped as well.
+  validateExponentialResistanceParameters();
+  resetExponentialTransition();
+  **mExponentialTransitionActive = true;
+  **mExponentialTransitionClosing = true;
+  **mExponentialProgress = 1.0;
+  synchronizeEffectiveResistance(false);
+  **mPoleClosed = false;
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "DP exponential ZCS-emulation closing command received. "
+                     "Switching duration={:.6e}s.",
+                     mExponentialSwitchingTime);
 }
 
 void DP::Ph1::Switch::initializeFromNodesAndTerminals(Real frequency) {
@@ -272,6 +315,7 @@ void DP::Ph1::Switch::mnaCompAddPostStepDependencies(
   modifiedAttributes.push_back(mZeroCrossingTime);
 
   modifiedAttributes.push_back(mExponentialTransitionActive);
+  modifiedAttributes.push_back(mExponentialTransitionClosing);
   modifiedAttributes.push_back(mExponentialProgress);
   modifiedAttributes.push_back(mExponentialTransitionStartTime);
   modifiedAttributes.push_back(mExponentialTransitionEndTime);
@@ -337,6 +381,7 @@ void DP::Ph1::Switch::synchronizeEffectiveResistance(Bool closed) {
 
 void DP::Ph1::Switch::resetExponentialTransition() {
   **mExponentialTransitionActive = false;
+  **mExponentialTransitionClosing = false;
   **mExponentialProgress = 0.0;
   **mExponentialTransitionStartTime = -1.0;
   **mExponentialTransitionEndTime = -1.0;
@@ -375,25 +420,31 @@ void DP::Ph1::Switch::updateExponentialTransition(Real time) {
   }
 
   const Real targetTime = time + mTimeStep;
-  const Real alpha = (targetTime - **mExponentialTransitionStartTime) /
-                     mExponentialSwitchingTime;
-  const Real boundedAlpha = std::max(0.0, std::min(1.0, alpha));
+  const Real elapsed = (targetTime - **mExponentialTransitionStartTime) /
+                       mExponentialSwitchingTime;
+  const Real boundedElapsed = std::max(0.0, std::min(1.0, elapsed));
 
-  **mExponentialProgress = boundedAlpha;
-  **mEffectiveResistance = exponentialResistance(boundedAlpha);
+  const Bool closing = **mExponentialTransitionClosing;
 
-  if (boundedAlpha >= 1.0) {
-    synchronizeEffectiveResistance(false);
-    **mPoleClosed = false;
+  // alpha is the position on the resistance path: 0 at R_closed, 1 at R_open.
+  const Real alpha = closing ? 1.0 - boundedElapsed : boundedElapsed;
+
+  **mExponentialProgress = alpha;
+  **mEffectiveResistance = exponentialResistance(alpha);
+
+  if (boundedElapsed >= 1.0) {
+    synchronizeEffectiveResistance(closing);
+    **mPoleClosed = closing;
     **mOpeningRequested = false;
     **mExponentialTransitionActive = false;
+    **mExponentialTransitionClosing = false;
 
     SPDLOG_LOGGER_INFO(
         mSLog,
-        "DP exponential ZCS-emulation opening completed: start={:.9f}s, "
+        "DP exponential ZCS-emulation {:s} completed: start={:.9f}s, "
         "end={:.9f}s, duration={:.6e}s.",
-        **mExponentialTransitionStartTime, **mExponentialTransitionEndTime,
-        mExponentialSwitchingTime);
+        closing ? "closing" : "opening", **mExponentialTransitionStartTime,
+        **mExponentialTransitionEndTime, mExponentialSwitchingTime);
   }
 }
 

--- a/dpsim-models/src/DP/DP_Ph3_Capacitor.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_Capacitor.cpp
@@ -42,14 +42,29 @@ void DP::Ph3::Capacitor::initializeFromNodesAndTerminals(Real frequency) {
       Complex(0, omega * (**mCapacitance)(2, 1)),
       Complex(0, omega * (**mCapacitance)(2, 2));
 
-  // IntfVoltage initialization for each phase
-  (**mIntfVoltage)(0, 0) = initialSingleVoltage(1) - initialSingleVoltage(0);
-  Real voltMag = Math::abs((**mIntfVoltage)(0, 0));
-  Real voltPhase = Math::phase((**mIntfVoltage)(0, 0));
-  (**mIntfVoltage)(1, 0) = Complex(voltMag * cos(voltPhase - 2. / 3. * M_PI),
-                                   voltMag * sin(voltPhase - 2. / 3. * M_PI));
-  (**mIntfVoltage)(2, 0) = Complex(voltMag * cos(voltPhase + 2. / 3. * M_PI),
-                                   voltMag * sin(voltPhase + 2. / 3. * M_PI));
+  // ---------------------------------------------------------------------------
+  // IMPORTANT DP / PF CONVENTION CONVERSION
+  // ---------------------------------------------------------------------------
+  // Power-flow node voltages are line-line RMS phasors.
+  // DP::Ph3 electrical states use phase-peak complex envelopes.
+  //
+  // This conversion is already used by DP::Ph3::PiLine, DP::Ph3::Inductor and
+  // DP::Ph3::Resistor and must also be used by the primitive capacitor. The
+  // previous implementation omitted the RMS3PH_TO_PEAK1PH factor here, which
+  // initialized the capacitor state too small by sqrt(3/2) and produced a
+  // startup transient after PF initialization.
+  // ---------------------------------------------------------------------------
+
+  MatrixComp vInitABC = MatrixComp::Zero(3, 1);
+
+  vInitABC(0, 0) =
+      RMS3PH_TO_PEAK1PH * (initialSingleVoltage(1) - initialSingleVoltage(0));
+
+  vInitABC(1, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_B;
+
+  vInitABC(2, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_C;
+
+  **mIntfVoltage = vInitABC;
 
   **mIntfCurrent = susceptance * **mIntfVoltage;
 

--- a/dpsim-models/src/DP/DP_Ph3_Switch.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_Switch.cpp
@@ -24,6 +24,8 @@ DP::Ph3::Switch::Switch(String uid, String name, Logger::Level logLevel)
       mZeroCrossingTimeC(mAttributes->create<Real>("zero_crossing_time_c")),
       mExponentialTransitionActive(
           mAttributes->create<Bool>("exponential_transition_active")),
+      mExponentialTransitionClosing(
+          mAttributes->create<Bool>("exponential_transition_closing")),
       mExponentialProgress(mAttributes->create<Real>("exponential_progress")),
       mExponentialTransitionStartTime(
           mAttributes->create<Real>("exponential_transition_start_time")),
@@ -51,6 +53,7 @@ DP::Ph3::Switch::Switch(String uid, String name, Logger::Level logLevel)
   resetZeroCrossingTimes();
 
   **mExponentialTransitionActive = false;
+  **mExponentialTransitionClosing = false;
   **mExponentialProgress = 0.0;
   **mExponentialTransitionStartTime = -1.0;
   **mExponentialTransitionEndTime = -1.0;
@@ -103,6 +106,20 @@ void DP::Ph3::Switch::setExponentialSwitchingTime(Real switchingTime) {
 void DP::Ph3::Switch::openSwitch() {
   Base::Ph3::Switch::openSwitch();
 
+  // An opening command during a closing ramp abandons that ramp. The poles are
+  // still open at that point, so the switch simply stays open.
+  if (**mExponentialTransitionActive && **mExponentialTransitionClosing) {
+    resetExponentialTransition();
+    setAllPoles(false);
+    synchronizeEffectiveResistance(false);
+    **mOpeningRequested = false;
+
+    SPDLOG_LOGGER_INFO(mSLog,
+                       "DP opening command received during an exponential "
+                       "closing transition. Transition abandoned.");
+    return;
+  }
+
   if (mSwitchingMode == SwitchingMode::Ideal) {
     **mOpeningRequested = false;
     setAllPoles(false);
@@ -147,15 +164,41 @@ void DP::Ph3::Switch::closeSwitch() {
   Base::Ph3::Switch::closeSwitch();
 
   **mOpeningRequested = false;
-  setAllPoles(true);
   resetZeroCrossingTimes();
   mResetZeroCrossingHistory = false;
 
-  resetExponentialTransition();
-  synchronizeEffectiveResistance(true);
+  if (mSwitchingMode != SwitchingMode::ExponentialZCSEmulation) {
+    setAllPoles(true);
+    resetExponentialTransition();
+    synchronizeEffectiveResistance(true);
 
-  SPDLOG_LOGGER_INFO(
-      mSLog, "DP switch closing command: all three physical poles closed.");
+    SPDLOG_LOGGER_INFO(
+        mSLog, "DP switch closing command: all three physical poles closed.");
+    return;
+  }
+
+  if (allPolesClosed() && !**mExponentialTransitionActive) {
+    resetExponentialTransition();
+    synchronizeEffectiveResistance(true);
+    return;
+  }
+
+  // Energising a branch is the mirror image of interrupting it: the same
+  // resistance path is traversed from R_open towards R_closed. The DP envelope
+  // cannot represent the voltage step across a capacitance any more than it can
+  // represent an interrupted inductive current, so closing is ramped as well.
+  validateExponentialResistanceParameters();
+  resetExponentialTransition();
+  **mExponentialTransitionActive = true;
+  **mExponentialTransitionClosing = true;
+  **mExponentialProgress = 1.0;
+  synchronizeEffectiveResistance(false);
+  setAllPoles(false);
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "DP exponential ZCS-emulation closing command received. "
+                     "Switching duration={:.6e}s.",
+                     mExponentialSwitchingTime);
 }
 
 void DP::Ph3::Switch::initializeFromNodesAndTerminals(Real frequency) {
@@ -303,6 +346,7 @@ void DP::Ph3::Switch::mnaCompAddPostStepDependencies(
   modifiedAttributes.push_back(mZeroCrossingTimeC);
 
   modifiedAttributes.push_back(mExponentialTransitionActive);
+  modifiedAttributes.push_back(mExponentialTransitionClosing);
   modifiedAttributes.push_back(mExponentialProgress);
   modifiedAttributes.push_back(mExponentialTransitionStartTime);
   modifiedAttributes.push_back(mExponentialTransitionEndTime);
@@ -496,6 +540,7 @@ void DP::Ph3::Switch::synchronizeEffectiveResistance(Bool closed) {
 
 void DP::Ph3::Switch::resetExponentialTransition() {
   **mExponentialTransitionActive = false;
+  **mExponentialTransitionClosing = false;
   **mExponentialProgress = 0.0;
   **mExponentialTransitionStartTime = -1.0;
   **mExponentialTransitionEndTime = -1.0;
@@ -545,27 +590,33 @@ void DP::Ph3::Switch::updateExponentialTransition(Real time) {
   }
 
   const Real targetTime = time + mTimeStep;
-  const Real alpha = (targetTime - **mExponentialTransitionStartTime) /
-                     mExponentialSwitchingTime;
-  const Real boundedAlpha = std::max(0.0, std::min(1.0, alpha));
+  const Real elapsed = (targetTime - **mExponentialTransitionStartTime) /
+                       mExponentialSwitchingTime;
+  const Real boundedElapsed = std::max(0.0, std::min(1.0, elapsed));
 
-  **mExponentialProgress = boundedAlpha;
+  const Bool closing = **mExponentialTransitionClosing;
+
+  // alpha is the position on the resistance path: 0 at R_closed, 1 at R_open.
+  const Real alpha = closing ? 1.0 - boundedElapsed : boundedElapsed;
+
+  **mExponentialProgress = alpha;
 
   for (UInt phase = 0; phase < 3; ++phase)
-    setEffectiveResistance(phase, exponentialResistance(phase, boundedAlpha));
+    setEffectiveResistance(phase, exponentialResistance(phase, alpha));
 
-  if (boundedAlpha >= 1.0) {
-    synchronizeEffectiveResistance(false);
-    setAllPoles(false);
+  if (boundedElapsed >= 1.0) {
+    synchronizeEffectiveResistance(closing);
+    setAllPoles(closing);
     **mOpeningRequested = false;
     **mExponentialTransitionActive = false;
+    **mExponentialTransitionClosing = false;
 
     SPDLOG_LOGGER_INFO(
         mSLog,
-        "DP exponential ZCS-emulation opening completed: start={:.9f}s, "
+        "DP exponential ZCS-emulation {:s} completed: start={:.9f}s, "
         "end={:.9f}s, duration={:.6e}s.",
-        **mExponentialTransitionStartTime, **mExponentialTransitionEndTime,
-        mExponentialSwitchingTime);
+        closing ? "closing" : "opening", **mExponentialTransitionStartTime,
+        **mExponentialTransitionEndTime, mExponentialSwitchingTime);
   }
 }
 

--- a/dpsim-models/src/EMT/EMT_Ph3_Switch.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_Switch.cpp
@@ -26,6 +26,8 @@ EMT::Ph3::Switch::Switch(String uid, String name, Logger::Level logLevel)
       mZeroCrossingTimeC(mAttributes->create<Real>("zero_crossing_time_c")),
       mExponentialTransitionActive(
           mAttributes->create<Bool>("exponential_transition_active")),
+      mExponentialTransitionClosing(
+          mAttributes->create<Bool>("exponential_transition_closing")),
       mExponentialProgress(mAttributes->create<Real>("exponential_progress")),
       mExponentialTransitionStartTime(
           mAttributes->create<Real>("exponential_transition_start_time")),
@@ -51,6 +53,7 @@ EMT::Ph3::Switch::Switch(String uid, String name, Logger::Level logLevel)
   resetZeroCrossingTimes();
 
   **mExponentialTransitionActive = false;
+  **mExponentialTransitionClosing = false;
   **mExponentialProgress = 0.0;
   **mExponentialTransitionStartTime = -1.0;
   **mExponentialTransitionEndTime = -1.0;
@@ -104,6 +107,19 @@ void EMT::Ph3::Switch::setExponentialSwitchingTime(Real switchingTime) {
 void EMT::Ph3::Switch::openSwitch() {
   Base::Ph3::Switch::openSwitch();
 
+  // An opening command during a closing ramp abandons that ramp. The poles are
+  // still open at that point, so the switch simply stays open.
+  if (**mExponentialTransitionActive && **mExponentialTransitionClosing) {
+    resetExponentialTransition();
+    setAllPoles(false);
+    synchronizeEffectiveResistance(false);
+    **mOpeningRequested = false;
+
+    SPDLOG_LOGGER_INFO(mSLog, "Opening command received during an exponential "
+                              "closing transition. Transition abandoned.");
+    return;
+  }
+
   if (mSwitchingMode == SwitchingMode::Ideal) {
     **mOpeningRequested = false;
     setAllPoles(false);
@@ -147,14 +163,40 @@ void EMT::Ph3::Switch::closeSwitch() {
   Base::Ph3::Switch::closeSwitch();
 
   **mOpeningRequested = false;
-  setAllPoles(true);
   resetZeroCrossingTimes();
   mResetZeroCrossingHistory = false;
 
-  resetExponentialTransition();
-  synchronizeEffectiveResistance(true);
+  if (mSwitchingMode != SwitchingMode::ExponentialZCSEmulation) {
+    setAllPoles(true);
+    resetExponentialTransition();
+    synchronizeEffectiveResistance(true);
 
-  SPDLOG_LOGGER_INFO(mSLog, "Switch closing command: all three poles closed.");
+    SPDLOG_LOGGER_INFO(mSLog,
+                       "Switch closing command: all three poles closed.");
+    return;
+  }
+
+  if (allPolesClosed() && !**mExponentialTransitionActive) {
+    resetExponentialTransition();
+    synchronizeEffectiveResistance(true);
+    return;
+  }
+
+  // Energising a branch is the mirror image of interrupting it: the same
+  // resistance path is traversed from R_open towards R_closed. The poles stay
+  // open until the ramp completes.
+  validateExponentialResistanceParameters();
+  resetExponentialTransition();
+  **mExponentialTransitionActive = true;
+  **mExponentialTransitionClosing = true;
+  **mExponentialProgress = 1.0;
+  synchronizeEffectiveResistance(false);
+  setAllPoles(false);
+
+  SPDLOG_LOGGER_INFO(mSLog,
+                     "Exponential ZCS-emulation closing command received. "
+                     "Switching duration={:.6e}s.",
+                     mExponentialSwitchingTime);
 }
 
 void EMT::Ph3::Switch::initializeFromNodesAndTerminals(Real frequency) {
@@ -293,6 +335,7 @@ void EMT::Ph3::Switch::mnaCompAddPostStepDependencies(
   modifiedAttributes.push_back(mZeroCrossingTimeC);
 
   modifiedAttributes.push_back(mExponentialTransitionActive);
+  modifiedAttributes.push_back(mExponentialTransitionClosing);
   modifiedAttributes.push_back(mExponentialProgress);
   modifiedAttributes.push_back(mExponentialTransitionStartTime);
   modifiedAttributes.push_back(mExponentialTransitionEndTime);
@@ -484,6 +527,7 @@ void EMT::Ph3::Switch::synchronizeEffectiveResistance(Bool closed) {
 
 void EMT::Ph3::Switch::resetExponentialTransition() {
   **mExponentialTransitionActive = false;
+  **mExponentialTransitionClosing = false;
   **mExponentialProgress = 0.0;
   **mExponentialTransitionStartTime = -1.0;
   **mExponentialTransitionEndTime = -1.0;
@@ -535,27 +579,33 @@ void EMT::Ph3::Switch::updateExponentialTransition(Real time) {
   // Prepare R(t+dt) in post-step so that the next MNA solve at t+dt stamps
   // the intended resistance trajectory without requiring a time-aware event API.
   const Real targetTime = time + mTimeStep;
-  const Real alpha = (targetTime - **mExponentialTransitionStartTime) /
-                     mExponentialSwitchingTime;
-  const Real boundedAlpha = std::max(0.0, std::min(1.0, alpha));
+  const Real elapsed = (targetTime - **mExponentialTransitionStartTime) /
+                       mExponentialSwitchingTime;
+  const Real boundedElapsed = std::max(0.0, std::min(1.0, elapsed));
 
-  **mExponentialProgress = boundedAlpha;
+  const Bool closing = **mExponentialTransitionClosing;
+
+  // alpha is the position on the resistance path: 0 at R_closed, 1 at R_open.
+  const Real alpha = closing ? 1.0 - boundedElapsed : boundedElapsed;
+
+  **mExponentialProgress = alpha;
 
   for (UInt phase = 0; phase < 3; ++phase)
-    setEffectiveResistance(phase, exponentialResistance(phase, boundedAlpha));
+    setEffectiveResistance(phase, exponentialResistance(phase, alpha));
 
-  if (boundedAlpha >= 1.0) {
-    synchronizeEffectiveResistance(false);
-    setAllPoles(false);
+  if (boundedElapsed >= 1.0) {
+    synchronizeEffectiveResistance(closing);
+    setAllPoles(closing);
     **mOpeningRequested = false;
     **mExponentialTransitionActive = false;
+    **mExponentialTransitionClosing = false;
 
     SPDLOG_LOGGER_INFO(
         mSLog,
-        "Exponential ZCS-emulation opening completed: start={:.9f}s, "
+        "Exponential ZCS-emulation {:s} completed: start={:.9f}s, "
         "end={:.9f}s, duration={:.6e}s.",
-        **mExponentialTransitionStartTime, **mExponentialTransitionEndTime,
-        mExponentialSwitchingTime);
+        closing ? "closing" : "opening", **mExponentialTransitionStartTime,
+        **mExponentialTransitionEndTime, mExponentialSwitchingTime);
   }
 }
 

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -135,7 +135,7 @@ set(SYNCGEN_SOURCES
 	Components/DP_SP_SynGenTrStab_testModels_doubleLine.cpp
 	Components/EMT_SynchronGenerator9OrderDCIM_LoadStep_TurbineGovernor_Exciter.cpp
 	Components/EMT_SynchronGenerator9OrderVBR_LoadStep_TurbineGovernor_Exciter.cpp
-	Components/EMT_DP_Ph3_Switch_3Mode_Benchmark.cpp
+	Components/EMT_DP_Switch_3Mode_Benchmark.cpp
 )
 
 set(INVERTER_SOURCES

--- a/dpsim/examples/cxx/Components/EMT_DP_Switch_3Mode_Benchmark.cpp
+++ b/dpsim/examples/cxx/Components/EMT_DP_Switch_3Mode_Benchmark.cpp
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
 // SPDX-License-Identifier: MPL-2.0
 
+// Runs every switching mode in both directions across EMT::Ph3, DP::Ph3 and
+// DP::Ph1 and checks the terminal state of each run.
+//
+// The opening cases interrupt inductive current. The closing cases energise the
+// switched bus, which carries a shunt capacitance: without it
+// there is no closing discontinuity and every mode would look the same.
+
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -38,6 +45,8 @@ struct Parameters {
 
   Real loadP = 1.0e6;
   Real loadQ = 0.3e6;
+
+  Real loadCapacitance = 1.0e-6;
 
   Real pathAResistance = 0.20;
   Real pathAInductance = 1.0e-3;
@@ -142,17 +151,21 @@ Int expectedMatrixRecomputations(const Parameters &p, BenchmarkMode mode,
     return 0;
   }
 
+  const Int exponentialSteps =
+      static_cast<Int>(std::ceil(p.exponentialSwitchingTime / p.timeStep)) + 1;
+
+  if (mode == BenchmarkMode::ExponentialZCSEmulation) {
+    // Both directions traverse the same resistance path step by step.
+    return exponentialSteps;
+  }
+
   if (direction == SwitchingDirection::OpenToClose) {
+    // CurrentZero closes immediately: there is no current zero to wait for.
     return 1;
   }
 
-  if (mode == BenchmarkMode::CurrentZero) {
-    // One recomputation per pole, since the poles clear at their own zeros.
-    return poleCount;
-  }
-
-  return static_cast<Int>(std::ceil(p.exponentialSwitchingTime / p.timeStep)) +
-         1;
+  // One recomputation per pole, since the poles clear at their own zeros.
+  return poleCount;
 }
 
 Bool nearlyEqual(Real a, Real b, Real relTol = 1e-9, Real absTol = 1e-12) {
@@ -180,9 +193,13 @@ void evaluateRunResult(const Parameters &p, RunResult &result) {
 
   if (result.mode == "ExponentialZCSEmulation") {
     if (expectedClosed) {
+      // Closing traverses the same path in the opposite direction, so the
+      // progress ends at 0 (R_closed) and the ramp must have run.
       result.passTransitionState =
           !result.exponentialActiveFinal &&
-          nearlyEqual(result.exponentialProgress, 0.0, 0.0, 1e-12);
+          nearlyEqual(result.exponentialProgress, 0.0, 0.0, 1e-12) &&
+          result.exponentialStart >= 0.0 &&
+          result.exponentialEnd >= result.exponentialStart;
     } else {
       result.passTransitionState =
           !result.exponentialActiveFinal &&
@@ -320,7 +337,8 @@ SystemTopology runPowerFlow(const Parameters &p, Bool breakerClosed) {
   auto load = SP::Ph1::Shunt::make("LoadPF", Logger::Level::info);
 
   load->setParameters(p.loadP / std::pow(p.nominalVoltage, 2),
-                      -p.loadQ / std::pow(p.nominalVoltage, 2));
+                      -p.loadQ / std::pow(p.nominalVoltage, 2) +
+                          2.0 * PI * p.frequency * p.loadCapacitance);
 
   load->setBaseVoltage(p.nominalVoltage);
 
@@ -457,11 +475,17 @@ RunResult runEMT(const Parameters &p, const SystemTopology &systemPF,
                       Math::singlePhasePowerToThreePhase(p.loadQ),
                       p.nominalVoltage);
 
+  auto loadCap = EMT::Ph3::Capacitor::make("LoadCap", Logger::Level::info);
+
+  loadCap->setParameters(
+      Math::singlePhaseParameterToThreePhase(p.loadCapacitance));
+
   slack->connect({n1});
   pathA->connect({n1, n2});
   breaker->connect({n2, n3});
   pathB->connect({n1, n3});
   load->connect({n3});
+  loadCap->connect({n3, SimNode<Real>::GND});
 
   auto system = SystemTopology(p.frequency,
                                SystemNodeList{
@@ -475,6 +499,7 @@ RunResult runEMT(const Parameters &p, const SystemTopology &systemPF,
                                    breaker,
                                    pathB,
                                    load,
+                                   loadCap,
                                });
 
   system.initWithPowerflow(systemPF, Domain::EMT);
@@ -527,6 +552,9 @@ RunResult runEMT(const Parameters &p, const SystemTopology &systemPF,
 
   logger->logAttribute("exponential_transition_active",
                        breaker->attribute("exponential_transition_active"));
+
+  logger->logAttribute("exponential_transition_closing",
+                       breaker->attribute("exponential_transition_closing"));
 
   logger->logAttribute("exponential_progress",
                        breaker->attribute("exponential_progress"));
@@ -707,6 +735,11 @@ RunResult runDP(const Parameters &p, const SystemTopology &systemPF,
                       Math::singlePhaseParameterToThreePhase(loadInductance),
                       Matrix::Zero(3, 3), Matrix::Zero(3, 3));
 
+  auto loadCap = DP::Ph3::Capacitor::make("LoadCap", Logger::Level::info);
+
+  loadCap->setParameters(
+      Math::singlePhaseParameterToThreePhase(p.loadCapacitance));
+
   slack->connect({n1});
   pathA->connect({n1, n2});
   breaker->connect({n2, n3});
@@ -715,6 +748,11 @@ RunResult runDP(const Parameters &p, const SystemTopology &systemPF,
   load->connect({
       DP::SimNode::GND,
       n3,
+  });
+
+  loadCap->connect({
+      n3,
+      DP::SimNode::GND,
   });
 
   auto system = SystemTopology(p.frequency,
@@ -729,6 +767,7 @@ RunResult runDP(const Parameters &p, const SystemTopology &systemPF,
                                    breaker,
                                    pathB,
                                    load,
+                                   loadCap,
                                });
 
   system.initWithPowerflow(systemPF, Domain::DP);
@@ -804,6 +843,9 @@ RunResult runDP(const Parameters &p, const SystemTopology &systemPF,
 
   logger->logAttribute("exponential_transition_active",
                        breaker->attribute("exponential_transition_active"));
+
+  logger->logAttribute("exponential_transition_closing",
+                       breaker->attribute("exponential_transition_closing"));
 
   logger->logAttribute("exponential_progress",
                        breaker->attribute("exponential_progress"));
@@ -974,6 +1016,10 @@ RunResult runDPPh1(const Parameters &p, const SystemTopology &systemPF,
 
   load->setParameters(loadResistance, loadInductance, 0.0, 0.0);
 
+  auto loadCap = DP::Ph1::Capacitor::make("LoadCap", Logger::Level::info);
+
+  loadCap->setParameters(p.loadCapacitance);
+
   slack->connect({n1});
   pathA->connect({n1, n2});
   breaker->connect({n2, n3});
@@ -982,6 +1028,11 @@ RunResult runDPPh1(const Parameters &p, const SystemTopology &systemPF,
   load->connect({
       DP::SimNode::GND,
       n3,
+  });
+
+  loadCap->connect({
+      n3,
+      DP::SimNode::GND,
   });
 
   auto system = SystemTopology(p.frequency,
@@ -996,6 +1047,7 @@ RunResult runDPPh1(const Parameters &p, const SystemTopology &systemPF,
                                    breaker,
                                    pathB,
                                    load,
+                                   loadCap,
                                });
 
   system.initWithPowerflow(systemPF, Domain::DP);
@@ -1033,6 +1085,9 @@ RunResult runDPPh1(const Parameters &p, const SystemTopology &systemPF,
 
   logger->logAttribute("exponential_transition_active",
                        breaker->attribute("exponential_transition_active"));
+
+  logger->logAttribute("exponential_transition_closing",
+                       breaker->attribute("exponential_transition_closing"));
 
   logger->logAttribute("exponential_progress",
                        breaker->attribute("exponential_progress"));

--- a/dpsim/examples/cxx/Components/EMT_DP_Switch_3Mode_Benchmark.cpp
+++ b/dpsim/examples/cxx/Components/EMT_DP_Switch_3Mode_Benchmark.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <DPsim.h>
+#include <dpsim-models/DP/DP_Ph1_Switch.h>
 #include <dpsim-models/DP/DP_Ph3_Switch.h>
 #include <dpsim-models/EMT/EMT_Ph3_Switch.h>
 #include <dpsim-models/Filesystem.h>
@@ -136,7 +137,7 @@ Real commandTime(const Parameters &p, SwitchingDirection direction) {
 }
 
 Int expectedMatrixRecomputations(const Parameters &p, BenchmarkMode mode,
-                                 SwitchingDirection direction) {
+                                 SwitchingDirection direction, Int poleCount) {
   if (mode == BenchmarkMode::Ideal) {
     return 0;
   }
@@ -146,7 +147,8 @@ Int expectedMatrixRecomputations(const Parameters &p, BenchmarkMode mode,
   }
 
   if (mode == BenchmarkMode::CurrentZero) {
-    return 3;
+    // One recomputation per pole, since the poles clear at their own zeros.
+    return poleCount;
   }
 
   return static_cast<Int>(std::ceil(p.exponentialSwitchingTime / p.timeStep)) +
@@ -217,7 +219,7 @@ String makeRunTimestamp() {
 
 String makeResultsDirectory() {
   return "logs/"
-         "EMT_DP_Ph3_Switch_3Mode_Bidirectional_Benchmark_results_" +
+         "EMT_DP_Switch_3Mode_Bidirectional_Benchmark_results_" +
          makeRunTimestamp();
 }
 
@@ -287,7 +289,7 @@ SystemTopology runPowerFlow(const Parameters &p, Bool breakerClosed) {
   const String stateName = breakerClosed ? "Closed" : "Open";
 
   const String simName =
-      "EMT_DP_Ph3_Switch_3Mode_Bidirectional_Benchmark_PF_" + stateName;
+      "EMT_DP_Switch_3Mode_Bidirectional_Benchmark_PF_" + stateName;
 
   auto n1 = SimNode<Complex>::make("n1", PhaseType::Single);
 
@@ -408,9 +410,8 @@ RunResult runEMT(const Parameters &p, const SystemTopology &systemPF,
 
   const Real eventTime = commandTime(p, direction);
 
-  const String simName =
-      "EMT_DP_Ph3_Switch_3Mode_Bidirectional_Benchmark_EMT_" + modeName(mode) +
-      "_" + directionName(direction);
+  const String simName = "EMT_DP_Switch_3Mode_Bidirectional_Benchmark_EMT_" +
+                         modeName(mode) + "_" + directionName(direction);
 
   auto n1 = SimNode<Real>::make("n1", PhaseType::ABC);
 
@@ -622,7 +623,7 @@ RunResult runEMT(const Parameters &p, const SystemTopology &systemPF,
   result.finalPoleC = **breaker->attributeTyped<Bool>("pole_closed_c");
 
   result.expectedMatrixRecomputations =
-      expectedMatrixRecomputations(p, mode, direction);
+      expectedMatrixRecomputations(p, mode, direction, 3);
 
   evaluateRunResult(p, result);
 
@@ -652,7 +653,7 @@ RunResult runDP(const Parameters &p, const SystemTopology &systemPF,
 
   const Real eventTime = commandTime(p, direction);
 
-  const String simName = "EMT_DP_Ph3_Switch_3Mode_Bidirectional_Benchmark_DP_" +
+  const String simName = "EMT_DP_Switch_3Mode_Bidirectional_Benchmark_DP_" +
                          modeName(mode) + "_" + directionName(direction);
 
   auto n1 = DP::SimNode::make("n1", PhaseType::ABC);
@@ -899,7 +900,236 @@ RunResult runDP(const Parameters &p, const SystemTopology &systemPF,
   result.finalPoleC = **breaker->attributeTyped<Bool>("pole_closed_c");
 
   result.expectedMatrixRecomputations =
-      expectedMatrixRecomputations(p, mode, direction);
+      expectedMatrixRecomputations(p, mode, direction, 3);
+
+  evaluateRunResult(p, result);
+
+  return result;
+}
+
+DP::Ph1::Switch::SwitchingMode toDPPh1Mode(BenchmarkMode mode) {
+  switch (mode) {
+  case BenchmarkMode::Ideal:
+    return DP::Ph1::Switch::SwitchingMode::Ideal;
+
+  case BenchmarkMode::CurrentZero:
+    return DP::Ph1::Switch::SwitchingMode::CurrentZero;
+
+  case BenchmarkMode::ExponentialZCSEmulation:
+    return DP::Ph1::Switch::SwitchingMode::ExponentialZCSEmulation;
+  }
+
+  return DP::Ph1::Switch::SwitchingMode::Ideal;
+}
+
+RunResult runDPPh1(const Parameters &p, const SystemTopology &systemPF,
+                   BenchmarkMode mode, SwitchingDirection direction) {
+  const Bool startsClosed = initialClosed(direction);
+
+  const Bool endsClosed = targetClosed(direction);
+
+  const Real eventTime = commandTime(p, direction);
+
+  const String simName = "EMT_DP_Switch_3Mode_Bidirectional_Benchmark_DP1Ph_" +
+                         modeName(mode) + "_" + directionName(direction);
+
+  auto n1 = DP::SimNode::make("n1", PhaseType::Single);
+
+  auto n2 = DP::SimNode::make("n2", PhaseType::Single);
+
+  auto n3 = DP::SimNode::make("n3", PhaseType::Single);
+
+  auto slack = DP::Ph1::NetworkInjection::make("Slack", Logger::Level::info);
+
+  auto pathA = DP::Ph1::PiLine::make("PathA", Logger::Level::info);
+
+  pathA->setParameters(p.pathAResistance, p.pathAInductance, 0.0, 0.0);
+
+  auto pathB = DP::Ph1::PiLine::make("PathB", Logger::Level::info);
+
+  pathB->setParameters(p.pathBResistance, p.pathBInductance, 0.0, 0.0);
+
+  auto breaker = DP::Ph1::Switch::make("Breaker", Logger::Level::info);
+
+  breaker->setParameters(p.switchOpenResistance, p.switchClosedResistance,
+                         startsClosed);
+
+  breaker->setSwitchingMode(toDPPh1Mode(mode));
+
+  breaker->setZeroCrossingTolerance(p.zeroCrossingTolerance);
+
+  breaker->setExponentialSwitchingTime(p.exponentialSwitchingTime);
+
+  const Real denominator = p.loadP * p.loadP + p.loadQ * p.loadQ;
+
+  const Real loadResistance =
+      p.nominalVoltage * p.nominalVoltage * p.loadP / denominator;
+
+  const Real loadReactance =
+      p.nominalVoltage * p.nominalVoltage * p.loadQ / denominator;
+
+  const Real loadInductance = loadReactance / (2.0 * PI * p.frequency);
+
+  auto load = DP::Ph1::PiLine::make("Load", Logger::Level::info);
+
+  load->setParameters(loadResistance, loadInductance, 0.0, 0.0);
+
+  slack->connect({n1});
+  pathA->connect({n1, n2});
+  breaker->connect({n2, n3});
+  pathB->connect({n1, n3});
+
+  load->connect({
+      DP::SimNode::GND,
+      n3,
+  });
+
+  auto system = SystemTopology(p.frequency,
+                               SystemNodeList{
+                                   n1,
+                                   n2,
+                                   n3,
+                               },
+                               SystemComponentList{
+                                   slack,
+                                   pathA,
+                                   breaker,
+                                   pathB,
+                                   load,
+                               });
+
+  system.initWithPowerflow(systemPF, Domain::DP);
+
+  // DP::Ph1 envelopes keep the power-flow amplitude scaling, so unlike the
+  // DP::Ph3 runner no RMS3PH_TO_PEAK1PH conversion is applied here.
+  slack->setParameters(n1->initialSingleVoltage(), 0.0);
+
+  auto logger = DataLogger::make(simName);
+
+  const auto breakerCurrent = breaker->attributeTyped<MatrixComp>("i_intf");
+
+  logger->logAttribute("i_breaker_env",
+                       breakerCurrent->deriveCoeff<Complex>(0, 0));
+
+  logger->logAttribute("i_instantaneous",
+                       breaker->attribute("i_instantaneous"));
+
+  const auto breakerVoltage = breaker->attributeTyped<MatrixComp>("v_intf");
+
+  logger->logAttribute("v_breaker_env",
+                       breakerVoltage->deriveCoeff<Complex>(0, 0));
+
+  logger->logAttribute("v_n3_env", n3->attribute("v"));
+
+  logger->logAttribute("commanded_closed", breaker->attribute("is_closed"));
+
+  logger->logAttribute("opening_requested",
+                       breaker->attribute("opening_requested"));
+
+  logger->logAttribute("pole_closed", breaker->attribute("pole_closed"));
+
+  logger->logAttribute("zero_crossing_time",
+                       breaker->attribute("zero_crossing_time"));
+
+  logger->logAttribute("exponential_transition_active",
+                       breaker->attribute("exponential_transition_active"));
+
+  logger->logAttribute("exponential_progress",
+                       breaker->attribute("exponential_progress"));
+
+  logger->logAttribute("exponential_transition_start_time",
+                       breaker->attribute("exponential_transition_start_time"));
+
+  logger->logAttribute("exponential_transition_end_time",
+                       breaker->attribute("exponential_transition_end_time"));
+
+  logger->logAttribute("effective_resistance",
+                       breaker->attribute("effective_resistance"));
+
+  Simulation sim(simName, Logger::Level::info);
+
+  sim.setSystem(system);
+
+  sim.setTimeStep(p.timeStep);
+
+  sim.setFinalTime(p.finalTime);
+
+  sim.setDomain(Domain::DP);
+
+  sim.setSolverType(Solver::Type::MNA);
+
+  sim.addLogger(logger);
+
+  auto event = SwitchEvent::make(eventTime, breaker, endsClosed);
+
+  sim.addEvent(event);
+
+  const auto wallStart = std::chrono::steady_clock::now();
+
+  sim.run();
+
+  const auto wallEnd = std::chrono::steady_clock::now();
+
+  RunResult result;
+
+  result.domain = "DP1Ph";
+
+  result.mode = modeName(mode);
+
+  result.direction = directionName(direction);
+
+  result.initialClosed = startsClosed;
+
+  result.targetClosed = endsClosed;
+
+  result.commandTime = eventTime;
+
+  result.runtimeSeconds =
+      std::chrono::duration<Real>(wallEnd - wallStart).count();
+
+  // The single-phase breaker has one pole. Its state is replicated across the
+  // three result columns so that the shared evaluation and CSV layout apply.
+  const Real zeroTime = **breaker->attributeTyped<Real>("zero_crossing_time");
+
+  result.zeroA = zeroTime;
+
+  result.zeroB = zeroTime;
+
+  result.zeroC = zeroTime;
+
+  result.exponentialStart =
+      **breaker->attributeTyped<Real>("exponential_transition_start_time");
+
+  result.exponentialEnd =
+      **breaker->attributeTyped<Real>("exponential_transition_end_time");
+
+  result.exponentialProgress =
+      **breaker->attributeTyped<Real>("exponential_progress");
+
+  result.exponentialActiveFinal =
+      **breaker->attributeTyped<Bool>("exponential_transition_active");
+
+  const Real finalResistance =
+      **breaker->attributeTyped<Real>("effective_resistance");
+
+  result.finalResistanceA = finalResistance;
+
+  result.finalResistanceB = finalResistance;
+
+  result.finalResistanceC = finalResistance;
+
+  result.finalCommandedClosed = **breaker->attributeTyped<Bool>("is_closed");
+
+  const Bool finalPole = **breaker->attributeTyped<Bool>("pole_closed");
+
+  result.finalPoleA = finalPole;
+
+  result.finalPoleB = finalPole;
+
+  result.finalPoleC = finalPole;
+
+  result.expectedMatrixRecomputations =
+      expectedMatrixRecomputations(p, mode, direction, 1);
 
   evaluateRunResult(p, result);
 
@@ -931,7 +1161,7 @@ int main() {
   };
 
   std::vector<RunResult> results;
-  results.reserve(12);
+  results.reserve(18);
 
   for (const auto mode : modes) {
     for (const auto direction : directions) {
@@ -950,6 +1180,16 @@ int main() {
           initialClosed(direction) ? systemPFClosed : systemPFOpen;
 
       results.push_back(runDP(p, systemPF, mode, direction));
+    }
+  }
+
+  for (const auto mode : modes) {
+    for (const auto direction : directions) {
+
+      const auto &systemPF =
+          initialClosed(direction) ? systemPFClosed : systemPFOpen;
+
+      results.push_back(runDPPh1(p, systemPF, mode, direction));
     }
   }
 


### PR DESCRIPTION
Follow-up to #687, covers the first two points of #688.

Three commits, because they are independent of each other:

  1. feature (models): add switching modes to DP::Ph1::Switch — #688 point 1. DP::Ph3 has Ideal / CurrentZero / ExponentialZCSEmulation,
  DP::Ph1 had none of them. Base::Ph1::Switch gets the virtual closeSwitch()/openSwitch()
  hooks that Base::Ph3::Switch already has; close()/open() call them, so existing users are unaffected. The mode benchmark now also runs DP::Ph1, 18 runs in total, and is renamed since it is no longer Ph3 only.

  2. fix (models): correct DP Ph3 capacitor initialization — the same defect 2efee228 fixed for the inductor and resistor: the missing
  RMS3PH_TO_PEAK1PH conversion. Unrelated to the switch models, but commit 3 puts a capacitor at the switched bus, and without this fix  its startup transient is larger than the switching transient that should be measured there. Kept separate

  3. feature (models): ramp the resistance on closing in exponential ZCS mode — #688 point 2. Closing into capacitance has the same problem as interrupting inductive current: the DP envelope cannot represent the step. The exponential mode now traverses the same resistance path in both directions in EMT::Ph3, DP::Ph3 and DP::Ph1. Ideal and CurrentZero still close immediately. Benchmark and documentation cover both directions.
  
  Closes #688