### PR TITLE
Fix component initialization in pi lines, RX loads

### DIFF
--- a/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_RXLoad.cpp
@@ -27,7 +27,8 @@ DP::Ph1::RXLoad::RXLoad(String name, Logger::Level logLevel)
 
 SimPowerComp<Complex>::Ptr DP::Ph1::RXLoad::clone(String name) {
   auto copy = RXLoad::make(name, mLogLevel);
-  copy->setParameters(**mActivePower, **mReactivePower, **mNomVoltage);
+  if (mParametersSet)
+    copy->setParameters(**mActivePower, **mReactivePower, **mNomVoltage);
   return copy;
 }
 
@@ -85,8 +86,11 @@ void DP::Ph1::RXLoad::initializeParentFromNodesAndTerminals(Real frequency) {
   }
 
   (**mIntfVoltage)(0, 0) = mTerminals[0]->initialSingleVoltage();
-  (**mIntfCurrent)(0, 0) = std::conj(Complex(**mActivePower, **mReactivePower) /
-                                     (**mIntfVoltage)(0, 0));
+  (**mIntfCurrent)(0, 0) =
+      (std::abs((**mIntfVoltage)(0, 0)) > 0)
+          ? std::conj(Complex(**mActivePower, **mReactivePower) /
+                      (**mIntfVoltage)(0, 0))
+          : Complex(0, 0);
 
   SPDLOG_LOGGER_INFO(mSLog,
                      "\n--- Initialization from powerflow ---"

--- a/dpsim-models/src/EMT/EMT_Ph1_PiLine.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph1_PiLine.cpp
@@ -102,12 +102,13 @@ void EMT::Ph1::PiLine::initializeParentFromNodesAndTerminals(Real frequency) {
   Complex impedance = {**mSeriesRes, omega * **mSeriesInd};
   Complex voltage =
       RMS3PH_TO_PEAK1PH * (initialSingleVoltage(1) - initialSingleVoltage(0));
+  Complex current = voltage / impedance;
   (**mIntfVoltage)(0, 0) = voltage.real();
-  (**mIntfCurrent)(0, 0) = (voltage / impedance).real();
+  (**mIntfCurrent)(0, 0) = current.real();
 
   // Initialization of virtual node
-  mVirtualNodes[0]->setInitialVoltage(initialSingleVoltage(0) +
-                                      (**mIntfCurrent)(0, 0) * **mSeriesRes);
+  mVirtualNodes[0]->setInitialVoltage(
+      initialSingleVoltage(0) + PEAK1PH_TO_RMS3PH * current * **mSeriesRes);
 
   SPDLOG_LOGGER_DEBUG(mSLog,
                       "\n--debug--"

--- a/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
@@ -11,7 +11,7 @@
 using namespace CPS;
 
 EMT::Ph3::RXLoad::RXLoad(String uid, String name, Logger::Level logLevel)
-    : CompositePowerComp<Real>(uid, name, true, true, Logger::Level::trace),
+    : CompositePowerComp<Real>(uid, name, true, true, logLevel),
       mActivePower(mAttributes->create<Matrix>("P")),
       mReactivePower(mAttributes->create<Matrix>("Q")),
       mNomVoltage(mAttributes->create<Real>("V_nom")),

--- a/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
@@ -125,10 +125,12 @@ void EMT::Ph3::RXLoad::initializeParentFromNodesAndTerminals(Real frequency) {
 
   // Compute derived impedance values and create+parametrize sub-components
   // now that power and voltage are guaranteed to be known.
-  if ((**mActivePower)(0, 0) != 0) {
+  if ((**mActivePower)(0, 0) != 0)
     mResistance =
         std::pow(**mNomVoltage / sqrt(3), 2) * (**mActivePower).inverse();
-  }
+  else
+    mResistance = Matrix::Zero(3, 3);
+
   if ((**mReactivePower)(0, 0) != 0)
     mReactance =
         std::pow(**mNomVoltage / sqrt(3), 2) * (**mReactivePower).inverse();
@@ -182,17 +184,6 @@ void EMT::Ph3::RXLoad::initializeParentFromNodesAndTerminals(Real frequency) {
   vInitABC(1, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_B;
   vInitABC(2, 0) = vInitABC(0, 0) * SHIFT_TO_PHASE_C;
   **mIntfVoltage = vInitABC.real();
-
-  if ((**mActivePower)(0, 0) != 0) {
-    mResistance =
-        std::pow(**mNomVoltage / sqrt(3), 2) * (**mActivePower).inverse();
-  }
-
-  if ((**mReactivePower)(0, 0) != 0)
-    mReactance =
-        std::pow(**mNomVoltage / sqrt(3), 2) * (**mReactivePower).inverse();
-  else
-    mReactance = Matrix::Zero(1, 1);
 
   if (mReactanceInSeries) {
     MatrixComp impedance = MatrixComp::Zero(3, 3);

--- a/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
+++ b/dpsim-models/src/EMT/EMT_Ph3_RXLoad.cpp
@@ -196,16 +196,17 @@ void EMT::Ph3::RXLoad::initializeParentFromNodesAndTerminals(Real frequency) {
         Complex(mResistance(2, 0), mReactance(2, 0)),
         Complex(mResistance(2, 1), mReactance(2, 1)),
         Complex(mResistance(2, 2), mReactance(2, 2));
-    **mIntfCurrent = (impedance.inverse() * vInitABC).real();
+    MatrixComp iInit = impedance.inverse() * vInitABC;
+    **mIntfCurrent = iInit.real();
 
     // Initialization of virtual node
     // Initial voltage of phase B,C is set after A
     MatrixComp vInitTerm0 = MatrixComp::Zero(3, 1);
-    vInitTerm0(0, 0) = initialSingleVoltage(0);
+    vInitTerm0(0, 0) = RMS3PH_TO_PEAK1PH * initialSingleVoltage(0);
     vInitTerm0(1, 0) = vInitTerm0(0, 0) * SHIFT_TO_PHASE_B;
     vInitTerm0(2, 0) = vInitTerm0(0, 0) * SHIFT_TO_PHASE_C;
-    mVirtualNodes[0]->setInitialVoltage(vInitTerm0 +
-                                        mResistance * **mIntfCurrent);
+    mVirtualNodes[0]->setInitialVoltage(PEAK1PH_TO_RMS3PH *
+                                        (vInitTerm0 - mResistance * iInit));
   }
 
   if ((**mActivePower)(0, 0) != 0) {

--- a/dpsim-models/src/SystemTopology.cpp
+++ b/dpsim-models/src/SystemTopology.cpp
@@ -105,10 +105,14 @@ void SystemTopology::initWithPowerflow(const SystemTopology &systemPF,
             compPF)) {
       if (domain == CPS::Domain::DP || domain == CPS::Domain::SP) {
         auto comp = this->component<SimPowerComp<Complex>>(compPF->name());
+        if (!comp)
+          continue;
         auto terminal = comp->terminals()[0];
         terminal->setPower(-genPF->getApparentPower());
       } else if (domain == CPS::Domain::EMT) {
         auto comp = this->component<SimPowerComp<Real>>(compPF->name());
+        if (!comp)
+          continue;
         auto terminal = comp->terminals()[0];
         terminal->setPower(-genPF->getApparentPower());
       }


### PR DESCRIPTION
Unrelated in relation to components, but all related to initialization.

1. `EMT::Ph1::PiLine` seeded its virtual node with a peak single-phase term added onto an RMS line-line voltage, phase discarded.
2. `EMT::Ph3::RXLoad` hardcoded `Logger::Level::trace`, so impossible to turn logging off.
3. It computed its impedances twice, the copy leaving a 1x1 matrix that series mode read out of bounds.
4. Its series-mode virtual node seed had the same unit error, and the sign wrong on top.
5. `DP::Ph1::RXLoad` divided by an unchecked terminal voltage, and `clone()` marked unparameterized copies as parameterized.
6. `SystemTopology::initWithPowerflow()` dereferenced a null generator lookup.

For some fixes related to RX loads, thanks to Matthias.