### PR TITLE
feat: Variable time step for the MNA solver (DP domain)

### DIFF
--- a/docs/hugo/content/en/docs/Developer Guide/Solvers/_index.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Solvers/_index.md
@@ -9,6 +9,7 @@ description: >
 The [MNA solver]({{< ref "/docs/Developer Guide/Solvers/mna-solver.md" >}}) is the default and the one almost every simulation
 uses; a component's side of it is under
 [interfacing with the MNA solver]({{< ref "/docs/Developer Guide/Writing a Model/mnainterface.md" >}}).
+Changing its time step during a run is an extension of it rather than a solver of its own.
 The remaining pages cover the powerflow solver, the alternatives to nodal analysis, the linear
 algebra backends, and the state-space model that can be recovered from a running simulation.
 

--- a/docs/hugo/content/en/docs/Developer Guide/Solvers/alternative-solvers.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Solvers/alternative-solvers.md
@@ -4,7 +4,7 @@ linkTitle: "Alternative Solvers"
 date: 2026-07-31
 description: >
   The DAE, ODE and diakoptics solvers, and how the linear backend under MNA is chosen.
-weight: 3
+weight: 4
 ---
 
 The methods are derived under

--- a/docs/hugo/content/en/docs/Developer Guide/Solvers/mna-solver.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Solvers/mna-solver.md
@@ -54,6 +54,10 @@ practice, since the enumeration grows as two to the power of that number.
 step and rebuilds and refactorises only when something reports a change, which is the expensive but
 general case used by variable components such as the SSN models.
 
+Both paths hold the time step fixed. Changing it during a run is covered under
+[variable time step]({{< ref "variable-time-step.md" >}}), which needs the recomputation path,
+since the precomputed factorisations carry the step they were built with.
+
 ## Iterative components
 
 After the solve, the solver checks whether any synchronous generator reports `requiresIteration`.

--- a/docs/hugo/content/en/docs/Developer Guide/Solvers/powerflow-solvers.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Solvers/powerflow-solvers.md
@@ -1,7 +1,7 @@
 ---
 title: "Power Flow Solvers"
 linkTitle: "Power Flow Solvers"
-weight: 2
+weight: 3
 description: >
   The Newton-Raphson implementations DPsim ships and how they are configured.
 ---

--- a/docs/hugo/content/en/docs/Developer Guide/Solvers/state-space-extraction.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Solvers/state-space-extraction.md
@@ -5,7 +5,7 @@ linkTitle: "State-Space Extraction"
 date: 2026-05-28
 description: >
   Enabling extraction, and running modal analysis on what it produces.
-weight: 4
+weight: 5
 ---
 
 The method itself, what the extracted model means and where it is valid, is derived under

--- a/docs/hugo/content/en/docs/Developer Guide/Solvers/variable-time-step.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Solvers/variable-time-step.md
@@ -1,0 +1,109 @@
+---
+title: "Variable Time Step in MNA"
+linkTitle: "Variable Time Step"
+date: 2026-08-26
+description: >
+  Changing the time step during a run, which components follow it, and refining the step around
+  scheduled events.
+weight: 2
+---
+
+An extension of the [MNA solver]({{< ref "mna-solver.md" >}}) rather than a solver of its own:
+assembly, stepping and the linear backends are unchanged, and a run that never changes its step
+never enters this path.
+
+`setTimeStep()` is an initialisation setting. Components derive their companion models from the step
+in `mnaCompInitialize()` and keep the result, so writing the step later changes only how far the
+simulation advances per step and leaves every discretisation behind.
+
+`Simulation::updateTimeStep(Real)` changes it properly, between steps.
+
+## How a change reaches the components
+
+```
+Simulation::updateTimeStep()   writes the step, calls every solver
+  Solver::updateTimeStep()     base, records the step
+  MnaSolver::updateTimeStep()  asks every component, re-stamps, refactorises
+    MNAInterface::mnaUpdateTimeStep()   per component
+```
+
+A component returns `false` when it cannot follow. `MnaSolver::updateTimeStep()` returns how many
+declined and names the declining types in the log, so a run that keeps a stale discretisation says
+so rather than looking merely degraded. `Simulation::updateTimeStep()` passes that count back to the
+caller.
+
+`CompositePowerComp` asks every sub-component and then its own
+`mnaParentUpdateTimeStep()`, which defaults to `false`. A composite that owns no step-dependent
+state overrides it to return `true`; one that owns a controller or its own discretisation converts
+that state first. The result is the conjunction, so a composite declines if any part of it does.
+
+{{% alert title="Watch out: the base matrix is not refreshed by a step change on its own" color="warning" %}}
+`recomputeSystemMatrix()` runs only when a *variable* component reports a change, and a step change
+is not that. `MnaSolverDirect::refreshStaticMatrixStamp()` therefore re-stamps the base matrix,
+which carries the static components with the old step, and factorises **fully** rather than through
+`partialRefactorize()`, whose entry list covers only the variable components.
+{{% /alert %}}
+
+With precomputed switch matrices there is nothing to re-stamp from — every switched matrix was
+factorised with the old step — so the change is refused with a warning. Enable system-matrix
+recomputation to change the step.
+
+## What a component has to do
+
+Three shapes cover almost everything:
+
+- **Nothing depends on the step.** Return `timeStep > 0`. Resistors, ideal sources, series switches.
+- **A companion model.** Re-derive the factors and rebuild the history term from the *present*
+  voltage and current. `DP::Ph1::Inductor` and `ResIndSeries` call `initVars()` for this but
+  preserve `mIntfCurrent` across the call: `initVars()` overwrites it, which is right at startup
+  where the current comes from the load flow and wrong mid-run where it is the state. The `Ph3`
+  inductor and capacitor need no such care, since their `initVars()` leaves the interface current
+  alone.
+- **A rotating machine.** Re-derive the constants, and re-anchor the rotor angle by
+  `mBase_OmMech * (oldTimeStep - timeStep)`. `mnaCompPreStep()` advances `mThetaMech` to the end of
+  the step and then passes the start time, so the dq transform argument carries a `w0*dt` term. That
+  term is constant while the step is, and jumps once when it changes, rotating the machine against
+  the network. The correction takes no factor `w`, so the real slip against the shift frame
+  survives. The VBR models additionally correct the history EMF for the new coefficients through
+  `adjustVBRHistoryForNewTimeStep()`.
+
+## Refining the step around events
+
+```cpp
+sim.setEventRefinement(fineTimeStep, leadTime, followTime);
+```
+
+The fine step is used from `leadTime` before a scheduled event until `followTime` after it, and the
+step given to `setTimeStep()` outside that window. `fineTimeStep <= 0` disables it. Event times are
+collected when the event is added, so no trigger logic is needed. `applyEventRefinement()` evaluates
+the window at the start of each step and goes through `updateTimeStep()`, so declining components
+are reported as usual.
+
+## Scope
+
+- **DP only.** `mnaUpdateTimeStep()` defaults to `false`, so an EMT or SP run declines everything
+  and warns. Coverage is `DP::Ph1` and `DP::Ph3`: passive elements, ideal sources, the passive
+  containers, the switches, and the reduced-order and PCM/TPM machines.
+- **Still declining in DP**, deliberately: the converter families, `SynchronGeneratorTrStab`,
+  `SynchronGeneratorIdeal`, `PQLoadCS`, `RXLoadSwitch`, `VoltageSourceRamp` and
+  `Ph3::SynchronGeneratorDQODE`, whose ODE solver holds its own step-dependent state.
+- **Scheduled events only.** A switching action driven from inside a component, such as a protection
+  trip, never enters the event queue and opens no window.
+
+## The test
+
+`DP_VarTimeStep` (`dpsim/examples/cxx/Components/`) checks six things and returns a non-zero exit
+code on failure:
+
+| check | measured |
+|---|---|
+| a change to the step already in use is a no-op | deviation `0` |
+| a coarse-to-fine change matches a run held fine | `4.4e-10` |
+| declining components are counted | `0` passive, `1` with a ramped source |
+| a refined window recovers a switching transient | peak error `2.9e-2` at the base step, `5.3e-8` refined |
+| a `Ph3` network converts completely | `0` declining |
+| a machine keeps its rotor angle | terminal voltage deviation `2.3e-11` |
+
+The machine check is a 24 kV SMIB with a 4th-order VBR generator. With the rotor re-anchoring
+removed the same check reads `2.3e-1`, so it measures that correction rather than passing by
+construction.

--- a/docs/hugo/content/en/docs/Developer Guide/Writing a Model/mnainterface.md
+++ b/docs/hugo/content/en/docs/Developer Guide/Writing a Model/mnainterface.md
@@ -33,6 +33,9 @@ virtual void mnaCompApplyRightSideVectorStampHarm(Matrix& sourceVector, Int freq
 
 `MNASimPowerComp` provides empty default implementations for all of these methods, so component classes are not forced to implement any of them.
 
+`MNAInterface` declares one further method, `mnaUpdateTimeStep(Real)`, which re-derives the quantities a component took from the time step in `mnaCompInitialize` and converts its history terms.
+It defaults to returning `false`, meaning the component cannot follow a change, so implementing it is only necessary for components that should support a [variable time step]({{< ref "../Solvers/variable-time-step.md" >}}).
+
 ## Controlling Common Base Class Behavior
 
 Child component classes can control the behavior of the base class through the constructor arguments of `MNASimPowerComp`.

--- a/dpsim-models/include/dpsim-models/CompositePowerComp.h
+++ b/dpsim-models/include/dpsim-models/CompositePowerComp.h
@@ -104,7 +104,11 @@ public:
                                  AttributeBase::List &modifiedAttributes,
                                  Attribute<Matrix>::Ptr &leftVector) override;
 
+  bool mnaUpdateTimeStep(Real timeStep) override final;
+
   // #### MNA Parent Functions ####
+  /// Converts parent-owned state to the new timestep. False means unconverted.
+  virtual bool mnaParentUpdateTimeStep(Real timeStep) { return false; }
   virtual void mnaParentInitialize(Real omega, Real timeStep,
                                    Attribute<Matrix>::Ptr leftVector){
       // By default, the parent has no custom initialization beyond what is done in CompositePowerComp::mnaCompInitialize

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Capacitor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Capacitor.h
@@ -54,6 +54,7 @@ public:
   /// Initializes internal variables of the component
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
+  bool mnaUpdateTimeStep(Real timeStep) override;
   void mnaCompInitializeHarm(
       Real omega, Real timeStep,
       std::vector<Attribute<Matrix>::Ptr> leftVector) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_CurrentSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_CurrentSource.h
@@ -47,6 +47,8 @@ public:
   ///
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
+  /// Nothing here depends on the timestep.
+  bool mnaUpdateTimeStep(Real timeStep) override { return timeStep > 0; }
   /// Stamps system matrix
   void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override {}
   /// Stamps right side (source) vector

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inductor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inductor.h
@@ -58,6 +58,17 @@ public:
   /// Initializes MNA specific variables
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
+  /// initVars() rebuilds the factors and the history term, and overwrites
+  /// mIntfCurrent, which is kept here.
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    const MatrixComp current = **mIntfCurrent;
+    initVars(timeStep);
+    **mIntfCurrent = current;
+    return true;
+  }
   void mnaCompInitializeHarm(
       Real omega, Real timeStep,
       std::vector<Attribute<Matrix>::Ptr> leftVectors) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inverter.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Inverter.h
@@ -107,6 +107,8 @@ public:
 
   // #### MNA Functions ####
   /// Initializes internal variables of the component
+  /// Nothing here depends on the timestep.
+  bool mnaUpdateTimeStep(Real timeStep) override { return timeStep > 0; }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
   void mnaCompInitializeHarm(

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_NetworkInjection.h
@@ -72,6 +72,8 @@ public:
 
   // #### MNA Section ####
   /// Stamps right side (source) vector
+  /// Holds nothing derived from the timestep.
+  bool mnaParentUpdateTimeStep(Real timeStep) override { return true; }
   void mnaParentApplyRightSideVectorStamp(Matrix &rightVector) override;
   /// Returns current through the component
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_PiLine.h
@@ -61,6 +61,8 @@ public:
   /// Updates internal voltage variable of the component
   void mnaCompUpdateVoltage(const Matrix &leftVector) override;
   /// MNA pre and post step operations
+  /// Holds nothing derived from the timestep.
+  bool mnaParentUpdateTimeStep(Real timeStep) override { return true; }
   void mnaParentPreStep(Real time, Int timeStepCount) override;
   void mnaParentPostStep(Real time, Int timeStepCount,
                          Attribute<Matrix>::Ptr &leftVector) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_ProfileVoltageSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_ProfileVoltageSource.h
@@ -58,6 +58,8 @@ public:
 
   // #### MNA Section ####
   /// Initializes internal variables of the component
+  /// Nothing here depends on the timestep.
+  bool mnaUpdateTimeStep(Real timeStep) override { return timeStep > 0; }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
   void mnaCompInitializeHarm(

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RXLoad.h
@@ -68,6 +68,8 @@ public:
   /// Update interface voltage from MNA system result
   void mnaCompUpdateVoltage(const Matrix &leftVector) override;
   /// MNA pre step operations
+  /// Holds nothing derived from the timestep.
+  bool mnaParentUpdateTimeStep(Real timeStep) override { return true; }
   void mnaParentPreStep(Real time, Int timeStepCount) override;
   /// MNA post step operations
   void mnaParentPostStep(Real time, Int timeStepCount,

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_ReducedOrderSynchronGeneratorVBR.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_ReducedOrderSynchronGeneratorVBR.h
@@ -54,6 +54,27 @@ protected:
   void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
   void mnaCompPostStep(const Matrix &leftVector) override;
+  /// Re-derives the companion and re-anchors the rotor angle: the dq transform
+  /// argument carries a w0*dt term that jumps when the step changes.
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    const Real oldAd_t = this->mAd_t;
+    const Real oldAq_t = this->mAq_t;
+    const Real oldTimeStep = this->mTimeStep;
+
+    this->mTimeStep = timeStep;
+    **this->mThetaMech += this->mBase_OmMech * (oldTimeStep - timeStep);
+    this->calculateVBRconstants();
+    // The stamped conductance is rebuilt from mA and mB every step.
+    this->calculateResistanceMatrixConstants();
+    this->adjustVBRHistoryForNewTimeStep(oldAd_t, oldAq_t);
+    return true;
+  }
+
+  /// Corrects the history EMF for the new coefficients.
+  virtual void adjustVBRHistoryForNewTimeStep(Real oldAd_t, Real oldAq_t) {}
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_ResIndSeries.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_ResIndSeries.h
@@ -50,6 +50,17 @@ public:
 
   // #### MNA section ####
   /// Initializes MNA specific variables
+  /// initVars() rebuilds the factors and the history term, and overwrites
+  /// mIntfCurrent, which is kept here.
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    const MatrixComp current = **mIntfCurrent;
+    initVars(timeStep);
+    **mIntfCurrent = current;
+    return true;
+  }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector);
   /// Stamps system matrix

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Resistor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Resistor.h
@@ -30,37 +30,40 @@ public:
   Resistor(String name, Logger::Level logLevel = Logger::Level::off)
       : Resistor(name, name, logLevel) {}
 
-  SimPowerComp<Complex>::Ptr clone(String name);
+  SimPowerComp<Complex>::Ptr clone(String name) override;
 
   // #### General ####
   /// Initializes component from power flow data
-  void initializeFromNodesAndTerminals(Real frequency);
+  void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
   void mnaCompInitialize(Real omega, Real timeStep,
-                         Attribute<Matrix>::Ptr leftVector);
+                         Attribute<Matrix>::Ptr leftVector) override;
+  /// Nothing here depends on the timestep.
+  bool mnaUpdateTimeStep(Real timeStep) override { return timeStep > 0; }
   void mnaCompInitializeHarm(Real omega, Real timeStep,
-                             std::vector<Attribute<Matrix>::Ptr> leftVector);
+                             std::vector<Attribute<Matrix>::Ptr> leftVector)
+      override;
   /// Stamps system matrix
-  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix);
+  void mnaCompApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) override;
   /// Stamps system matrix considering the frequency index
   void mnaCompApplySystemMatrixStampHarm(SparseMatrixRow &systemMatrix,
-                                         Int freqIdx);
+                                         Int freqIdx) override;
   /// Update interface voltage from MNA system result
-  void mnaCompUpdateVoltage(const Matrix &leftVector);
+  void mnaCompUpdateVoltage(const Matrix &leftVector) override;
   void mnaCompUpdateVoltageHarm(const Matrix &leftVector, Int freqIdx);
   /// Update interface current from MNA system result
-  void mnaCompUpdateCurrent(const Matrix &leftVector);
+  void mnaCompUpdateCurrent(const Matrix &leftVector) override;
   void mnaCompUpdateCurrentHarm();
   /// MNA pre and post step operations
   void mnaCompPostStep(Real time, Int timeStepCount,
-                       Attribute<Matrix>::Ptr &leftVector);
+                       Attribute<Matrix>::Ptr &leftVector) override;
   /// add MNA pre and post step dependencies
   void
   mnaCompAddPostStepDependencies(AttributeBase::List &prevStepDependencies,
                                  AttributeBase::List &attributeDependencies,
                                  AttributeBase::List &modifiedAttributes,
-                                 Attribute<Matrix>::Ptr &leftVector);
+                                 Attribute<Matrix>::Ptr &leftVector) override;
 
   class MnaPostStepHarm : public Task {
   public:
@@ -81,14 +84,14 @@ public:
   };
 
   // #### MNA Tear Section ####
-  void mnaTearApplyMatrixStamp(SparseMatrixRow &tearMatrix);
+  void mnaTearApplyMatrixStamp(SparseMatrixRow &tearMatrix) override;
 
   // #### DAE Section ####
   ///Residual Function for DAE Solver
   void daeResidual(double ttime, const double state[], const double dstate_dt[],
-                   double resid[], std::vector<int> &off);
+                   double resid[], std::vector<int> &off) override;
   ///Voltage Getter
-  Complex daeInitialize();
+  Complex daeInitialize() override;
 };
 } // namespace Ph1
 } // namespace DP

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_RxLine.h
@@ -48,6 +48,8 @@ public:
   // #### MNA section ####
   void mnaCompUpdateVoltage(const Matrix &leftVector) override;
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;
+  /// Holds nothing derived from the timestep.
+  bool mnaParentUpdateTimeStep(Real timeStep) override { return true; }
   void mnaParentAddPreStepDependencies(
       AttributeBase::List &prevStepDependencies,
       AttributeBase::List &attributeDependencies,

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SVC.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SVC.h
@@ -84,6 +84,8 @@ public:
   /// Update interface current from MNA system results
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;
   /// MNA pre step operations (parent-specific)
+  /// The regulator uses the elapsed time between steps, not a stored one.
+  bool mnaParentUpdateTimeStep(Real timeStep) override { return true; }
   void mnaParentPreStep(Real time, Int timeStepCount) override;
   /// MNA post step operations (parent-specific)
   void mnaParentPostStep(Real time, Int timeStepCount,

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Shunt.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Shunt.h
@@ -42,8 +42,10 @@ public:
 
   // #### MNA section ####
   /// Initializes component from power flow data
-  void initializeParentFromNodesAndTerminals(Real frequency);
+  void initializeParentFromNodesAndTerminals(Real frequency) override;
   /// Add MNA pre step dependencies
+  /// Holds nothing derived from the timestep.
+  bool mnaParentUpdateTimeStep(Real timeStep) override { return true; }
   void mnaParentAddPreStepDependencies(
       AttributeBase::List &prevStepDependencies,
       AttributeBase::List &attributeDependencies,

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Switch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Switch.h
@@ -102,6 +102,14 @@ public:
   void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### General MNA section ####
+  /// mTimeStep is the lookahead the exponential ramp is evaluated at.
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    mTimeStep = timeStep;
+    return true;
+  }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator4OrderPCM.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator4OrderPCM.h
@@ -59,6 +59,17 @@ public:
 
   // #### MNA Functions ####
   ///
+  /// Rebuilds the state space and re-anchors the rotor angle.
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    const Real oldTimeStep = mTimeStep;
+    mTimeStep = timeStep;
+    **mThetaMech += mBase_OmMech * (oldTimeStep - timeStep);
+    calculateStateSpaceMatrices();
+    return true;
+  }
   void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) final;
   ///
   void mnaCompPostStep(const Matrix &leftVector) final;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator4OrderTPM.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator4OrderTPM.h
@@ -96,6 +96,19 @@ public:
 
   // #### MNA Functions ####
   ///
+  /// Rebuilds the state space and re-anchors the rotor angle.
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    const Real oldTimeStep = mTimeStep;
+    mTimeStep = timeStep;
+    **mThetaMech += mBase_OmMech * (oldTimeStep - timeStep);
+    calculateVBRconstants();
+    calculateResistanceMatrixConstants();
+    calculateStateSpaceMatrices();
+    return true;
+  }
   void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) override;
   ///
   void mnaCompPostStep(const Matrix &leftVector) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator5OrderVBR.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator5OrderVBR.h
@@ -45,6 +45,7 @@ public:
   /// Initializes component from power flow data
   void specificInitialization() override;
   ///
+  void adjustVBRHistoryForNewTimeStep(Real oldAd_t, Real oldAq_t) override;
   void stepInPerUnit() override;
 };
 } // namespace Ph1

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator6OrderPCM.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator6OrderPCM.h
@@ -57,6 +57,17 @@ public:
 
   // #### MNA Functions ####
   ///
+  /// Rebuilds the state space and re-anchors the rotor angle.
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    const Real oldTimeStep = mTimeStep;
+    mTimeStep = timeStep;
+    **mThetaMech += mBase_OmMech * (oldTimeStep - timeStep);
+    calculateStateSpaceMatrices();
+    return true;
+  }
   void mnaCompApplyRightSideVectorStamp(Matrix &rightVector) final;
   ///
   void mnaCompPostStep(const Matrix &leftVector) final;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator6aOrderVBR.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator6aOrderVBR.h
@@ -45,6 +45,7 @@ public:
   /// Initializes component from power flow data
   void specificInitialization() final;
   ///
+  void adjustVBRHistoryForNewTimeStep(Real oldAd_t, Real oldAq_t) override;
   void stepInPerUnit() final;
 };
 } // namespace Ph1

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator6bOrderVBR.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_SynchronGenerator6bOrderVBR.h
@@ -44,6 +44,7 @@ public:
   /// Initializes component from power flow data
   void specificInitialization() final;
   ///
+  void adjustVBRHistoryForNewTimeStep(Real oldAd_t, Real oldAq_t) override;
   void stepInPerUnit() final;
 };
 } // namespace Ph1

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_Transformer.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_Transformer.h
@@ -76,6 +76,8 @@ public:
 
   // #### MNA section ####
   /// Initializes internal variables of the component
+  /// Holds nothing derived from the timestep.
+  bool mnaParentUpdateTimeStep(Real timeStep) override { return true; }
   void mnaParentInitialize(Real omega, Real timeStep,
                            Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSource.h
@@ -89,6 +89,8 @@ public:
   /// Initializes internal variables of the component
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
+  /// Nothing here depends on the timestep.
+  bool mnaUpdateTimeStep(Real timeStep) override { return timeStep > 0; }
   void mnaCompInitializeHarm(
       Real omega, Real timeStep,
       std::vector<Attribute<Matrix>::Ptr> leftVectors) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceNorton.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_VoltageSourceNorton.h
@@ -60,6 +60,8 @@ public:
 
   // #### MNA section ####
   /// Initializes internal variables of the component
+  /// Nothing here depends on the timestep.
+  bool mnaUpdateTimeStep(Real timeStep) override { return timeStep > 0; }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph1_varResSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph1_varResSwitch.h
@@ -57,6 +57,15 @@ public:
 
   // #### MNA section ####
   /// Initializes MNA specific variables
+  /// The resistance growth per step is derived from the step, as in
+  /// setInitParameters().
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    mDeltaResOpen = 0.5 * timeStep / 0.001 + 1;
+    return true;
+  }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_Capacitor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_Capacitor.h
@@ -34,6 +34,8 @@ protected:
   MatrixComp mPrevVoltCoeff;
   /// init resistive companion model of capacitor
   void initVars(Real omega, Real timeStep);
+  /// Reference frequency initVars() was last called with
+  Real mOmega = 0.0;
 
 public:
   /// Defines UID, name and logging level
@@ -50,6 +52,13 @@ public:
   void initializeFromNodesAndTerminals(Real frequency) override;
   // #### MNA section ####
   /// Initializes internal variables of the component
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    initVars(mOmega, timeStep);
+    return true;
+  }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_CurrentSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_CurrentSource.h
@@ -42,6 +42,8 @@ public:
 
   // #### MNA section ####
   /// Initializes internal variables of the component
+  /// Nothing here depends on the timestep.
+  bool mnaUpdateTimeStep(Real timeStep) override { return timeStep > 0; }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps right side (source) vector

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_Inductor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_Inductor.h
@@ -35,6 +35,8 @@ protected:
   Complex mPrevCurrFac;
 
   void initVars(Real omega, Real timeStep);
+  /// Reference frequency initVars() was last called with
+  Real mOmega = 0.0;
 
 public:
   Inductor(String uid, String name,
@@ -56,6 +58,13 @@ public:
   void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    initVars(mOmega, timeStep);
+    return true;
+  }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_NetworkInjection.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_NetworkInjection.h
@@ -47,6 +47,8 @@ public:
 
   // #### MNA Section ####
   /// Stamps right side (source) vector
+  /// Holds nothing derived from the timestep.
+  bool mnaParentUpdateTimeStep(Real timeStep) override { return true; }
   void mnaParentApplyRightSideVectorStamp(Matrix &rightVector) override;
   /// Returns current through the component
   void mnaCompUpdateCurrent(const Matrix &leftVector) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_PiLine.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_PiLine.h
@@ -61,6 +61,8 @@ public:
   /// Updates internal voltage variable of the component
   void mnaCompUpdateVoltage(const Matrix &leftVector) override;
   /// MNA pre and post step operations
+  /// Holds nothing derived from the timestep.
+  bool mnaParentUpdateTimeStep(Real timeStep) override { return true; }
   void mnaParentPreStep(Real time, Int timeStepCount) override;
   void mnaParentPostStep(Real time, Int timeStepCount,
                          Attribute<Matrix>::Ptr &leftVector) override;

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_Resistor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_Resistor.h
@@ -41,6 +41,8 @@ public:
   void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### MNA section ####
+  /// Nothing here depends on the timestep.
+  bool mnaUpdateTimeStep(Real timeStep) override { return timeStep > 0; }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesResistor.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesResistor.h
@@ -37,6 +37,8 @@ public:
   void initializeFromNodesAndTerminals(Real frequency) override;
   // #### MNA section ####
   ///
+  /// Nothing here depends on the timestep.
+  bool mnaUpdateTimeStep(Real timeStep) override { return timeStep > 0; }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesSwitch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_SeriesSwitch.h
@@ -46,6 +46,8 @@ public:
 
   // #### General MNA section ####
   ///
+  /// Nothing here depends on the timestep.
+  bool mnaUpdateTimeStep(Real timeStep) override { return timeStep > 0; }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_Switch.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_Switch.h
@@ -104,6 +104,14 @@ public:
   void initializeFromNodesAndTerminals(Real frequency) override;
 
   // #### General MNA ####
+  /// mTimeStep is the lookahead the exponential ramp is evaluated at.
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    mTimeStep = timeStep;
+    return true;
+  }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_SynchronGeneratorDQODE.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_SynchronGeneratorDQODE.h
@@ -44,6 +44,8 @@ public:
                          Logger::Level loglevel = Logger::Level::off);
 
   // #### MNA Section ####
+  /// The ODE solver holds its own step-dependent state.
+  bool mnaUpdateTimeStep(Real timeStep) override { return false; }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_SynchronGeneratorDQTrapez.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_SynchronGeneratorDQTrapez.h
@@ -25,6 +25,13 @@ public:
   void setMultisamplingRate(Int rate);
 
   // #### MNA Section ####
+  bool mnaUpdateTimeStep(Real timeStep) override {
+    if (timeStep <= 0)
+      return false;
+
+    mTimeStep = timeStep;
+    return true;
+  }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
 

--- a/dpsim-models/include/dpsim-models/DP/DP_Ph3_VoltageSource.h
+++ b/dpsim-models/include/dpsim-models/DP/DP_Ph3_VoltageSource.h
@@ -59,6 +59,8 @@ public:
 
   // #### MNA Section ####
   ///
+  /// Nothing here depends on the timestep.
+  bool mnaUpdateTimeStep(Real timeStep) override { return timeStep > 0; }
   void mnaCompInitialize(Real omega, Real timeStep,
                          Attribute<Matrix>::Ptr leftVector) override;
   /// Stamps system matrix

--- a/dpsim-models/include/dpsim-models/Solver/MNAInterface.h
+++ b/dpsim-models/include/dpsim-models/Solver/MNAInterface.h
@@ -27,6 +27,9 @@ public:
   virtual void mnaInitialize(Real omega, Real timeStep) = 0;
   virtual void mnaInitialize(Real omega, Real timeStep,
                              Attribute<Matrix>::Ptr leftVector) = 0;
+  /// Re-derives the timestep-dependent quantities and converts the history
+  /// terms. False if the component cannot follow.
+  virtual bool mnaUpdateTimeStep(Real timeStep) { return false; }
   /// Stamps system matrix
   virtual void mnaApplySystemMatrixStamp(SparseMatrixRow &systemMatrix) = 0;
   /// Stamps right side (source) vector

--- a/dpsim-models/src/CompositePowerComp.cpp
+++ b/dpsim-models/src/CompositePowerComp.cpp
@@ -73,6 +73,17 @@ void CompositePowerComp<VarType>::mnaCompInitialize(
 }
 
 template <typename VarType>
+bool CompositePowerComp<VarType>::mnaUpdateTimeStep(Real timeStep) {
+  // Every sub-component is asked, regardless of earlier results.
+  bool handled = true;
+  for (auto subComp : mSubcomponentsMNA) {
+    const bool subHandled = subComp->mnaUpdateTimeStep(timeStep);
+    handled = handled && subHandled;
+  }
+  return mnaParentUpdateTimeStep(timeStep) && handled;
+}
+
+template <typename VarType>
 void CompositePowerComp<VarType>::mnaCompApplySystemMatrixStamp(
     SparseMatrixRow &systemMatrix) {
   for (auto subComp : mSubcomponentsMNA) {

--- a/dpsim-models/src/DP/DP_Ph1_Capacitor.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_Capacitor.cpp
@@ -67,6 +67,29 @@ void DP::Ph1::Capacitor::initializeFromNodesAndTerminals(Real frequency) {
   mSLog->flush();
 }
 
+bool DP::Ph1::Capacitor::mnaUpdateTimeStep(Real timeStep) {
+  if (timeStep <= 0)
+    return false;
+
+  // As mnaCompInitialize(), without the mIntfCurrent overwrite. Only the real
+  // parts of the factors carry the timestep.
+  Real equivCondReal = 2.0 * **mCapacitance / timeStep;
+  Real prevVoltCoeffReal = 2.0 * **mCapacitance / timeStep;
+
+  for (UInt freq = 0; freq < mNumFreqs; freq++) {
+    Real equivCondImag = 2. * PI * mFrequencies(freq, 0) * **mCapacitance;
+    mEquivCond(freq, 0) = {equivCondReal, equivCondImag};
+    Real prevVoltCoeffImag = -2. * PI * mFrequencies(freq, 0) * **mCapacitance;
+    mPrevVoltCoeff(freq, 0) = {prevVoltCoeffReal, prevVoltCoeffImag};
+
+    mEquivCurrent(freq, 0) =
+        -(**mIntfCurrent)(0, freq) +
+        -mPrevVoltCoeff(freq, 0) * (**mIntfVoltage)(0, freq);
+  }
+
+  return true;
+}
+
 void DP::Ph1::Capacitor::mnaCompInitialize(Real omega, Real timeStep,
                                            Attribute<Matrix>::Ptr leftVector) {
   updateMatrixNodeIndices();

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGenerator5OrderVBR.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGenerator5OrderVBR.cpp
@@ -59,6 +59,12 @@ void DP::Ph1::SynchronGenerator5OrderVBR::specificInitialization() {
   mSLog->flush();
 }
 
+void DP::Ph1::SynchronGenerator5OrderVBR::adjustVBRHistoryForNewTimeStep(
+    Real /*oldAd_t*/, Real oldAq_t) {
+  // No transient d-axis EMF in this model.
+  mEh_t(1, 0) += (oldAq_t - mAq_t) * (**mIdq)(0, 0);
+}
+
 void DP::Ph1::SynchronGenerator5OrderVBR::stepInPerUnit() {
   // update DP-DQ transforms
   mDomainInterface.updateDQToDPTransform(**mThetaMech, mSimTime);

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGenerator6aOrderVBR.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGenerator6aOrderVBR.cpp
@@ -59,6 +59,12 @@ void DP::Ph1::SynchronGenerator6aOrderVBR::specificInitialization() {
   mSLog->flush();
 }
 
+void DP::Ph1::SynchronGenerator6aOrderVBR::adjustVBRHistoryForNewTimeStep(
+    Real oldAd_t, Real oldAq_t) {
+  mEh_t(0, 0) += (oldAd_t - mAd_t) * (**mIdq)(1, 0);
+  mEh_t(1, 0) += (oldAq_t - mAq_t) * (**mIdq)(0, 0);
+}
+
 void DP::Ph1::SynchronGenerator6aOrderVBR::stepInPerUnit() {
 
   // update DP-DQ transforms

--- a/dpsim-models/src/DP/DP_Ph1_SynchronGenerator6bOrderVBR.cpp
+++ b/dpsim-models/src/DP/DP_Ph1_SynchronGenerator6bOrderVBR.cpp
@@ -59,6 +59,12 @@ void DP::Ph1::SynchronGenerator6bOrderVBR::specificInitialization() {
   mSLog->flush();
 }
 
+void DP::Ph1::SynchronGenerator6bOrderVBR::adjustVBRHistoryForNewTimeStep(
+    Real oldAd_t, Real oldAq_t) {
+  mEh_t(0, 0) += (oldAd_t - mAd_t) * (**mIdq)(1, 0);
+  mEh_t(1, 0) += (oldAq_t - mAq_t) * (**mIdq)(0, 0);
+}
+
 void DP::Ph1::SynchronGenerator6bOrderVBR::stepInPerUnit() {
 
   // update DP-DQ transforms

--- a/dpsim-models/src/DP/DP_Ph3_Capacitor.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_Capacitor.cpp
@@ -72,6 +72,8 @@ void DP::Ph3::Capacitor::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void DP::Ph3::Capacitor::initVars(Real omega, Real timeStep) {
+  mOmega = omega;
+
   Matrix a = timeStep / 2 * (**mCapacitance).inverse();
   Real b = timeStep * omega / 2.;
 

--- a/dpsim-models/src/DP/DP_Ph3_Inductor.cpp
+++ b/dpsim-models/src/DP/DP_Ph3_Inductor.cpp
@@ -80,6 +80,8 @@ void DP::Ph3::Inductor::initializeFromNodesAndTerminals(Real frequency) {
 }
 
 void DP::Ph3::Inductor::initVars(Real omega, Real timeStep) {
+  mOmega = omega;
+
   Matrix a = timeStep / 2.0 * (**mInductance).inverse();
 
   const Real b = timeStep * omega / 2.0;

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -127,7 +127,6 @@ endif()
 set(SYNCGEN_SOURCES
 	Components/DP_SynGenDq7odTrapez_SteadyState.cpp
 	Components/DP_SynGenDq7odTrapez_ThreePhFault.cpp
-	Components/DP_VarTimeStep.cpp
 	Components/DP_SynGenTrStab_SteadyState.cpp
 	Components/DP_SynGenTrStab_LoadStep.cpp
 	Components/DP_EMT_SynGenDq7odTrapez_SteadyState.cpp
@@ -159,6 +158,10 @@ Components/EMT_SSN_GFM_Test.cpp
 Components/EMT_Ph3_SSN_GFM_JacobianCheck.cpp
 Components/EMT_Ph3_GFL_Comparison.cpp
 Components/EMT_Ph3_SSN_InductionMotor_LoadSwitch.cpp
+)
+
+set(VAR_TIME_STEP_SOURCES
+	Components/DP_VarTimeStep.cpp
 )
 
 set(STATE_SPACE_SOURCES
@@ -312,6 +315,7 @@ foreach(SOURCE
 		${DAE_SOURCES}
 		${INVERTER_SOURCES}
 		${SSN_SOURCES}
+		${VAR_TIME_STEP_SOURCES}
 		${STATE_SPACE_SOURCES})
 	get_filename_component(TARGET ${SOURCE} NAME_WE)
 

--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -127,6 +127,7 @@ endif()
 set(SYNCGEN_SOURCES
 	Components/DP_SynGenDq7odTrapez_SteadyState.cpp
 	Components/DP_SynGenDq7odTrapez_ThreePhFault.cpp
+	Components/DP_VarTimeStep.cpp
 	Components/DP_SynGenTrStab_SteadyState.cpp
 	Components/DP_SynGenTrStab_LoadStep.cpp
 	Components/DP_EMT_SynGenDq7odTrapez_SteadyState.cpp

--- a/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
+++ b/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
@@ -1,0 +1,224 @@
+/* Author: Christoph Wirtz <christoph.wirtz@fgh-ma.de>
+ * SPDX-FileCopyrightText: 2026 FGH e.V.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Checks Simulation::updateTimeStep() on a network of DP passive elements.
+//
+//   [1] Changing to the step already in use must reproduce the undisturbed run.
+//       Any deviation is produced by the conversion itself.
+//   [2] Changing from a coarse to a fine step must stay close to a run held at
+//       the fine step throughout.
+//   [3] The return value must count the components that did not convert.
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+#include <DPsim.h>
+
+using namespace DPsim;
+using namespace CPS;
+
+namespace {
+
+struct Parameters {
+  Real frequency = 50.0;
+  Real sourceVoltage = 100e3;
+  Real sourceResistance = 10.0;
+  Real inductance = 50e-3;
+  Real capacitance = 1e-6;
+  Real loadResistance = 100.0;
+
+  Real coarseStep = 200e-6;
+  Real fineStep = 50e-6;
+  Real changeTime = 0.1;
+  Real finalTime = 0.2;
+};
+
+/// Source - R - L - probe, with C and a load resistor from probe to ground.
+SystemTopology build(const Parameters &p,
+                     std::shared_ptr<SimNode<Complex>> &probe) {
+  auto n1 = SimNode<Complex>::make("n1", PhaseType::Single);
+  auto n2 = SimNode<Complex>::make("n2", PhaseType::Single);
+
+  n1->setInitialVoltage(Complex(p.sourceVoltage, 0.0));
+
+  auto vs = DP::Ph1::VoltageSource::make("vs", Logger::Level::off);
+  vs->setParameters(Complex(p.sourceVoltage, 0.0));
+
+  auto res = DP::Ph1::Resistor::make("R_src", Logger::Level::off);
+  res->setParameters(p.sourceResistance);
+
+  auto ind = DP::Ph1::Inductor::make("L", Logger::Level::off);
+  ind->setParameters(p.inductance);
+
+  auto cap = DP::Ph1::Capacitor::make("C", Logger::Level::off);
+  cap->setParameters(p.capacitance);
+
+  auto load = DP::Ph1::Resistor::make("R_load", Logger::Level::off);
+  load->setParameters(p.loadResistance);
+
+  vs->connect({SimNode<Complex>::GND, n1});
+  res->connect({n1, n2});
+  ind->connect({n2, SimNode<Complex>::GND});
+  cap->connect({n2, SimNode<Complex>::GND});
+  load->connect({n2, SimNode<Complex>::GND});
+
+  probe = n2;
+
+  return SystemTopology(p.frequency, SystemNodeList{n1, n2},
+                        SystemComponentList{vs, res, ind, cap, load});
+}
+
+struct Trace {
+  std::vector<Real> time;
+  std::vector<Complex> voltage;
+  UInt unconverted = 0;
+};
+
+/// changeTo <= 0 runs at startStep throughout.
+Trace run(const Parameters &p, const String &name, Real startStep,
+          Real changeTo) {
+  const String simName = "DP_VarTimeStep_" + name;
+  Logger::setLogDir("logs/" + simName);
+
+  std::shared_ptr<SimNode<Complex>> probe;
+  auto system = build(p, probe);
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(system);
+  sim.setDomain(Domain::DP);
+  sim.setSolverType(Solver::Type::MNA);
+  sim.setTimeStep(startStep);
+  sim.setFinalTime(p.finalTime);
+  sim.doSystemMatrixRecomputation(true);
+
+  Trace trace;
+  Bool changed = changeTo <= 0;
+
+  sim.start();
+
+  while (sim.time() < p.finalTime + DOUBLE_EPSILON) {
+    if (!changed && sim.time() >= p.changeTime - DOUBLE_EPSILON) {
+      trace.unconverted = sim.updateTimeStep(changeTo);
+      changed = true;
+    }
+
+    sim.next();
+    trace.time.push_back(sim.time());
+    trace.voltage.push_back(
+        probe->attributeTyped<MatrixComp>("v")->get()(0, 0));
+  }
+
+  sim.stop();
+
+  return trace;
+}
+
+/// Largest deviation between the samples the two traces share, relative to the
+/// reference magnitude.
+Real deviationAfter(const Trace &test, const Trace &reference, Real from) {
+  Real worst = 0.0;
+  Real scale = 0.0;
+
+  for (const auto &value : reference.voltage)
+    scale = std::max(scale, std::abs(value));
+
+  for (std::size_t idx = 0; idx < test.time.size(); ++idx) {
+    if (test.time[idx] < from)
+      continue;
+
+    for (std::size_t ref = 0; ref < reference.time.size(); ++ref) {
+      if (std::abs(reference.time[ref] - test.time[idx]) > 1e-12)
+        continue;
+      worst =
+          std::max(worst, std::abs(test.voltage[idx] - reference.voltage[ref]));
+      break;
+    }
+  }
+
+  return scale > 0 ? worst / scale : worst;
+}
+
+/// A PiLine is a CompositePowerComp whose parent hook does not convert.
+UInt countUnconverted(const Parameters &p) {
+  const String simName = "DP_VarTimeStep_Composite";
+  Logger::setLogDir("logs/" + simName);
+
+  auto n1 = SimNode<Complex>::make("n1", PhaseType::Single);
+  auto n2 = SimNode<Complex>::make("n2", PhaseType::Single);
+
+  n1->setInitialVoltage(Complex(p.sourceVoltage, 0.0));
+
+  auto vs = DP::Ph1::VoltageSource::make("vs", Logger::Level::off);
+  vs->setParameters(Complex(p.sourceVoltage, 0.0));
+
+  auto line = DP::Ph1::PiLine::make("line", Logger::Level::off);
+  line->setParameters(p.sourceResistance, p.inductance, p.capacitance, 0.0);
+
+  auto load = DP::Ph1::Resistor::make("R_load", Logger::Level::off);
+  load->setParameters(p.loadResistance);
+
+  vs->connect({SimNode<Complex>::GND, n1});
+  line->connect({n1, n2});
+  load->connect({n2, SimNode<Complex>::GND});
+
+  auto system = SystemTopology(p.frequency, SystemNodeList{n1, n2},
+                               SystemComponentList{vs, line, load});
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(system);
+  sim.setDomain(Domain::DP);
+  sim.setSolverType(Solver::Type::MNA);
+  sim.setTimeStep(p.coarseStep);
+  sim.setFinalTime(2.0 * p.coarseStep);
+  sim.doSystemMatrixRecomputation(true);
+
+  sim.start();
+  sim.next();
+  const UInt unconverted = sim.updateTimeStep(p.fineStep);
+  sim.next();
+  sim.stop();
+
+  return unconverted;
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  const Parameters p;
+
+  const Trace coarse = run(p, "Coarse", p.coarseStep, -1.0);
+  const Trace fine = run(p, "Fine", p.fineStep, -1.0);
+  const Trace sameStep = run(p, "SameStep", p.coarseStep, p.coarseStep);
+  const Trace refined = run(p, "Refined", p.coarseStep, p.fineStep);
+
+  const Real window = p.changeTime + 1e-3;
+  const Real sameDeviation = deviationAfter(sameStep, coarse, window);
+  const Real refinedDeviation = deviationAfter(refined, fine, window);
+  const UInt unconverted = countUnconverted(p);
+
+  const Bool passSame = sameDeviation < 1e-9;
+  const Bool passRefined = refinedDeviation < 1e-2;
+  const Bool passCount = sameStep.unconverted == 0 && unconverted == 1;
+
+  std::cout << std::scientific << std::setprecision(6);
+  std::cout << "Same step is a no-op: " << (passSame ? "PASS" : "FAIL")
+            << " (deviation " << sameDeviation << ")" << std::endl;
+  std::cout << "Refined follows the fine run: "
+            << (passRefined ? "PASS" : "FAIL") << " (deviation "
+            << refinedDeviation << ")" << std::endl;
+  std::cout << "Unconverted components counted: "
+            << (passCount ? "PASS" : "FAIL") << " (passive "
+            << sameStep.unconverted << ", with a PiLine " << unconverted << ")"
+            << std::endl;
+
+  const Bool passed = passSame && passRefined && passCount;
+  std::cout << "Variable time step: " << (passed ? "3/3" : "failed")
+            << std::endl;
+
+  return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
+++ b/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
@@ -11,6 +11,8 @@
 //       the fine step throughout.
 //   [3] The return value must count the components that did not convert. A
 //       PiLine converts, a varResSwitch does not.
+//   [4] Refining around a switching event must recover the transient that the
+//       base step alone misses.
 
 #include <algorithm>
 #include <cmath>
@@ -19,6 +21,7 @@
 #include <vector>
 
 #include <DPsim.h>
+#include <dpsim-models/DP/DP_Ph1_Switch.h>
 
 using namespace DPsim;
 using namespace CPS;
@@ -37,6 +40,10 @@ struct Parameters {
   Real fineStep = 50e-6;
   Real changeTime = 0.1;
   Real finalTime = 0.2;
+
+  Real switchResistance = 20.0;
+  Real leadTime = 1e-3;
+  Real followTime = 5e-3;
 };
 
 /// Source - R - L - probe, with C and a load resistor from probe to ground.
@@ -185,6 +192,76 @@ UInt unconvertedWith(const Parameters &p, const String &name,
   return unconverted;
 }
 
+/// The load branch is interrupted at changeTime, which rings the L-C pair. With
+/// refinement the fine step covers the event window only.
+Real switchedPeak(const Parameters &p, const String &name, Real baseStep,
+                  Real fineStep) {
+  const String simName = "DP_VarTimeStep_" + name;
+  Logger::setLogDir("logs/" + simName);
+
+  auto n1 = SimNode<Complex>::make("n1", PhaseType::Single);
+  auto n2 = SimNode<Complex>::make("n2", PhaseType::Single);
+  auto n3 = SimNode<Complex>::make("n3", PhaseType::Single);
+
+  n1->setInitialVoltage(Complex(p.sourceVoltage, 0.0));
+
+  auto vs = DP::Ph1::VoltageSource::make("vs", Logger::Level::off);
+  vs->setParameters(Complex(p.sourceVoltage, 0.0));
+
+  auto res = DP::Ph1::Resistor::make("R_src", Logger::Level::off);
+  res->setParameters(p.sourceResistance);
+
+  auto ind = DP::Ph1::Inductor::make("L", Logger::Level::off);
+  ind->setParameters(p.inductance);
+
+  auto cap = DP::Ph1::Capacitor::make("C", Logger::Level::off);
+  cap->setParameters(p.capacitance);
+
+  auto breaker = DP::Ph1::Switch::make("breaker", Logger::Level::off);
+  breaker->setParameters(1e9, 1e-3, true);
+
+  auto load = DP::Ph1::Resistor::make("R_load", Logger::Level::off);
+  load->setParameters(p.switchResistance);
+
+  vs->connect({SimNode<Complex>::GND, n1});
+  res->connect({n1, n2});
+  ind->connect({n2, SimNode<Complex>::GND});
+  cap->connect({n2, SimNode<Complex>::GND});
+  breaker->connect({n2, n3});
+  load->connect({n3, SimNode<Complex>::GND});
+
+  auto system =
+      SystemTopology(p.frequency, SystemNodeList{n1, n2, n3},
+                     SystemComponentList{vs, res, ind, cap, breaker, load});
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(system);
+  sim.setDomain(Domain::DP);
+  sim.setSolverType(Solver::Type::MNA);
+  sim.setTimeStep(baseStep);
+  sim.setFinalTime(p.finalTime);
+  sim.doSystemMatrixRecomputation(true);
+  sim.addEvent(SwitchEvent::make(p.changeTime, breaker, false));
+
+  if (fineStep > 0)
+    sim.setEventRefinement(fineStep, p.leadTime, p.followTime);
+
+  Real peak = 0.0;
+
+  sim.start();
+
+  while (sim.time() < p.finalTime + DOUBLE_EPSILON) {
+    sim.next();
+    if (sim.time() >= p.changeTime && sim.time() <= p.changeTime + p.followTime)
+      peak = std::max(
+          peak, std::abs(n2->attributeTyped<MatrixComp>("v")->get()(0, 0)));
+  }
+
+  sim.stop();
+
+  return peak;
+}
+
 } // namespace
 
 int main(int argc, char *argv[]) {
@@ -208,10 +285,19 @@ int main(int argc, char *argv[]) {
   const UInt withLine = unconvertedWith(p, "PiLine", line);
   const UInt withSwitch = unconvertedWith(p, "VarResSwitch", varSwitch);
 
+  const Real peakFine = switchedPeak(p, "SwitchFine", p.fineStep, -1.0);
+  const Real peakCoarse = switchedPeak(p, "SwitchCoarse", p.coarseStep, -1.0);
+  const Real peakWindow =
+      switchedPeak(p, "SwitchRefined", p.coarseStep, p.fineStep);
+
+  const Real coarseError = std::abs(peakCoarse - peakFine) / peakFine;
+  const Real windowError = std::abs(peakWindow - peakFine) / peakFine;
+
   const Bool passSame = sameDeviation < 1e-9;
   const Bool passRefined = refinedDeviation < 1e-2;
   const Bool passCount =
       sameStep.unconverted == 0 && withLine == 0 && withSwitch == 1;
+  const Bool passWindow = windowError < 0.5 * coarseError;
 
   std::cout << std::scientific << std::setprecision(6);
   std::cout << "Same step is a no-op: " << (passSame ? "PASS" : "FAIL")
@@ -224,8 +310,12 @@ int main(int argc, char *argv[]) {
             << sameStep.unconverted << ", with a PiLine " << withLine
             << ", with a varResSwitch " << withSwitch << ")" << std::endl;
 
-  const Bool passed = passSame && passRefined && passCount;
-  std::cout << "Variable time step: " << (passed ? "3/3" : "failed")
+  std::cout << "Refined window recovers the transient: "
+            << (passWindow ? "PASS" : "FAIL") << " (peak error, base step "
+            << coarseError << ", refined " << windowError << ")" << std::endl;
+
+  const Bool passed = passSame && passRefined && passCount && passWindow;
+  std::cout << "Variable time step: " << (passed ? "4/4" : "failed")
             << std::endl;
 
   return passed ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
+++ b/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
@@ -9,7 +9,8 @@
 //       Any deviation is produced by the conversion itself.
 //   [2] Changing from a coarse to a fine step must stay close to a run held at
 //       the fine step throughout.
-//   [3] The return value must count the components that did not convert.
+//   [3] The return value must count the components that did not convert. A
+//       PiLine converts, a varResSwitch does not.
 
 #include <algorithm>
 #include <cmath>
@@ -143,9 +144,10 @@ Real deviationAfter(const Trace &test, const Trace &reference, Real from) {
   return scale > 0 ? worst / scale : worst;
 }
 
-/// A PiLine is a CompositePowerComp whose parent hook does not convert.
-UInt countUnconverted(const Parameters &p) {
-  const String simName = "DP_VarTimeStep_Composite";
+/// Source - extra - load, two steps with a change between them.
+UInt unconvertedWith(const Parameters &p, const String &name,
+                     SimPowerComp<Complex>::Ptr extra) {
+  const String simName = "DP_VarTimeStep_" + name;
   Logger::setLogDir("logs/" + simName);
 
   auto n1 = SimNode<Complex>::make("n1", PhaseType::Single);
@@ -156,18 +158,15 @@ UInt countUnconverted(const Parameters &p) {
   auto vs = DP::Ph1::VoltageSource::make("vs", Logger::Level::off);
   vs->setParameters(Complex(p.sourceVoltage, 0.0));
 
-  auto line = DP::Ph1::PiLine::make("line", Logger::Level::off);
-  line->setParameters(p.sourceResistance, p.inductance, p.capacitance, 0.0);
-
   auto load = DP::Ph1::Resistor::make("R_load", Logger::Level::off);
   load->setParameters(p.loadResistance);
 
   vs->connect({SimNode<Complex>::GND, n1});
-  line->connect({n1, n2});
+  extra->connect({n1, n2});
   load->connect({n2, SimNode<Complex>::GND});
 
   auto system = SystemTopology(p.frequency, SystemNodeList{n1, n2},
-                               SystemComponentList{vs, line, load});
+                               SystemComponentList{vs, extra, load});
 
   Simulation sim(simName, Logger::Level::info);
   sim.setSystem(system);
@@ -196,14 +195,23 @@ int main(int argc, char *argv[]) {
   const Trace sameStep = run(p, "SameStep", p.coarseStep, p.coarseStep);
   const Trace refined = run(p, "Refined", p.coarseStep, p.fineStep);
 
+  auto line = DP::Ph1::PiLine::make("line", Logger::Level::off);
+  line->setParameters(p.sourceResistance, p.inductance, p.capacitance, 0.0);
+
+  auto varSwitch = DP::Ph1::varResSwitch::make("switch", Logger::Level::off);
+  varSwitch->setParameters(1e6, 1e-3, true);
+  varSwitch->setInitParameters(p.coarseStep);
+
   const Real window = p.changeTime + 1e-3;
   const Real sameDeviation = deviationAfter(sameStep, coarse, window);
   const Real refinedDeviation = deviationAfter(refined, fine, window);
-  const UInt unconverted = countUnconverted(p);
+  const UInt withLine = unconvertedWith(p, "PiLine", line);
+  const UInt withSwitch = unconvertedWith(p, "VarResSwitch", varSwitch);
 
   const Bool passSame = sameDeviation < 1e-9;
   const Bool passRefined = refinedDeviation < 1e-2;
-  const Bool passCount = sameStep.unconverted == 0 && unconverted == 1;
+  const Bool passCount =
+      sameStep.unconverted == 0 && withLine == 0 && withSwitch == 1;
 
   std::cout << std::scientific << std::setprecision(6);
   std::cout << "Same step is a no-op: " << (passSame ? "PASS" : "FAIL")
@@ -213,8 +221,8 @@ int main(int argc, char *argv[]) {
             << refinedDeviation << ")" << std::endl;
   std::cout << "Unconverted components counted: "
             << (passCount ? "PASS" : "FAIL") << " (passive "
-            << sameStep.unconverted << ", with a PiLine " << unconverted << ")"
-            << std::endl;
+            << sameStep.unconverted << ", with a PiLine " << withLine
+            << ", with a varResSwitch " << withSwitch << ")" << std::endl;
 
   const Bool passed = passSame && passRefined && passCount;
   std::cout << "Variable time step: " << (passed ? "3/3" : "failed")

--- a/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
+++ b/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
@@ -10,7 +10,7 @@
 //   [2] Changing from a coarse to a fine step must stay close to a run held at
 //       the fine step throughout.
 //   [3] The return value must count the components that did not convert. A
-//       PiLine converts, a varResSwitch does not.
+//       PiLine and a varResSwitch convert, a ramped source does not.
 //   [4] Refining around a switching event must recover the transient that the
 //       base step alone misses.
 //   [5] A Ph3 network must convert as completely as the Ph1 one.
@@ -336,11 +336,16 @@ int main(int argc, char *argv[]) {
   varSwitch->setParameters(1e6, 1e-3, true);
   varSwitch->setInitParameters(p.coarseStep);
 
+  auto ramp = DP::Ph1::VoltageSourceRamp::make("ramp", Logger::Level::off);
+  ramp->setParameters(Complex(p.sourceVoltage, 0.0), Complex(0.0, 0.0),
+                      p.frequency, 0.0, p.finalTime, 0.0);
+
   const Real window = p.changeTime + 1e-3;
   const Real sameDeviation = deviationAfter(sameStep, coarse, window);
   const Real refinedDeviation = deviationAfter(refined, fine, window);
   const UInt withLine = unconvertedWith(p, "PiLine", line);
   const UInt withSwitch = unconvertedWith(p, "VarResSwitch", varSwitch);
+  const UInt withRamp = unconvertedWith(p, "RampSource", ramp);
 
   const Real peakFine = switchedPeak(p, "SwitchFine", p.fineStep, -1.0);
   const Real peakCoarse = switchedPeak(p, "SwitchCoarse", p.coarseStep, -1.0);
@@ -352,8 +357,8 @@ int main(int argc, char *argv[]) {
 
   const Bool passSame = sameDeviation < 1e-9;
   const Bool passRefined = refinedDeviation < 1e-2;
-  const Bool passCount =
-      sameStep.unconverted == 0 && withLine == 0 && withSwitch == 1;
+  const Bool passCount = sameStep.unconverted == 0 && withLine == 0 &&
+                         withSwitch == 0 && withRamp == 1;
   const Bool passWindow = windowError < 0.5 * coarseError;
   const UInt ph3 = ph3Unconverted(p);
   const Bool passPh3 = ph3 == 0;
@@ -366,8 +371,9 @@ int main(int argc, char *argv[]) {
             << refinedDeviation << ")" << std::endl;
   std::cout << "Unconverted components counted: "
             << (passCount ? "PASS" : "FAIL") << " (passive "
-            << sameStep.unconverted << ", with a PiLine " << withLine
-            << ", with a varResSwitch " << withSwitch << ")" << std::endl;
+            << sameStep.unconverted << ", PiLine " << withLine
+            << ", varResSwitch " << withSwitch << ", ramped source " << withRamp
+            << ")" << std::endl;
 
   std::cout << "Refined window recovers the transient: "
             << (passWindow ? "PASS" : "FAIL") << " (peak error, base step "

--- a/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
+++ b/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
@@ -13,6 +13,7 @@
 //       PiLine converts, a varResSwitch does not.
 //   [4] Refining around a switching event must recover the transient that the
 //       base step alone misses.
+//   [5] A Ph3 network must convert as completely as the Ph1 one.
 
 #include <algorithm>
 #include <cmath>
@@ -192,6 +193,62 @@ UInt unconvertedWith(const Parameters &p, const String &name,
   return unconverted;
 }
 
+/// Ph3 source, R, L, C and a PiLine, one step and a change.
+UInt ph3Unconverted(const Parameters &p) {
+  const String simName = "DP_VarTimeStep_Ph3";
+  Logger::setLogDir("logs/" + simName);
+
+  auto n1 = SimNode<Complex>::make("n1", PhaseType::ABC);
+  auto n2 = SimNode<Complex>::make("n2", PhaseType::ABC);
+  auto n3 = SimNode<Complex>::make("n3", PhaseType::ABC);
+
+  const Complex phase(p.sourceVoltage, 0.0);
+  n1->setInitialVoltage(Math::singlePhaseVariableToThreePhase(phase));
+
+  auto vs = DP::Ph3::VoltageSource::make("vs", Logger::Level::off);
+  vs->setParameters(Math::singlePhaseVariableToThreePhase(phase), p.frequency);
+
+  auto line = DP::Ph3::PiLine::make("line", Logger::Level::off);
+  line->setParameters(
+      Math::singlePhaseParameterToThreePhase(p.sourceResistance),
+      Math::singlePhaseParameterToThreePhase(p.inductance),
+      Math::singlePhaseParameterToThreePhase(p.capacitance));
+
+  auto ind = DP::Ph3::Inductor::make("L", Logger::Level::off);
+  ind->setParameters(Math::singlePhaseParameterToThreePhase(p.inductance));
+
+  auto cap = DP::Ph3::Capacitor::make("C", Logger::Level::off);
+  cap->setParameters(Math::singlePhaseParameterToThreePhase(p.capacitance));
+
+  auto load = DP::Ph3::Resistor::make("R_load", Logger::Level::off);
+  load->setParameters(Math::singlePhaseParameterToThreePhase(p.loadResistance));
+
+  vs->connect({SimNode<Complex>::GND, n1});
+  line->connect({n1, n2});
+  ind->connect({n2, n3});
+  cap->connect({n3, SimNode<Complex>::GND});
+  load->connect({n3, SimNode<Complex>::GND});
+
+  auto system = SystemTopology(p.frequency, SystemNodeList{n1, n2, n3},
+                               SystemComponentList{vs, line, ind, cap, load});
+
+  Simulation sim(simName, Logger::Level::info);
+  sim.setSystem(system);
+  sim.setDomain(Domain::DP);
+  sim.setSolverType(Solver::Type::MNA);
+  sim.setTimeStep(p.coarseStep);
+  sim.setFinalTime(2.0 * p.coarseStep);
+  sim.doSystemMatrixRecomputation(true);
+
+  sim.start();
+  sim.next();
+  const UInt unconverted = sim.updateTimeStep(p.fineStep);
+  sim.next();
+  sim.stop();
+
+  return unconverted;
+}
+
 /// The load branch is interrupted at changeTime, which rings the L-C pair. With
 /// refinement the fine step covers the event window only.
 Real switchedPeak(const Parameters &p, const String &name, Real baseStep,
@@ -298,6 +355,8 @@ int main(int argc, char *argv[]) {
   const Bool passCount =
       sameStep.unconverted == 0 && withLine == 0 && withSwitch == 1;
   const Bool passWindow = windowError < 0.5 * coarseError;
+  const UInt ph3 = ph3Unconverted(p);
+  const Bool passPh3 = ph3 == 0;
 
   std::cout << std::scientific << std::setprecision(6);
   std::cout << "Same step is a no-op: " << (passSame ? "PASS" : "FAIL")
@@ -314,8 +373,12 @@ int main(int argc, char *argv[]) {
             << (passWindow ? "PASS" : "FAIL") << " (peak error, base step "
             << coarseError << ", refined " << windowError << ")" << std::endl;
 
-  const Bool passed = passSame && passRefined && passCount && passWindow;
-  std::cout << "Variable time step: " << (passed ? "4/4" : "failed")
+  std::cout << "Ph3 network converts: " << (passPh3 ? "PASS" : "FAIL")
+            << " (unconverted " << ph3 << ")" << std::endl;
+
+  const Bool passed =
+      passSame && passRefined && passCount && passWindow && passPh3;
+  std::cout << "Variable time step: " << (passed ? "5/5" : "failed")
             << std::endl;
 
   return passed ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
+++ b/dpsim/examples/cxx/Components/DP_VarTimeStep.cpp
@@ -3,17 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-// Checks Simulation::updateTimeStep() on a network of DP passive elements.
-//
-//   [1] Changing to the step already in use must reproduce the undisturbed run.
-//       Any deviation is produced by the conversion itself.
-//   [2] Changing from a coarse to a fine step must stay close to a run held at
-//       the fine step throughout.
-//   [3] The return value must count the components that did not convert. A
-//       PiLine and a varResSwitch convert, a ramped source does not.
-//   [4] Refining around a switching event must recover the transient that the
-//       base step alone misses.
-//   [5] A Ph3 network must convert as completely as the Ph1 one.
+// Checks updateTimeStep() and setEventRefinement() on DP networks: a change to
+// the step already in use is a no-op, a coarse-to-fine change matches a run held
+// fine, unconverted components are counted, a refined window recovers a
+// switching transient, Ph3 converts, and a machine keeps its rotor angle.
 
 #include <algorithm>
 #include <cmath>
@@ -21,6 +14,7 @@
 #include <iostream>
 #include <vector>
 
+#include "../Examples.h"
 #include <DPsim.h>
 #include <dpsim-models/DP/DP_Ph1_Switch.h>
 
@@ -41,6 +35,11 @@ struct Parameters {
   Real fineStep = 50e-6;
   Real changeTime = 0.1;
   Real finalTime = 0.2;
+
+  Real machineStep = 1e-3;
+  Real machineFineStep = 1e-4;
+  Real machineChangeTime = 1.0;
+  Real machineFinalTime = 1.2;
 
   Real switchResistance = 20.0;
   Real leadTime = 1e-3;
@@ -191,6 +190,145 @@ UInt unconvertedWith(const Parameters &p, const String &name,
   sim.stop();
 
   return unconverted;
+}
+
+/// SMIB with a 4th order VBR machine. Largest relative deviation of the terminal
+/// voltage after the change, against a run held at the fine step.
+Real machineDeviation(const Parameters &p) {
+  using namespace CPS::CIM::Examples::Grids::SMIB::
+      ReducedOrderSynchronGenerator;
+  Scenario6::GridParams grid;
+  CPS::CIM::Examples::Components::SynchronousGeneratorKundur::MachineParameters
+      machine;
+
+  // ----- power flow, for the machine's initial operating point -----
+  Logger::setLogDir("logs/DP_VarTimeStep_MachinePF");
+
+  auto n1PF = SimNode<Complex>::make("n1", PhaseType::Single);
+  auto n2PF = SimNode<Complex>::make("n2", PhaseType::Single);
+
+  auto genPF = SP::Ph1::SynchronGenerator::make("gen", Logger::Level::off);
+  genPF->setParameters(machine.nomPower, grid.VnomMV, grid.setPointActivePower,
+                       grid.setPointVoltage, PowerflowBusType::PV);
+  genPF->setBaseVoltage(grid.VnomMV);
+
+  auto slackPF = SP::Ph1::NetworkInjection::make("slack", Logger::Level::off);
+  slackPF->setParameters(grid.VnomMV);
+  slackPF->setBaseVoltage(grid.VnomMV);
+  slackPF->modifyPowerFlowBusType(PowerflowBusType::VD);
+
+  auto linePF = SP::Ph1::PiLine::make("line", Logger::Level::off);
+  linePF->setParameters(grid.lineResistance, grid.lineInductance,
+                        grid.lineCapacitance, grid.lineConductance);
+  linePF->setBaseVoltage(grid.VnomMV);
+
+  genPF->connect({n1PF});
+  linePF->connect({n1PF, n2PF});
+  slackPF->connect({n2PF});
+
+  auto systemPF = SystemTopology(grid.nomFreq, SystemNodeList{n1PF, n2PF},
+                                 SystemComponentList{genPF, linePF, slackPF});
+
+  Simulation simPF("DP_VarTimeStep_MachinePF", Logger::Level::off);
+  simPF.setSystem(systemPF);
+  simPF.setTimeStep(0.1);
+  simPF.setFinalTime(0.1);
+  simPF.setDomain(Domain::SP);
+  simPF.setSolverType(Solver::Type::NRP);
+  simPF.setSolverAndComponentBehaviour(Solver::Behaviour::Initialization);
+  simPF.doInitFromNodesAndTerminals(false);
+  simPF.run();
+
+  const Complex initPower(genPF->getApparentPower().real(),
+                          genPF->getApparentPower().imag());
+  const Real initMechPower = genPF->getApparentPower().real();
+  const Complex initTerminal = n1PF->voltage()(0, 0);
+  const Complex initSlack = n2PF->voltage()(0, 0);
+
+  // ----- the two dynamic runs -----
+  auto runMachine = [&](const String &name, Real baseStep,
+                        Real changeTo) -> std::vector<std::pair<Real, Real>> {
+    const String simName = "DP_VarTimeStep_" + name;
+    Logger::setLogDir("logs/" + simName);
+
+    auto n1 = SimNode<Complex>::make("n1", PhaseType::Single,
+                                     std::vector<Complex>{initTerminal});
+    auto n2 = SimNode<Complex>::make("n2", PhaseType::Single,
+                                     std::vector<Complex>{initSlack});
+
+    auto gen =
+        DP::Ph1::SynchronGenerator4OrderVBR::make("gen", Logger::Level::off);
+    gen->setOperationalParametersPerUnit(
+        machine.nomPower, machine.nomVoltage, machine.nomFreq, machine.H,
+        machine.Ld, machine.Lq, machine.Ll, machine.Ld_t, machine.Lq_t,
+        machine.Td0_t, machine.Tq0_t);
+    gen->setInitialValues(initPower, initMechPower, initTerminal);
+
+    auto slack = DP::Ph1::NetworkInjection::make("slack", Logger::Level::off);
+    slack->setParameters(grid.VnomMV);
+
+    auto line = DP::Ph1::PiLine::make("line", Logger::Level::off);
+    line->setParameters(grid.lineResistance, grid.lineInductance,
+                        grid.lineCapacitance, grid.lineConductance);
+
+    gen->connect({n1});
+    line->connect({n1, n2});
+    slack->connect({n2});
+
+    auto system = SystemTopology(grid.nomFreq, SystemNodeList{n1, n2},
+                                 SystemComponentList{gen, line, slack});
+
+    Simulation sim(simName, Logger::Level::info);
+    sim.setSystem(system);
+    sim.setDomain(Domain::DP);
+    sim.setSolverType(Solver::Type::MNA);
+    sim.setTimeStep(baseStep);
+    sim.setFinalTime(p.machineFinalTime);
+    sim.doSystemMatrixRecomputation(true);
+
+    std::vector<std::pair<Real, Real>> trace;
+    Bool changed = changeTo <= 0;
+
+    sim.start();
+
+    while (sim.time() < p.machineFinalTime + DOUBLE_EPSILON) {
+      if (!changed && sim.time() >= p.machineChangeTime - DOUBLE_EPSILON) {
+        sim.updateTimeStep(changeTo);
+        changed = true;
+      }
+
+      sim.next();
+      trace.emplace_back(
+          sim.time(),
+          std::abs(n1->attributeTyped<MatrixComp>("v")->get()(0, 0)));
+    }
+
+    sim.stop();
+
+    return trace;
+  };
+
+  const auto fine = runMachine("MachineFine", p.machineFineStep, -1.0);
+  const auto refined =
+      runMachine("MachineRefined", p.machineStep, p.machineFineStep);
+
+  Real scale = 0.0;
+  for (const auto &sample : fine)
+    scale = std::max(scale, sample.second);
+
+  Real worst = 0.0;
+  for (const auto &sample : refined) {
+    if (sample.first < p.machineChangeTime)
+      continue;
+    for (const auto &reference : fine) {
+      if (std::abs(reference.first - sample.first) > 1e-12)
+        continue;
+      worst = std::max(worst, std::abs(sample.second - reference.second));
+      break;
+    }
+  }
+
+  return scale > 0 ? worst / scale : worst;
 }
 
 /// Ph3 source, R, L, C and a PiLine, one step and a change.
@@ -362,6 +500,8 @@ int main(int argc, char *argv[]) {
   const Bool passWindow = windowError < 0.5 * coarseError;
   const UInt ph3 = ph3Unconverted(p);
   const Bool passPh3 = ph3 == 0;
+  const Real machine = machineDeviation(p);
+  const Bool passMachine = machine < 1e-2;
 
   std::cout << std::scientific << std::setprecision(6);
   std::cout << "Same step is a no-op: " << (passSame ? "PASS" : "FAIL")
@@ -382,9 +522,12 @@ int main(int argc, char *argv[]) {
   std::cout << "Ph3 network converts: " << (passPh3 ? "PASS" : "FAIL")
             << " (unconverted " << ph3 << ")" << std::endl;
 
-  const Bool passed =
-      passSame && passRefined && passCount && passWindow && passPh3;
-  std::cout << "Variable time step: " << (passed ? "5/5" : "failed")
+  std::cout << "Machine follows the change: " << (passMachine ? "PASS" : "FAIL")
+            << " (terminal voltage deviation " << machine << ")" << std::endl;
+
+  const Bool passed = passSame && passRefined && passCount && passWindow &&
+                      passPh3 && passMachine;
+  std::cout << "Variable time step: " << (passed ? "6/6" : "failed")
             << std::endl;
 
   return passed ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/dpsim/include/dpsim/Event.h
+++ b/dpsim/include/dpsim/Event.h
@@ -39,6 +39,9 @@ public:
 
   Event(CPS::Real t) : mTime(t) {}
 
+  /// Scheduled time
+  CPS::Real time() const { return mTime; }
+
   virtual ~Event() {}
 };
 

--- a/dpsim/include/dpsim/MNASolver.h
+++ b/dpsim/include/dpsim/MNASolver.h
@@ -237,5 +237,14 @@ public:
 
   /// Read-only access to the MNA state-space extractor.
   const MNAStateSpaceExtractor &getStateSpaceExtractor() const;
+
+  /// Asks every component to re-derive its discretisation. Declining types are
+  /// named in the log, since a stale discretisation still looks plausible.
+  UInt updateTimeStep(Real timeStep) override;
+
+protected:
+  /// Re-stamps what a timestep change invalidates without a variable component
+  /// reporting it.
+  virtual void refreshStaticMatrixStamp() {}
 };
 } // namespace DPsim

--- a/dpsim/include/dpsim/MNASolverDirect.h
+++ b/dpsim/include/dpsim/MNASolverDirect.h
@@ -137,6 +137,8 @@ protected:
   std::shared_ptr<CPS::Task> createSolveTaskRecomp() override;
   /// Recomputes systems matrix
   virtual void recomputeSystemMatrix(Real time);
+  /// Rebuilds the base matrix and refactorises after a timestep change
+  void refreshStaticMatrixStamp() override;
   /// Runs state-space extraction using the active linear solver.
   void extractStateSpace(Real time);
 

--- a/dpsim/include/dpsim/Simulation.h
+++ b/dpsim/include/dpsim/Simulation.h
@@ -192,6 +192,16 @@ public:
   void setSystem(const CPS::SystemTopology &system) { mSystem = system; }
   ///
   void setTimeStep(Real timeStep) { **mTimeStep = timeStep; }
+
+  /// Changes the timestep mid-run, unlike setTimeStep. Returns the number of
+  /// components that could not follow.
+  UInt updateTimeStep(Real timeStep) {
+    **mTimeStep = timeStep;
+    UInt unhandled = 0;
+    for (auto &solver : mSolvers)
+      unhandled += solver->updateTimeStep(timeStep);
+    return unhandled;
+  }
   ///
   void setFinalTime(Real finalTime) { **mFinalTime = finalTime; }
   ///

--- a/dpsim/include/dpsim/Simulation.h
+++ b/dpsim/include/dpsim/Simulation.h
@@ -336,10 +336,8 @@ public:
     mEvents.addEvent(e);
   }
 
-  /// Uses fineTimeStep from leadTime before a scheduled event until followTime
-  /// after it, and the step set by setTimeStep() outside. fineTimeStep <= 0
-  /// disables it. Only components that implement mnaUpdateTimeStep() follow the
-  /// change; the solver names those that do not.
+  /// Fine step from leadTime before a scheduled event to followTime after it,
+  /// the step from setTimeStep() outside. fineTimeStep <= 0 disables it.
   void setEventRefinement(Real fineTimeStep, Real leadTime, Real followTime) {
     mRefineTimeStep = fineTimeStep;
     mRefineLeadTime = leadTime;

--- a/dpsim/include/dpsim/Simulation.h
+++ b/dpsim/include/dpsim/Simulation.h
@@ -130,6 +130,9 @@ protected:
   Real mRefineBaseTimeStep = -1.0;
   Bool mRefineInWindow = false;
 
+  /// Selects the fine or the base step for the coming step
+  UInt applyEventRefinement();
+
   /// If tearing components exist, the Diakoptics
   /// solver is selected automatically.
   CPS::IdentifiedObject::List mTearComponents = CPS::IdentifiedObject::List();
@@ -323,8 +326,6 @@ public:
   void run();
   /// Solve system A * x = z for x and current time
   virtual Real step();
-  /// Selects the fine or the base step for the coming step
-  UInt applyEventRefinement();
   /// Synchronize simulation with remotes by exchanging intial state over interfaces
   void sync() const;
   /// Create the schedule for the independent tasks

--- a/dpsim/include/dpsim/Simulation.h
+++ b/dpsim/include/dpsim/Simulation.h
@@ -122,6 +122,14 @@ protected:
   /// Enable extraction of the MNA-coupled discrete-time state matrix.
   Bool mStateSpaceExtraction = false;
 
+  /// Scheduled event times, for the refinement windows
+  std::vector<Real> mEventTimes;
+  Real mRefineTimeStep = -1.0;
+  Real mRefineLeadTime = 0.0;
+  Real mRefineFollowTime = 0.0;
+  Real mRefineBaseTimeStep = -1.0;
+  Bool mRefineInWindow = false;
+
   /// If tearing components exist, the Diakoptics
   /// solver is selected automatically.
   CPS::IdentifiedObject::List mTearComponents = CPS::IdentifiedObject::List();
@@ -315,13 +323,28 @@ public:
   void run();
   /// Solve system A * x = z for x and current time
   virtual Real step();
+  /// Selects the fine or the base step for the coming step
+  UInt applyEventRefinement();
   /// Synchronize simulation with remotes by exchanging intial state over interfaces
   void sync() const;
   /// Create the schedule for the independent tasks
   void schedule();
 
   /// Schedule an event in the simulation
-  void addEvent(Event::Ptr e) { mEvents.addEvent(e); }
+  void addEvent(Event::Ptr e) {
+    mEventTimes.push_back(e->time());
+    mEvents.addEvent(e);
+  }
+
+  /// Uses fineTimeStep from leadTime before a scheduled event until followTime
+  /// after it, and the step set by setTimeStep() outside. fineTimeStep <= 0
+  /// disables it. Only components that implement mnaUpdateTimeStep() follow the
+  /// change; the solver names those that do not.
+  void setEventRefinement(Real fineTimeStep, Real leadTime, Real followTime) {
+    mRefineTimeStep = fineTimeStep;
+    mRefineLeadTime = leadTime;
+    mRefineFollowTime = followTime;
+  }
   /// Add a new data logger
   void addLogger(DataLoggerInterface::Ptr logger) {
     mLoggers.push_back(logger);

--- a/dpsim/include/dpsim/Solver.h
+++ b/dpsim/include/dpsim/Solver.h
@@ -93,6 +93,13 @@ public:
   enum class Type { MNA, DAE, NRP };
   ///
   void setTimeStep(Real timeStep) { mTimeStep = timeStep; }
+
+  /// Changes the timestep mid-run. Returns the number of components that could
+  /// not follow.
+  virtual UInt updateTimeStep(Real timeStep) {
+    mTimeStep = timeStep;
+    return 0;
+  }
   ///
   void doFrequencyParallelization(Bool freqParallel) {
     mFrequencyParallel = freqParallel;

--- a/dpsim/src/MNASolver.cpp
+++ b/dpsim/src/MNASolver.cpp
@@ -10,6 +10,7 @@
 #include <dpsim/MNASolver.h>
 #include <dpsim/SequentialScheduler.h>
 #include <functional>
+#include <map>
 #include <memory>
 #include <stdexcept>
 #include <type_traits>
@@ -39,6 +40,51 @@ void MnaSolver<VarType>::setSystem(const CPS::SystemTopology &system) {
 template <typename VarType>
 void MnaSolver<VarType>::doStateSpaceExtraction(Bool value) {
   mStateSpaceExtraction = value;
+}
+
+template <typename VarType>
+UInt MnaSolver<VarType>::updateTimeStep(Real timeStep) {
+  if (timeStep <= 0)
+    return 0;
+
+  mTimeStep = timeStep;
+  UInt unhandled = 0;
+  std::map<String, UInt> declinedByType;
+
+  auto ask = [&](auto &comp) {
+    if (comp->mnaUpdateTimeStep(timeStep))
+      return;
+    ++unhandled;
+    auto idObj = std::dynamic_pointer_cast<IdentifiedObject>(comp);
+    ++declinedByType[idObj ? idObj->type() : "<unnamed>"];
+  };
+
+  for (auto &comp : mMNAComponents)
+    ask(comp);
+  for (auto &comp : mMNAIntfVariableComps)
+    ask(comp);
+
+  refreshStaticMatrixStamp();
+
+  if (unhandled == 0) {
+    SPDLOG_LOGGER_INFO(mSLog,
+                       "Time step changed to {:e}s, all components re-derived "
+                       "their discretisation.",
+                       timeStep);
+    return 0;
+  }
+
+  String types;
+  for (const auto &declined : declinedByType)
+    types += (types.empty() ? "" : ", ") + declined.first + " x" +
+             std::to_string(declined.second);
+
+  SPDLOG_LOGGER_WARN(mSLog,
+                     "Time step changed to {:e}s, but {:d} component(s) do not "
+                     "implement mnaUpdateTimeStep and keep their old "
+                     "discretisation: {:s}",
+                     timeStep, unhandled, types);
+  return unhandled;
 }
 
 template <typename VarType>

--- a/dpsim/src/MNASolverDirect.cpp
+++ b/dpsim/src/MNASolverDirect.cpp
@@ -137,6 +137,32 @@ void MnaSolverDirect<VarType>::solveWithSystemMatrixRecomputation(
 }
 
 template <typename VarType>
+void MnaSolverDirect<VarType>::refreshStaticMatrixStamp() {
+  if (!mSystemMatrixRecomputationEnabled) {
+    // The precomputed matrices were factorised with the old timestep.
+    SPDLOG_LOGGER_WARN(mSLog,
+                       "Time step changed while using precomputed switch "
+                       "matrices. They keep the factorisation of the old step; "
+                       "enable system matrix recomputation to change it.");
+    return;
+  }
+
+  // The base matrix holds the static components with the old timestep, and
+  // recomputeSystemMatrix() only runs when a variable component changes.
+  mBaseSystemMatrix.setZero();
+  for (auto comp : mMNAComponents)
+    comp->mnaApplySystemMatrixStamp(mBaseSystemMatrix);
+
+  mVariableSystemMatrix = mBaseSystemMatrix;
+  for (auto comp : mMNAIntfVariableComps)
+    comp->mnaApplySystemMatrixStamp(mVariableSystemMatrix);
+
+  // Full factorisation: the static entries changed too, and the entry list
+  // partialRefactorize() works from covers only the variable components.
+  mDirectLinearSolverVariableSystemMatrix->factorize(mVariableSystemMatrix);
+}
+
+template <typename VarType>
 void MnaSolverDirect<VarType>::recomputeSystemMatrix(Real time) {
   // Start from base matrix
   mVariableSystemMatrix = mBaseSystemMatrix;

--- a/dpsim/src/Simulation.cpp
+++ b/dpsim/src/Simulation.cpp
@@ -472,11 +472,45 @@ void Simulation::run() {
   stop();
 }
 
+UInt Simulation::applyEventRefinement() {
+  if (mRefineTimeStep <= 0)
+    return 0;
+
+  if (mRefineBaseTimeStep <= 0)
+    mRefineBaseTimeStep = **mTimeStep;
+
+  Bool wantFine = false;
+  for (Real eventTime : mEventTimes)
+    if (mTime >= eventTime - mRefineLeadTime &&
+        mTime <= eventTime + mRefineFollowTime)
+      wantFine = true;
+
+  if (wantFine == mRefineInWindow)
+    return 0;
+
+  const Real wanted = wantFine ? mRefineTimeStep : mRefineBaseTimeStep;
+  const UInt unhandled = updateTimeStep(wanted);
+
+  mRefineInWindow = wantFine;
+  SPDLOG_LOGGER_INFO(mLog, "t = {:e}s: time step {:e}s, {:s} refinement window",
+                     mTime, wanted, wantFine ? "entering" : "leaving");
+
+  if (unhandled > 0)
+    SPDLOG_LOGGER_WARN(mLog,
+                       "{:d} component(s) did not follow the change at "
+                       "t = {:e}s and keep their old discretisation.",
+                       unhandled, mTime);
+
+  return unhandled;
+}
+
 Real Simulation::step() {
   std::chrono::steady_clock::time_point start;
   if (mLogStepTimes) {
     start = std::chrono::steady_clock::now();
   }
+
+  applyEventRefinement();
 
   mEvents.handleEvents(mTime);
   mScheduler->step(mTime, mTimeStepCount);

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -237,6 +237,8 @@ PYBIND11_MODULE(dpsimpy, m) {
            "loglevel"_a = CPS::Logger::Level::off)
       .def("name", &DPsim::Simulation::name)
       .def("set_time_step", &DPsim::Simulation::setTimeStep)
+      .def("update_time_step", &DPsim::Simulation::updateTimeStep)
+      .def("set_event_refinement", &DPsim::Simulation::setEventRefinement)
       .def("set_final_time", &DPsim::Simulation::setFinalTime)
       .def("add_logger", &DPsim::Simulation::addLogger)
       .def("set_system", &DPsim::Simulation::setSystem)


### PR DESCRIPTION
First stage of #680. There i proposed implementing an event-driven variable step so a run can use a large step in the settled state and a fine step after a fault. This branch starts with DP domain and scheduled events.

What it adds

  setTimeStep() only works before a run starts, because components build their companion models from the step at initialisation and keep them. New: Simulation::updateTimeStep(Real) changes the step properly between steps, and setEventRefinement(fine, lead, follow) uses a finer step around scheduled events.

  A change travels Simulation::updateTimeStep() → MnaSolver::updateTimeStep() → MNAInterface::mnaUpdateTimeStep() per component. A component returns false if it cannot follow; the solver counts those, logs the declining types and returns the count, so a stale discretisation is reported rather than silently simulated.

  Two solver details:

  - The base matrix holds the static components with the old step, and recomputeSystemMatrix() only runs when a variable component reports a change. refreshStaticMatrixStamp() re-stamps it and factorises fully, since partialRefactorize() only covers variable components.
  - With precomputed switch matrices every factorisation carries the old step, so the change is refused with a warning. Matrix recomputation must be enabled.

  Coverage and limits

  All of DP::Ph1 and DP::Ph3: passive elements, ideal sources, containers, switches, and the reduced-order and PCM/TPM machines. Machines also re-anchor the rotor angle by mBase_OmMech * (oldTimeStep - timeStep), otherwise the dq transform argument jumps by w0*dt and the machine rotates against the network.

  mnaUpdateTimeStep() defaults to false, so EMT and SP decline and warn, and existing runs are untouched. Still declining in DP on purpose: the converter families, SynchronGeneratorTrStab, SynchronGeneratorIdeal, VoltageSourceRamp, Ph3::SynchronGeneratorDQODE. 
Refinement covers scheduled events only for now. Important: Logs get non-uniform time stamps, so anything downstream has to read the time column instead of assuming a constant step.

  Testing

  DP_VarTimeStep in dpsim/examples/cxx/Components/, six checks: 
- nothing changes on an unchanged step 0 
- coarse-to-fine against a run held fine 4.4e-10 
- decline count 0 passive and 1 with a ramped source 
- refined window on a switching transient 2.9e-2 at the base step against
  5.3e-8 refined; 
machine rotor angle 2.3e-11.

  The machine case is a 24 kV SMIB with a 4th-order VBR generator. Remove the rotor re-anchoring and the same check reads 2.3e-1, so it measures that correction rather than passing by construction.

  Documented under Developer Guide, Solvers, next to the MNA solver page.

An LLM was used to rework my local implementation for this merge request - i verified changes and modified some things manually.