### PR TITLE
Fix Norton matrix stamping for mixed DP Ph1 SSN components

### DIFF
--- a/docs/hugo/content/en/docs/Concepts/ssn-domain-formulation.md
+++ b/docs/hugo/content/en/docs/Concepts/ssn-domain-formulation.md
@@ -58,14 +58,16 @@ shifted operator becomes a real system of twice the size,
 The off-diagonal $\pm\omega_s \boldsymbol{I}$ blocks are the carrier rotation, and the block
 structure $\begin{bmatrix} P & -Q \\ Q & P \end{bmatrix}$ is the real representation of the complex
 number $P + jQ$. Discretising this real system with the same trapezoidal rule and recombining the
-blocks recovers the complex discrete pair, from which the equivalent admittance and the history term
-follow exactly as in the instantaneous case.
+blocks recovers the complex discrete pair for a complex-linear component, from which the equivalent
+admittance and the history term follow exactly as in the instantaneous case.
 
-Two things follow. The equivalent admittance is complex in an envelope domain and real in an
-instantaneous one, so the same component stamps differently. And setting $\omega_s = 0$ collapses
-the augmented system back to the instantaneous one, which is the general statement about the
-envelope transform applied here: the instantaneous formulation is the zero-carrier special case, not
-a separate method.
+For a complex-linear envelope model, the resulting real block can be folded into one complex
+admittance. A model that mixes real control states with complex-envelope states need not preserve
+the $\begin{bmatrix} P & -Q \\ Q & P \end{bmatrix}$ structure. Its equivalent admittance must then
+remain a full real block rather than being reduced to a complex scalar. Setting $\omega_s = 0$
+still collapses the carrier-shifted state equations back to the instantaneous formulation; the
+difference in the Norton representation comes from the component's axis coupling, not from a
+different integration method.
 
 ## Why this matters for accuracy
 

--- a/docs/hugo/content/en/docs/Concepts/state-space-nodal.md
+++ b/docs/hugo/content/en/docs/Concepts/state-space-nodal.md
@@ -39,14 +39,17 @@ $\frac{d}{dt} + j\omega_s$, so what is discretised is $\mathbf{A} - j\omega_s\ma
 $\mathbf{A}$, and splitting the envelope into real and imaginary parts turns that into a real system
 of twice the size. This is derived in full under
 [SSN across domains]({{< ref "ssn-domain-formulation.md" >}}), together with why the equivalent
-admittance is complex in an envelope domain and real in an instantaneous one.
+admittance is represented differently in envelope and instantaneous domains.
 
 The real-augmented form matches how the rest of the dynamic phasor system is already assembled: a
 complex admittance $g = g_r + j g_i$ is stamped as the real block
 $\left[\begin{smallmatrix} g_r & -g_i \\ g_i & g_r \end{smallmatrix}\right]$, with real and
-imaginary node parts in separate halves of a real-valued system. The SSN component therefore needs
-no complex assembly of its own, and the trapezoidal discretisation used by the instantaneous models
-applies unchanged.
+imaginary node parts in separate halves of a real-valued system. This complex-scalar representation
+is sufficient when the component is complex-linear. A mixed real/envelope model, such as a
+controlled converter, may instead produce a general real $2 \times 2$ block because its $d$- and
+$q$-axis responses differ. That block must be retained when it is stamped into the same
+real-augmented system. In both cases, the trapezoidal discretisation used by the instantaneous
+models applies unchanged.
 
 ## Components
 

--- a/docs/hugo/content/en/docs/Developer Guide/Model Implementations/ssn-components.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Model Implementations/ssn-components.md
@@ -70,7 +70,9 @@ One base does not follow this pattern. `MixedVTypeVariableSSNComp` does **not** 
 it requires the derived component to hand it a state matrix that is already carrier shifted, because
 its steady-state solve assumes so. Supplying an unshifted matrix there initializes to the wrong
 operating point rather than failing, and it is the single easiest mistake to make when porting a
-component from EMT to DP.
+component from EMT to DP. Its discrete Norton admittance is also retained as the full packed-real
+`2 x 2` block `C * Bd + D`. Mixed real/envelope controls do not generally have the
+`[[P, -Q], [Q, P]]` structure required to fold that block into one complex scalar.
 {{% /alert %}}
 
 ## Frame metadata

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_MixedVTypeVariableSSNComp.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_MixedVTypeVariableSSNComp.h
@@ -32,8 +32,8 @@ protected:
   /// Discretized (trapezoidal) real operators.
   Matrix mdA, mdB, mdE;
 
-  /// Complex Norton admittance / history current stamped into the network.
-  Complex mW;
+  /// Packed real 2x2 Norton admittance and complex history current.
+  Matrix mW;
   Complex mYHist;
 
   /// Packed real state: [realStates..., Re(cplxState0), Im(cplxState0), ...].

--- a/dpsim-models/include/dpsim-models/MNAStampUtils.h
+++ b/dpsim-models/include/dpsim-models/MNAStampUtils.h
@@ -19,6 +19,15 @@ public:
                               const Logger::Log &mSLog, Int maxFreq = 1,
                               Int freqIdx = 0);
 
+  /// Stamp a packed real 2x2 admittance block that maps [Re(v), Im(v)] to
+  /// [Re(i), Im(i)] for a single complex node voltage/current pair.
+  static void stampAdmittance(const Matrix &admittance, SparseMatrixRow &mat,
+                              UInt node1Index, UInt node2Index,
+                              Bool isTerminal1NotGrounded,
+                              Bool isTerminal2NotGrounded,
+                              const Logger::Log &mSLog, Int maxFreq = 1,
+                              Int freqIdx = 0);
+
   static void stampConductanceMatrix(const Matrix &conductanceMat,
                                      SparseMatrixRow &mat, UInt node1Index,
                                      UInt node2Index,
@@ -98,6 +107,11 @@ private:
 
   static void addToMatrixElement(SparseMatrixRow &mat, Matrix::Index row,
                                  Matrix::Index column, Complex value,
+                                 Int maxFreq, Int freqIdx,
+                                 const Logger::Log &mSLog);
+
+  static void addToMatrixElement(SparseMatrixRow &mat, Matrix::Index row,
+                                 Matrix::Index column, const Matrix &value,
                                  Int maxFreq, Int freqIdx,
                                  const Logger::Log &mSLog);
 };

--- a/dpsim-models/src/DP/DP_Ph1_MixedVTypeVariableSSNComp.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_MixedVTypeVariableSSNComp.cpp
@@ -12,8 +12,9 @@ DP::Ph1::MixedVTypeVariableSSNComp::MixedVTypeVariableSSNComp(
     Logger::Level logLevel)
     : MNASimPowerComp<Complex>(uid, name, true, true, logLevel),
       mParameterChanged(false), mRealStateCount(realStateCount),
-      mComplexStateCount(complexStateCount), mTimeStep(0.0), mW(0.0, 0.0),
-      mYHist(0.0, 0.0), mX(mAttributes->create<Matrix>("x")) {
+      mComplexStateCount(complexStateCount), mTimeStep(0.0),
+      mW(Matrix::Zero(2, 2)), mYHist(0.0, 0.0),
+      mX(mAttributes->create<Matrix>("x")) {
   mPhaseType = PhaseType::Single;
   setTerminalNumber(2);
 
@@ -114,7 +115,7 @@ void DP::Ph1::MixedVTypeVariableSSNComp::setParameters(
   mdB = Matrix::Zero(n, 2);
   mdE = Matrix::Zero(n, 1);
 
-  mW = Complex(0.0, 0.0);
+  mW = Matrix::Zero(2, 2);
   mYHist = Complex(0.0, 0.0);
 
   mParametersSet = true;
@@ -158,10 +159,7 @@ void DP::Ph1::MixedVTypeVariableSSNComp::recomputeDiscreteModel() {
   Math::calculateStateSpaceTrapezoidalMatrices(mA, mB, mE, mTimeStep, mdA, mdB,
                                                mdE);
 
-  // Fold the 2x2 real u->y block into a complex admittance; requires it to
-  // have the [[a,-b],[b,a]] complex-multiplication structure.
-  const Matrix wReal = mC * mdB + mD;
-  mW = Complex(wReal(0, 0), wReal(1, 0));
+  mW = mC * mdB + mD;
 }
 
 void DP::Ph1::MixedVTypeVariableSSNComp::updateStateSpaceModel() {
@@ -318,7 +316,8 @@ void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompUpdateVoltage(
 }
 
 void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompUpdateCurrent(const Matrix &) {
-  (**mIntfCurrent)(0, 0) = mW * (**mIntfVoltage)(0, 0) + mYHist;
+  (**mIntfCurrent)(0, 0) =
+      unpackComplex(mW * packComplex((**mIntfVoltage)(0, 0))) + mYHist;
 }
 
 void DP::Ph1::MixedVTypeVariableSSNComp::mnaCompPostStep(

--- a/dpsim-models/src/MNAStampUtils.cpp
+++ b/dpsim-models/src/MNAStampUtils.cpp
@@ -30,6 +30,24 @@ void MNAStampUtils::stampAdmittance(Complex admittance, SparseMatrixRow &mat,
   SPDLOG_LOGGER_DEBUG(mSLog, "Stamping completed.");
 }
 
+void MNAStampUtils::stampAdmittance(
+    const Matrix &admittance, SparseMatrixRow &mat, UInt node1Index,
+    UInt node2Index, Bool isTerminal1NotGrounded, Bool isTerminal2NotGrounded,
+    const Logger::Log &mSLog, Int maxFreq, Int freqIdx) {
+  if (admittance.rows() != 2 || admittance.cols() != 2)
+    throw InvalidArgumentException();
+
+  SPDLOG_LOGGER_DEBUG(
+      mSLog,
+      "Start stamping packed real admittance for frequency index {:d}...",
+      freqIdx);
+
+  stampValue(admittance, mat, node1Index, node2Index, isTerminal1NotGrounded,
+             isTerminal2NotGrounded, maxFreq, freqIdx, mSLog);
+
+  SPDLOG_LOGGER_DEBUG(mSLog, "Stamping completed.");
+}
+
 void MNAStampUtils::stampConductanceMatrix(const Matrix &conductanceMat,
                                            SparseMatrixRow &mat,
                                            UInt node1Index, UInt node2Index,
@@ -234,6 +252,18 @@ void MNAStampUtils::addToMatrixElement(SparseMatrixRow &mat, Matrix::Index row,
   SPDLOG_LOGGER_DEBUG(mSLog,
                       "- Adding {:s} to system matrix element ({:d},{:d})",
                       Logger::complexToString(value), row, column);
+
+  Math::addToMatrixElement(mat, row, column, value, maxFreq, freqIdx);
+}
+
+void MNAStampUtils::addToMatrixElement(SparseMatrixRow &mat, Matrix::Index row,
+                                       Matrix::Index column,
+                                       const Matrix &value, Int maxFreq,
+                                       Int freqIdx, const Logger::Log &mSLog) {
+  SPDLOG_LOGGER_DEBUG(
+      mSLog,
+      "- Adding packed real 2x2 block to system matrix element ({:d},{:d})",
+      row, column);
 
   Math::addToMatrixElement(mat, row, column, value, maxFreq, freqIdx);
 }

--- a/dpsim/examples/cxx/StateSpace/DP_Ph1_Inverter_StateSpaceExtraction.cpp
+++ b/dpsim/examples/cxx/StateSpace/DP_Ph1_Inverter_StateSpaceExtraction.cpp
@@ -3,11 +3,12 @@
 #include <DPsim.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <iostream>
 #include <limits>
 #include <memory>
-#include <vector>
+#include <utility>
 
 using namespace DPsim;
 using namespace CPS::DP;
@@ -38,28 +39,6 @@ struct SteadyState {
   Matrix inverterState;
 };
 
-void printEigenvalues(const String &title, const CPS::VectorComp &eigenvalues) {
-  std::cout << "\n" << title << "\n";
-  for (Eigen::Index idx = 0; idx < eigenvalues.rows(); ++idx)
-    std::cout << "  [" << idx << "] " << eigenvalues(idx) << "\n";
-}
-
-CPS::VectorComp finiteEigenvalues(const CPS::VectorComp &eigenvalues) {
-  std::vector<Complex> finiteValues;
-
-  for (Eigen::Index idx = 0; idx < eigenvalues.rows(); ++idx) {
-    const Complex value = eigenvalues(idx);
-    if (std::isfinite(value.real()) && std::isfinite(value.imag()))
-      finiteValues.push_back(value);
-  }
-
-  CPS::VectorComp result(finiteValues.size());
-  for (Eigen::Index idx = 0; idx < result.rows(); ++idx)
-    result(idx) = finiteValues[static_cast<std::size_t>(idx)];
-
-  return result;
-}
-
 Real maxNearestDistance(const CPS::VectorComp &reference,
                         const CPS::VectorComp &actual) {
   Real maxDistance = 0.0;
@@ -78,24 +57,23 @@ Real maxNearestDistance(const CPS::VectorComp &reference,
   return maxDistance;
 }
 
-Complex mapContinuousToDiscrete(const Complex &lambda, Real timeStep) {
-  const Complex two(2.0, 0.0);
-  return (two + timeStep * lambda) / (two - timeStep * lambda);
+Real maxEigenvalueDistance(const CPS::VectorComp &first,
+                           const CPS::VectorComp &second) {
+  return std::max(maxNearestDistance(first, second),
+                  maxNearestDistance(second, first));
 }
 
-CPS::VectorComp mapContinuousToDiscrete(const CPS::VectorComp &lambda,
-                                        Real timeStep) {
-  CPS::VectorComp result(lambda.rows());
-
-  for (Eigen::Index idx = 0; idx < lambda.rows(); ++idx)
-    result(idx) = mapContinuousToDiscrete(lambda(idx), timeStep);
-
-  return result;
-}
-
-CPS::VectorComp continuousEigenvalues(const Matrix &aMatrix) {
-  Eigen::EigenSolver<Matrix> eigenSolver(aMatrix);
+CPS::VectorComp eigenvalues(const Matrix &matrix) {
+  Eigen::EigenSolver<Matrix> eigenSolver(matrix);
   return eigenSolver.eigenvalues();
+}
+
+Matrix trapezoidalStateMatrix(const Matrix &continuousA, Real timeStep) {
+  const Matrix identity =
+      Matrix::Identity(continuousA.rows(), continuousA.cols());
+  return (identity - 0.5 * timeStep * continuousA)
+      .partialPivLu()
+      .solve(identity + 0.5 * timeStep * continuousA);
 }
 
 } // namespace
@@ -103,8 +81,7 @@ CPS::VectorComp continuousEigenvalues(const Matrix &aMatrix) {
 class DPPh1InverterStateSpaceExtractionExample {
 public:
   DPPh1InverterStateSpaceExtractionExample()
-      : mTimeStep(100e-6), mFinalTime(1e-3), mFrequency(50.0),
-        mOmega(2.0 * PI * mFrequency),
+      : mFinalTime(1e-3), mFrequency(50.0), mOmega(2.0 * PI * mFrequency),
         mSourceVoltage(RMS3PH_TO_PEAK1PH * 400.0, 0.0), mGridResistance(0.3),
         mGridInductance(0.1e-3), mLf(2e-3), mCf(10e-6), mRf(0.2), mRc(0.2),
         mKpPLL(0.25), mKiPLL(0.2), mOmegaCutoff(mOmega), mPRef(10000.0),
@@ -113,10 +90,39 @@ public:
 
   void run() const {
     const SteadyState steadyState = calculateSteadyState();
+    const Matrix analyticalNativeA = buildAnalyticalStateMatrix(steadyState);
+    const Matrix analyticalDqA =
+        buildAnalyticalDqStateMatrix(steadyState, analyticalNativeA);
 
-    const String simName = "DP_Ph1_Inverter_StateSpaceExtraction";
+    const std::array<std::pair<Real, String>, 4> timeSteps = {{
+        {1e-6, "1us"},
+        {10e-6, "10us"},
+        {100e-6, "100us"},
+        {1e-3, "1ms"},
+    }};
+
+    std::cout
+        << "\n============================================================\n";
+    std::cout << "DP Ph1 inverter state-space extraction comparison\n";
+    std::cout
+        << "============================================================\n";
+    std::cout << "Topology: ideal DP source -> R/L grid -> averaged inverter\n";
+    std::cout << "Analysis frame: native DP/global synchronous dq\n";
+    std::cout << "Reference: independently assembled continuous-time dq model, "
+                 "trapezoidal discretization\n";
+    std::cout << "Time steps: 1 us, 10 us, 100 us, 1 ms\n";
+
+    for (const auto &[timeStep, label] : timeSteps)
+      runCase(steadyState, analyticalDqA, timeStep, label);
+  }
+
+private:
+  void runCase(const SteadyState &steadyState, const Matrix &analyticalDqA,
+               Real timeStep, const String &timeStepLabel) const {
+    const String simName =
+        "DP_Ph1_Inverter_StateSpaceExtraction_dt_" + timeStepLabel;
+
     Logger::setLogDir("logs/" + simName);
-
     auto logger = DataLogger::make(simName);
 
     Simulation sim(simName, Logger::Level::warn);
@@ -124,7 +130,7 @@ public:
     sim.addLogger(logger);
     sim.setDomain(Domain::DP);
     sim.setSolverType(Solver::Type::MNA);
-    sim.setTimeStep(mTimeStep);
+    sim.setTimeStep(timeStep);
     sim.setFinalTime(mFinalTime);
     sim.doStateSpaceExtraction(true);
     sim.doSystemMatrixRecomputation(true);
@@ -136,71 +142,15 @@ public:
     modalAnalysis.update();
 
     const CPS::VectorComp extractedZ = modalAnalysis.getDiscreteEigenvalues();
-    const CPS::VectorComp extractedLambda =
-        modalAnalysis.getContinuousEigenvalues();
-    const CPS::VectorComp extractedFiniteLambda =
-        finiteEigenvalues(extractedLambda);
-
-    const Matrix analyticalNativeA = buildAnalyticalStateMatrix(steadyState);
-    const Matrix analyticalDqA =
-        buildAnalyticalDqStateMatrix(steadyState, analyticalNativeA);
-
-    const CPS::VectorComp analyticalNativeLambda =
-        continuousEigenvalues(analyticalNativeA);
-    const CPS::VectorComp analyticalDqLambda =
-        continuousEigenvalues(analyticalDqA);
     const CPS::VectorComp analyticalDqZ =
-        mapContinuousToDiscrete(analyticalDqLambda, mTimeStep);
+        eigenvalues(trapezoidalStateMatrix(analyticalDqA, timeStep));
 
-    std::cout
-        << "\n============================================================\n";
-    std::cout << "DP Ph1 inverter state-space extraction\n";
-    std::cout
-        << "============================================================\n";
-    std::cout << "Topology: ideal DP voltage source -> R/L grid branch -> "
-                 "DP Ph1 averaged inverter\n";
-    std::cout << "Number of extraction states: " << extractor.getStateCount()
-              << "\n";
-    std::cout << "Simulation log written to logs/" << simName << "/" << simName
-              << ".csv\n";
-
-    std::cout << "\nOperating point:\n";
-    std::cout << "  source voltage = " << steadyState.sourceVoltage << "\n";
-    std::cout << "  PCC voltage    = " << steadyState.pccVoltage << "\n";
-    std::cout << "  filter voltage = " << steadyState.filterVoltage << "\n";
-    std::cout << "  grid current   = " << steadyState.gridCurrent << "\n";
-
-    printEigenvalues("Extracted discrete-time eigenvalues z:", extractedZ);
-    printEigenvalues("Extracted continuous-time native DP eigenvalues lambda:",
-                     extractedLambda);
-    printEigenvalues(
-        "Analytical continuous-time native DP/mixed-frame eigenvalues lambda:",
-        analyticalNativeLambda);
-    printEigenvalues("Analytical continuous-time dq-frame eigenvalues lambda:",
-                     analyticalDqLambda);
-    printEigenvalues(
-        "Analytical dq-frame trapezoidal discrete-time eigenvalues z:",
-        analyticalDqZ);
-
-    std::cout << "\nMaximum nearest-neighbour difference between extracted "
-                 "finite lambda and analytical native DP/mixed-frame lambda: "
-              << maxNearestDistance(analyticalNativeLambda,
-                                    extractedFiniteLambda)
-              << "\n";
-    std::cout << "Maximum nearest-neighbour difference between extracted "
-                 "finite lambda and analytical dq-frame lambda: "
-              << maxNearestDistance(analyticalDqLambda, extractedFiniteLambda)
-              << "\n";
-    std::cout << "Maximum nearest-neighbour difference between analytical "
-                 "native DP/mixed-frame lambda and analytical dq-frame lambda: "
-              << maxNearestDistance(analyticalNativeLambda, analyticalDqLambda)
-              << "\n";
-    std::cout << "Maximum nearest-neighbour difference between extracted z "
-                 "and analytical dq-frame z: "
-              << maxNearestDistance(analyticalDqZ, extractedZ) << "\n";
+    std::cout << "\nDelta t = " << timeStepLabel << "\n";
+    std::cout << "  extraction states: " << extractor.getStateCount() << "\n";
+    std::cout << "  extracted vs analytical discrete eigenvalue max error: "
+              << maxEigenvalueDistance(analyticalDqZ, extractedZ) << "\n";
   }
 
-private:
   SystemTopology createSystem(const SteadyState &steadyState,
                               std::shared_ptr<DataLogger> logger) const {
     auto nGrid = SimNode::make("nGrid");
@@ -570,7 +520,6 @@ private:
     B(IfIm, 1) = dVRefEnvIm(dVRefDByUIm, dVRefQByUIm) / mLf;
   }
 
-  Real mTimeStep;
   Real mFinalTime;
   Real mFrequency;
   Real mOmega;


### PR DESCRIPTION
This PR fixes the Norton-equivalent stamping of `DP::Ph1::MixedVTypeVariableSSNComp`.

Previously, the full real matrix

$$W = C B_d + D$$

was reduced to one complex scalar. This is only valid when $W$ has the complex-multiplication structure 

$$
\begin{bmatrix}
a & -b \\
b & a
\end{bmatrix}
$$

Mixed real/envelope models such as controlled converters do not generally satisfy this condition, so the reduction discarded part of their $d-q$ coupling.

The component now retains and stamps the full packed-real $2\times2$ Norton matrix. The same matrix is also used to reconstruct the interface current.

The DP Ph1 inverter state-space extraction example is extended to compare the extracted discrete eigenvalues against an independently assembled and trapezoidally discretized $dq$ model for time steps from $1 \mu s$ to $1\mathrm{ms}$. With full-matrix stamping, the models agree within numerical precision.

The documentation is updated to distinguish complex-linear DP components, whose Norton matrix can be represented by one complex scalar, from mixed real/envelope components that require a full real block.