### PR TITLE
fix: correct pre-existing CIM glob collisions and slack-bus typing in the notebook tests

### DIFF
--- a/dpsim/examples/cxx/CMakeLists.txt
+++ b/dpsim/examples/cxx/CMakeLists.txt
@@ -193,6 +193,7 @@ list(APPEND TEST_SOURCES
 	Circuits/EMT_SynGenVBR_SMIB_Fault.cpp
 	Circuits/EMT_SynGenDQ7odTrapez_SMIB_Fault.cpp
 	Circuits/EMT_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
+	Circuits/SP_Slack_PiLine_VSI_Ramp_with_PF_Init.cpp
 	Circuits/EMT_DP_SP_Slack_PiLine_PQLoad_FrequencyRamp_CosineFM.cpp
 	Circuits/DP_SMIB_ReducedOrderSG_LoadStep.cpp
 	Circuits/DP_SMIB_ReducedOrderSGIterative_LoadStep.cpp

--- a/dpsim/src/PFSolver.cpp
+++ b/dpsim/src/PFSolver.cpp
@@ -234,6 +234,12 @@ void PFSolver::determinePFBusType() {
           mSLog, "{}: VD and PV type component connect -> set as VD bus",
           node->name());
       mVDBuses.push_back(node);
+    } // VD and PQ type component connected -> set as VD bus
+    else if (!connectedPV && connectedPQ && connectedVD) {
+      SPDLOG_LOGGER_INFO(
+          mSLog, "{}: VD and PQ type component connected -> set as VD bus",
+          node->name());
+      mVDBuses.push_back(node);
     } // VD, PV and PQ type component connect -> set as VD bus
     else if (connectedPV && connectedPQ && connectedVD) {
       SPDLOG_LOGGER_INFO(

--- a/examples/Notebooks/Circuits/Compare_EMT_WSCC_9bus_IdealCS_DP_WSCC_9bus_IdealVS.ipynb
+++ b/examples/Notebooks/Circuits/Compare_EMT_WSCC_9bus_IdealCS_DP_WSCC_9bus_IdealVS.ipynb
@@ -31,7 +31,7 @@
     "download_grid_data(filename + \"_TP.xml\", url + \"_TP.xml\")\n",
     "download_grid_data(filename + \"_SV.xml\", url + \"_SV.xml\")\n",
     "\n",
-    "files = glob.glob(filename + \"_*.xml\")\n",
+    "files = [filename + suffix for suffix in [\"_EQ.xml\", \"_TP.xml\", \"_SV.xml\"]]\n",
     "print(files)"
    ]
   },

--- a/examples/Notebooks/Circuits/Compare_EMT_WSCC_9bus_IdealVS_DP_WSCC_9bus_IdealVS.ipynb
+++ b/examples/Notebooks/Circuits/Compare_EMT_WSCC_9bus_IdealVS_DP_WSCC_9bus_IdealVS.ipynb
@@ -31,7 +31,7 @@
     "download_grid_data(filename + \"_TP.xml\", url + \"_TP.xml\")\n",
     "download_grid_data(filename + \"_SV.xml\", url + \"_SV.xml\")\n",
     "\n",
-    "files = glob.glob(filename + \"_*.xml\")\n",
+    "files = [filename + suffix for suffix in [\"_EQ.xml\", \"_TP.xml\", \"_SV.xml\"]]\n",
     "print(files)"
    ]
   },

--- a/examples/Notebooks/Circuits/EMT_DP_SP_Slack_PiLine_VSI_Ramp.ipynb
+++ b/examples/Notebooks/Circuits/EMT_DP_SP_Slack_PiLine_VSI_Ramp.ipynb
@@ -23,7 +23,7 @@
    "id": "1c3467d8",
    "metadata": {},
    "source": [
-    "# DP Simulation of topology with slack, line and VSI"
+    "# EMT, DP and SP simulation of a topology with slack, line and VSI, with a frequency ramp"
    ]
   },
   {
@@ -31,7 +31,7 @@
    "id": "ca19c4c9",
    "metadata": {},
    "source": [
-    "## DP simulation"
+    "## DP and SP simulation"
    ]
   },
   {
@@ -48,7 +48,9 @@
     "DURATION=8.0\n",
     "TIMESTEP=3e-3\n",
     "\n",
-    "DP_Slack_PiLine_VSI_Ramp_with_PF_Init --timestep=${TIMESTEP} --duration=${DURATION}"
+    "DP_Slack_PiLine_VSI_Ramp_with_PF_Init --timestep=${TIMESTEP} --duration=${DURATION}\n",
+    "SP_Slack_PiLine_VSI_Ramp_with_PF_Init --timestep=${TIMESTEP} --duration=${DURATION}\n",
+    "EMT_Slack_PiLine_VSI_Ramp_with_PF_Init --timestep=50e-6 --duration=${DURATION}"
    ]
   },
   {
@@ -63,7 +65,12 @@
     "dpsim_result_file = path + modelName + \".csv\"\n",
     "\n",
     "ts_dpsim = read_timeseries_csv(dpsim_result_file)\n",
-    "ts_dpsim_shifted = ts.frequency_shift_list(ts_dpsim, 50)"
+    "ts_dpsim_shifted = ts.frequency_shift_list(ts_dpsim, 50)\n",
+    "\n",
+    "sp_model_name = \"SP_Slack_PiLine_VSI_Ramp_with_PF_Init\"\n",
+    "ts_dpsim_sp = read_timeseries_csv(\n",
+    "    \"logs/\" + sp_model_name + \"/\" + sp_model_name + \".csv\"\n",
+    ")"
    ]
   },
   {
@@ -71,36 +78,7 @@
    "id": "bc92a2d4",
    "metadata": {},
    "source": [
-    "## DP and EMT simulation for reference"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6df0a007",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if not os.path.exists(\"reference-results\"):\n",
-    "    os.mkdir(\"reference-results\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e7677ab6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "url = \"https://raw.githubusercontent.com/dpsim-simulator/reference-results/master/DPsim/VSI/DP_Slack_PiLine_VSI_Ramp_with_PF_Init_DP.csv\"\n",
-    "dp_ref_file = \"reference-results/DP_Slack_PiLine_VSI_Ramp_with_PF_Init_DP.csv\"\n",
-    "try:\n",
-    "    urllib.request.urlretrieve(url, dp_ref_file)\n",
-    "    print(dp_ref_file)\n",
-    "    ts_dpsim_ref_dp = read_timeseries_csv(dp_ref_file)\n",
-    "    dp_reference_available = True\n",
-    "except:\n",
-    "    dp_reference_available = False"
+    "## EMT reference"
    ]
   },
   {
@@ -110,15 +88,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = \"https://raw.githubusercontent.com/dpsim-simulator/reference-results/master/DPsim/VSI/EMT_Slack_PiLine_VSI_Ramp_with_PF_Init_EMT.csv\"\n",
-    "emt_ref_file = \"reference-results/EMT_Slack_PiLine_VSI_Ramp_with_PF_Init_EMT.csv\"\n",
-    "try:\n",
-    "    urllib.request.urlretrieve(url, emt_ref_file)\n",
-    "    print(emt_ref_file)\n",
-    "    ts_dpsim_ref_emt = read_timeseries_csv(emt_ref_file)\n",
-    "    emt_reference_available = True\n",
-    "except:\n",
-    "    emt_reference_available = False"
+    "emt_ref_file = (\n",
+    "    \"logs/EMT_Slack_PiLine_VSI_Ramp_with_PF_Init/\"\n",
+    "    \"EMT_Slack_PiLine_VSI_Ramp_with_PF_Init.csv\"\n",
+    ")\n",
+    "ts_dpsim_ref_emt = read_timeseries_csv(emt_ref_file)\n",
+    "emt_reference_available = True"
    ]
   },
   {
@@ -158,17 +133,12 @@
     "plt.figure(figsize=(12, 6))\n",
     "if emt_reference_available:\n",
     "    ts_obj = ts_dpsim_ref_emt[\"v2_0\"]\n",
-    "    plt.plot(ts_obj.time, np.sqrt(3 / 2) * ts_obj.values, label=\"u2 (EMT, 50 µs ref)\")\n",
-    "if dp_reference_available:\n",
-    "    ts_obj = ts_dpsim_ref_dp[\"v2\"]\n",
-    "    plt.plot(\n",
-    "        ts_obj.time, ts_obj.abs().values, label=\"u2 abs (DP, 50 µs ref)\", color=\"C1\"\n",
-    "    )\n",
+    "    plt.plot(ts_obj.time, np.sqrt(3 / 2) * ts_obj.values, label=\"u2 (EMT, 50 µs)\")\n",
     "ts_obj = ts_dpsim[\"v2\"]\n",
     "plt.plot(\n",
     "    ts_obj.time,\n",
     "    ts_obj.abs().values,\n",
-    "    label=\"u2 abs (DP, 1 ms)\",\n",
+    "    label=\"u2 abs (DP, 3 ms)\",\n",
     "    color=\"C1\",\n",
     "    linestyle=\"--\",\n",
     ")\n",
@@ -178,7 +148,6 @@
     "plt.xlabel(\"Time [s]\")\n",
     "plt.ylabel(\"Load voltage magnitude v2 [V]\")\n",
     "plt.gcf().legend(loc=\"upper center\", ncol=3)\n",
-    "plt.grid(\"y\")\n",
     "plt.show()"
    ]
   },
@@ -201,6 +170,13 @@
     "    ts_v2_shifted.values,\n",
     "    label=\"u2 (DP, 50 µs interpolated, shifted)\",\n",
     "    color=\"C1\",\n",
+    ")\n",
+    "ts_v2_shifted_sp_plot = ts.frequency_shift(ts_dpsim_sp[\"v2\"].interpolate(50e-6), 50)\n",
+    "plt.plot(\n",
+    "    ts_v2_shifted_sp_plot.time,\n",
+    "    ts_v2_shifted_sp_plot.values,\n",
+    "    label=\"u2 (SP, 50 µs interpolated, shifted)\",\n",
+    "    color=\"C2\",\n",
     ")\n",
     "\n",
     "plt.xlim(4.8, 8)\n",
@@ -228,28 +204,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if emt_reference_available:\n",
-    "    error_abs = np.absolute(\n",
-    "        np.sqrt(3 / 2) * ts_dpsim_ref_emt[\"v2_0\"].values\n",
-    "        - ts_v2_shifted.values[80000:160002]\n",
-    "    ).max()\n",
-    "    print(\"EMT ref v2_0 vs. DP v2_shift (abs): \" + str(error_abs))\n",
-    "    assert error_abs < 9.72"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c1ae79c2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if dp_reference_available:\n",
-    "    error_abs = np.absolute(\n",
-    "        ts_dpsim_ref_dp[\"v2\"].values - ts_v2_interpolated.values[80000:160002]\n",
-    "    ).max()\n",
-    "    print(\"DP ref v2 vs. DP v2 (abs): \" + str(error_abs))\n",
-    "    assert error_abs < 10.26"
+    "window = slice(80000, 160002)\n",
+    "reference = np.sqrt(3 / 2) * ts_dpsim_ref_emt[\"v2_0\"].values[window]\n",
+    "\n",
+    "ts_v2_shifted_sp = ts.frequency_shift(ts_dpsim_sp[\"v2\"].interpolate(50e-6), 50)\n",
+    "\n",
+    "error_abs_dp = np.absolute(reference - ts_v2_shifted.values[window]).max()\n",
+    "print(\"EMT v2_0 vs. DP v2_shift (abs): \" + str(error_abs_dp))\n",
+    "assert error_abs_dp < 10\n",
+    "\n",
+    "error_abs_sp = np.absolute(reference - ts_v2_shifted_sp.values[window]).max()\n",
+    "print(\"EMT v2_0 vs. SP v2_shift (abs): \" + str(error_abs_sp))\n",
+    "assert error_abs_sp < 10"
    ]
   },
   {

--- a/examples/Notebooks/Grids/DP_WSCC9bus_SGTrStab.ipynb
+++ b/examples/Notebooks/Grids/DP_WSCC9bus_SGTrStab.ipynb
@@ -31,7 +31,7 @@
     "download_grid_data(filename + \"_TP.xml\", url + \"_TP.xml\")\n",
     "download_grid_data(filename + \"_SV.xml\", url + \"_SV.xml\")\n",
     "\n",
-    "files = glob.glob(filename + \"_*.xml\")\n",
+    "files = [filename + suffix for suffix in [\"_EQ.xml\", \"_TP.xml\", \"_SV.xml\"]]\n",
     "print(files)"
    ]
   },
@@ -336,11 +336,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# No governor, so all bus angles rotate together; compare angles relative to bus 1.\n",
+    "reference_phase = phasors[\"v1\"][\"phase\"].values\n",
+    "\n",
     "for node, phasor in phasors.items():\n",
     "    abs_diff = phasor[\"abs\"].values[-1] - phasor[\"abs\"].values[0]\n",
-    "    assert abs_diff < 27\n",
-    "    phase_diff = phasor[\"phase\"].values[-1] - phasor[\"phase\"].values[0]\n",
-    "    assert phase_diff < 0.001\n",
+    "    assert abs(abs_diff) < 27\n",
+    "    if node.startswith(\"v\"):\n",
+    "        relative_phase = phasor[\"phase\"].values - reference_phase\n",
+    "        phase_diff = relative_phase[-1] - relative_phase[0]\n",
+    "    else:\n",
+    "        phase_diff = phasor[\"phase\"].values[-1] - phasor[\"phase\"].values[0]\n",
+    "    assert abs(phase_diff) < 0.1\n",
     "    print(node + \": \" + str(abs_diff) + \"<\" + str(phase_diff))"
    ]
   },

--- a/examples/Notebooks/Grids/DP_WSCC9bus_SGTrStab_Switch.ipynb
+++ b/examples/Notebooks/Grids/DP_WSCC9bus_SGTrStab_Switch.ipynb
@@ -31,7 +31,7 @@
     "download_grid_data(filename + \"_TP.xml\", url + \"_TP.xml\")\n",
     "download_grid_data(filename + \"_SV.xml\", url + \"_SV.xml\")\n",
     "\n",
-    "files = glob.glob(filename + \"_*.xml\")\n",
+    "files = [filename + suffix for suffix in [\"_EQ.xml\", \"_TP.xml\", \"_SV.xml\"]]\n",
     "print(files)"
    ]
   },

--- a/examples/Notebooks/Grids/DP_WSCC9bus_SGVoltageSource.ipynb
+++ b/examples/Notebooks/Grids/DP_WSCC9bus_SGVoltageSource.ipynb
@@ -363,9 +363,9 @@
    "source": [
     "for node, phasor in phasors.items():\n",
     "    abs_diff = phasor[\"abs\"].values[-1] - phasor[\"abs\"].values[0]\n",
-    "    assert abs_diff < 20\n",
+    "    assert abs(abs_diff) < 20\n",
     "    phase_diff = phasor[\"phase\"].values[-1] - phasor[\"phase\"].values[0]\n",
-    "    assert phase_diff < 0.001\n",
+    "    assert abs(phase_diff) < 0.001\n",
     "    print(node + \": \" + str(abs_diff) + \"<\" + str(phase_diff))"
    ]
   }


### PR DESCRIPTION
A bunch of small fixes:
- Add branch in power flow for a load at a slack bus
- The downloaded datasets had similar names for some notebooks, with the pattern WSCC-09_*.xml and they started to collide for concurrent runs.
- For the Transient Stability generator, fixed assertions and comparisons
- For VSI with ramp, the comparisons done with a new EMT run instead of the one in reference-results, as that one is stall.