### PR TITLE
fix(models): correct the SP::Ph3 voltage source current readback and stamp

### DIFF
--- a/dpsim-models/src/SP/SP_Ph3_VoltageSource.cpp
+++ b/dpsim-models/src/SP/SP_Ph3_VoltageSource.cpp
@@ -76,7 +76,7 @@ void SP::Ph3::VoltageSource::mnaCompApplySystemMatrixStamp(
                              Complex(-1, 0));
     Math::addToMatrixElement(systemMatrix,
                              mVirtualNodes[0]->matrixNodeIndex(PhaseType::C),
-                             matrixNodeIndex(0, 2), -Complex(-1, 0));
+                             matrixNodeIndex(0, 2), Complex(-1, 0));
   }
   if (terminalNotGrounded(1)) {
     Math::addToMatrixElement(systemMatrix, matrixNodeIndex(1, 0),

--- a/dpsim-models/src/SP/SP_Ph3_VoltageSource.cpp
+++ b/dpsim-models/src/SP/SP_Ph3_VoltageSource.cpp
@@ -162,9 +162,9 @@ void SP::Ph3::VoltageSource::mnaCompPostStep(
 void SP::Ph3::VoltageSource::mnaCompUpdateCurrent(const Matrix &leftVector) {
   (**mIntfCurrent)(0, 0) = Math::complexFromVectorElement(
       leftVector, mVirtualNodes[0]->matrixNodeIndex(PhaseType::A));
-  (**mIntfCurrent)(1, 0) = Math::realFromVectorElement(
+  (**mIntfCurrent)(1, 0) = Math::complexFromVectorElement(
       leftVector, mVirtualNodes[0]->matrixNodeIndex(PhaseType::B));
-  (**mIntfCurrent)(2, 0) = Math::realFromVectorElement(
+  (**mIntfCurrent)(2, 0) = Math::complexFromVectorElement(
       leftVector, mVirtualNodes[0]->matrixNodeIndex(PhaseType::C));
 }
 


### PR DESCRIPTION
Fixes to the Voltage Source in SP 3 phase domain
- Stamp all phases
- Update as a complex value in the current