### PR TITLE
test(notebooks): skip slow notebook tests in CI

### DIFF
--- a/examples/Notebooks/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.ipynb
+++ b/examples/Notebooks/Circuits/EMT_Ph3_IEEE9_SSN_InverterMix.ipynb
@@ -275,6 +275,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.15"
+  },
+  "tests": {
+   "skip": true
   }
  },
  "nbformat": 4,

--- a/examples/Notebooks/Components/EMT_Ph3_GFL_Comparison.ipynb
+++ b/examples/Notebooks/Components/EMT_Ph3_GFL_Comparison.ipynb
@@ -1293,6 +1293,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
+  },
+  "tests": {
+   "skip": true
   }
  },
  "nbformat": 4,

--- a/examples/Notebooks/Components/Syngen_9Order_DCIM_VBR_Governor_Exciter.ipynb
+++ b/examples/Notebooks/Components/Syngen_9Order_DCIM_VBR_Governor_Exciter.ipynb
@@ -689,7 +689,7 @@
    "version": "3.9.10"
   },
   "tests": {
-   "skip": false
+   "skip": true
   }
  },
  "nbformat": 4,

--- a/examples/Notebooks/Performance/DP_WSCC9bus_SGReducedOrderVBR_SparseLU_KLU_fault_comparison.ipynb
+++ b/examples/Notebooks/Performance/DP_WSCC9bus_SGReducedOrderVBR_SparseLU_KLU_fault_comparison.ipynb
@@ -702,7 +702,7 @@
    "version": "3.9.13"
   },
   "tests": {
-   "skip": false
+   "skip": true
   },
   "vscode": {
    "interpreter": {

--- a/examples/Notebooks/Performance/EMT_IEEE_39bus_Multi_Diakoptics.ipynb
+++ b/examples/Notebooks/Performance/EMT_IEEE_39bus_Multi_Diakoptics.ipynb
@@ -277,6 +277,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.0"
+  },
+  "tests": {
+   "skip": true
   }
  },
  "nbformat": 4,

--- a/examples/Notebooks/StateSpace/DP_Ph1_Inverter_StateSpaceExtraction.ipynb
+++ b/examples/Notebooks/StateSpace/DP_Ph1_Inverter_StateSpaceExtraction.ipynb
@@ -1314,6 +1314,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.13"
+  },
+  "tests": {
+   "skip": true
   }
  },
  "nbformat": 4,

--- a/examples/Notebooks/StateSpace/EMT_Ph3_Inverter_StateSpaceExtraction.ipynb
+++ b/examples/Notebooks/StateSpace/EMT_Ph3_Inverter_StateSpaceExtraction.ipynb
@@ -2152,6 +2152,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.11"
+  },
+  "tests": {
+   "skip": true
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

This PR marks the longest-running notebook tests as skipped using the existing `metadata.tests.skip` mechanism.

The skipped notebooks are simulation-heavy examples that currently dominate the pytest runtime in CI. They remain available as examples, but are no longer executed as part of the regular notebook test job.

## Motivation

The notebook pytest job currently takes around 40 minutes, with a small number of notebooks accounting for most of the runtime. Skipping these notebooks keeps the CI feedback loop shorter while preserving the notebooks in the repository.