### PR TITLE
fix(solver): tighten the default steady-state initialization accuracy limit

### DIFF
--- a/dpsim/include/dpsim/Simulation.h
+++ b/dpsim/include/dpsim/Simulation.h
@@ -136,9 +136,9 @@ protected:
 
   // #### Initialization ####
   /// steady state initialization time limit
-  Real mSteadStIniTimeLimit = 10;
+  Real mSteadStIniTimeLimit = Solver::DEFAULT_STEAD_ST_INI_TIME_LIMIT;
   /// steady state initialization accuracy limit
-  Real mSteadStIniAccLimit = 0.0001;
+  Real mSteadStIniAccLimit = Solver::DEFAULT_STEAD_ST_INI_ACC_LIMIT;
 
   // #### Task dependencies und scheduling ####
   /// Scheduler used for task scheduling

--- a/dpsim/include/dpsim/Solver.h
+++ b/dpsim/include/dpsim/Solver.h
@@ -29,6 +29,11 @@ struct SwitchConfiguration {
 /// Base class for more specific solvers such as MNA, ODE or IDA.
 class Solver {
 public:
+  /// Default steady state initialization time limit
+  static constexpr Real DEFAULT_STEAD_ST_INI_TIME_LIMIT = 10;
+  /// Default steady state initialization accuracy limit
+  static constexpr Real DEFAULT_STEAD_ST_INI_ACC_LIMIT = 1e-8;
+
   typedef std::shared_ptr<Solver> Ptr;
   typedef std::vector<Ptr> List;
 
@@ -60,9 +65,9 @@ protected:
 
   // #### Initialization ####
   /// steady state initialization time limit
-  Real mSteadStIniTimeLimit = 10;
+  Real mSteadStIniTimeLimit = DEFAULT_STEAD_ST_INI_TIME_LIMIT;
   /// steady state initialization accuracy limit
-  Real mSteadStIniAccLimit = 0.0001;
+  Real mSteadStIniAccLimit = DEFAULT_STEAD_ST_INI_ACC_LIMIT;
   /// Activates steady state initialization
   Bool mSteadyStateInit = false;
   /// Determines if solver is in initialization phase, which requires different behavior

--- a/dpsim/src/pybind/main.cpp
+++ b/dpsim/src/pybind/main.cpp
@@ -290,6 +290,10 @@ PYBIND11_MODULE(dpsimpy, m) {
            &DPsim::Simulation::getStateSpaceExtractor, "solver_index"_a = 0,
            py::return_value_policy::reference_internal)
       .def("do_steady_state_init", &DPsim::Simulation::doSteadyStateInit)
+      .def("set_steady_state_init_acc_limit",
+           &DPsim::Simulation::setSteadStIniAccLimit)
+      .def("set_steady_state_init_time_limit",
+           &DPsim::Simulation::setSteadStIniTimeLimit)
       .def("do_frequency_parallelization",
            &DPsim::Simulation::doFrequencyParallelization)
       .def("do_split_subnets", &DPsim::Simulation::doSplitSubnets)


### PR DESCRIPTION
Initialization needs to be a bit more accurate for some cases.
Opt-in lets you change it also as an option.