### PR TITLE
ci: update test- pypi publishing version resolution and triggers

### DIFF
--- a/.github/workflows/packaging-python.yaml
+++ b/.github/workflows/packaging-python.yaml
@@ -10,6 +10,11 @@ on:
         description: 'Revision under test'
         required: true
         type: string
+      version:
+        description: 'Version to set in the pyproject.toml'
+        required: false
+        type: string
+        default: ''
       image:
         description: 'Development image the source distribution is built in'
         required: true
@@ -32,9 +37,9 @@ jobs:
         submodules: recursive
 
     - name: Set development version for Test PyPI
-      if: "!startsWith(github.ref, 'refs/tags')"
+      if: inputs.version != ''
       shell: bash
-      run: python3 scripts/set_dev_version.py pyproject.toml ${{ github.run_number }}
+      run: python3 scripts/set_dev_version.py pyproject.toml ${{ inputs.version }}
 
     - name: Build DPsim source distribution
       shell: bash

--- a/.github/workflows/packaging-python.yaml
+++ b/.github/workflows/packaging-python.yaml
@@ -36,7 +36,7 @@ jobs:
         allow-unsafe-pr-checkout: true
         submodules: recursive
 
-    - name: Set development version for Test PyPI
+    - name: Set the version resolved by the caller
       if: inputs.version != ''
       shell: bash
       run: python3 scripts/set_dev_version.py pyproject.toml ${{ inputs.version }}
@@ -77,10 +77,10 @@ jobs:
       with:
         python-version: '3.13'
 
-    - name: Set development version for Test PyPI
+    - name: Set the version resolved by the caller
       if: "!startsWith(github.ref, 'refs/tags')"
       shell: bash
-      run: python scripts/set_dev_version.py pyproject.toml ${{ github.run_number }}
+      run: python scripts/set_dev_version.py pyproject.toml ${{ inputs.version }}
 
     - name: Build wheel
       uses: pypa/cibuildwheel@v3.4.1

--- a/.github/workflows/packaging-python.yaml
+++ b/.github/workflows/packaging-python.yaml
@@ -78,7 +78,7 @@ jobs:
         python-version: '3.13'
 
     - name: Set the version resolved by the caller
-      if: "!startsWith(github.ref, 'refs/tags')"
+      if: inputs.version != ''
       shell: bash
       run: python scripts/set_dev_version.py pyproject.toml ${{ inputs.version }}
 

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -31,15 +31,18 @@ jobs:
       - name: Determine version string
         id: get_version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          REF_NAME="${{ github.ref_name }}"
+          #testpypi resolution if tag push contains rc or wf is dispatched
+          if [ "${{ github.event_name }}" = "workflow_dispatch" || "$REF_NAME" == *rc*]; then
+            #this is dispatched over branch, fetch latest tag
             if [ "${{ github.ref_type}}" = "branch" ]; then
               TAG=$(git describe --tags --abbrev=0)
+            #otherwise use pushed tag
             else
-              TAG="${{ github.ref_name }}"
+              TAG="$REF_NAME"
             fi
 
-            #safe remove dash anyway
-            #this has no effect on vx.y.z
+            #remove dash in case it contains rc ( publish fails )
             TAG=$(echo "$TAG" | tr -d'-')
 
             #if not rc, need modify string
@@ -47,8 +50,9 @@ jobs:
             if [[ "$TAG" != *rc* ]]; then
               TAG="$(echo $TAG | awk print -F . '{print $1"."$2"."$3+1}').dev${{ github.run_number }}"
             fi
+          #tag push without rc
           else
-            TAG="${{ github.ref_name }}"
+            TAG="$REF_NAME"
           fi
           echo "version=${TAG}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           REF_NAME="${{ github.ref_name }}"
           #testpypi resolution if tag push contains rc or wf is dispatched
-if [[ "${{ github.event_name }}" = "workflow_dispatch" || "$REF_NAME" == *rc* ]]; then
+          if [[ "${{ github.event_name }}" = "workflow_dispatch" || "$REF_NAME" == *rc* ]]; then
             #this is dispatched over branch, fetch latest tag
             if [ "${{ github.ref_type}}" = "branch" ]; then
               TAG=$(git describe --tags --abbrev=0)
@@ -48,7 +48,7 @@ if [[ "${{ github.event_name }}" = "workflow_dispatch" || "$REF_NAME" == *rc* ]]
             #if not rc, need modify string
             #increase fix number by one, add .dev<run_number>
             if [[ "$TAG" != *rc* ]]; then
-TAG="$(echo "$TAG" | awk -F. '{print $1"."$2"."$3+1}').dev${{ github.run_number }}"
+              TAG="$(echo "$TAG" | awk -F. '{print $1"."$2"."$3+1}').dev${{ github.run_number }}"
             fi
           #tag push without rc
           else

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -32,12 +32,25 @@ jobs:
         id: get_version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            LATEST_TAG=$(git describe --tags --abbrev=0)
-            VERSION="${LATEST_TAG}.dev${{ github.run_number }}"
+            if [ "${{ github.ref_type}}" = "branch" ]; then
+              TAG=$(git describe --tags --abbrev=0)
+            else
+              TAG="${{ github.ref_name }}"
+            fi
+
+            #safe remove dash anyway
+            #this has no effect on vx.y.z
+            TAG=$(echo "$TAG" | tr -d'-')
+
+            #if not rc, need modify string
+            #increase fix number by one, add .dev<run_number>
+            if [[ "$TAG" != *rc* ]]; then
+              TAG="$(echo $TAG | awk print -F . '{print $1"."$2"."$3+1}').dev${{ github.run_number }}"
+            fi
           else
-            VERSION="${{ github.ref_name }}"
+            TAG="${{ github.ref_name }}"
           fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${TAG}" >> $GITHUB_OUTPUT
 
   build:
     name: Packaging
@@ -53,8 +66,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-    needs: [version,build]
-    if: github.event_name == 'workflow_dispatch' || contains(github.ref_name, '-rc')
+    needs: [version, build]
+    if: github.event_name == 'workflow_dispatch' || contains(github.ref, 'rc')
     steps:
     - name: Download wheels from build jobs
       uses: actions/download-artifact@v8
@@ -72,11 +85,11 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-24.04
-    if: startsWith(github.ref, 'refs/tags') && !contains(github.ref, '-rc')
+    if: github.event_name != 'workflow_dispatch' && !contains(github.ref, 'rc')
     environment: pypi
     permissions:
       id-token: write
-    needs: [build]
+    needs: [version, build]
 
     steps:
     - name: Download wheels from build jobs

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           REF_NAME="${{ github.ref_name }}"
           #testpypi resolution if tag push contains rc or wf is dispatched
-          if [ "${{ github.event_name }}" = "workflow_dispatch" || "$REF_NAME" == *rc*]; then
+if [[ "${{ github.event_name }}" = "workflow_dispatch" || "$REF_NAME" == *rc* ]]; then
             #this is dispatched over branch, fetch latest tag
             if [ "${{ github.ref_type}}" = "branch" ]; then
               TAG=$(git describe --tags --abbrev=0)

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -48,7 +48,7 @@ jobs:
             #if not rc, need modify string
             #increase fix number by one, add .dev<run_number>
             if [[ "$TAG" != *rc* ]]; then
-              TAG="$(echo $TAG | awk print -F . '{print $1"."$2"."$3+1}').dev${{ github.run_number }}"
+TAG="$(echo "$TAG" | awk -F. '{print $1"."$2"."$3+1}').dev${{ github.run_number }}"
             fi
           #tag push without rc
           else

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -5,11 +5,8 @@ name: Publish to PyPI
 
 on:
   push:
-    branches:
-      - master
     tags:
       - '*'
-  # Release Please dispatches this at the new tag; a tag it pushes starts no run by itself.
   workflow_dispatch:
 
 permissions:
@@ -20,11 +17,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version:
+    name: Resolve Version
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version string
+        id: get_version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            LATEST_TAG=$(git describe --tags --abbrev=0)
+            VERSION="${LATEST_TAG}.dev${{ github.run_number }}"
+          else
+            VERSION="${{ github.ref_name }}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
   build:
     name: Packaging
+    needs: [version]
     uses: ./.github/workflows/packaging-python.yaml
     with:
       ref: ${{ github.sha }}
+      version: ${{ needs.version.outputs.version }}
       image: sogno/dpsim:dev
 
   publish-testpypi:
@@ -32,8 +53,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-    needs: [build]
-
+    needs: [version,build]
+    if: github.event_name == 'workflow_dispatch' || contains(github.ref_name, '-rc')
     steps:
     - name: Download wheels from build jobs
       uses: actions/download-artifact@v8

--- a/scripts/set_dev_version.py
+++ b/scripts/set_dev_version.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2026 Institute for Automation of Complex Power Systems, EONERC, RWTH Aachen University
 # SPDX-License-Identifier: MPL-2.0
-# Bumps patch + appends .devN so Test PyPI never sees a reused, stale version.
+# Substitutes the version the calling workflow resolved from the ref.
 
 import re
 import sys

--- a/scripts/set_dev_version.py
+++ b/scripts/set_dev_version.py
@@ -8,7 +8,7 @@ import sys
 
 
 def main() -> None:
-    path, run_number = sys.argv[1], sys.argv[2]
+    path, version = sys.argv[1], sys.argv[2]
 
     with open(path) as f:
         content = f.read()
@@ -17,17 +17,15 @@ def main() -> None:
     if not match:
         sys.exit(f'could not find a version = "X.Y.Z" line in {path}')
 
-    major, minor, patch = match.groups()
-    dev_version = f"{major}.{minor}.{int(patch) + 1}.dev{run_number}"
 
     content = (
-        content[: match.start()] + f'version = "{dev_version}"' + content[match.end() :]
+        content[: match.start()] + f'version = "{version}"' + content[match.end() :]
     )
 
     with open(path, "w") as f:
         f.write(content)
 
-    print(f"set version to {dev_version}")
+    print(f"set version to {version}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Notable changes:
Resolve version substituted in pyproject.toml, depending on use case. 
Packaging-python is called from two different workflows: ci.yaml and publish_to_pypi.
If its called from ci, default version is '' and substitution is skipped, and no subsequent publishing seems to be happening
If its called from publish_to_pypi then:
If its a manually triggered workflow, the version is given the <version>.dev<run_number> treatment
Publishing to testpypi will trigger if the version string contains either dev or rc
Otherwise the provided tag is substituted into the pyproject.toml anyway , and the publishing to pypi triggers only if the tag ( NOT THE CALCULATED VERSION STRING ) doesnt contain -rc
This should cover all use cases, but please do check whether it is correct, as i cannot test it easily